### PR TITLE
feat: add username + password authentication

### DIFF
--- a/src/houndarr/auth.py
+++ b/src/houndarr/auth.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from collections.abc import Callable
+from hmac import compare_digest
 from typing import Any
 
 import bcrypt
@@ -25,6 +27,9 @@ logger = logging.getLogger(__name__)
 SESSION_COOKIE_NAME = "houndarr_session"
 SESSION_MAX_AGE_SECONDS = 86400  # 24 hours
 BCRYPT_COST = 12
+USERNAME_MIN_LENGTH = 3
+USERNAME_MAX_LENGTH = 32
+_USERNAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
 
 # Routes that don't require authentication
 _PUBLIC_PATHS = frozenset(
@@ -127,12 +132,61 @@ async def set_password(password: str) -> None:
     await set_setting("password_hash", hash_password(password))
 
 
+def normalize_username(username: str) -> str:
+    """Return a normalized username for storage and comparison."""
+    return username.strip().lower()
+
+
+def validate_username(username: str) -> str | None:
+    """Return an error message if username is invalid, else None."""
+    normalized = normalize_username(username)
+    if not normalized:
+        return "Username is required."
+    if len(normalized) < USERNAME_MIN_LENGTH or len(normalized) > USERNAME_MAX_LENGTH:
+        return "Username must be 3-32 characters."
+    if _USERNAME_PATTERN.fullmatch(normalized) is None:
+        return "Username may only contain lowercase letters, numbers, dots, dashes, or underscores."
+    return None
+
+
+async def set_username(username: str) -> None:
+    """Persist the normalized single-admin username."""
+    await set_setting("username", normalize_username(username))
+
+
+async def get_username() -> str | None:
+    """Return the configured single-admin username."""
+    return await get_setting("username")
+
+
 async def check_password(password: str) -> bool:
     """Return True if password matches the stored hash."""
     stored = await get_setting("password_hash")
     if not stored:
         return False
     return verify_password(password, stored)
+
+
+async def check_credentials(username: str, password: str) -> bool:
+    """Return True if the provided username and password are valid.
+
+    If a legacy install has a password hash but no username yet, the first
+    successful password login claims the submitted username.
+    """
+    normalized_username = normalize_username(username)
+    username_error = validate_username(normalized_username)
+    if username_error is not None:
+        return False
+
+    if not await check_password(password):
+        return False
+
+    stored_username = await get_username()
+    if stored_username is None:
+        await set_username(normalized_username)
+        return True
+
+    return compare_digest(normalized_username, normalize_username(stored_username))
 
 
 # ---------------------------------------------------------------------------

--- a/src/houndarr/routes/pages.py
+++ b/src/houndarr/routes/pages.py
@@ -8,14 +8,17 @@ from fastapi.templating import Jinja2Templates
 
 from houndarr import __version__
 from houndarr.auth import (
+    check_credentials,
     check_login_rate_limit,
-    check_password,
     clear_login_attempts,
     clear_session,
     create_session,
     is_setup_complete,
+    normalize_username,
     record_failed_login,
     set_password,
+    set_username,
+    validate_username,
 )
 
 router = APIRouter()
@@ -65,12 +68,23 @@ async def setup_get(request: Request) -> HTMLResponse:
 @router.post("/setup", response_class=HTMLResponse)
 async def setup_post(
     request: Request,
+    username: str = Form(...),
     password: str = Form(...),
     password_confirm: str = Form(...),
 ) -> HTMLResponse:
     """Process the first-run password setup form."""
     if await is_setup_complete():
         return RedirectResponse(url="/login", status_code=302)  # type: ignore[return-value]
+
+    username_error = validate_username(username)
+    if username_error is not None:
+        return _render(
+            request,
+            "setup.html",
+            status_code=422,
+            show_nav=False,
+            error=username_error,
+        )
 
     if len(password) < 8:
         return _render(
@@ -90,6 +104,7 @@ async def setup_post(
             error="Passwords do not match.",
         )
 
+    await set_username(normalize_username(username))
     await set_password(password)
     return RedirectResponse(url="/login", status_code=303)  # type: ignore[return-value]
 
@@ -110,6 +125,7 @@ async def login_get(request: Request) -> HTMLResponse:
 @router.post("/login", response_class=HTMLResponse)
 async def login_post(
     request: Request,
+    username: str = Form(...),
     password: str = Form(...),
 ) -> HTMLResponse:
     """Process login form."""
@@ -125,14 +141,14 @@ async def login_post(
             error="Too many attempts. Please wait a moment.",
         )
 
-    if not await check_password(password):
+    if not await check_credentials(username, password):
         record_failed_login(request)
         return _render(
             request,
             "login.html",
             status_code=401,
             show_nav=False,
-            error="Incorrect password.",
+            error="Invalid credentials.",
         )
 
     clear_login_attempts(request)

--- a/src/houndarr/templates/login.html
+++ b/src/houndarr/templates/login.html
@@ -15,7 +15,7 @@
         </svg>
       </div>
       <h1 class="text-2xl font-bold text-white">Houndarr</h1>
-      <p class="mt-2 text-slate-400 text-sm">Enter your password to continue.</p>
+      <p class="mt-2 text-slate-400 text-sm">Enter your username and password to continue.</p>
     </div>
 
     <!-- Login form -->
@@ -28,6 +28,25 @@
 
       <form action="/login" method="post" class="space-y-5">
         <div>
+          <label for="username" class="block text-sm font-medium text-slate-300 mb-1.5">
+            Username
+          </label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            autocomplete="username"
+            required
+            minlength="3"
+            maxlength="32"
+            pattern="[A-Za-z0-9_.-]+"
+            class="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-colors"
+            placeholder="Your username"
+            autofocus
+          />
+        </div>
+
+        <div>
           <label for="password" class="block text-sm font-medium text-slate-300 mb-1.5">
             Password
           </label>
@@ -39,7 +58,6 @@
             required
             class="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-colors"
             placeholder="Your password"
-            autofocus
           />
         </div>
 

--- a/src/houndarr/templates/setup.html
+++ b/src/houndarr/templates/setup.html
@@ -15,7 +15,7 @@
         </svg>
       </div>
       <h1 class="text-2xl font-bold text-white">Welcome to Houndarr</h1>
-      <p class="mt-2 text-slate-400 text-sm">Create a password to secure your instance.</p>
+      <p class="mt-2 text-slate-400 text-sm">Create your admin username and password.</p>
     </div>
 
     <!-- Setup form -->
@@ -27,6 +27,25 @@
       {% endif %}
 
       <form action="/setup" method="post" class="space-y-5">
+        <div>
+          <label for="username" class="block text-sm font-medium text-slate-300 mb-1.5">
+            Username
+          </label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            autocomplete="username"
+            required
+            minlength="3"
+            maxlength="32"
+            pattern="[A-Za-z0-9_.-]+"
+            class="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-colors"
+            placeholder="admin"
+            autofocus
+          />
+        </div>
+
         <div>
           <label for="password" class="block text-sm font-medium text-slate-300 mb-1.5">
             Password
@@ -40,7 +59,6 @@
             minlength="8"
             class="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-colors"
             placeholder="Minimum 8 characters"
-            autofocus
           />
         </div>
 
@@ -63,13 +81,13 @@
         <button
           type="submit"
           class="w-full bg-brand-600 hover:bg-brand-500 text-white font-semibold py-2.5 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-slate-900">
-          Set Password &amp; Get Started
+          Create Account &amp; Get Started
         </button>
       </form>
     </div>
 
     <p class="mt-6 text-center text-xs text-slate-600">
-      This password protects your Houndarr instance. Keep it safe.
+      Keep your username and password secure.
     </p>
   </div>
 </div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from houndarr.auth import hash_password, is_setup_complete, verify_password
+from houndarr.auth import check_credentials, hash_password, is_setup_complete, verify_password
+from houndarr.database import get_setting
 
 # ---------------------------------------------------------------------------
 # Unit tests — password hashing
@@ -66,6 +67,33 @@ async def test_check_password_incorrect(db: None) -> None:
     assert await check_password("wrong_password") is False
 
 
+@pytest.mark.asyncio()
+async def test_check_credentials_correct(db: None) -> None:
+    from houndarr.auth import set_password, set_username
+
+    await set_username("admin")
+    await set_password("correct_password")
+    assert await check_credentials("admin", "correct_password") is True
+
+
+@pytest.mark.asyncio()
+async def test_check_credentials_wrong_username(db: None) -> None:
+    from houndarr.auth import set_password, set_username
+
+    await set_username("admin")
+    await set_password("correct_password")
+    assert await check_credentials("operator", "correct_password") is False
+
+
+@pytest.mark.asyncio()
+async def test_check_credentials_claims_username_for_legacy_install(db: None) -> None:
+    from houndarr.auth import set_password
+
+    await set_password("correct_password")
+    assert await check_credentials("admin", "correct_password") is True
+    assert await get_setting("username") == "admin"
+
+
 # ---------------------------------------------------------------------------
 # Integration tests — HTTP routes
 # ---------------------------------------------------------------------------
@@ -94,16 +122,33 @@ def test_setup_page_renders(app: TestClient) -> None:
 
 def test_setup_post_short_password(app: TestClient) -> None:
     """Password shorter than 8 chars should fail validation."""
-    response = app.post("/setup", data={"password": "short", "password_confirm": "short"})
+    response = app.post(
+        "/setup",
+        data={"username": "admin", "password": "short", "password_confirm": "short"},
+    )
     assert response.status_code == 422
     assert b"at least 8 characters" in response.content
+
+
+def test_setup_post_invalid_username(app: TestClient) -> None:
+    """Invalid username should fail validation."""
+    response = app.post(
+        "/setup",
+        data={
+            "username": "bad username",
+            "password": "ValidPass1!",
+            "password_confirm": "ValidPass1!",
+        },
+    )
+    assert response.status_code == 422
+    assert b"Username may only contain" in response.content
 
 
 def test_setup_post_mismatched_passwords(app: TestClient) -> None:
     """Mismatched confirmation should return error."""
     response = app.post(
         "/setup",
-        data={"password": "password123", "password_confirm": "password456"},
+        data={"username": "admin", "password": "password123", "password_confirm": "password456"},
     )
     assert response.status_code == 422
     assert b"do not match" in response.content
@@ -113,7 +158,7 @@ def test_setup_post_success(app: TestClient) -> None:
     """Valid setup should redirect to login."""
     response = app.post(
         "/setup",
-        data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
         follow_redirects=False,
     )
     assert response.status_code == 303
@@ -125,7 +170,7 @@ def test_login_page_renders_after_setup(app: TestClient) -> None:
     # Complete setup first
     app.post(
         "/setup",
-        data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
     )
     response = app.get("/login")
     assert response.status_code == 200
@@ -134,18 +179,35 @@ def test_login_page_renders_after_setup(app: TestClient) -> None:
 
 def test_login_wrong_password(app: TestClient) -> None:
     """Wrong password should return 401."""
-    app.post("/setup", data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"})
-    response = app.post("/login", data={"password": "WrongPass!"})
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    response = app.post("/login", data={"username": "admin", "password": "WrongPass!"})
     assert response.status_code == 401
-    assert b"Incorrect password" in response.content
+    assert b"Invalid credentials" in response.content
+
+
+def test_login_wrong_username(app: TestClient) -> None:
+    """Wrong username should return 401 with generic error."""
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    response = app.post("/login", data={"username": "other", "password": "ValidPass1!"})
+    assert response.status_code == 401
+    assert b"Invalid credentials" in response.content
 
 
 def test_login_correct_password(app: TestClient) -> None:
     """Correct password should create session and redirect to dashboard."""
-    app.post("/setup", data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"})
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
     response = app.post(
         "/login",
-        data={"password": "ValidPass1!"},
+        data={"username": "admin", "password": "ValidPass1!"},
         follow_redirects=False,
     )
     assert response.status_code == 303
@@ -156,8 +218,11 @@ def test_login_correct_password(app: TestClient) -> None:
 
 def test_dashboard_accessible_after_login(app: TestClient) -> None:
     """Dashboard should be accessible after logging in."""
-    app.post("/setup", data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"})
-    app.post("/login", data={"password": "ValidPass1!"})
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
     response = app.get("/")
     assert response.status_code == 200
     assert b"Dashboard" in response.content
@@ -165,8 +230,11 @@ def test_dashboard_accessible_after_login(app: TestClient) -> None:
 
 def test_logout_clears_session(app: TestClient) -> None:
     """Logout should clear the session and redirect to login."""
-    app.post("/setup", data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"})
-    app.post("/login", data={"password": "ValidPass1!"})
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
     response = app.post("/logout", follow_redirects=False)
     assert response.status_code == 303
     assert "/login" in response.headers["location"]

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -18,8 +18,11 @@ _VALID_FORM = {
 
 def _login(client: TestClient) -> None:
     """Complete setup + login so subsequent requests are authenticated."""
-    client.post("/setup", data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"})
-    client.post("/login", data={"password": "ValidPass1!"})
+    client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes/test_status.py
+++ b/tests/test_routes/test_status.py
@@ -21,8 +21,11 @@ _VALID_FORM = {
 
 
 def _login(client: TestClient) -> None:
-    client.post("/setup", data={"password": "ValidPass1!", "password_confirm": "ValidPass1!"})
-    client.post("/login", data={"password": "ValidPass1!"})
+    client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add single-admin username support in auth helpers using the existing settings table
- update setup and login flows/templates to require username + password and return generic invalid-credentials errors
- preserve password-only local/dev compatibility by claiming username on the first successful post-upgrade login
- update auth and route tests for the new flow and legacy compatibility behavior

## Testing

- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest

Closes #24