### PR TITLE
fix: remove boxed logo styling from auth and navbar

### DIFF
--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -52,11 +52,11 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex items-center justify-between h-14">
         <!-- Logo -->
-        <a href="/" class="flex items-center gap-2 text-brand-400 font-semibold text-lg hover:text-brand-300 transition-colors">
+        <a href="/" class="-ml-1 flex items-center gap-2 text-brand-400 font-semibold text-lg hover:text-brand-300 transition-colors">
           <img
             src="/static/img/houndarr-logo-dark-ui.png"
             alt="Houndarr logo"
-            class="w-7 h-7 object-contain drop-shadow-[0_0_8px_rgba(34,211,238,0.18)]"
+            class="w-12 h-12 object-contain drop-shadow-[0_0_12px_rgba(34,211,238,0.22)]"
           />
           Houndarr
         </a>

--- a/src/houndarr/templates/login.html
+++ b/src/houndarr/templates/login.html
@@ -11,7 +11,7 @@
       <img
         src="/static/img/houndarr-logo-dark-ui.png"
         alt="Houndarr logo"
-        class="mx-auto mb-4 w-20 h-20 object-contain drop-shadow-[0_0_18px_rgba(34,211,238,0.18)]"
+        class="mx-auto w-36 h-36 object-contain drop-shadow-[0_0_22px_rgba(34,211,238,0.22)]"
       />
       <h1 class="text-2xl font-bold text-white">Houndarr</h1>
       <p class="mt-2 text-slate-400 text-sm">Enter your username and password to continue.</p>

--- a/src/houndarr/templates/setup.html
+++ b/src/houndarr/templates/setup.html
@@ -11,7 +11,7 @@
       <img
         src="/static/img/houndarr-logo-dark-ui.png"
         alt="Houndarr logo"
-        class="mx-auto mb-4 w-20 h-20 object-contain drop-shadow-[0_0_18px_rgba(34,211,238,0.18)]"
+        class="mx-auto w-36 h-36 object-contain drop-shadow-[0_0_22px_rgba(34,211,238,0.22)]"
       />
       <h1 class="text-2xl font-bold text-white">Welcome to Houndarr</h1>
       <p class="mt-2 text-slate-400 text-sm">Create your admin username and password.</p>


### PR DESCRIPTION
## Summary

- remove bordered/boxed logo container styles from setup and login headers
- remove bordered/boxed logo container styles from navbar branding
- keep logo sizes unchanged while rendering the logo itself at full visible area with subtle shadow only

## Testing

- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest

Closes #30