### PR TITLE
feat: Sonarr and Radarr async API clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "httpx>=0.27.0",
+    "respx>=0.21.0",
     "anyio>=4.6.0",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@ mypy>=1.13.0
 pytest>=8.3.0
 pytest-asyncio>=0.24.0
 pytest-cov>=6.0.0
+respx>=0.21.0
 anyio>=4.6.0

--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -1,0 +1,102 @@
+"""Abstract base class for *arr API clients (Sonarr / Radarr)."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Default timeouts (seconds): connect=5, read=30
+_DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
+
+
+class ArrClient(ABC):
+    """Thin async wrapper around the *arr v3 REST API.
+
+    Subclasses implement :meth:`get_missing` and :meth:`search` for their
+    specific resource type (episodes vs. movies).
+
+    Usage::
+
+        async with SonarrClient(url="http://sonarr:8989", api_key="abc") as client:
+            missing = await client.get_missing(page=1, page_size=10)
+
+    The client can also be used without the context manager if the caller
+    manages the lifecycle of the underlying :class:`httpx.AsyncClient`.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        api_key: str,
+        timeout: httpx.Timeout = _DEFAULT_TIMEOUT,
+    ) -> None:
+        base = url.rstrip("/")
+        self._client = httpx.AsyncClient(
+            base_url=base,
+            headers={"X-Api-Key": api_key, "Accept": "application/json"},
+            timeout=timeout,
+        )
+
+    # ------------------------------------------------------------------
+    # Context-manager support
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> ArrClient:
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self._client.__aexit__(*args)
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    # ------------------------------------------------------------------
+    # Low-level helpers
+    # ------------------------------------------------------------------
+
+    async def _get(self, path: str, **params: Any) -> Any:
+        """GET *path* with optional query *params*, raise on non-2xx."""
+        response = await self._client.get(path, params=params)
+        response.raise_for_status()
+        return response.json()
+
+    async def _post(self, path: str, json: Any = None) -> Any:
+        """POST *path* with optional JSON body, raise on non-2xx."""
+        response = await self._client.post(path, json=json)
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Health check
+    # ------------------------------------------------------------------
+
+    async def ping(self) -> bool:
+        """Return ``True`` if the instance is reachable and healthy.
+
+        Uses the ``/api/v3/system/status`` endpoint which all *arr v3
+        applications expose without extra permissions.
+        """
+        try:
+            await self._get("/api/v3/system/status")
+            return True
+        except (httpx.HTTPError, httpx.InvalidURL):
+            return False
+
+    # ------------------------------------------------------------------
+    # Abstract interface
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    async def get_missing(self, *, page: int = 1, page_size: int = 10) -> list[Any]:
+        """Return a page of missing items from the *arr instance."""
+
+    @abstractmethod
+    async def search(self, item_id: int) -> None:
+        """Trigger an automatic search for the item identified by *item_id*."""

