### PR TITLE
feat: settings page UI with HTMX instance management

### DIFF
--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -70,8 +70,10 @@ def create_app() -> FastAPI:
     # -----------------------------------------------------------------------
     from houndarr.routes.health import router as health_router
     from houndarr.routes.pages import router as pages_router
+    from houndarr.routes.settings import router as settings_router
 
     app.include_router(health_router)
     app.include_router(pages_router)
+    app.include_router(settings_router)
 
     return app

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -1,0 +1,246 @@
+"""Settings page routes — instance management via HTMX."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, Response
+from fastapi.templating import Jinja2Templates
+
+from houndarr import __version__
+from houndarr.config import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_COOLDOWN_DAYS,
+    DEFAULT_CUTOFF_BATCH_SIZE,
+    DEFAULT_HOURLY_CAP,
+    DEFAULT_SLEEP_INTERVAL_MINUTES,
+    DEFAULT_UNRELEASED_DELAY_HOURS,
+)
+from houndarr.services.instances import (
+    Instance,
+    InstanceType,
+    create_instance,
+    delete_instance,
+    get_instance,
+    list_instances,
+    update_instance,
+)
+
+router = APIRouter()
+
+_templates: Jinja2Templates | None = None
+
+
+def _get_templates() -> Jinja2Templates:
+    global _templates  # noqa: PLW0603
+    if _templates is None:
+        _templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+    return _templates
+
+
+def _render(
+    request: Request,
+    template_name: str,
+    status_code: int = 200,
+    **ctx: object,
+) -> HTMLResponse:
+    context = {"version": __version__, **ctx}
+    return _get_templates().TemplateResponse(
+        request=request,
+        name=template_name,
+        context=context,
+        status_code=status_code,
+    )
+
+
+def _master_key(request: Request) -> bytes:
+    return request.app.state.master_key  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Settings index
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings", response_class=HTMLResponse)
+async def settings_get(request: Request) -> HTMLResponse:
+    """Render the settings page with the current list of instances."""
+    instances = await list_instances(master_key=_master_key(request))
+    return _render(request, "settings.html", instances=instances)
+
+
+# ---------------------------------------------------------------------------
+# Add-form partial (injected into the slot below the table)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings/instances/add-form", response_class=HTMLResponse)
+async def instance_add_form(request: Request) -> HTMLResponse:
+    """Return the blank add-instance form partial for HTMX injection."""
+    # Pass a dummy Instance-like object with defaults so the template can
+    # reference instance.* without conditionals everywhere.
+    from houndarr.services.instances import Instance, InstanceType
+
+    blank: Instance = Instance(
+        id=0,
+        name="",
+        type=InstanceType.sonarr,
+        url="",
+        api_key="",
+        enabled=True,
+        batch_size=DEFAULT_BATCH_SIZE,
+        sleep_interval_mins=DEFAULT_SLEEP_INTERVAL_MINUTES,
+        hourly_cap=DEFAULT_HOURLY_CAP,
+        cooldown_days=DEFAULT_COOLDOWN_DAYS,
+        unreleased_delay_hrs=DEFAULT_UNRELEASED_DELAY_HOURS,
+        cutoff_enabled=False,
+        cutoff_batch_size=DEFAULT_CUTOFF_BATCH_SIZE,
+        created_at="",
+        updated_at="",
+    )
+    return _render(request, "partials/instance_form.html", instance=blank, editing=False)
+
+
+# ---------------------------------------------------------------------------
+# Create instance
+# ---------------------------------------------------------------------------
+
+
+@router.post("/settings/instances", response_class=HTMLResponse)
+async def instance_create(
+    request: Request,
+    name: Annotated[str, Form()],
+    type: Annotated[str, Form()],  # noqa: A002
+    url: Annotated[str, Form()],
+    api_key: Annotated[str, Form()],
+    enabled: Annotated[str, Form()] = "on",
+    batch_size: Annotated[int, Form()] = DEFAULT_BATCH_SIZE,
+    sleep_interval_mins: Annotated[int, Form()] = DEFAULT_SLEEP_INTERVAL_MINUTES,
+    hourly_cap: Annotated[int, Form()] = DEFAULT_HOURLY_CAP,
+    cooldown_days: Annotated[int, Form()] = DEFAULT_COOLDOWN_DAYS,
+    unreleased_delay_hrs: Annotated[int, Form()] = DEFAULT_UNRELEASED_DELAY_HOURS,
+    cutoff_enabled: Annotated[str, Form()] = "",
+    cutoff_batch_size: Annotated[int, Form()] = DEFAULT_CUTOFF_BATCH_SIZE,
+) -> HTMLResponse:
+    """Create a new instance and return the updated instance table body."""
+    try:
+        instance_type = InstanceType(type)
+    except ValueError:
+        instances = await list_instances(master_key=_master_key(request))
+        return _render(
+            request,
+            "settings.html",
+            status_code=422,
+            instances=instances,
+            error=f"Invalid instance type: {type!r}. Must be 'sonarr' or 'radarr'.",
+        )
+
+    await create_instance(
+        master_key=_master_key(request),
+        name=name,
+        type=instance_type,
+        url=url.rstrip("/"),
+        api_key=api_key,
+        enabled=enabled == "on",
+        batch_size=batch_size,
+        sleep_interval_mins=sleep_interval_mins,
+        hourly_cap=hourly_cap,
+        cooldown_days=cooldown_days,
+        unreleased_delay_hrs=unreleased_delay_hrs,
+        cutoff_enabled=cutoff_enabled == "on",
+        cutoff_batch_size=cutoff_batch_size,
+    )
+    instances = await list_instances(master_key=_master_key(request))
+    # HTMX: return just the refreshed table body partial
+    return _render(request, "partials/instance_table_body.html", instances=instances)
+
+
+# ---------------------------------------------------------------------------
+# Edit form partial
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings/instances/{instance_id}/edit", response_class=HTMLResponse)
+async def instance_edit_get(request: Request, instance_id: int) -> HTMLResponse:
+    """Return the edit form partial for an existing instance."""
+    instance = await get_instance(instance_id, master_key=_master_key(request))
+    if instance is None:
+        return HTMLResponse(content="Not found", status_code=404)
+    return _render(request, "partials/instance_form.html", instance=instance, editing=True)
+
+
+# ---------------------------------------------------------------------------
+# Update instance
+# ---------------------------------------------------------------------------
+
+
+@router.post("/settings/instances/{instance_id}", response_class=HTMLResponse)
+async def instance_update(
+    request: Request,
+    instance_id: int,
+    name: Annotated[str, Form()],
+    type: Annotated[str, Form()],  # noqa: A002
+    url: Annotated[str, Form()],
+    api_key: Annotated[str, Form()],
+    enabled: Annotated[str, Form()] = "on",
+    batch_size: Annotated[int, Form()] = DEFAULT_BATCH_SIZE,
+    sleep_interval_mins: Annotated[int, Form()] = DEFAULT_SLEEP_INTERVAL_MINUTES,
+    hourly_cap: Annotated[int, Form()] = DEFAULT_HOURLY_CAP,
+    cooldown_days: Annotated[int, Form()] = DEFAULT_COOLDOWN_DAYS,
+    unreleased_delay_hrs: Annotated[int, Form()] = DEFAULT_UNRELEASED_DELAY_HOURS,
+    cutoff_enabled: Annotated[str, Form()] = "",
+    cutoff_batch_size: Annotated[int, Form()] = DEFAULT_CUTOFF_BATCH_SIZE,
+) -> HTMLResponse:
+    """Update an existing instance and return the refreshed row partial."""
+    try:
+        instance_type = InstanceType(type)
+    except ValueError:
+        instance = await get_instance(instance_id, master_key=_master_key(request))
+        if instance is None:
+            return HTMLResponse(content="Not found", status_code=404)
+        return _render(
+            request,
+            "partials/instance_form.html",
+            status_code=422,
+            instance=instance,
+            editing=True,
+            error=f"Invalid type: {type!r}.",
+        )
+
+    updated = await update_instance(
+        instance_id,
+        master_key=_master_key(request),
+        name=name,
+        type=instance_type,
+        url=url.rstrip("/"),
+        api_key=api_key,
+        enabled=enabled == "on",
+        batch_size=batch_size,
+        sleep_interval_mins=sleep_interval_mins,
+        hourly_cap=hourly_cap,
+        cooldown_days=cooldown_days,
+        unreleased_delay_hrs=unreleased_delay_hrs,
+        cutoff_enabled=cutoff_enabled == "on",
+        cutoff_batch_size=cutoff_batch_size,
+    )
+    if updated is None:
+        return HTMLResponse(content="Not found", status_code=404)
+
+    # HTMX: return just the refreshed row
+    return _render(request, "partials/instance_row.html", instance=updated)
+
+
+# ---------------------------------------------------------------------------
+# Delete instance
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/settings/instances/{instance_id}")
+async def instance_delete(request: Request, instance_id: int) -> Response:
+    """Delete an instance; returns empty 200 so HTMX removes the row."""
+    await delete_instance(instance_id)
+    # Return an empty 200 — HTMX hx-swap="outerHTML" with empty content
+    # removes the row from the DOM.
+    return Response(status_code=200)

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -1,0 +1,170 @@
+{#
+  Add / Edit instance form.
+  When editing=True the form POSTs to /settings/instances/{id} and the row is
+  swapped back after a successful save.  When adding (editing=False / unset)
+  the form POSTs to /settings/instances and the table body is refreshed.
+#}
+{% set is_edit = editing is defined and editing %}
+{% set form_id = "edit-form-" ~ instance.id if is_edit else "add-instance-form" %}
+{% set post_url = "/settings/instances/" ~ instance.id if is_edit else "/settings/instances" %}
+{% set target  = "#instance-row-" ~ instance.id if is_edit else "#instance-tbody" %}
+{% set swap    = "outerHTML" if is_edit else "innerHTML" %}
+
+<tr id="{{ 'instance-row-' ~ instance.id if is_edit else 'add-instance-row' }}"
+    class="border-b border-slate-700 bg-slate-800/60">
+  <td colspan="6" class="px-4 py-4">
+    {% if error is defined and error %}
+    <div class="mb-3 text-sm text-red-400 bg-red-900/30 border border-red-700 rounded px-3 py-2">
+      {{ error }}
+    </div>
+    {% endif %}
+
+    <form id="{{ form_id }}"
+          hx-post="{{ post_url }}"
+          hx-target="{{ target }}"
+          hx-swap="{{ swap }}"
+          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+      {# Name #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-name">Name</label>
+        <input id="{{ form_id }}-name" name="name" type="text" required
+               value="{{ instance.name if is_edit else '' }}"
+               placeholder="My Sonarr"
+               class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+      </div>
+
+      {# Type #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-type">Type</label>
+        <select id="{{ form_id }}-type" name="type" required
+                class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                       focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500">
+          <option value="sonarr" {% if is_edit and instance.type.value == 'sonarr' %}selected{% endif %}>Sonarr</option>
+          <option value="radarr" {% if is_edit and instance.type.value == 'radarr' %}selected{% endif %}>Radarr</option>
+        </select>
+      </div>
+
+      {# URL #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-url">URL</label>
+        <input id="{{ form_id }}-url" name="url" type="url" required
+               value="{{ instance.url if is_edit else '' }}"
+               placeholder="http://sonarr:8989"
+               class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+      </div>
+
+      {# API Key #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-api-key">API Key</label>
+        <input id="{{ form_id }}-api-key" name="api_key" type="password" required
+               value="{{ instance.api_key if is_edit else '' }}"
+               placeholder="••••••••••••••••"
+               class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+      </div>
+
+      {# Batch size #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-batch">Batch Size</label>
+        <input id="{{ form_id }}-batch" name="batch_size" type="number" min="1" max="250"
+               value="{{ instance.batch_size if is_edit else 10 }}"
+               class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+      </div>
+
+      {# Sleep interval #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-sleep">Sleep (minutes)</label>
+        <input id="{{ form_id }}-sleep" name="sleep_interval_mins" type="number" min="1"
+               value="{{ instance.sleep_interval_mins if is_edit else 15 }}"
+               class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+      </div>
+
+      {# Hourly cap #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-hcap">Hourly Cap</label>
+        <input id="{{ form_id }}-hcap" name="hourly_cap" type="number" min="1"
+               value="{{ instance.hourly_cap if is_edit else 20 }}"
+               class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+      </div>
+
+      {# Cooldown days #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-cool">Cooldown (days)</label>
+        <input id="{{ form_id }}-cool" name="cooldown_days" type="number" min="0"
+               value="{{ instance.cooldown_days if is_edit else 7 }}"
+               class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+      </div>
+
+      {# Unreleased delay #}
+      <div>
+        <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-delay">Unreleased Delay (hrs)</label>
+        <input id="{{ form_id }}-delay" name="unreleased_delay_hrs" type="number" min="0"
+               value="{{ instance.unreleased_delay_hrs if is_edit else 24 }}"
+               class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+      </div>
+
+      {# Cutoff enabled + batch size — span full width on small screens #}
+      <div class="flex items-center gap-6 sm:col-span-2 lg:col-span-1">
+        <label class="flex items-center gap-2 cursor-pointer select-none">
+          <input type="checkbox" name="cutoff_enabled" value="on"
+                 {% if is_edit and instance.cutoff_enabled %}checked{% endif %}
+                 class="rounded border-slate-600 bg-slate-900 text-brand-500
+                        focus:ring-brand-500 focus:ring-offset-slate-950" />
+          <span class="text-xs text-slate-300">Cutoff search</span>
+        </label>
+        <div>
+          <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-cbatch">Cutoff Batch</label>
+          <input id="{{ form_id }}-cbatch" name="cutoff_batch_size" type="number" min="1" max="250"
+                 value="{{ instance.cutoff_batch_size if is_edit else 5 }}"
+                 class="w-24 bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
+                        focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+        </div>
+      </div>
+
+      {# Enabled toggle #}
+      <div class="flex items-center">
+        <label class="flex items-center gap-2 cursor-pointer select-none">
+          <input type="checkbox" name="enabled" value="on"
+                 {% if not is_edit or instance.enabled %}checked{% endif %}
+                 class="rounded border-slate-600 bg-slate-900 text-brand-500
+                        focus:ring-brand-500 focus:ring-offset-slate-950" />
+          <span class="text-xs text-slate-300">Enabled</span>
+        </label>
+      </div>
+
+      {# Buttons — span full width #}
+      <div class="sm:col-span-2 lg:col-span-3 flex items-center gap-3 pt-1">
+        <button type="submit"
+                class="px-4 py-1.5 rounded bg-brand-600 hover:bg-brand-500 text-white text-sm font-medium transition-colors">
+          {{ 'Save Changes' if is_edit else 'Add Instance' }}
+        </button>
+        {% if is_edit %}
+        {# Cancel edit — swap the form back to the read-only row #}
+        <button type="button"
+                hx-get="/settings"
+                hx-target="#instance-row-{{ instance.id }}"
+                hx-swap="outerHTML"
+                hx-select="#instance-row-{{ instance.id }}"
+                class="px-4 py-1.5 rounded bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm transition-colors">
+          Cancel
+        </button>
+        {% else %}
+        <button type="button"
+                onclick="this.closest('tr').remove()"
+                class="px-4 py-1.5 rounded bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm transition-colors">
+          Cancel
+        </button>
+        {% endif %}
+      </div>
+
+    </form>
+  </td>
+</tr>

--- a/src/houndarr/templates/partials/instance_row.html
+++ b/src/houndarr/templates/partials/instance_row.html
@@ -1,0 +1,48 @@
+{# Single instance row — used by both initial render and HTMX swap after update. #}
+<tr id="instance-row-{{ instance.id }}"
+    class="border-b border-slate-800 hover:bg-slate-800/40 transition-colors">
+  <td class="px-4 py-3 font-medium text-white">{{ instance.name }}</td>
+  <td class="px-4 py-3">
+    {% if instance.type.value == 'sonarr' %}
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-sky-900/60 text-sky-300 border border-sky-700">
+        Sonarr
+      </span>
+    {% else %}
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-900/60 text-amber-300 border border-amber-700">
+        Radarr
+      </span>
+    {% endif %}
+  </td>
+  <td class="px-4 py-3 text-slate-400 text-sm truncate max-w-xs">{{ instance.url }}</td>
+  <td class="px-4 py-3 text-center">
+    {% if instance.enabled %}
+      <span class="inline-block w-2 h-2 rounded-full bg-green-500" title="Enabled"></span>
+    {% else %}
+      <span class="inline-block w-2 h-2 rounded-full bg-slate-600" title="Disabled"></span>
+    {% endif %}
+  </td>
+  <td class="px-4 py-3 text-sm text-slate-400">
+    {{ instance.batch_size }} / {{ instance.sleep_interval_mins }}m
+  </td>
+  <td class="px-4 py-3 text-right">
+    <div class="flex items-center justify-end gap-2">
+      {# Edit — swaps this row with the edit form partial #}
+      <button
+        hx-get="/settings/instances/{{ instance.id }}/edit"
+        hx-target="#instance-row-{{ instance.id }}"
+        hx-swap="outerHTML"
+        class="px-3 py-1 text-xs rounded bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">
+        Edit
+      </button>
+      {# Delete — removes this row on success #}
+      <button
+        hx-delete="/settings/instances/{{ instance.id }}"
+        hx-target="#instance-row-{{ instance.id }}"
+        hx-swap="outerHTML"
+        hx-confirm="Delete '{{ instance.name }}'? This cannot be undone."
+        class="px-3 py-1 text-xs rounded bg-red-900/60 hover:bg-red-800 text-red-300 transition-colors">
+        Delete
+      </button>
+    </div>
+  </td>
+</tr>

--- a/src/houndarr/templates/partials/instance_table_body.html
+++ b/src/houndarr/templates/partials/instance_table_body.html
@@ -1,0 +1,4 @@
+{# Refreshed table body — returned by POST /settings/instances after create. #}
+{% for instance in instances %}
+  {% include "partials/instance_row.html" %}
+{% endfor %}

--- a/src/houndarr/templates/settings.html
+++ b/src/houndarr/templates/settings.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}Settings — Houndarr{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold text-white">Settings</h1>
+</div>
+
+{% if error is defined and error %}
+<div class="mb-4 text-sm text-red-400 bg-red-900/30 border border-red-700 rounded px-4 py-3">
+  {{ error }}
+</div>
+{% endif %}
+
+<!-- Instance table -->
+<section class="mb-10">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-lg font-semibold text-slate-200">Instances</h2>
+    <button
+      hx-get="/settings/instances/add-form"
+      hx-target="#add-instance-slot"
+      hx-swap="innerHTML"
+      id="add-instance-btn"
+      class="px-3 py-1.5 rounded bg-brand-600 hover:bg-brand-500 text-white text-sm font-medium transition-colors">
+      + Add Instance
+    </button>
+  </div>
+
+  <div class="rounded-lg border border-slate-800 overflow-hidden">
+    <table class="w-full text-sm">
+      <thead class="bg-slate-800/80 text-xs text-slate-400 uppercase tracking-wider">
+        <tr>
+          <th class="px-4 py-3 text-left">Name</th>
+          <th class="px-4 py-3 text-left">Type</th>
+          <th class="px-4 py-3 text-left">URL</th>
+          <th class="px-4 py-3 text-center">Status</th>
+          <th class="px-4 py-3 text-left">Batch / Interval</th>
+          <th class="px-4 py-3 text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody id="instance-tbody" class="divide-y divide-slate-800">
+        {% for instance in instances %}
+          {% include "partials/instance_row.html" %}
+        {% else %}
+        <tr id="no-instances-row">
+          <td colspan="6" class="px-4 py-10 text-center text-slate-500 text-sm">
+            No instances configured yet. Click <strong class="text-slate-400">+ Add Instance</strong> to get started.
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  {# Slot where the add-form row is injected by HTMX #}
+  <div id="add-instance-slot"></div>
+</section>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  // After a successful create, clear the add-form slot
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+    if (evt.detail.target.id === 'instance-tbody') {
+      document.getElementById('add-instance-slot').innerHTML = '';
+    }
+  });
+</script>
+{% endblock %}

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -1,0 +1,208 @@
+"""Tests for the settings page routes (instance management)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_FORM = {
+    "name": "My Sonarr",
+    "type": "sonarr",
+    "url": "http://sonarr:8989",
+    "api_key": "test-api-key-abc123",
+}
+
+
+def _login(client: TestClient) -> None:
+    """Complete setup + login so subsequent requests are authenticated."""
+    client.post("/setup", data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"})
+    client.post("/login", data={"password": "ValidPass1!"})
+
+
+# ---------------------------------------------------------------------------
+# Authentication guard — all settings routes require a session
+# ---------------------------------------------------------------------------
+
+
+_AUTH_LOCATIONS = {"/setup", "/login", "http://testserver/setup", "http://testserver/login"}
+
+
+def test_settings_redirects_unauthenticated(app: TestClient) -> None:
+    resp = app.get("/settings", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
+def test_settings_create_redirects_unauthenticated(app: TestClient) -> None:
+    resp = app.post("/settings/instances", data=_VALID_FORM, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
+def test_settings_edit_redirects_unauthenticated(app: TestClient) -> None:
+    resp = app.get("/settings/instances/1/edit", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
+def test_settings_update_redirects_unauthenticated(app: TestClient) -> None:
+    resp = app.post("/settings/instances/1", data=_VALID_FORM, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
+def test_settings_delete_redirects_unauthenticated(app: TestClient) -> None:
+    resp = app.delete("/settings/instances/1", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
+# ---------------------------------------------------------------------------
+# GET /settings
+# ---------------------------------------------------------------------------
+
+
+def test_settings_page_renders(app: TestClient) -> None:
+    _login(app)
+    resp = app.get("/settings")
+    assert resp.status_code == 200
+    assert b"Settings" in resp.content
+    assert b"Instances" in resp.content
+
+
+def test_settings_page_shows_no_instances_message(app: TestClient) -> None:
+    _login(app)
+    resp = app.get("/settings")
+    assert resp.status_code == 200
+    assert b"No instances configured" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# POST /settings/instances (create)
+# ---------------------------------------------------------------------------
+
+
+def test_create_instance_returns_table_body(app: TestClient) -> None:
+    _login(app)
+    resp = app.post("/settings/instances", data=_VALID_FORM)
+    assert resp.status_code == 200
+    assert b"My Sonarr" in resp.content
+
+
+def test_create_instance_sonarr_badge(app: TestClient) -> None:
+    _login(app)
+    resp = app.post("/settings/instances", data=_VALID_FORM)
+    assert b"Sonarr" in resp.content
+
+
+def test_create_instance_radarr(app: TestClient) -> None:
+    _login(app)
+    form = {**_VALID_FORM, "name": "My Radarr", "type": "radarr", "url": "http://radarr:7878"}
+    resp = app.post("/settings/instances", data=form)
+    assert resp.status_code == 200
+    assert b"My Radarr" in resp.content
+    assert b"Radarr" in resp.content
+
+
+def test_create_instance_invalid_type_returns_422(app: TestClient) -> None:
+    _login(app)
+    form = {**_VALID_FORM, "type": "plex"}
+    resp = app.post("/settings/instances", data=form)
+    assert resp.status_code == 422
+
+
+def test_create_instance_missing_name_returns_422(app: TestClient) -> None:
+    _login(app)
+    form = {k: v for k, v in _VALID_FORM.items() if k != "name"}
+    resp = app.post("/settings/instances", data=form)
+    assert resp.status_code == 422
+
+
+def test_create_instance_missing_api_key_returns_422(app: TestClient) -> None:
+    _login(app)
+    form = {k: v for k, v in _VALID_FORM.items() if k != "api_key"}
+    resp = app.post("/settings/instances", data=form)
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /settings/instances/{id}/edit
+# ---------------------------------------------------------------------------
+
+
+def test_edit_form_returns_partial(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM)
+    resp = app.get("/settings/instances/1/edit")
+    assert resp.status_code == 200
+    assert b"My Sonarr" in resp.content
+    assert b"Save Changes" in resp.content
+
+
+def test_edit_form_not_found(app: TestClient) -> None:
+    _login(app)
+    resp = app.get("/settings/instances/9999/edit")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /settings/instances/{id} (update)
+# ---------------------------------------------------------------------------
+
+
+def test_update_instance(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM)
+    updated_form = {**_VALID_FORM, "name": "Renamed Sonarr"}
+    resp = app.post("/settings/instances/1", data=updated_form)
+    assert resp.status_code == 200
+    assert b"Renamed Sonarr" in resp.content
+
+
+def test_update_instance_not_found(app: TestClient) -> None:
+    _login(app)
+    resp = app.post("/settings/instances/9999", data=_VALID_FORM)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /settings/instances/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_instance_returns_200(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM)
+    resp = app.delete("/settings/instances/1")
+    assert resp.status_code == 200
+
+
+def test_delete_instance_gone_from_settings(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM)
+    app.delete("/settings/instances/1")
+    resp = app.get("/settings")
+    assert resp.status_code == 200
+    assert b"No instances configured" in resp.content
+
+
+def test_delete_nonexistent_returns_200(app: TestClient) -> None:
+    """Deleting a non-existent ID is idempotent — still 200."""
+    _login(app)
+    resp = app.delete("/settings/instances/9999")
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /settings/instances/add-form
+# ---------------------------------------------------------------------------
+
+
+def test_add_form_partial_renders(app: TestClient) -> None:
+    _login(app)
+    resp = app.get("/settings/instances/add-form")
+    assert resp.status_code == 200
+    assert b"Add Instance" in resp.content


### PR DESCRIPTION
## Summary

- Adds `routes/settings.py` — full CRUD for instances via 5 routes: `GET /settings`, `GET /settings/instances/add-form`, `POST /settings/instances`, `GET/POST /settings/instances/{id}/edit`, `DELETE /settings/instances/{id}`
- Adds `templates/settings.html` — instance table with add button
- Adds `templates/partials/instance_row.html` — read-only row with Edit/Delete buttons wired to HTMX
- Adds `templates/partials/instance_form.html` — shared add/edit form; edit swaps the row in-place, add injects below the table then refreshes the tbody
- Adds `templates/partials/instance_table_body.html` — tbody refresh after create
- All mutations use HTMX (`hx-post`, `hx-delete`, `hx-swap`); no full-page reloads after initial GET
- `master_key` sourced from `request.app.state.master_key`
- 21 tests: auth guard (5), page render (2), create (5), edit partial (2), update (2), delete (3), add-form (1), invalid type (1)

## Testing

102 tests pass locally. `ruff`, `mypy`, `bandit` clean.

## Related

Closes #14