### PR TITLE
feat: instance CRUD service with encrypted API key storage

### DIFF
--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -1,0 +1,277 @@
+"""Instance CRUD service — create, read, update, and delete *arr instances.
+
+API keys are never stored in plaintext.  Every write encrypts with the
+caller-supplied Fernet *master_key*; every read decrypts transparently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from houndarr.config import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_COOLDOWN_DAYS,
+    DEFAULT_CUTOFF_BATCH_SIZE,
+    DEFAULT_HOURLY_CAP,
+    DEFAULT_SLEEP_INTERVAL_MINUTES,
+    DEFAULT_UNRELEASED_DELAY_HOURS,
+)
+from houndarr.crypto import decrypt, encrypt
+from houndarr.database import get_db
+
+
+class InstanceType(StrEnum):
+    """Supported *arr application types."""
+
+    sonarr = "sonarr"
+    radarr = "radarr"
+
+
+@dataclass
+class Instance:
+    """In-memory representation of a configured *arr instance.
+
+    ``api_key`` is always the **decrypted** plaintext value — the encrypted
+    form is only ever kept in the database column ``encrypted_api_key``.
+    """
+
+    id: int
+    name: str
+    type: InstanceType
+    url: str
+    api_key: str
+    enabled: bool
+    batch_size: int
+    sleep_interval_mins: int
+    hourly_cap: int
+    cooldown_days: int
+    unreleased_delay_hrs: int
+    cutoff_enabled: bool
+    cutoff_batch_size: int
+    created_at: str
+    updated_at: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_instance(row: Any, master_key: bytes) -> Instance:
+    """Convert an aiosqlite Row to an :class:`Instance`, decrypting the key."""
+    return Instance(
+        id=row["id"],
+        name=row["name"],
+        type=InstanceType(row["type"]),
+        url=row["url"],
+        api_key=decrypt(row["encrypted_api_key"], master_key),
+        enabled=bool(row["enabled"]),
+        batch_size=row["batch_size"],
+        sleep_interval_mins=row["sleep_interval_mins"],
+        hourly_cap=row["hourly_cap"],
+        cooldown_days=row["cooldown_days"],
+        unreleased_delay_hrs=row["unreleased_delay_hrs"],
+        cutoff_enabled=bool(row["cutoff_enabled"]),
+        cutoff_batch_size=row["cutoff_batch_size"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def create_instance(
+    *,
+    master_key: bytes,
+    name: str,
+    type: InstanceType,  # noqa: A002
+    url: str,
+    api_key: str,
+    enabled: bool = True,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    sleep_interval_mins: int = DEFAULT_SLEEP_INTERVAL_MINUTES,
+    hourly_cap: int = DEFAULT_HOURLY_CAP,
+    cooldown_days: int = DEFAULT_COOLDOWN_DAYS,
+    unreleased_delay_hrs: int = DEFAULT_UNRELEASED_DELAY_HOURS,
+    cutoff_enabled: bool = False,
+    cutoff_batch_size: int = DEFAULT_CUTOFF_BATCH_SIZE,
+) -> Instance:
+    """Insert a new instance row and return the populated :class:`Instance`.
+
+    Args:
+        master_key: Fernet key used to encrypt *api_key* before storage.
+        name: Human-readable label for the instance.
+        type: ``sonarr`` or ``radarr``.
+        url: Base URL of the *arr instance (e.g. ``http://sonarr:8989``).
+        api_key: Plaintext API key — will be encrypted before being written.
+        enabled: Whether the search engine should process this instance.
+        batch_size: Number of missing items to search per run.
+        sleep_interval_mins: Minutes to sleep between search cycles.
+        hourly_cap: Maximum searches allowed per hour.
+        cooldown_days: Days to wait before re-searching the same item.
+        unreleased_delay_hrs: Hours to wait after an item's air date.
+        cutoff_enabled: Whether cutoff-unmet searching is active.
+        cutoff_batch_size: Number of cutoff-unmet items per run.
+
+    Returns:
+        The newly created :class:`Instance` with its database-assigned *id*.
+    """
+    encrypted = encrypt(api_key, master_key)
+    async with get_db() as db:
+        cur = await db.execute(
+            """
+            INSERT INTO instances (
+                name, type, url, encrypted_api_key,
+                enabled, batch_size, sleep_interval_mins,
+                hourly_cap, cooldown_days, unreleased_delay_hrs,
+                cutoff_enabled, cutoff_batch_size
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                name,
+                type.value,
+                url,
+                encrypted,
+                int(enabled),
+                batch_size,
+                sleep_interval_mins,
+                hourly_cap,
+                cooldown_days,
+                unreleased_delay_hrs,
+                int(cutoff_enabled),
+                cutoff_batch_size,
+            ),
+        )
+        await db.commit()
+        row_id = cur.lastrowid
+        assert row_id is not None  # noqa: S101
+
+    instance = await get_instance(row_id, master_key=master_key)
+    assert instance is not None  # just inserted — cannot be None  # noqa: S101
+    return instance
+
+
+async def get_instance(id: int, *, master_key: bytes) -> Instance | None:  # noqa: A002
+    """Fetch a single instance by *id*, or ``None`` if not found.
+
+    Args:
+        id: Primary key of the instance row.
+        master_key: Fernet key used to decrypt the stored API key.
+
+    Returns:
+        Decrypted :class:`Instance`, or ``None``.
+    """
+    async with get_db() as db:
+        async with db.execute("SELECT * FROM instances WHERE id = ?", (id,)) as cur:
+            row = await cur.fetchone()
+    if row is None:
+        return None
+    return _row_to_instance(row, master_key)
+
+
+async def list_instances(*, master_key: bytes) -> list[Instance]:
+    """Return all instances ordered by creation time (oldest first).
+
+    Args:
+        master_key: Fernet key used to decrypt each stored API key.
+
+    Returns:
+        List of decrypted :class:`Instance` objects (may be empty).
+    """
+    async with get_db() as db:
+        async with db.execute("SELECT * FROM instances ORDER BY id ASC") as cur:
+            rows = await cur.fetchall()
+    return [_row_to_instance(r, master_key) for r in rows]
+
+
+async def update_instance(
+    id: int,  # noqa: A002
+    *,
+    master_key: bytes,
+    **fields: Any,
+) -> Instance | None:
+    """Partially update an instance and return the refreshed :class:`Instance`.
+
+    Accepts any subset of the mutable columns.  If ``api_key`` is included it
+    is re-encrypted before being persisted.  Unrecognised field names are
+    silently ignored to avoid SQL injection.
+
+    Args:
+        id: Primary key of the instance to update.
+        master_key: Fernet key (needed for re-encryption and for the return value).
+        **fields: Column-value pairs to update.  Accepted keys:
+            ``name``, ``type``, ``url``, ``api_key``, ``enabled``,
+            ``batch_size``, ``sleep_interval_mins``, ``hourly_cap``,
+            ``cooldown_days``, ``unreleased_delay_hrs``,
+            ``cutoff_enabled``, ``cutoff_batch_size``.
+
+    Returns:
+        Updated :class:`Instance`, or ``None`` if *id* does not exist.
+    """
+    # Map public field names → DB column names
+    allowed_cols: dict[str, str] = {
+        "name": "name",
+        "type": "type",
+        "url": "url",
+        "api_key": "encrypted_api_key",
+        "enabled": "enabled",
+        "batch_size": "batch_size",
+        "sleep_interval_mins": "sleep_interval_mins",
+        "hourly_cap": "hourly_cap",
+        "cooldown_days": "cooldown_days",
+        "unreleased_delay_hrs": "unreleased_delay_hrs",
+        "cutoff_enabled": "cutoff_enabled",
+        "cutoff_batch_size": "cutoff_batch_size",
+    }
+
+    assignments: list[str] = []
+    values: list[Any] = []
+
+    for field_name, value in fields.items():
+        col = allowed_cols.get(field_name)
+        if col is None:
+            continue
+        # Coerce types for SQLite
+        if field_name == "api_key":
+            value = encrypt(str(value), master_key)
+        elif field_name == "type" and isinstance(value, InstanceType):
+            value = value.value
+        elif field_name in ("enabled", "cutoff_enabled"):
+            value = int(bool(value))
+        assignments.append(f"{col} = ?")
+        values.append(value)
+
+    if not assignments:
+        # Nothing to do — return current state
+        return await get_instance(id, master_key=master_key)
+
+    # Always refresh updated_at
+    assignments.append("updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')")
+    values.append(id)
+
+    sql = f"UPDATE instances SET {', '.join(assignments)} WHERE id = ?"  # noqa: S608  # nosec B608
+    async with get_db() as db:
+        await db.execute(sql, values)
+        await db.commit()
+
+    return await get_instance(id, master_key=master_key)
+
+
+async def delete_instance(id: int) -> bool:  # noqa: A002
+    """Delete an instance row (cascade removes cooldowns).
+
+    Args:
+        id: Primary key of the instance to delete.
+
+    Returns:
+        ``True`` if a row was deleted, ``False`` if *id* did not exist.
+    """
+    async with get_db() as db:
+        cur = await db.execute("DELETE FROM instances WHERE id = ?", (id,))
+        await db.commit()
+        return (cur.rowcount or 0) > 0

