### PR TITLE
feat: unify instance modal UX and validation

### DIFF
--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -10,6 +10,9 @@ from fastapi.responses import HTMLResponse, Response
 from fastapi.templating import Jinja2Templates
 
 from houndarr import __version__
+from houndarr.clients.base import ArrClient
+from houndarr.clients.radarr import RadarrClient
+from houndarr.clients.sonarr import SonarrClient
 from houndarr.config import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_COOLDOWN_DAYS,
@@ -59,31 +62,8 @@ def _master_key(request: Request) -> bytes:
     return request.app.state.master_key  # type: ignore[no-any-return]
 
 
-# ---------------------------------------------------------------------------
-# Settings index
-# ---------------------------------------------------------------------------
-
-
-@router.get("/settings", response_class=HTMLResponse)
-async def settings_get(request: Request) -> HTMLResponse:
-    """Render the settings page with the current list of instances."""
-    instances = await list_instances(master_key=_master_key(request))
-    return _render(request, "settings.html", instances=instances)
-
-
-# ---------------------------------------------------------------------------
-# Add-form partial (injected into the slot below the table)
-# ---------------------------------------------------------------------------
-
-
-@router.get("/settings/instances/add-form", response_class=HTMLResponse)
-async def instance_add_form(request: Request) -> HTMLResponse:
-    """Return the blank add-instance form partial for HTMX injection."""
-    # Pass a dummy Instance-like object with defaults so the template can
-    # reference instance.* without conditionals everywhere.
-    from houndarr.services.instances import Instance, InstanceType
-
-    blank: Instance = Instance(
+def _blank_instance() -> Instance:
+    return Instance(
         id=0,
         name="",
         type=InstanceType.sonarr,
@@ -100,7 +80,96 @@ async def instance_add_form(request: Request) -> HTMLResponse:
         created_at="",
         updated_at="",
     )
-    return _render(request, "partials/instance_form.html", instance=blank, editing=False)
+
+
+def _build_client(instance_type: InstanceType, url: str, api_key: str) -> ArrClient:
+    if instance_type == InstanceType.sonarr:
+        return SonarrClient(url=url, api_key=api_key)
+    return RadarrClient(url=url, api_key=api_key)
+
+
+async def _connection_ok(instance_type: InstanceType, url: str, api_key: str) -> bool:
+    client = _build_client(instance_type, url, api_key)
+    async with client:
+        return await client.ping()
+
+
+def _connection_status_response(message: str, ok: bool, status_code: int) -> HTMLResponse:
+    trigger = "houndarr-connection-test-success" if ok else "houndarr-connection-test-failure"
+    color = "text-green-400" if ok else "text-red-400"
+    return HTMLResponse(
+        content=f'<span class="text-xs {color}">{message}</span>',
+        status_code=status_code,
+        headers={"HX-Trigger": trigger},
+    )
+
+
+def _connection_guard_response(message: str) -> HTMLResponse:
+    return HTMLResponse(
+        content=f'<span class="text-xs text-red-400">{message}</span>',
+        status_code=422,
+        headers={
+            "HX-Retarget": "#instance-connection-status",
+            "HX-Reswap": "innerHTML",
+            "HX-Trigger": "houndarr-connection-test-failure",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Settings index
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings", response_class=HTMLResponse)
+async def settings_get(request: Request) -> HTMLResponse:
+    """Render the settings page with the current list of instances."""
+    instances = await list_instances(master_key=_master_key(request))
+    return _render(request, "settings.html", instances=instances)
+
+
+# ---------------------------------------------------------------------------
+# Add-form partial (injected into the add-instance modal)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/settings/instances/add-form", response_class=HTMLResponse)
+async def instance_add_form(request: Request) -> HTMLResponse:
+    """Return the blank add-instance form partial for HTMX modal injection."""
+    return _render(
+        request, "partials/instance_form.html", instance=_blank_instance(), editing=False
+    )
+
+
+@router.post("/settings/instances/test-connection", response_class=HTMLResponse)
+async def instance_test_connection(
+    request: Request,
+    type: Annotated[str, Form()],  # noqa: A002
+    url: Annotated[str, Form()],
+    api_key: Annotated[str, Form()],
+) -> HTMLResponse:
+    """Test Sonarr/Radarr connectivity and return a status snippet."""
+    try:
+        instance_type = InstanceType(type)
+    except ValueError:
+        return _connection_status_response(
+            "Invalid type. Must be Sonarr or Radarr.",
+            ok=False,
+            status_code=422,
+        )
+
+    ok = await _connection_ok(instance_type, url.rstrip("/"), api_key)
+    if ok:
+        return _connection_status_response(
+            "Connection successful.",
+            ok=True,
+            status_code=200,
+        )
+    return _connection_status_response(
+        "Connection failed. Check URL/API key and try again.",
+        ok=False,
+        status_code=422,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -123,19 +192,19 @@ async def instance_create(
     unreleased_delay_hrs: Annotated[int, Form()] = DEFAULT_UNRELEASED_DELAY_HOURS,
     cutoff_enabled: Annotated[str, Form()] = "",
     cutoff_batch_size: Annotated[int, Form()] = DEFAULT_CUTOFF_BATCH_SIZE,
+    connection_verified: Annotated[str, Form()] = "false",
 ) -> HTMLResponse:
     """Create a new instance and return the updated instance table body."""
     try:
         instance_type = InstanceType(type)
     except ValueError:
-        instances = await list_instances(master_key=_master_key(request))
-        return _render(
-            request,
-            "settings.html",
-            status_code=422,
-            instances=instances,
-            error=f"Invalid instance type: {type!r}. Must be 'sonarr' or 'radarr'.",
-        )
+        return _connection_guard_response("Invalid instance type.")
+
+    if connection_verified != "true":
+        return _connection_guard_response("Test connection successfully before adding.")
+
+    if not await _connection_ok(instance_type, url.rstrip("/"), api_key):
+        return _connection_guard_response("Connection test failed. Re-test before adding.")
 
     await create_instance(
         master_key=_master_key(request),
@@ -192,22 +261,19 @@ async def instance_update(
     unreleased_delay_hrs: Annotated[int, Form()] = DEFAULT_UNRELEASED_DELAY_HOURS,
     cutoff_enabled: Annotated[str, Form()] = "",
     cutoff_batch_size: Annotated[int, Form()] = DEFAULT_CUTOFF_BATCH_SIZE,
+    connection_verified: Annotated[str, Form()] = "false",
 ) -> HTMLResponse:
     """Update an existing instance and return the refreshed row partial."""
     try:
         instance_type = InstanceType(type)
     except ValueError:
-        instance = await get_instance(instance_id, master_key=_master_key(request))
-        if instance is None:
-            return HTMLResponse(content="Not found", status_code=404)
-        return _render(
-            request,
-            "partials/instance_form.html",
-            status_code=422,
-            instance=instance,
-            editing=True,
-            error=f"Invalid type: {type!r}.",
-        )
+        return _connection_guard_response("Invalid instance type.")
+
+    if connection_verified != "true":
+        return _connection_guard_response("Test connection successfully before saving changes.")
+
+    if not await _connection_ok(instance_type, url.rstrip("/"), api_key):
+        return _connection_guard_response("Connection test failed. Re-test before saving changes.")
 
     updated = await update_instance(
         instance_id,
@@ -244,3 +310,32 @@ async def instance_delete(request: Request, instance_id: int) -> Response:
     # Return an empty 200 — HTMX hx-swap="outerHTML" with empty content
     # removes the row from the DOM.
     return Response(status_code=200)
+
+
+@router.post("/settings/instances/{instance_id}/toggle-enabled", response_class=HTMLResponse)
+async def instance_toggle_enabled(request: Request, instance_id: int) -> HTMLResponse:
+    """Toggle enabled state for an instance and return refreshed row partial."""
+    instance = await get_instance(instance_id, master_key=_master_key(request))
+    if instance is None:
+        return HTMLResponse(content="Not found", status_code=404)
+
+    updated = await update_instance(
+        instance_id,
+        master_key=_master_key(request),
+        name=instance.name,
+        type=instance.type,
+        url=instance.url,
+        api_key=instance.api_key,
+        enabled=not instance.enabled,
+        batch_size=instance.batch_size,
+        sleep_interval_mins=instance.sleep_interval_mins,
+        hourly_cap=instance.hourly_cap,
+        cooldown_days=instance.cooldown_days,
+        unreleased_delay_hrs=instance.unreleased_delay_hrs,
+        cutoff_enabled=instance.cutoff_enabled,
+        cutoff_batch_size=instance.cutoff_batch_size,
+    )
+    if updated is None:
+        return HTMLResponse(content="Not found", status_code=404)
+
+    return _render(request, "partials/instance_row.html", instance=updated)

--- a/src/houndarr/templates/dashboard.html
+++ b/src/houndarr/templates/dashboard.html
@@ -2,6 +2,47 @@
 
 {% block title %}Dashboard — Houndarr{% endblock %}
 
+{% block head %}
+<style>
+  [data-run-now-btn="true"] {
+    transition: background-color 180ms ease, color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+  }
+
+  [data-run-now-btn="true"].is-running {
+    background-color: rgb(14 116 144);
+    color: rgb(224 242 254);
+    box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.38) inset;
+  }
+
+  [data-run-now-btn="true"].is-success {
+    background-color: rgb(22 101 52);
+    color: rgb(220 252 231);
+    box-shadow: 0 0 0 1px rgba(74, 222, 128, 0.4) inset;
+  }
+
+  [data-run-now-btn="true"].is-error {
+    background-color: rgb(153 27 27);
+    color: rgb(254 226 226);
+    box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.45) inset;
+    animation: run-now-shake 320ms ease;
+  }
+
+  @keyframes run-now-shake {
+    0%, 100% { transform: translateX(0); }
+    20% { transform: translateX(-3px); }
+    40% { transform: translateX(3px); }
+    60% { transform: translateX(-2px); }
+    80% { transform: translateX(2px); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-run-now-btn="true"].is-error {
+      animation: none;
+    }
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="flex items-center justify-between mb-6">
   <h1 class="text-2xl font-bold text-white">Dashboard</h1>
@@ -31,6 +72,79 @@
 
 {% block scripts %}
 <script>
+  const RUN_NOW_MIN_RUNNING_MS = 700;
+  const RUN_NOW_SUCCESS_HOLD_MS = 900;
+  const RUN_NOW_ERROR_HOLD_MS = 1100;
+
+  function setRunNowButtonState(button, state) {
+    const label = button.querySelector('[data-run-now-label]');
+    const icon = button.querySelector('[data-run-now-icon]');
+
+    button.classList.remove('is-running', 'is-success', 'is-error');
+    if (icon) {
+      icon.classList.remove('animate-spin');
+    }
+
+    if (state === 'running') {
+      button.classList.add('is-running');
+      button.disabled = true;
+      button.setAttribute('aria-busy', 'true');
+      if (label) {
+        label.textContent = 'Running...';
+      }
+      if (icon) {
+        icon.classList.add('animate-spin');
+      }
+      return;
+    }
+
+    button.disabled = false;
+    button.setAttribute('aria-busy', 'false');
+
+    if (state === 'success') {
+      button.classList.add('is-success');
+      if (label) {
+        label.textContent = 'Queued';
+      }
+      return;
+    }
+
+    if (state === 'error') {
+      button.classList.add('is-error');
+      if (label) {
+        label.textContent = 'Failed';
+      }
+      return;
+    }
+
+    if (label) {
+      label.textContent = 'Run now';
+    }
+  }
+
+  function completeRunNowRequest(button, statusCode) {
+    const startedAt = Number(button.dataset.runNowStartedAt || 0);
+    const elapsed = Math.max(0, Date.now() - startedAt);
+    const waitForMin = Math.max(0, RUN_NOW_MIN_RUNNING_MS - elapsed);
+    const outcome = statusCode >= 200 && statusCode < 300 ? 'success' : 'error';
+    const holdMs = outcome === 'success' ? RUN_NOW_SUCCESS_HOLD_MS : RUN_NOW_ERROR_HOLD_MS;
+
+    window.setTimeout(function() {
+      if (!document.body.contains(button)) {
+        return;
+      }
+
+      setRunNowButtonState(button, outcome);
+
+      window.setTimeout(function() {
+        if (!document.body.contains(button)) {
+          return;
+        }
+        setRunNowButtonState(button, 'idle');
+      }, holdMs);
+    }, waitForMin);
+  }
+
   // HTMX renders JSON from /api/status into the grid — we use a response
   // handler to convert the JSON array into cards.
   document.body.addEventListener("htmx:beforeSwap", function (evt) {
@@ -72,7 +186,7 @@
 
       const typeBadge = inst.type === "sonarr"
         ? `<span class="text-xs font-mono bg-sky-900/50 text-sky-300 px-2 py-0.5 rounded">Sonarr</span>`
-        : `<span class="text-xs font-mono bg-violet-900/50 text-violet-300 px-2 py-0.5 rounded">Radarr</span>`;
+        : `<span class="text-xs font-mono bg-red-900/50 text-red-300 px-2 py-0.5 rounded">Radarr</span>`;
 
       const lastSearch = inst.last_search_at
         ? new Date(inst.last_search_at).toLocaleString()
@@ -92,16 +206,18 @@
             <button
               hx-post="/api/instances/${inst.id}/run-now"
               hx-swap="none"
+              data-run-now-btn="true"
+              data-instance-id="${inst.id}"
               title="Run search now"
               class="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium
                      bg-brand-600 hover:bg-brand-500 text-white transition-colors disabled:opacity-50">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg data-run-now-icon class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/>
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
               </svg>
-              Run now
+              <span data-run-now-label>Run now</span>
             </button>
           </div>
 
@@ -138,5 +254,25 @@
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;");
   }
+
+  document.body.addEventListener('htmx:beforeRequest', function(evt) {
+    const triggerEl = evt.detail.elt;
+    if (!triggerEl || !triggerEl.matches('[data-run-now-btn="true"]')) {
+      return;
+    }
+
+    triggerEl.dataset.runNowStartedAt = String(Date.now());
+    setRunNowButtonState(triggerEl, 'running');
+  });
+
+  document.body.addEventListener('htmx:afterRequest', function(evt) {
+    const triggerEl = evt.detail.elt;
+    if (!triggerEl || !triggerEl.matches('[data-run-now-btn="true"]')) {
+      return;
+    }
+
+    const statusCode = evt.detail.xhr ? evt.detail.xhr.status : 0;
+    completeRunNowRequest(triggerEl, statusCode);
+  });
 </script>
 {% endblock %}

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -9,36 +9,45 @@
 {% set post_url = "/settings/instances/" ~ instance.id if is_edit else "/settings/instances" %}
 {% set target  = "#instance-row-" ~ instance.id if is_edit else "#instance-tbody" %}
 {% set swap    = "outerHTML" if is_edit else "innerHTML" %}
+{% set form_grid = "grid grid-cols-1 sm:grid-cols-2 gap-4" %}
 
-<tr id="{{ 'instance-row-' ~ instance.id if is_edit else 'add-instance-row' }}"
-    class="border-b border-slate-700 bg-slate-800/60">
-  <td colspan="6" class="px-4 py-4">
-    {% if error is defined and error %}
-    <div class="mb-3 text-sm text-red-400 bg-red-900/30 border border-red-700 rounded px-3 py-2">
-      {{ error }}
-    </div>
-    {% endif %}
+<div id="{{ 'edit-instance-form-shell-' ~ instance.id if is_edit else 'add-instance-form-shell' }}">
+  {% if error is defined and error %}
+  <div class="mb-3 text-sm text-red-400 bg-red-900/30 border border-red-700 rounded px-3 py-2">
+    {{ error }}
+  </div>
+  {% endif %}
 
-    <form id="{{ form_id }}"
-          hx-post="{{ post_url }}"
-          hx-target="{{ target }}"
-          hx-swap="{{ swap }}"
-          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+  <form id="{{ form_id }}"
+        data-form-mode="{{ 'edit' if is_edit else 'add' }}"
+        data-instance-name="{{ instance.name if is_edit else '' }}"
+        hx-post="{{ post_url }}"
+        hx-target="{{ target }}"
+        hx-swap="{{ swap }}"
+        class="{{ form_grid }}">
+      <input type="hidden"
+             id="instance-connection-verified"
+             name="connection_verified"
+             value="false" />
 
       {# Name #}
       <div>
         <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-name">Name</label>
         <input id="{{ form_id }}-name" name="name" type="text" required
+               data-instance-field="name"
+               data-sonarr-placeholder="My Sonarr"
+               data-radarr-placeholder="My Radarr"
                value="{{ instance.name if is_edit else '' }}"
                placeholder="My Sonarr"
                class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
-                      focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
+                       focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500" />
       </div>
 
       {# Type #}
       <div>
         <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-type">Type</label>
         <select id="{{ form_id }}-type" name="type" required
+                data-instance-field="type"
                 class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
                        focus:outline-none focus:border-brand-500 focus:ring-1 focus:ring-brand-500">
           <option value="sonarr" {% if is_edit and instance.type.value == 'sonarr' %}selected{% endif %}>Sonarr</option>
@@ -50,6 +59,9 @@
       <div>
         <label class="block text-xs text-slate-400 mb-1" for="{{ form_id }}-url">URL</label>
         <input id="{{ form_id }}-url" name="url" type="url" required
+               data-instance-field="url"
+               data-sonarr-placeholder="http://sonarr:8989"
+               data-radarr-placeholder="http://radarr:7878"
                value="{{ instance.url if is_edit else '' }}"
                placeholder="http://sonarr:8989"
                class="w-full bg-slate-900 border border-slate-700 rounded px-3 py-1.5 text-sm text-white
@@ -112,7 +124,7 @@
       </div>
 
       {# Cutoff enabled + batch size — span full width on small screens #}
-      <div class="flex items-center gap-6 sm:col-span-2 lg:col-span-1">
+      <div class="flex items-center gap-6 sm:col-span-2">
         <label class="flex items-center gap-2 cursor-pointer select-none">
           <input type="checkbox" name="cutoff_enabled" value="on"
                  {% if is_edit and instance.cutoff_enabled %}checked{% endif %}
@@ -141,30 +153,37 @@
       </div>
 
       {# Buttons — span full width #}
-      <div class="sm:col-span-2 lg:col-span-3 flex items-center gap-3 pt-1">
-        <button type="submit"
-                class="px-4 py-1.5 rounded bg-brand-600 hover:bg-brand-500 text-white text-sm font-medium transition-colors">
+      <div class="sm:col-span-2 flex items-center gap-3 pt-2">
+        <button type="button"
+                id="instance-test-connection-btn"
+                data-test-connection-btn="true"
+                hx-post="/settings/instances/test-connection"
+                hx-include="#{{ form_id }} [name='type'],#{{ form_id }} [name='url'],#{{ form_id }} [name='api_key']"
+                hx-target="#instance-connection-status"
+                hx-swap="innerHTML"
+                class="px-4 py-2 rounded bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm font-medium transition-colors">
+          Test Connection
+        </button>
+        <button id="instance-submit-btn"
+                type="submit"
+                disabled
+                class="px-4 py-2 rounded bg-brand-600 text-white text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 hover:enabled:bg-brand-500">
           {{ 'Save Changes' if is_edit else 'Add Instance' }}
         </button>
-        {% if is_edit %}
-        {# Cancel edit — swap the form back to the read-only row #}
         <button type="button"
-                hx-get="/settings"
-                hx-target="#instance-row-{{ instance.id }}"
-                hx-swap="outerHTML"
-                hx-select="#instance-row-{{ instance.id }}"
-                class="px-4 py-1.5 rounded bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm transition-colors">
+                onclick="window.houndarrCloseAddInstanceModal()"
+                class="px-4 py-2 rounded bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm transition-colors">
           Cancel
         </button>
-        {% else %}
-        <button type="button"
-                onclick="this.closest('tr').remove()"
-                class="px-4 py-1.5 rounded bg-slate-700 hover:bg-slate-600 text-slate-200 text-sm transition-colors">
-          Cancel
-        </button>
-        {% endif %}
       </div>
 
-    </form>
-  </td>
-</tr>
+      <div class="sm:col-span-2">
+        <div id="instance-connection-status"
+             class="text-xs text-slate-400"
+             aria-live="polite">
+          {{ 'Test connection before saving changes.' if is_edit else 'Test connection before adding this instance.' }}
+        </div>
+      </div>
+
+  </form>
+</div>

--- a/src/houndarr/templates/partials/instance_row.html
+++ b/src/houndarr/templates/partials/instance_row.html
@@ -8,7 +8,7 @@
         Sonarr
       </span>
     {% else %}
-      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-900/60 text-amber-300 border border-amber-700">
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-900/60 text-red-300 border border-red-700">
         Radarr
       </span>
     {% endif %}
@@ -16,9 +16,9 @@
   <td class="px-4 py-3 text-slate-400 text-sm truncate max-w-xs">{{ instance.url }}</td>
   <td class="px-4 py-3 text-center">
     {% if instance.enabled %}
-      <span class="inline-block w-2 h-2 rounded-full bg-green-500" title="Enabled"></span>
+      <span class="inline-block w-2 h-2 rounded-full bg-green-500" title="Search enabled" aria-label="Search enabled"></span>
     {% else %}
-      <span class="inline-block w-2 h-2 rounded-full bg-slate-600" title="Disabled"></span>
+      <span class="inline-block w-2 h-2 rounded-full bg-slate-600" title="Search disabled" aria-label="Search disabled"></span>
     {% endif %}
   </td>
   <td class="px-4 py-3 text-sm text-slate-400">
@@ -26,11 +26,20 @@
   </td>
   <td class="px-4 py-3 text-right">
     <div class="flex items-center justify-end gap-2">
-      {# Edit — swaps this row with the edit form partial #}
       <button
-        hx-get="/settings/instances/{{ instance.id }}/edit"
+        hx-post="/settings/instances/{{ instance.id }}/toggle-enabled"
         hx-target="#instance-row-{{ instance.id }}"
         hx-swap="outerHTML"
+        class="px-3 py-1 text-xs rounded transition-colors {% if instance.enabled %}bg-amber-900/60 hover:bg-amber-800 text-amber-300{% else %}bg-emerald-900/60 hover:bg-emerald-800 text-emerald-300{% endif %}">
+        {{ 'Disable' if instance.enabled else 'Enable' }}
+      </button>
+      {# Edit — swaps this row with the edit form partial #}
+      <button
+        type="button"
+        onclick="window.houndarrOpenAddInstanceModal()"
+        hx-get="/settings/instances/{{ instance.id }}/edit"
+        hx-target="#add-instance-modal-content"
+        hx-swap="innerHTML"
         class="px-3 py-1 text-xs rounded bg-slate-700 hover:bg-slate-600 text-slate-200 transition-colors">
         Edit
       </button>

--- a/src/houndarr/templates/settings.html
+++ b/src/houndarr/templates/settings.html
@@ -2,6 +2,125 @@
 
 {% block title %}Settings — Houndarr{% endblock %}
 
+{% block head %}
+<style>
+  #add-instance-modal {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+
+  #add-instance-modal[open] {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    animation: add-instance-modal-in 180ms ease-out;
+  }
+
+  #add-instance-modal[open].is-closing {
+    animation: add-instance-modal-out 160ms ease-in forwards;
+  }
+
+  #add-instance-modal::backdrop {
+    background: rgba(2, 6, 23, 0);
+  }
+
+  #add-instance-modal[open]::backdrop {
+    animation: add-instance-backdrop-in 180ms ease-out forwards;
+    backdrop-filter: blur(2px);
+  }
+
+  #add-instance-modal[open].is-closing::backdrop {
+    animation: add-instance-backdrop-out 160ms ease-in forwards;
+  }
+
+  @keyframes add-instance-modal-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes add-instance-backdrop-in {
+    from {
+      background: rgba(2, 6, 23, 0);
+    }
+    to {
+      background: rgba(2, 6, 23, 0.8);
+    }
+  }
+
+  @keyframes add-instance-modal-out {
+    from {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(8px) scale(0.985);
+    }
+  }
+
+  @keyframes add-instance-backdrop-out {
+    from {
+      background: rgba(2, 6, 23, 0.8);
+    }
+    to {
+      background: rgba(2, 6, 23, 0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #add-instance-modal,
+    #add-instance-modal[open],
+    #add-instance-modal::backdrop,
+    #add-instance-modal[open]::backdrop {
+      animation: none;
+      transition: none;
+      transform: none;
+      opacity: 1;
+    }
+  }
+
+  #instance-test-connection-btn {
+    transition: background-color 180ms ease, color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+  }
+
+  #instance-test-connection-btn.is-testing {
+    box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.55) inset;
+  }
+
+  #instance-test-connection-btn.is-success {
+    background-color: rgb(22 101 52);
+    color: rgb(220 252 231);
+    box-shadow: 0 0 0 1px rgba(74, 222, 128, 0.4) inset;
+  }
+
+  #instance-test-connection-btn.is-error {
+    background-color: rgb(153 27 27);
+    color: rgb(254 226 226);
+    box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.45) inset;
+    animation: test-connection-shake 320ms ease;
+  }
+
+  @keyframes test-connection-shake {
+    0%, 100% { transform: translateX(0); }
+    20% { transform: translateX(-3px); }
+    40% { transform: translateX(3px); }
+    60% { transform: translateX(-2px); }
+    80% { transform: translateX(2px); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #instance-test-connection-btn.is-error {
+      animation: none;
+    }
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="flex items-center justify-between mb-6">
   <h1 class="text-2xl font-bold text-white">Settings</h1>
@@ -18,8 +137,10 @@
   <div class="flex items-center justify-between mb-3">
     <h2 class="text-lg font-semibold text-slate-200">Instances</h2>
     <button
+      type="button"
+      onclick="window.houndarrOpenAddInstanceModal()"
       hx-get="/settings/instances/add-form"
-      hx-target="#add-instance-slot"
+      hx-target="#add-instance-modal-content"
       hx-swap="innerHTML"
       id="add-instance-btn"
       class="px-3 py-1.5 rounded bg-brand-600 hover:bg-brand-500 text-white text-sm font-medium transition-colors">
@@ -53,17 +174,291 @@
     </table>
   </div>
 
-  {# Slot where the add-form row is injected by HTMX #}
-  <div id="add-instance-slot"></div>
+  <dialog id="add-instance-modal"
+          class="m-auto p-0 w-[min(92vw,48rem)] rounded-2xl border border-slate-700 bg-slate-900 text-slate-100 shadow-2xl">
+    <div class="flex items-center justify-between border-b border-slate-800 px-5 py-4">
+      <div>
+        <h3 id="add-instance-modal-title" class="text-lg font-semibold text-white">Add Instance</h3>
+        <p id="add-instance-modal-subtitle" class="text-sm text-slate-400">Configure a Sonarr or Radarr instance.</p>
+      </div>
+      <button type="button"
+              aria-label="Close add instance dialog"
+              onclick="window.houndarrCloseAddInstanceModal()"
+              class="rounded-md p-1.5 text-slate-400 hover:bg-slate-800 hover:text-slate-200 transition-colors">
+        <span aria-hidden="true" class="text-xl leading-none">&times;</span>
+      </button>
+    </div>
+
+    <div id="add-instance-modal-content"
+         role="dialog"
+         aria-modal="true"
+         aria-labelledby="add-instance-modal-title"
+         class="max-h-[min(80vh,44rem)] overflow-y-auto px-5 py-5">
+    </div>
+  </dialog>
 </section>
 {% endblock %}
 
 {% block scripts %}
 <script>
-  // After a successful create, clear the add-form slot
+  const addInstanceBtn = document.getElementById('add-instance-btn');
+  const addInstanceModal = document.getElementById('add-instance-modal');
+  const addInstanceModalContent = document.getElementById('add-instance-modal-content');
+  const addInstanceModalTitle = document.getElementById('add-instance-modal-title');
+  const addInstanceModalSubtitle = document.getElementById('add-instance-modal-subtitle');
+  const closeAnimationMs = 160;
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let isClosingAddInstanceModal = false;
+
+  function setAddInstanceModalChrome(mode, instanceName) {
+    if (mode === 'edit') {
+      addInstanceModalTitle.textContent = 'Edit Instance';
+      addInstanceModalSubtitle.textContent = instanceName
+        ? `Update settings for ${instanceName}.`
+        : 'Update instance settings.';
+      return;
+    }
+
+    addInstanceModalTitle.textContent = 'Add Instance';
+    addInstanceModalSubtitle.textContent = 'Configure a Sonarr or Radarr instance.';
+  }
+
+  function getModalForm() {
+    return addInstanceModalContent.querySelector('form[data-form-mode]');
+  }
+
+  function getModalFormMode() {
+    const modalForm = getModalForm();
+    return modalForm ? modalForm.dataset.formMode : null;
+  }
+
+  function getConnectionTestButton() {
+    return addInstanceModalContent.querySelector('#instance-test-connection-btn');
+  }
+
+  function isConnectionGuardedFormLoaded() {
+    return Boolean(addInstanceModalContent.querySelector('#instance-connection-verified'));
+  }
+
+  function syncAddInstancePlaceholders() {
+    const typeSelect = addInstanceModalContent.querySelector('[data-instance-field="type"]');
+    const nameInput = addInstanceModalContent.querySelector('[data-instance-field="name"]');
+    const urlInput = addInstanceModalContent.querySelector('[data-instance-field="url"]');
+
+    if (!typeSelect || !nameInput || !urlInput) {
+      return;
+    }
+
+    const isRadarr = typeSelect.value === 'radarr';
+    nameInput.placeholder = isRadarr ? nameInput.dataset.radarrPlaceholder : nameInput.dataset.sonarrPlaceholder;
+    urlInput.placeholder = isRadarr ? urlInput.dataset.radarrPlaceholder : urlInput.dataset.sonarrPlaceholder;
+  }
+
+  function addConnectionStatusClass(statusTone) {
+    if (statusTone === 'success') {
+      return 'text-xs text-green-400';
+    }
+    if (statusTone === 'error') {
+      return 'text-xs text-red-400';
+    }
+    return 'text-xs text-slate-400';
+  }
+
+  function isConnectionVerified() {
+    const verifiedInput = addInstanceModalContent.querySelector('#instance-connection-verified');
+    return verifiedInput && verifiedInput.value === 'true';
+  }
+
+  function setConnectionState(isVerified, statusText, statusTone) {
+    const verifiedInput = addInstanceModalContent.querySelector('#instance-connection-verified');
+    const submitBtn = addInstanceModalContent.querySelector('#instance-submit-btn');
+    const statusEl = addInstanceModalContent.querySelector('#instance-connection-status');
+
+    if (verifiedInput) {
+      verifiedInput.value = isVerified ? 'true' : 'false';
+    }
+    if (submitBtn) {
+      submitBtn.disabled = !isVerified;
+    }
+    if (statusEl && statusText) {
+      statusEl.textContent = statusText;
+      statusEl.className = addConnectionStatusClass(statusTone);
+    }
+  }
+
+  function setConnectionTestButtonState(state) {
+    const testBtn = getConnectionTestButton();
+    if (!testBtn) {
+      return;
+    }
+
+    testBtn.classList.remove('is-testing', 'is-success', 'is-error');
+
+    if (state === 'testing') {
+      testBtn.classList.add('is-testing');
+    }
+    if (state === 'success') {
+      testBtn.classList.add('is-success');
+    }
+    if (state === 'error') {
+      // Force restart of shake animation on repeated failures.
+      void testBtn.offsetWidth;
+      testBtn.classList.add('is-error');
+    }
+  }
+
+  function neutralConnectionPromptForMode(mode) {
+    if (mode === 'edit') {
+      return 'Test connection before saving changes.';
+    }
+    return 'Test connection before adding this instance.';
+  }
+
+  function resetConnectionStateOnFieldChange(target) {
+    const mode = getModalFormMode();
+    if (!isConnectionGuardedFormLoaded() || mode === null) {
+      return;
+    }
+
+    if (!target.matches('[data-instance-field="type"], [data-instance-field="url"], form[data-form-mode] [name="api_key"]')) {
+      return;
+    }
+
+    const actionLabel = mode === 'edit' ? 'Save Changes' : 'Add Instance';
+    if (isConnectionVerified()) {
+      setConnectionState(false, `Connection details changed. Test again to enable ${actionLabel}.`, 'error');
+      setConnectionTestButtonState('neutral');
+      return;
+    }
+
+    setConnectionState(false, neutralConnectionPromptForMode(mode), 'neutral');
+    setConnectionTestButtonState('neutral');
+  }
+
+  window.houndarrOpenAddInstanceModal = function() {
+    addInstanceModal.classList.remove('is-closing');
+    isClosingAddInstanceModal = false;
+    setAddInstanceModalChrome('add');
+    if (!addInstanceModal.open) {
+      addInstanceModal.showModal();
+    }
+  };
+
+  window.houndarrCloseAddInstanceModal = function() {
+    if (!addInstanceModal.open || isClosingAddInstanceModal) {
+      return;
+    }
+
+    const finalizeClose = function() {
+      addInstanceModal.classList.remove('is-closing');
+      if (addInstanceModal.open) {
+        addInstanceModal.close();
+      }
+      addInstanceModalContent.innerHTML = '';
+      isClosingAddInstanceModal = false;
+      setAddInstanceModalChrome('add');
+      addInstanceBtn.focus();
+    };
+
+    if (prefersReducedMotion) {
+      finalizeClose();
+      return;
+    }
+
+    isClosingAddInstanceModal = true;
+    addInstanceModal.classList.add('is-closing');
+    window.setTimeout(finalizeClose, closeAnimationMs);
+  };
+
+  addInstanceModal.addEventListener('cancel', function(event) {
+    event.preventDefault();
+    window.houndarrCloseAddInstanceModal();
+  });
+
+  addInstanceModal.addEventListener('click', function(event) {
+    if (event.target === addInstanceModal) {
+      window.houndarrCloseAddInstanceModal();
+    }
+  });
+
+  addInstanceModalContent.addEventListener('change', function(event) {
+    if (event.target.matches('[data-instance-field="type"]')) {
+      syncAddInstancePlaceholders();
+    }
+    resetConnectionStateOnFieldChange(event.target);
+  });
+
+  addInstanceModalContent.addEventListener('input', function(event) {
+    resetConnectionStateOnFieldChange(event.target);
+  });
+
+  document.body.addEventListener('htmx:beforeRequest', function(evt) {
+    const triggerEl = evt.detail.elt;
+    if (!triggerEl || !triggerEl.matches('[data-test-connection-btn="true"]')) {
+      return;
+    }
+    setConnectionTestButtonState('testing');
+  });
+
+  document.body.addEventListener('houndarr-connection-test-success', function() {
+    const mode = getModalFormMode();
+    if (!isConnectionGuardedFormLoaded() || mode === null) {
+      return;
+    }
+
+    const actionLabel = mode === 'edit' ? 'save changes' : 'add this instance';
+    setConnectionState(true, `Connection successful. You can now ${actionLabel}.`, 'success');
+    setConnectionTestButtonState('success');
+  });
+
+  document.body.addEventListener('houndarr-connection-test-failure', function() {
+    if (!isConnectionGuardedFormLoaded()) {
+      return;
+    }
+    setConnectionState(false, 'Connection failed. Fix details and test again.', 'error');
+    setConnectionTestButtonState('error');
+  });
+
+  document.body.addEventListener('htmx:afterRequest', function(evt) {
+    const triggerEl = evt.detail.elt;
+    if (!triggerEl || !triggerEl.matches('[data-test-connection-btn="true"]')) {
+      return;
+    }
+
+    // Keep success/error styling if one was applied via HX-Trigger.
+    const testBtn = getConnectionTestButton();
+    if (!testBtn) {
+      return;
+    }
+    testBtn.classList.remove('is-testing');
+  });
+
+  // Close modal after successful create and focus first field when form loads.
   document.body.addEventListener('htmx:afterSwap', function(evt) {
     if (evt.detail.target.id === 'instance-tbody') {
-      document.getElementById('add-instance-slot').innerHTML = '';
+      window.houndarrCloseAddInstanceModal();
+    }
+
+    if (evt.detail.target.id.startsWith('instance-row-')) {
+      window.houndarrCloseAddInstanceModal();
+    }
+
+    if (evt.detail.target.id === 'add-instance-modal-content') {
+      const modalForm = addInstanceModalContent.querySelector('form[data-form-mode]');
+      if (modalForm) {
+        setAddInstanceModalChrome(modalForm.dataset.formMode, modalForm.dataset.instanceName);
+      }
+
+      const firstInput = addInstanceModalContent.querySelector('input, select, textarea, button');
+      if (firstInput) {
+        firstInput.focus();
+      }
+      syncAddInstancePlaceholders();
+
+      if (isConnectionGuardedFormLoaded()) {
+        setConnectionState(false, neutralConnectionPromptForMode(getModalFormMode()), 'neutral');
+        setConnectionTestButtonState('neutral');
+      }
     }
   });
 </script>

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
+
+from houndarr.clients.base import ArrClient
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -13,7 +16,16 @@ _VALID_FORM = {
     "type": "sonarr",
     "url": "http://sonarr:8989",
     "api_key": "test-api-key-abc123",
+    "connection_verified": "true",
 }
+
+
+@pytest.fixture(autouse=True)
+def _mock_connection_ping(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _always_true(self: ArrClient) -> bool:
+        return True
+
+    monkeypatch.setattr(ArrClient, "ping", _always_true)
 
 
 def _login(client: TestClient) -> None:
@@ -63,6 +75,12 @@ def test_settings_delete_redirects_unauthenticated(app: TestClient) -> None:
     assert resp.headers["location"] in _AUTH_LOCATIONS
 
 
+def test_settings_toggle_redirects_unauthenticated(app: TestClient) -> None:
+    resp = app.post("/settings/instances/1/toggle-enabled", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
 # ---------------------------------------------------------------------------
 # GET /settings
 # ---------------------------------------------------------------------------
@@ -81,6 +99,14 @@ def test_settings_page_shows_no_instances_message(app: TestClient) -> None:
     resp = app.get("/settings")
     assert resp.status_code == 200
     assert b"No instances configured" in resp.content
+
+
+def test_settings_page_includes_add_instance_modal(app: TestClient) -> None:
+    _login(app)
+    resp = app.get("/settings")
+    assert resp.status_code == 200
+    assert b"add-instance-modal" in resp.content
+    assert b"add-instance-modal-content" in resp.content
 
 
 # ---------------------------------------------------------------------------
@@ -117,6 +143,14 @@ def test_create_instance_invalid_type_returns_422(app: TestClient) -> None:
     assert resp.status_code == 422
 
 
+def test_create_instance_requires_successful_test(app: TestClient) -> None:
+    _login(app)
+    form = {k: v for k, v in _VALID_FORM.items() if k != "connection_verified"}
+    resp = app.post("/settings/instances", data=form)
+    assert resp.status_code == 422
+    assert b"Test connection successfully before adding" in resp.content
+
+
 def test_create_instance_missing_name_returns_422(app: TestClient) -> None:
     _login(app)
     form = {k: v for k, v in _VALID_FORM.items() if k != "name"}
@@ -143,6 +177,8 @@ def test_edit_form_returns_partial(app: TestClient) -> None:
     assert resp.status_code == 200
     assert b"My Sonarr" in resp.content
     assert b"Save Changes" in resp.content
+    assert b"<tr" not in resp.content
+    assert b'data-form-mode="edit"' in resp.content
 
 
 def test_edit_form_not_found(app: TestClient) -> None:
@@ -165,9 +201,39 @@ def test_update_instance(app: TestClient) -> None:
     assert b"Renamed Sonarr" in resp.content
 
 
+def test_update_instance_requires_successful_test(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM)
+    updated_form = {k: v for k, v in _VALID_FORM.items() if k != "connection_verified"}
+    resp = app.post("/settings/instances/1", data=updated_form)
+    assert resp.status_code == 422
+    assert b"Test connection successfully before saving changes" in resp.content
+
+
 def test_update_instance_not_found(app: TestClient) -> None:
     _login(app)
     resp = app.post("/settings/instances/9999", data=_VALID_FORM)
+    assert resp.status_code == 404
+
+
+def test_toggle_instance_enabled(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM)
+
+    first = app.post("/settings/instances/1/toggle-enabled")
+    assert first.status_code == 200
+    assert b"Enable" in first.content
+    assert b"Search disabled" in first.content
+
+    second = app.post("/settings/instances/1/toggle-enabled")
+    assert second.status_code == 200
+    assert b"Disable" in second.content
+    assert b"Search enabled" in second.content
+
+
+def test_toggle_instance_not_found(app: TestClient) -> None:
+    _login(app)
+    resp = app.post("/settings/instances/9999/toggle-enabled")
     assert resp.status_code == 404
 
 
@@ -209,3 +275,23 @@ def test_add_form_partial_renders(app: TestClient) -> None:
     resp = app.get("/settings/instances/add-form")
     assert resp.status_code == 200
     assert b"Add Instance" in resp.content
+
+
+def test_connection_check_endpoint_success(app: TestClient) -> None:
+    _login(app)
+    resp = app.post(
+        "/settings/instances/test-connection",
+        data={"type": "sonarr", "url": "http://sonarr:8989", "api_key": "abc"},
+    )
+    assert resp.status_code == 200
+    assert b"Connection successful" in resp.content
+
+
+def test_connection_check_endpoint_invalid_type(app: TestClient) -> None:
+    _login(app)
+    resp = app.post(
+        "/settings/instances/test-connection",
+        data={"type": "plex", "url": "http://sonarr:8989", "api_key": "abc"},
+    )
+    assert resp.status_code == 422
+    assert b"Invalid type" in resp.content

--- a/tests/test_routes/test_status.py
+++ b/tests/test_routes/test_status.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 import respx
 from fastapi.testclient import TestClient
+
+from houndarr.clients.base import ArrClient
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -17,7 +20,16 @@ _VALID_FORM = {
     "type": "sonarr",
     "url": "http://sonarr:8989",
     "api_key": "test-api-key",
+    "connection_verified": "true",
 }
+
+
+@pytest.fixture(autouse=True)
+def _mock_connection_ping(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _always_true(self: ArrClient) -> bool:
+        return True
+
+    monkeypatch.setattr(ArrClient, "ping", _always_true)
 
 
 def _login(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Move both Add and Edit instance flows into one polished modal interaction with correct modal titles, close behavior, and state handling.
- Require successful connection validation before both create and update, including server-side revalidation to prevent bypass via crafted requests.
- Improve interaction polish: animated/semantic feedback for Test Connection and Run now actions, plus instant enabled/disabled row toggle and consistent Sonarr/Radarr badge colors.

## Why
- Inline form expansion and mixed add/edit behavior made settings UX feel inconsistent and error-prone.
- Saving invalid connection details caused confusing outcomes during testing; mandatory test-before-save prevents invalid persisted endpoints.
- Fast local responses made stateful actions feel abrupt; minimum-visible visual feedback improves confidence and clarity.

## Changes
- `src/houndarr/templates/settings.html`
  - Unified modal state for add/edit, close animations, outside/Escape handling, and contextual modal chrome.
  - Added robust client-side connection-state invalidation and visual feedback orchestration.
- `src/houndarr/templates/partials/instance_form.html`
  - Shared modal form for add/edit.
  - Added mandatory test-connection workflow hooks for both modes.
- `src/houndarr/routes/settings.py`
  - Added and reused connection guard helpers.
  - Enforced connection verification and live ping for create/update.
  - Added `POST /settings/instances/{id}/toggle-enabled` for instant row toggle.
- `src/houndarr/templates/partials/instance_row.html`
  - Added instant Enable/Disable action.
  - Clarified status dot labels to "Search enabled/disabled".
  - Standardized Radarr badge to red.
- `src/houndarr/templates/dashboard.html`
  - Added run-now visual states (running/success/error) with minimum visible timing.
  - Standardized Radarr type badge to red.
- Tests
  - Extended settings route coverage (`tests/test_routes/test_settings.py`) for modal behavior, connection gating, and toggle actions.
  - Updated status tests (`tests/test_routes/test_status.py`) for required connection verification behavior.

## Testing
- `.venv/bin/python -m ruff check src/ tests/`
- `.venv/bin/python -m ruff format --check src/ tests/`
- `.venv/bin/python -m mypy src/`
- `.venv/bin/python -m bandit -r src/ -c pyproject.toml`
- `.venv/bin/python -m pytest`

Closes #35