### PR TITLE
feat: search loop and background supervisor

### DIFF
--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -15,6 +15,7 @@ from houndarr.auth import AuthMiddleware
 from houndarr.config import get_settings
 from houndarr.crypto import ensure_master_key
 from houndarr.database import init_db, set_db_path
+from houndarr.engine.supervisor import Supervisor
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +37,15 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await init_db()
     logger.info("Database ready at %s", settings.db_path)
 
+    # Start the background search supervisor
+    supervisor = Supervisor(master_key=app.state.master_key)
+    await supervisor.start()
+    app.state.supervisor = supervisor
+
     yield  # Application runs here
 
     logger.info("Houndarr shutting down")
+    await supervisor.stop()
 
 
 def create_app() -> FastAPI:

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -1,0 +1,133 @@
+"""Per-instance search loop.
+
+:func:`run_instance_search` is the single entry point called by the supervisor.
+It fetches one batch of missing items, applies cooldown and hourly-cap checks,
+triggers the *arr search command for each eligible item, and writes a row to
+``search_log`` for every item processed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from houndarr.clients.radarr import RadarrClient
+from houndarr.clients.sonarr import SonarrClient
+from houndarr.database import get_db
+from houndarr.services.cooldown import (
+    count_searches_last_hour,
+    is_on_cooldown,
+    record_search,
+)
+from houndarr.services.instances import Instance, InstanceType
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# search_log helper
+# ---------------------------------------------------------------------------
+
+
+async def _write_log(
+    instance_id: int | None,
+    item_id: int | None,
+    item_type: str | None,
+    action: str,
+    reason: str | None = None,
+    message: str | None = None,
+) -> None:
+    """Insert a single row into ``search_log``."""
+    async with get_db() as db:
+        await db.execute(
+            """
+            INSERT INTO search_log
+                (instance_id, item_id, item_type, action, reason, message)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (instance_id, item_id, item_type, action, reason, message),
+        )
+        await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def run_instance_search(instance: Instance, master_key: bytes) -> int:
+    """Execute one search cycle for *instance*.
+
+    Steps:
+    1. Build the appropriate client (Sonarr or Radarr).
+    2. Fetch one page of missing items (size = ``instance.batch_size``).
+    3. For each item:
+       - If the hourly cap is reached → log *skipped* and stop.
+       - If the item is on cooldown → log *skipped* and continue.
+       - Otherwise → trigger search, record cooldown, log *searched*.
+    4. Return the number of items actually searched.
+
+    Args:
+        instance: Fully-populated (decrypted) instance.
+        master_key: Unused here but kept in signature for symmetry with
+            supervisor; future callers may need it for re-encryption.
+
+    Returns:
+        Count of items searched in this cycle.
+    """
+    logger.info(
+        "[%s] starting search cycle (batch_size=%d)",
+        instance.name,
+        instance.batch_size,
+    )
+
+    searched = 0
+
+    if instance.type == InstanceType.sonarr:
+        client: SonarrClient | RadarrClient = SonarrClient(
+            url=instance.url, api_key=instance.api_key
+        )
+        item_type = "episode"
+    else:
+        client = RadarrClient(url=instance.url, api_key=instance.api_key)
+        item_type = "movie"
+
+    async with client:
+        items = await client.get_missing(page=1, page_size=instance.batch_size)
+
+    logger.debug("[%s] fetched %d missing %s(s)", instance.name, len(items), item_type)
+
+    for item in items:
+        item_id: int = item.episode_id if item_type == "episode" else item.movie_id  # type: ignore[union-attr]
+
+        # --- hourly cap check ---
+        searches_this_hour = await count_searches_last_hour(instance.id)
+        if instance.hourly_cap > 0 and searches_this_hour >= instance.hourly_cap:
+            reason = f"hourly cap reached ({instance.hourly_cap})"
+            logger.info("[%s] %s — %s", instance.name, item_id, reason)
+            await _write_log(instance.id, item_id, item_type, "skipped", reason=reason)
+            break
+
+        # --- cooldown check ---
+        if await is_on_cooldown(instance.id, item_id, item_type, instance.cooldown_days):  # type: ignore[arg-type]
+            reason = f"on cooldown ({instance.cooldown_days}d)"
+            logger.debug("[%s] %s — %s", instance.name, item_id, reason)
+            await _write_log(instance.id, item_id, item_type, "skipped", reason=reason)
+            continue
+
+        # --- search ---
+        try:
+            async with client.__class__(url=instance.url, api_key=instance.api_key) as c:
+                await c.search(item_id)
+        except Exception as exc:  # noqa: BLE001
+            msg = str(exc)
+            logger.warning("[%s] search failed for %s: %s", instance.name, item_id, msg)
+            await _write_log(instance.id, item_id, item_type, "error", message=msg)
+            continue
+
+        await record_search(instance.id, item_id, item_type)  # type: ignore[arg-type]
+        await _write_log(instance.id, item_id, item_type, "searched")
+        searched += 1
+        logger.info("[%s] searched %s %s", instance.name, item_type, item_id)
+
+    logger.info("[%s] cycle complete — %d searched", instance.name, searched)
+    return searched

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -1,0 +1,131 @@
+"""Background supervisor — manages one asyncio.Task per enabled instance.
+
+The supervisor is started once during application lifespan and runs until
+shutdown.  Each task loops indefinitely: run a search cycle, sleep for
+``sleep_interval_mins``, repeat.  Cancellation (on shutdown) is handled
+gracefully.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from houndarr.engine.search_loop import _write_log, run_instance_search
+from houndarr.services.instances import list_instances
+
+logger = logging.getLogger(__name__)
+
+_SHUTDOWN_TIMEOUT = 10  # seconds to wait for tasks to finish on stop()
+
+
+class Supervisor:
+    """Manages one background search task per enabled *arr instance.
+
+    Usage (in FastAPI lifespan)::
+
+        supervisor = Supervisor(master_key=app.state.master_key)
+        await supervisor.start()
+        app.state.supervisor = supervisor
+        yield
+        await supervisor.stop()
+    """
+
+    def __init__(self, master_key: bytes) -> None:
+        self._master_key = master_key
+        self._tasks: dict[int, asyncio.Task[None]] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Load enabled instances and launch one loop-task per instance."""
+        instances = await list_instances(master_key=self._master_key)
+        enabled = [i for i in instances if i.enabled]
+
+        if not enabled:
+            logger.warning("Supervisor: no enabled instances configured — nothing to do")
+            return
+
+        for instance in enabled:
+            task = asyncio.create_task(
+                self._instance_loop(instance.id),
+                name=f"search-loop-{instance.id}",
+            )
+            self._tasks[instance.id] = task
+            logger.info(
+                "Supervisor: started task for instance %r (id=%d)", instance.name, instance.id
+            )
+
+        await _write_log(
+            instance_id=None,
+            item_id=None,
+            item_type=None,
+            action="info",
+            message=f"Supervisor started {len(self._tasks)} task(s)",
+        )
+
+    async def stop(self) -> None:
+        """Cancel all running tasks and wait up to 10 s for clean exit."""
+        if not self._tasks:
+            return
+
+        for task in self._tasks.values():
+            task.cancel()
+
+        results = await asyncio.gather(*self._tasks.values(), return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception) and not isinstance(result, asyncio.CancelledError):
+                logger.error("Supervisor: task raised unexpected exception: %s", result)
+
+        self._tasks.clear()
+        logger.info("Supervisor: all tasks stopped")
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _instance_loop(self, instance_id: int) -> None:
+        """Run search cycles for one instance until cancelled."""
+        logger.debug("Supervisor: loop started for instance id=%d", instance_id)
+        try:
+            while True:
+                # Re-fetch the instance on each cycle so config changes take effect
+                from houndarr.services.instances import get_instance
+
+                instance = await get_instance(instance_id, master_key=self._master_key)
+                if instance is None:
+                    logger.warning(
+                        "Supervisor: instance id=%d no longer exists — stopping loop",
+                        instance_id,
+                    )
+                    return
+
+                if not instance.enabled:
+                    logger.info(
+                        "Supervisor: instance %r disabled — sleeping until re-enabled",
+                        instance.name,
+                    )
+                else:
+                    try:
+                        await run_instance_search(instance, self._master_key)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error(
+                            "Supervisor: unhandled error in search loop for %r: %s",
+                            instance.name,
+                            exc,
+                        )
+                        await _write_log(
+                            instance_id=instance_id,
+                            item_id=None,
+                            item_type=None,
+                            action="error",
+                            message=str(exc),
+                        )
+
+                await asyncio.sleep(instance.sleep_interval_mins * 60)
+
+        except asyncio.CancelledError:
+            logger.debug("Supervisor: loop cancelled for instance id=%d", instance_id)
+            raise

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -1,0 +1,359 @@
+"""Tests for the search loop engine — all HTTP calls mocked with respx."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from cryptography.fernet import Fernet
+
+from houndarr.database import get_db
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import Instance, InstanceType
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+SONARR_URL = "http://sonarr:8989"
+RADARR_URL = "http://radarr:7878"
+# Valid Fernet key required wherever crypto.decrypt is called (supervisor tests)
+MASTER_KEY: bytes = Fernet.generate_key()
+
+_EPISODE_RECORD: dict[str, Any] = {
+    "id": 101,
+    "title": "Pilot",
+    "seasonNumber": 1,
+    "episodeNumber": 1,
+    "airDateUtc": "2023-09-01T00:00:00Z",
+    "series": {"title": "My Show"},
+}
+
+_MOVIE_RECORD: dict[str, Any] = {
+    "id": 201,
+    "title": "My Movie",
+    "year": 2023,
+    "digitalRelease": None,
+}
+
+_MISSING_SONARR = {"page": 1, "pageSize": 10, "totalRecords": 1, "records": [_EPISODE_RECORD]}
+_MISSING_RADARR = {"page": 1, "pageSize": 10, "totalRecords": 1, "records": [_MOVIE_RECORD]}
+_COMMAND_RESP = {"id": 1, "name": "EpisodeSearch"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_instance(
+    *,
+    instance_id: int = 1,
+    itype: InstanceType = InstanceType.sonarr,
+    url: str = SONARR_URL,
+    batch_size: int = 10,
+    hourly_cap: int = 20,
+    cooldown_days: int = 7,
+    enabled: bool = True,
+) -> Instance:
+    return Instance(
+        id=instance_id,
+        name="Test Instance",
+        type=itype,
+        url=url,
+        api_key="test-api-key",
+        enabled=enabled,
+        batch_size=batch_size,
+        sleep_interval_mins=15,
+        hourly_cap=hourly_cap,
+        cooldown_days=cooldown_days,
+        unreleased_delay_hrs=24,
+        cutoff_enabled=False,
+        cutoff_batch_size=5,
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+    )
+
+
+@pytest_asyncio.fixture()
+async def seeded_instances(db: None) -> AsyncGenerator[None, None]:
+    """Seed FK-required rows into instances so cooldowns can reference them.
+
+    encrypted_api_key is set to a valid Fernet-encrypted value so that
+    list_instances / get_instance can decrypt it without errors.
+    """
+    from houndarr.crypto import encrypt
+
+    encrypted = encrypt("test-api-key", MASTER_KEY)
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
+            [
+                (1, "Sonarr Test", "sonarr", SONARR_URL, encrypted),
+                (2, "Radarr Test", "radarr", RADARR_URL, encrypted),
+            ],
+        )
+        await conn.commit()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helper: fetch all search_log rows
+# ---------------------------------------------------------------------------
+
+
+async def _get_log_rows() -> list[dict[str, Any]]:
+    async with get_db() as conn:
+        async with conn.execute("SELECT * FROM search_log ORDER BY id ASC") as cur:
+            rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Tests — items searched
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_item_is_searched_when_not_on_cooldown(seeded_instances: None) -> None:
+    """A fresh item with no cooldown record should be searched."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance()
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    rows = await _get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "searched"
+    assert rows[0]["item_id"] == 101
+    assert rows[0]["item_type"] == "episode"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_item_is_searched(seeded_instances: None) -> None:
+    """A Radarr missing movie should be searched with the movie item_type."""
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_RADARR)
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+
+    instance = _make_instance(instance_id=2, itype=InstanceType.radarr, url=RADARR_URL)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    rows = await _get_log_rows()
+    assert rows[0]["action"] == "searched"
+    assert rows[0]["item_id"] == 201
+    assert rows[0]["item_type"] == "movie"
+
+
+# ---------------------------------------------------------------------------
+# Tests — items skipped (cooldown)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_item_skipped_when_on_cooldown(seeded_instances: None) -> None:
+    """An item that was recently searched should be skipped."""
+    # Pre-record a cooldown for episode 101
+    from houndarr.services.cooldown import record_search
+
+    await record_search(1, 101, "episode")
+
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+    # search endpoint should NOT be called
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(cooldown_days=7)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert not search_route.called
+
+    rows = await _get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "skipped"
+    assert rows[0]["item_id"] == 101
+    assert "cooldown" in (rows[0]["reason"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Tests — hourly cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_hourly_cap_stops_searches(seeded_instances: None) -> None:
+    """When the hourly cap is already reached, items should be skipped."""
+    # Fill up the hourly cap by recording searches for other items
+    from houndarr.services.cooldown import record_search
+
+    for i in range(5):
+        await record_search(1, 900 + i, "episode")
+
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    # hourly_cap=5 — already used up
+    instance = _make_instance(hourly_cap=5)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert not search_route.called
+
+    rows = await _get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "skipped"
+    assert "hourly cap" in (rows[0]["reason"] or "")
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_hourly_cap_zero_means_unlimited(seeded_instances: None) -> None:
+    """hourly_cap=0 should disable the cap and allow all searches."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(hourly_cap=0)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — search_log rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_log_row_written_on_success(seeded_instances: None) -> None:
+    """A successful search must produce a 'searched' log row with correct fields."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance()
+    await run_instance_search(instance, MASTER_KEY)
+
+    rows = await _get_log_rows()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["instance_id"] == 1
+    assert row["item_id"] == 101
+    assert row["item_type"] == "episode"
+    assert row["action"] == "searched"
+    assert row["reason"] is None
+    assert row["timestamp"] is not None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_log_row_written_on_error(seeded_instances: None) -> None:
+    """A failed search command must produce an 'error' log row."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(return_value=httpx.Response(500))
+
+    instance = _make_instance()
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    rows = await _get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "error"
+    assert rows[0]["item_id"] == 101
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_no_log_rows_when_no_missing_items(seeded_instances: None) -> None:
+    """An empty missing list should produce no log rows."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200, json={"page": 1, "pageSize": 10, "totalRecords": 0, "records": []}
+        )
+    )
+
+    instance = _make_instance()
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    rows = await _get_log_rows()
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Tests — supervisor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_supervisor_starts_and_stops_cleanly(db: None) -> None:
+    """Supervisor with no instances should start and stop without error."""
+    from houndarr.engine.supervisor import Supervisor
+
+    sup = Supervisor(master_key=MASTER_KEY)
+    await sup.start()
+    await sup.stop()
+    assert sup._tasks == {}  # noqa: SLF001
+
+
+@pytest.mark.asyncio()
+async def test_supervisor_stop_cancels_tasks(seeded_instances: None) -> None:
+    """Supervisor tasks should be cancelled cleanly on stop()."""
+    from houndarr.engine.supervisor import Supervisor
+
+    # Patch run_instance_search to block indefinitely so we can test cancellation
+    async def _block(*_: object, **__: object) -> int:
+        import asyncio
+
+        await asyncio.sleep(9999)
+        return 0
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        new=AsyncMock(side_effect=_block),
+    ):
+        sup = Supervisor(master_key=MASTER_KEY)
+        await sup.start()
+        # Give the tasks a moment to start and enter their sleep
+        import asyncio
+
+        await asyncio.sleep(0.05)
+        await sup.stop()
+
+    assert sup._tasks == {}  # noqa: SLF001


### PR DESCRIPTION
## Summary

- Adds `src/houndarr/engine/search_loop.py` with `run_instance_search()`: fetches one batch of missing items, checks hourly cap and per-item cooldown, triggers the *arr search command for each eligible item, and writes a `search_log` row for every outcome (searched / skipped / error)
- Adds `src/houndarr/engine/supervisor.py` with `Supervisor`: spawns one `asyncio.Task` per enabled instance, loops indefinitely (search → sleep → repeat), handles `CancelledError` gracefully on shutdown
- Wires `Supervisor` into `app.py` lifespan — starts on startup, stops on shutdown
- 10 new tests in `tests/test_engine/test_search_loop.py` covering: normal search, Radarr path, cooldown skip, hourly cap enforcement, zero-cap bypass, log rows on success/error/empty, supervisor start/stop, graceful task cancellation

Closes #18