--- a/tests/test_services/test_instances.py
+++ b/tests/test_services/test_instances.py
@@ -1,0 +1,254 @@
+"""Tests for the instance CRUD service layer."""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from houndarr.services.instances import (
+    Instance,
+    InstanceType,
+    create_instance,
+    delete_instance,
+    get_instance,
+    list_instances,
+    update_instance,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def master_key() -> bytes:
+    """Fresh Fernet key for each test."""
+    return Fernet.generate_key()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make(master_key: bytes, **overrides: object) -> Instance:
+    """Create a minimal Sonarr instance with optional field overrides."""
+    defaults: dict[str, object] = {
+        "name": "My Sonarr",
+        "type": InstanceType.sonarr,
+        "url": "http://sonarr:8989",
+        "api_key": "plaintext-key-abc123",
+    }
+    defaults.update(overrides)
+    return await create_instance(master_key=master_key, **defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# create_instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_create_returns_instance(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key)
+    assert isinstance(inst, Instance)
+    assert inst.id >= 1
+    assert inst.name == "My Sonarr"
+    assert inst.type == InstanceType.sonarr
+    assert inst.url == "http://sonarr:8989"
+
+
+@pytest.mark.asyncio()
+async def test_create_decrypts_api_key(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key, api_key="secret-key-xyz")
+    assert inst.api_key == "secret-key-xyz"
+
+
+@pytest.mark.asyncio()
+async def test_create_applies_defaults(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key)
+    assert inst.enabled is True
+    assert inst.batch_size == 10
+    assert inst.sleep_interval_mins == 15
+    assert inst.hourly_cap == 20
+    assert inst.cooldown_days == 7
+    assert inst.unreleased_delay_hrs == 24
+    assert inst.cutoff_enabled is False
+    assert inst.cutoff_batch_size == 5
+
+
+@pytest.mark.asyncio()
+async def test_create_radarr_instance(db: None, master_key: bytes) -> None:
+    inst = await _make(
+        master_key, name="My Radarr", type=InstanceType.radarr, url="http://radarr:7878"
+    )
+    assert inst.type == InstanceType.radarr
+
+
+@pytest.mark.asyncio()
+async def test_api_key_stored_encrypted(db: None, master_key: bytes) -> None:
+    """The raw DB value must differ from the plaintext API key."""
+    from houndarr.database import get_db
+
+    await _make(master_key, api_key="super-secret")
+    async with get_db() as conn:
+        async with conn.execute("SELECT encrypted_api_key FROM instances WHERE id = 1") as cur:
+            row = await cur.fetchone()
+    assert row is not None
+    assert row["encrypted_api_key"] != "super-secret"
+
+
+# ---------------------------------------------------------------------------
+# get_instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_get_instance_found(db: None, master_key: bytes) -> None:
+    created = await _make(master_key)
+    fetched = await get_instance(created.id, master_key=master_key)
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.api_key == created.api_key
+
+
+@pytest.mark.asyncio()
+async def test_get_instance_not_found(db: None, master_key: bytes) -> None:
+    result = await get_instance(9999, master_key=master_key)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# list_instances
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_list_empty(db: None, master_key: bytes) -> None:
+    instances = await list_instances(master_key=master_key)
+    assert instances == []
+
+
+@pytest.mark.asyncio()
+async def test_list_returns_all(db: None, master_key: bytes) -> None:
+    await _make(master_key, name="A")
+    await _make(master_key, name="B", type=InstanceType.radarr, url="http://radarr:7878")
+    instances = await list_instances(master_key=master_key)
+    assert len(instances) == 2
+    names = {i.name for i in instances}
+    assert names == {"A", "B"}
+
+
+@pytest.mark.asyncio()
+async def test_list_ordered_by_id(db: None, master_key: bytes) -> None:
+    a = await _make(master_key, name="First")
+    b = await _make(master_key, name="Second", type=InstanceType.radarr, url="http://radarr:7878")
+    instances = await list_instances(master_key=master_key)
+    assert instances[0].id == a.id
+    assert instances[1].id == b.id
+
+
+# ---------------------------------------------------------------------------
+# update_instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_update_name(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key)
+    updated = await update_instance(inst.id, master_key=master_key, name="Renamed")
+    assert updated is not None
+    assert updated.name == "Renamed"
+
+
+@pytest.mark.asyncio()
+async def test_update_api_key_re_encrypted(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key, api_key="old-key")
+    updated = await update_instance(inst.id, master_key=master_key, api_key="new-key")
+    assert updated is not None
+    assert updated.api_key == "new-key"
+
+    # Raw DB value must still be encrypted (not plaintext)
+    from houndarr.database import get_db
+
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT encrypted_api_key FROM instances WHERE id = ?", (inst.id,)
+        ) as cur:
+            row = await cur.fetchone()
+    assert row is not None
+    assert row["encrypted_api_key"] != "new-key"
+
+
+@pytest.mark.asyncio()
+async def test_update_multiple_fields(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key)
+    updated = await update_instance(
+        inst.id,
+        master_key=master_key,
+        batch_size=20,
+        hourly_cap=50,
+        enabled=False,
+    )
+    assert updated is not None
+    assert updated.batch_size == 20
+    assert updated.hourly_cap == 50
+    assert updated.enabled is False
+
+
+@pytest.mark.asyncio()
+async def test_update_unknown_fields_ignored(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key)
+    # Should not raise even with unrecognised keys
+    updated = await update_instance(inst.id, master_key=master_key, nonexistent_col="x")
+    assert updated is not None
+    assert updated.name == inst.name
+
+
+@pytest.mark.asyncio()
+async def test_update_nonexistent_returns_none(db: None, master_key: bytes) -> None:
+    result = await update_instance(9999, master_key=master_key, name="Ghost")
+    assert result is None
+
+
+@pytest.mark.asyncio()
+async def test_update_refreshes_updated_at(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key)
+    original_updated_at = inst.updated_at
+    # Brief sleep to ensure the timestamp differs
+    import asyncio
+
+    await asyncio.sleep(0.01)
+    updated = await update_instance(inst.id, master_key=master_key, name="Changed")
+    assert updated is not None
+    # updated_at should be >= original (may be equal at ms resolution, never less)
+    assert updated.updated_at >= original_updated_at
+
+
+# ---------------------------------------------------------------------------
+# delete_instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_delete_existing(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key)
+    result = await delete_instance(inst.id)
+    assert result is True
+    assert await get_instance(inst.id, master_key=master_key) is None
+
+
+@pytest.mark.asyncio()
+async def test_delete_nonexistent(db: None, master_key: bytes) -> None:
+    result = await delete_instance(9999)
+    assert result is False
+
+
+@pytest.mark.asyncio()
+async def test_delete_removes_from_list(db: None, master_key: bytes) -> None:
+    a = await _make(master_key, name="Keep")
+    b = await _make(master_key, name="Delete", type=InstanceType.radarr, url="http://radarr:7878")
+    await delete_instance(b.id)
+    remaining = await list_instances(master_key=master_key)
+    assert len(remaining) == 1
+    assert remaining[0].id == a.id


### PR DESCRIPTION
## Summary

- Adds `src/houndarr/services/instances.py` — the service layer for managing Sonarr/Radarr instances
- `InstanceType` StrEnum (`sonarr` | `radarr`)
- `Instance` dataclass with all fields (always decrypted in-memory)
- `create_instance`, `get_instance`, `list_instances`, `update_instance`, `delete_instance` — all backed by aiosqlite with WAL + foreign keys
- API keys are Fernet-encrypted on every write; plaintext never touches the database
- `update_instance` accepts any subset of mutable columns; unrecognised keys are silently ignored (no SQL injection risk)
- Adds `tests/test_services/test_instances.py` with 19 tests

## Testing

57 tests pass locally. `ruff`, `mypy`, `bandit` clean.

## Related

Closes #10