### PR TITLE
feat: add production Dockerfile, entrypoint, and docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Version control
+.git/
+.gitignore
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+.eggs/
+dist/
+build/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Development tools
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Tests (not needed in production image)
+tests/
+
+# Documentation
+docs/
+*.md
+
+# Dev compose and data
+docker-compose.dev.yml
+data/
+data-dev/
+*.db
+*.masterkey
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# Research artifacts
+.opencode/
+
+# CI/CD
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,60 @@
 # syntax=docker/dockerfile:1
+# =============================================================================
 # Houndarr — production Docker image
-# Full implementation in Issue #4; this stub satisfies CI scaffolding.
+# Base: python:3.12-slim (Debian bookworm slim)
+# =============================================================================
 FROM python:3.12-slim
+
+ARG HOUNDARR_VERSION=dev
+
+# OCI labels
+LABEL org.opencontainers.image.title="Houndarr" \
+      org.opencontainers.image.description="Focused self-hosted companion for Sonarr and Radarr" \
+      org.opencontainers.image.url="https://github.com/av1155/houndarr" \
+      org.opencontainers.image.source="https://github.com/av1155/houndarr" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app/src \
+    HOUNDARR_VERSION="${HOUNDARR_VERSION}" \
+    HOUNDARR_DATA_DIR=/data
 
 WORKDIR /app
 
+# Install gosu for privilege dropping (audited, Debian-native)
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies before copying source (better layer caching)
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Copy application source
 COPY src/ ./src/
 COPY VERSION ./
 
-ENV PYTHONPATH=/app/src \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+# Create non-root runtime user and data directory
+RUN groupadd -g 1000 appgroup \
+    && useradd -u 1000 -g appgroup -m -s /sbin/nologin appuser \
+    && mkdir -p /data \
+    && chown -R appuser:appgroup /app /data
 
+# Copy and make entrypoint executable
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Expose web UI port
 EXPOSE 8877
 
-CMD ["python", "-m", "houndarr", "--help"]
+# Data volume for persistent state
+VOLUME ["/data"]
+
+# Health check: poll the unauthenticated /api/health endpoint
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8877/api/health')" || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python", "-m", "houndarr", "--data-dir", "/data"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,19 @@
+services:
+  houndarr:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: houndarr-dev
+    restart: "no"
+    ports:
+      - "8877:8877"
+    volumes:
+      # Mount source for hot-reload
+      - ./src:/app/src:ro
+      - ./data-dev:/data
+    environment:
+      - TZ=America/New_York
+      - PUID=1000
+      - PGID=1000
+      - HOUNDARR_LOG_LEVEL=debug
+    command: ["python", "-m", "houndarr", "--data-dir", "/data", "--dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  houndarr:
+    image: ghcr.io/av1155/houndarr:latest
+    container_name: houndarr
+    restart: unless-stopped
+    ports:
+      - "8877:8877"
+    volumes:
+      - ./data:/data
+    environment:
+      - TZ=America/New_York
+      - PUID=1000
+      - PGID=1000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Houndarr container entrypoint
+# Handles PUID/PGID user remapping so /data files are owned by the host user.
+set -e
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+# If running as root, remap the appuser UID/GID to match host PUID/PGID
+if [ "$(id -u)" = "0" ]; then
+    # Update group if needed
+    if ! getent group "$PGID" > /dev/null 2>&1; then
+        groupmod -g "$PGID" appgroup 2>/dev/null || groupadd -g "$PGID" appgroup
+    fi
+
+    # Update user if needed
+    CURRENT_UID=$(id -u appuser 2>/dev/null || echo "")
+    if [ "$CURRENT_UID" != "$PGID" ]; then
+        usermod -u "$PUID" -g "$PGID" appuser 2>/dev/null || true
+    fi
+
+    # Ensure /data is owned by the mapped user
+    mkdir -p /data
+    chown -R "${PUID}:${PGID}" /data
+
+    # Drop privileges and exec the application
+    exec gosu appuser "$@"
+else
+    # Already non-root (e.g., in dev), just exec directly
+    exec "$@"
+fi


### PR DESCRIPTION
## Summary
- **Dockerfile**: `python:3.12-slim`, `gosu` for privilege dropping, non-root `appuser` (uid=1000), `HEALTHCHECK` polling `/api/health`, PUID/PGID env var support, OCI labels, layer-cached pip install
- **entrypoint.sh**: remaps `appuser` UID/GID to PUID/PGID at container start, ensures `/data` ownership, drops privileges with `gosu`  
- **docker-compose.yml**: minimal production deployment example
- **docker-compose.dev.yml**: dev mode with source volume mount and `--dev` auto-reload flag
- **.dockerignore**: excludes tests, docs, .venv, .git, data/ from build context

Verified locally: image builds, runs as uid=1000, `--help` works, hadolint passes.

## Related Issue
Closes #6

## Type of Change
- [x] New feature

## Checklist
- [x] Docker build succeeds locally
- [x] Container runs as non-root (uid=1000)
- [x] All CI checks pass