--- a/src/houndarr/clients/radarr.py
+++ b/src/houndarr/clients/radarr.py
@@ -1,0 +1,99 @@
+"""Radarr v3 API client — missing movies and automatic search."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from houndarr.clients.base import ArrClient
+
+__all__ = ["MissingMovie", "RadarrClient"]
+
+
+@dataclass(frozen=True)
+class MissingMovie:
+    """A single missing movie returned by Radarr's wanted/missing endpoint."""
+
+    movie_id: int
+    title: str
+    year: int
+    digital_release: str | None  # ISO-8601 date or None if unknown
+
+
+class RadarrClient(ArrClient):
+    """Async client for the Radarr v3 REST API."""
+
+    async def get_missing(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 10,
+    ) -> list[MissingMovie]:
+        """Return a page of monitored missing movies.
+
+        Calls ``GET /api/v3/wanted/missing`` sorted by in-cinema date
+        (oldest first) so higher-priority titles are processed first.
+
+        Args:
+            page: 1-based page number.
+            page_size: Number of records per page (max 250 in Radarr).
+
+        Returns:
+            List of :class:`MissingMovie` dataclasses.
+        """
+        data: dict[str, Any] = await self._get(
+            "/api/v3/wanted/missing",
+            page=page,
+            pageSize=page_size,
+            sortKey="inCinemas",
+            sortDirection="ascending",
+        )
+        records: list[dict[str, Any]] = data.get("records", [])
+        return [_parse_movie(r) for r in records]
+
+    async def search(self, item_id: int) -> None:
+        """Trigger an automatic movie search in Radarr.
+
+        Calls ``POST /api/v3/command`` with command ``MoviesSearch``.
+
+        Args:
+            item_id: Radarr movie ID to search for.
+        """
+        await self._post(
+            "/api/v3/command",
+            json={"name": "MoviesSearch", "movieIds": [item_id]},
+        )
+
+    async def search_movie(self, movie_id: int) -> None:
+        """Alias for :meth:`search` with a more descriptive name."""
+        await self.search(movie_id)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_movie(record: dict[str, Any]) -> MissingMovie:
+    return MissingMovie(
+        movie_id=record["id"],
+        title=record.get("title") or "",
+        year=record.get("year", 0),
+        digital_release=record.get("digitalRelease"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience factory
+# ---------------------------------------------------------------------------
+
+
+def make_radarr_client(
+    url: str,
+    api_key: str,
+    timeout: httpx.Timeout = httpx.Timeout(30.0, connect=5.0),
+) -> RadarrClient:
+    """Return a :class:`RadarrClient` ready for use as an async context manager."""
+    return RadarrClient(url=url, api_key=api_key, timeout=timeout)

--- a/src/houndarr/clients/sonarr.py
+++ b/src/houndarr/clients/sonarr.py
@@ -1,0 +1,105 @@
+"""Sonarr v3 API client — missing episodes and automatic search."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from houndarr.clients.base import ArrClient
+
+__all__ = ["MissingEpisode", "SonarrClient"]
+
+
+@dataclass(frozen=True)
+class MissingEpisode:
+    """A single missing episode returned by Sonarr's wanted/missing endpoint."""
+
+    episode_id: int
+    series_title: str
+    episode_title: str
+    season: int
+    episode: int
+    air_date_utc: str | None  # ISO-8601 or None if not yet aired
+
+
+class SonarrClient(ArrClient):
+    """Async client for the Sonarr v3 REST API."""
+
+    async def get_missing(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 10,
+    ) -> list[MissingEpisode]:
+        """Return a page of monitored missing episodes.
+
+        Calls ``GET /api/v3/wanted/missing`` with ``includeSeries=true`` so
+        that series metadata (title) is embedded in each record.
+
+        Args:
+            page: 1-based page number.
+            page_size: Number of records per page (max 250 in Sonarr).
+
+        Returns:
+            List of :class:`MissingEpisode` dataclasses, oldest first.
+        """
+        data: dict[str, Any] = await self._get(
+            "/api/v3/wanted/missing",
+            page=page,
+            pageSize=page_size,
+            sortKey="airDateUtc",
+            sortDirection="ascending",
+            includeSeries="true",
+        )
+        records: list[dict[str, Any]] = data.get("records", [])
+        return [_parse_episode(r) for r in records]
+
+    async def search(self, item_id: int) -> None:
+        """Trigger an automatic episode search in Sonarr.
+
+        Calls ``POST /api/v3/command`` with command ``EpisodeSearch``.
+
+        Args:
+            item_id: Sonarr episode ID to search for.
+        """
+        await self._post(
+            "/api/v3/command",
+            json={"name": "EpisodeSearch", "episodeIds": [item_id]},
+        )
+
+    async def search_episode(self, episode_id: int) -> None:
+        """Alias for :meth:`search` with a more descriptive name."""
+        await self.search(episode_id)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_episode(record: dict[str, Any]) -> MissingEpisode:
+    series: dict[str, Any] = record.get("series") or {}
+    return MissingEpisode(
+        episode_id=record["id"],
+        series_title=series.get("title") or record.get("seriesTitle") or "",
+        episode_title=record.get("title") or "",
+        season=record.get("seasonNumber", 0),
+        episode=record.get("episodeNumber", 0),
+        air_date_utc=record.get("airDateUtc"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience factory (mirrors httpx.AsyncClient signature)
+# ---------------------------------------------------------------------------
+
+
+def make_sonarr_client(
+    url: str,
+    api_key: str,
+    timeout: httpx.Timeout = httpx.Timeout(30.0, connect=5.0),
+) -> SonarrClient:
+    """Return a :class:`SonarrClient` ready for use as an async context manager."""
+    return SonarrClient(url=url, api_key=api_key, timeout=timeout)

--- a/tests/test_clients/test_radarr.py
+++ b/tests/test_clients/test_radarr.py
@@ -1,0 +1,176 @@
+"""Tests for RadarrClient — all HTTP calls mocked with respx."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from houndarr.clients.radarr import MissingMovie, RadarrClient
+
+BASE = "http://radarr:7878"
+API_KEY = "test-api-key"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client() -> RadarrClient:
+    return RadarrClient(url=BASE, api_key=API_KEY)
+
+
+# ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_ping_success(client: RadarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/system/status").mock(
+        return_value=httpx.Response(200, json={"version": "5.0.0"})
+    )
+    assert await client.ping() is True
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_ping_non_2xx_returns_false(client: RadarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/system/status").mock(return_value=httpx.Response(401))
+    assert await client.ping() is False
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_ping_network_error_returns_false(client: RadarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/system/status").mock(side_effect=httpx.ConnectError("refused"))
+    assert await client.ping() is False
+
+
+# ---------------------------------------------------------------------------
+# get_missing
+# ---------------------------------------------------------------------------
+
+_MOVIE_RECORD = {
+    "id": 201,
+    "title": "Great Film",
+    "year": 2022,
+    "digitalRelease": "2022-12-01",
+}
+
+_MISSING_RESPONSE = {"page": 1, "pageSize": 10, "totalRecords": 1, "records": [_MOVIE_RECORD]}
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_returns_movies(client: RadarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_RESPONSE)
+    )
+    results = await client.get_missing(page=1, page_size=10)
+    assert len(results) == 1
+    movie = results[0]
+    assert isinstance(movie, MissingMovie)
+    assert movie.movie_id == 201
+    assert movie.title == "Great Film"
+    assert movie.year == 2022
+    assert movie.digital_release == "2022-12-01"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_empty(client: RadarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200, json={"page": 1, "pageSize": 10, "totalRecords": 0, "records": []}
+        )
+    )
+    results = await client.get_missing()
+    assert results == []
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_null_digital_release(client: RadarrClient) -> None:
+    record = {**_MOVIE_RECORD, "digitalRelease": None}
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [record]})
+    )
+    results = await client.get_missing()
+    assert results[0].digital_release is None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_non_2xx_raises(client: RadarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(return_value=httpx.Response(403))
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.get_missing()
+
+
+# ---------------------------------------------------------------------------
+# search / search_movie
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_movie_posts_correct_payload(client: RadarrClient) -> None:
+    route = respx.post(f"{BASE}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 1, "name": "MoviesSearch"})
+    )
+    await client.search_movie(201)
+    assert route.called
+    sent = route.calls[0].request
+    import json
+
+    body = json.loads(sent.content)
+    assert body["name"] == "MoviesSearch"
+    assert body["movieIds"] == [201]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_alias_works(client: RadarrClient) -> None:
+    route = respx.post(f"{BASE}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+    await client.search(202)
+    assert route.called
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_non_2xx_raises(client: RadarrClient) -> None:
+    respx.post(f"{BASE}/api/v3/command").mock(return_value=httpx.Response(500))
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.search_movie(201)
+
+
+# ---------------------------------------------------------------------------
+# Timeout propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_timeout_propagates(client: RadarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(side_effect=httpx.ReadTimeout("timed out"))
+    with pytest.raises(httpx.ReadTimeout):
+        await client.get_missing()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_context_manager() -> None:
+    respx.get(f"{BASE}/api/v3/system/status").mock(return_value=httpx.Response(200, json={}))
+    async with RadarrClient(url=BASE, api_key=API_KEY) as c:
+        result = await c.ping()
+    assert result is True

--- a/tests/test_clients/test_sonarr.py
+++ b/tests/test_clients/test_sonarr.py
@@ -1,0 +1,180 @@
+"""Tests for SonarrClient — all HTTP calls mocked with respx."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from houndarr.clients.sonarr import MissingEpisode, SonarrClient
+
+BASE = "http://sonarr:8989"
+API_KEY = "test-api-key"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client() -> SonarrClient:
+    return SonarrClient(url=BASE, api_key=API_KEY)
+
+
+# ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_ping_success(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/system/status").mock(
+        return_value=httpx.Response(200, json={"version": "4.0.0"})
+    )
+    assert await client.ping() is True
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_ping_non_2xx_returns_false(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/system/status").mock(return_value=httpx.Response(401))
+    assert await client.ping() is False
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_ping_network_error_returns_false(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/system/status").mock(side_effect=httpx.ConnectError("refused"))
+    assert await client.ping() is False
+
+
+# ---------------------------------------------------------------------------
+# get_missing
+# ---------------------------------------------------------------------------
+
+_EPISODE_RECORD = {
+    "id": 101,
+    "title": "Pilot",
+    "seasonNumber": 1,
+    "episodeNumber": 1,
+    "airDateUtc": "2023-09-01T00:00:00Z",
+    "series": {"title": "My Show"},
+}
+
+_MISSING_RESPONSE = {"page": 1, "pageSize": 10, "totalRecords": 1, "records": [_EPISODE_RECORD]}
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_returns_episodes(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_RESPONSE)
+    )
+    results = await client.get_missing(page=1, page_size=10)
+    assert len(results) == 1
+    ep = results[0]
+    assert isinstance(ep, MissingEpisode)
+    assert ep.episode_id == 101
+    assert ep.series_title == "My Show"
+    assert ep.episode_title == "Pilot"
+    assert ep.season == 1
+    assert ep.episode == 1
+    assert ep.air_date_utc == "2023-09-01T00:00:00Z"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_empty(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200, json={"page": 1, "pageSize": 10, "totalRecords": 0, "records": []}
+        )
+    )
+    results = await client.get_missing()
+    assert results == []
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_null_air_date(client: SonarrClient) -> None:
+    record = {**_EPISODE_RECORD, "airDateUtc": None}
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [record]})
+    )
+    results = await client.get_missing()
+    assert results[0].air_date_utc is None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_non_2xx_raises(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(return_value=httpx.Response(403))
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.get_missing()
+
+
+# ---------------------------------------------------------------------------
+# search / search_episode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_episode_posts_correct_payload(client: SonarrClient) -> None:
+    route = respx.post(f"{BASE}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 1, "name": "EpisodeSearch"})
+    )
+    await client.search_episode(101)
+    assert route.called
+    sent = route.calls[0].request
+    import json
+
+    body = json.loads(sent.content)
+    assert body["name"] == "EpisodeSearch"
+    assert body["episodeIds"] == [101]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_alias_works(client: SonarrClient) -> None:
+    route = respx.post(f"{BASE}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+    await client.search(202)
+    assert route.called
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_non_2xx_raises(client: SonarrClient) -> None:
+    respx.post(f"{BASE}/api/v3/command").mock(return_value=httpx.Response(500))
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.search_episode(101)
+
+
+# ---------------------------------------------------------------------------
+# Timeout propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_timeout_propagates(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(side_effect=httpx.ReadTimeout("timed out"))
+    with pytest.raises(httpx.ReadTimeout):
+        await client.get_missing()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_context_manager() -> None:
+    respx.get(f"{BASE}/api/v3/system/status").mock(return_value=httpx.Response(200, json={}))
+    async with SonarrClient(url=BASE, api_key=API_KEY) as c:
+        result = await c.ping()
+    assert result is True


### PR DESCRIPTION
## Summary

- Adds `src/houndarr/clients/base.py` — `ArrClient` abstract base class wrapping `httpx.AsyncClient` with API key auth header, configurable timeouts, `ping()`, `_get()`/`_post()` helpers, and async context manager support
- Adds `src/houndarr/clients/sonarr.py` — `SonarrClient` with `get_missing(page, page_size)` and `search_episode(episode_id)` + `MissingEpisode` frozen dataclass
- Adds `src/houndarr/clients/radarr.py` — `RadarrClient` with `get_missing(page, page_size)` and `search_movie(movie_id)` + `MissingMovie` frozen dataclass
- Adds `respx>=0.21.0` to dev dependencies for HTTP mocking
- Adds 24 tests (12 per client) covering: `get_missing` parsing, empty results, null optional fields, non-2xx errors, correct search POST payloads, timeout propagation, `ping` success/failure/network-error, and context manager

## Testing

81 tests pass locally. `ruff`, `mypy`, `bandit` all clean.

## Related

Closes #12