### PR TITLE
feat: log viewer with filters

### DIFF
--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -75,6 +75,7 @@ def create_app() -> FastAPI:
     # -----------------------------------------------------------------------
     # Routes
     # -----------------------------------------------------------------------
+    from houndarr.routes.api.logs import router as logs_router
     from houndarr.routes.api.status import router as status_router
     from houndarr.routes.health import router as health_router
     from houndarr.routes.pages import router as pages_router
@@ -82,6 +83,7 @@ def create_app() -> FastAPI:
 
     app.include_router(health_router)
     app.include_router(status_router)
+    app.include_router(logs_router)
     app.include_router(pages_router)
     app.include_router(settings_router)
 

--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -1,0 +1,170 @@
+"""Logs API — paginated search_log entries with optional filters.
+
+GET /api/logs         → JSON list of log rows (used by tests and external consumers)
+GET /api/logs/partial → server-rendered <tbody> HTMX partial (used by the /logs page)
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+
+from houndarr.database import get_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_LOG_LIMIT_DEFAULT = 50
+_LOG_LIMIT_MAX = 200
+
+# ---------------------------------------------------------------------------
+# Template loader (shared lazy singleton)
+# ---------------------------------------------------------------------------
+
+_templates: Jinja2Templates | None = None
+
+
+def _get_templates() -> Jinja2Templates:
+    global _templates  # noqa: PLW0603
+    if _templates is None:
+        _templates = Jinja2Templates(
+            directory=str(Path(__file__).parent.parent.parent / "templates")
+        )
+    return _templates
+
+
+# ---------------------------------------------------------------------------
+# DB query helper
+# ---------------------------------------------------------------------------
+
+
+async def _query_logs(
+    instance_id: int | None,
+    action: str | None,
+    before: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Fetch log rows from search_log with optional filters.
+
+    Args:
+        instance_id: Restrict to a specific instance (None = all).
+        action: One of ``searched``, ``skipped``, ``error``, ``info`` (None = all).
+        before: ISO-8601 timestamp cursor — return rows older than this value.
+        limit: Maximum number of rows to return.
+
+    Returns:
+        List of dicts with keys: id, instance_id, instance_name, item_id,
+        item_type, action, reason, message, timestamp.
+    """
+    limit = min(max(1, limit), _LOG_LIMIT_MAX)
+
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if instance_id is not None:
+        conditions.append("sl.instance_id = ?")
+        params.append(instance_id)
+
+    if action is not None:
+        conditions.append("sl.action = ?")
+        params.append(action)
+
+    if before is not None:
+        conditions.append("sl.timestamp < ?")
+        params.append(before)
+
+    where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    sql = f"""
+        SELECT
+            sl.id,
+            sl.instance_id,
+            COALESCE(i.name, 'Deleted') AS instance_name,
+            sl.item_id,
+            sl.item_type,
+            sl.action,
+            sl.reason,
+            sl.message,
+            sl.timestamp
+        FROM search_log sl
+        LEFT JOIN instances i ON i.id = sl.instance_id
+        {where_clause}
+        ORDER BY sl.timestamp DESC, sl.id DESC
+        LIMIT ?
+    """  # noqa: S608  # nosec B608
+    params.append(limit)
+
+    async with get_db() as db:
+        async with db.execute(sql, params) as cur:
+            rows = await cur.fetchall()
+
+    return [dict(row) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/logs")
+async def get_logs(
+    instance_id: int | None = Query(default=None),
+    action: str | None = Query(default=None),
+    before: str | None = Query(default=None),
+    limit: int = Query(default=_LOG_LIMIT_DEFAULT, ge=1, le=_LOG_LIMIT_MAX),
+) -> JSONResponse:
+    """Return paginated log rows as JSON.
+
+    Args:
+        instance_id: Filter to a specific instance ID.
+        action: Filter by action (``searched``, ``skipped``, ``error``, ``info``).
+        before: Timestamp cursor — only return rows older than this ISO-8601 value.
+        limit: Max rows (1–200, default 50).
+
+    Returns:
+        JSON array of log-row objects.
+    """
+    rows = await _query_logs(instance_id, action, before, limit)
+    return JSONResponse(rows)
+
+
+@router.get("/api/logs/partial", response_class=HTMLResponse)
+async def get_logs_partial(
+    request: Request,
+    instance_id: int | None = Query(default=None),
+    action: str | None = Query(default=None),
+    before: str | None = Query(default=None),
+    limit: int = Query(default=_LOG_LIMIT_DEFAULT, ge=1, le=_LOG_LIMIT_MAX),
+) -> HTMLResponse:
+    """Return a server-rendered <tbody> partial for HTMX swaps.
+
+    Args:
+        request: FastAPI request (required for template rendering).
+        instance_id: Filter to a specific instance ID.
+        action: Filter by action.
+        before: Timestamp cursor.
+        limit: Max rows.
+
+    Returns:
+        HTML fragment containing ``<tbody>`` rows.
+    """
+    rows = await _query_logs(instance_id, action, before, limit)
+
+    return _get_templates().TemplateResponse(
+        request=request,
+        name="partials/log_rows.html",
+        context={
+            "rows": rows,
+            # Pass back current filter values so the partial can render pagination
+            "instance_id": instance_id,
+            "action": action,
+            "before": before,
+            "limit": limit,
+        },
+    )

--- a/src/houndarr/routes/pages.py
+++ b/src/houndarr/routes/pages.py
@@ -20,6 +20,7 @@ from houndarr.auth import (
     set_username,
     validate_username,
 )
+from houndarr.services.instances import list_instances
 
 router = APIRouter()
 
@@ -174,3 +175,33 @@ async def logout(request: Request) -> RedirectResponse:
 async def dashboard(request: Request) -> HTMLResponse:
     """Main dashboard page."""
     return _render(request, "dashboard.html")
+
+
+# ---------------------------------------------------------------------------
+# Logs
+# ---------------------------------------------------------------------------
+
+
+@router.get("/logs", response_class=HTMLResponse)
+async def logs_page(request: Request) -> HTMLResponse:
+    """Search log viewer page — initial render with no filters applied."""
+    from houndarr.routes.api.logs import _query_logs
+
+    master_key: bytes = request.app.state.master_key
+    instances = await list_instances(master_key=master_key)
+    rows = await _query_logs(
+        instance_id=None,
+        action=None,
+        before=None,
+        limit=50,
+    )
+    return _render(
+        request,
+        "logs.html",
+        instances=instances,
+        rows=rows,
+        limit=50,
+        selected_instance_id=None,
+        selected_action=None,
+        before=None,
+    )

--- a/src/houndarr/templates/logs.html
+++ b/src/houndarr/templates/logs.html
@@ -1,0 +1,94 @@
+{% extends "base.html" %}
+
+{% block title %}Logs — Houndarr{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold text-white">Search Logs</h1>
+  <span class="text-xs text-slate-500">Most recent first · auto-filters apply instantly</span>
+</div>
+
+{# ------------------------------------------------------------------ #}
+{# Filter bar                                                          #}
+{# ------------------------------------------------------------------ #}
+<form id="log-filter-form"
+      hx-get="/api/logs/partial"
+      hx-target="#log-tbody"
+      hx-swap="innerHTML"
+      hx-trigger="change, submit"
+      hx-indicator="#log-spinner"
+      class="flex flex-wrap items-end gap-3 mb-5">
+
+  {# Instance dropdown #}
+  <div class="flex flex-col gap-1 min-w-[180px]">
+    <label for="filter-instance" class="text-xs text-slate-400 font-medium">Instance</label>
+    <select id="filter-instance" name="instance_id"
+            class="bg-slate-800 border border-slate-700 text-slate-200 text-sm rounded-lg px-3 py-2
+                   focus:outline-none focus:ring-1 focus:ring-brand-500 focus:border-brand-500">
+      <option value="">All instances</option>
+      {% for inst in instances %}
+      <option value="{{ inst.id }}" {% if selected_instance_id == inst.id %}selected{% endif %}>
+        {{ inst.name }}
+      </option>
+      {% endfor %}
+    </select>
+  </div>
+
+  {# Action filter #}
+  <div class="flex flex-col gap-1">
+    <label for="filter-action" class="text-xs text-slate-400 font-medium">Action</label>
+    <select id="filter-action" name="action"
+            class="bg-slate-800 border border-slate-700 text-slate-200 text-sm rounded-lg px-3 py-2
+                   focus:outline-none focus:ring-1 focus:ring-brand-500 focus:border-brand-500">
+      <option value="">All actions</option>
+      <option value="searched" {% if selected_action == "searched" %}selected{% endif %}>Searched</option>
+      <option value="skipped"  {% if selected_action == "skipped"  %}selected{% endif %}>Skipped</option>
+      <option value="error"    {% if selected_action == "error"    %}selected{% endif %}>Error</option>
+      <option value="info"     {% if selected_action == "info"     %}selected{% endif %}>Info</option>
+    </select>
+  </div>
+
+  {# Row limit #}
+  <div class="flex flex-col gap-1">
+    <label for="filter-limit" class="text-xs text-slate-400 font-medium">Rows</label>
+    <select id="filter-limit" name="limit"
+            class="bg-slate-800 border border-slate-700 text-slate-200 text-sm rounded-lg px-3 py-2
+                   focus:outline-none focus:ring-1 focus:ring-brand-500 focus:border-brand-500">
+      <option value="50"  selected>50</option>
+      <option value="100">100</option>
+      <option value="200">200</option>
+    </select>
+  </div>
+
+  {# Spinner indicator #}
+  <div id="log-spinner" class="htmx-indicator flex items-center gap-2 text-xs text-slate-400 pb-2">
+    <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
+    </svg>
+    Loading…
+  </div>
+</form>
+
+{# ------------------------------------------------------------------ #}
+{# Log table                                                           #}
+{# ------------------------------------------------------------------ #}
+<div class="overflow-x-auto rounded-xl border border-slate-800 bg-slate-900">
+  <table class="w-full text-left text-sm">
+    <thead class="border-b border-slate-800">
+      <tr class="text-[11px] uppercase tracking-wide text-slate-500">
+        <th class="px-3 py-2.5 font-medium">Timestamp (UTC)</th>
+        <th class="px-3 py-2.5 font-medium">Instance</th>
+        <th class="px-3 py-2.5 font-medium">Action</th>
+        <th class="px-3 py-2.5 font-medium">Type</th>
+        <th class="px-3 py-2.5 font-medium">ID</th>
+        <th class="px-3 py-2.5 font-medium">Reason / Message</th>
+      </tr>
+    </thead>
+    <tbody id="log-tbody">
+      {# Initial render — server-side rows injected directly #}
+      {% include "partials/log_rows.html" %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/src/houndarr/templates/partials/log_rows.html
+++ b/src/houndarr/templates/partials/log_rows.html
@@ -1,0 +1,67 @@
+{# Log table rows partial — rendered by GET /api/logs/partial and swapped into #log-tbody #}
+{% if rows %}
+  {% for row in rows %}
+  <tr class="border-b border-slate-800 hover:bg-slate-800/40 transition-colors">
+    {# Timestamp #}
+    <td class="px-3 py-2.5 text-xs text-slate-400 whitespace-nowrap font-mono">
+      {{ row.timestamp[:19].replace("T", " ") if row.timestamp else "—" }}
+    </td>
+
+    {# Instance #}
+    <td class="px-3 py-2.5 text-xs text-slate-300 max-w-[140px] truncate" title="{{ row.instance_name }}">
+      {{ row.instance_name }}
+    </td>
+
+    {# Action badge #}
+    <td class="px-3 py-2.5">
+      {% if row.action == "searched" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-green-900/60 text-green-300">searched</span>
+      {% elif row.action == "skipped" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-yellow-900/50 text-yellow-300">skipped</span>
+      {% elif row.action == "error" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-red-900/60 text-red-300">error</span>
+      {% else %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-slate-700 text-slate-400">info</span>
+      {% endif %}
+    </td>
+
+    {# Type #}
+    <td class="px-3 py-2.5 text-xs text-slate-400 capitalize">
+      {{ row.item_type or "—" }}
+    </td>
+
+    {# Item ID #}
+    <td class="px-3 py-2.5 text-xs text-slate-400 font-mono">
+      {{ row.item_id if row.item_id is not none else "—" }}
+    </td>
+
+    {# Reason / Message #}
+    <td class="px-3 py-2.5 text-xs text-slate-400 max-w-[260px] truncate"
+        title="{{ (row.reason or row.message or '') }}">
+      {{ row.reason or row.message or "—" }}
+    </td>
+  </tr>
+  {% endfor %}
+
+  {# Pagination: "Load older" link — only show if we got a full page #}
+  {% if rows | length >= limit %}
+  <tr id="pagination-row">
+    <td colspan="6" class="px-3 py-3 text-center">
+      <button
+        hx-get="/api/logs/partial?limit={{ limit }}{% if instance_id %}&instance_id={{ instance_id }}{% endif %}{% if action %}&action={{ action }}{% endif %}&before={{ rows[-1].timestamp }}"
+        hx-target="#log-tbody"
+        hx-swap="innerHTML"
+        class="text-xs text-brand-400 hover:text-brand-300 transition-colors underline-offset-2 hover:underline">
+        Load older entries &darr;
+      </button>
+    </td>
+  </tr>
+  {% endif %}
+
+{% else %}
+  <tr id="log-empty-row">
+    <td colspan="6" class="px-3 py-12 text-center text-slate-500 text-sm">
+      No log entries found.
+    </td>
+  </tr>
+{% endif %}

--- a/tests/test_routes/test_logs.py
+++ b/tests/test_routes/test_logs.py
@@ -1,0 +1,291 @@
+"""Tests for GET /api/logs, GET /api/logs/partial, and GET /logs."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+
+from houndarr.clients.base import ArrClient
+from houndarr.database import get_db
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_AUTH_LOCATIONS = {"/setup", "/login", "http://testserver/setup", "http://testserver/login"}
+
+_VALID_FORM = {
+    "name": "My Sonarr",
+    "type": "sonarr",
+    "url": "http://sonarr:8989",
+    "api_key": "test-api-key",
+    "connection_verified": "true",
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_connection_ping(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _always_true(self: ArrClient) -> bool:
+        return True
+
+    monkeypatch.setattr(ArrClient, "ping", _always_true)
+
+
+def _login(client: TestClient) -> None:
+    client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+
+@pytest_asyncio.fixture()
+async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[misc]
+    """Seed search_log with rows across two instances for filter/pagination tests."""
+    async with get_db() as conn:
+        # Seed two instances so FK constraint on search_log is satisfied
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url) VALUES (?, ?, ?, ?)",
+            [
+                (1, "Sonarr Test", "sonarr", "http://sonarr:8989"),
+                (2, "Radarr Test", "radarr", "http://radarr:7878"),
+            ],
+        )
+        # Seed a variety of log rows
+        await conn.executemany(
+            """
+            INSERT INTO search_log
+                (instance_id, item_id, item_type, action, reason, message, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, 101, "episode", "searched", None, None, "2024-01-01T12:00:00.000Z"),
+                (
+                    1,
+                    102,
+                    "episode",
+                    "skipped",
+                    "on cooldown (7d)",
+                    None,
+                    "2024-01-01T12:01:00.000Z",
+                ),
+                (2, 201, "movie", "searched", None, None, "2024-01-01T12:02:00.000Z"),
+                (2, 202, "movie", "error", None, "connection refused", "2024-01-01T12:03:00.000Z"),
+                (
+                    None,
+                    None,
+                    None,
+                    "info",
+                    None,
+                    "Supervisor started 2 task(s)",
+                    "2024-01-01T11:59:00.000Z",
+                ),
+            ],
+        )
+        await conn.commit()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Authentication guard
+# ---------------------------------------------------------------------------
+
+
+def test_logs_api_redirects_unauthenticated(app: TestClient) -> None:
+    """Unauthenticated request to /api/logs should redirect to login."""
+    resp = app.get("/api/logs", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
+def test_logs_page_redirects_unauthenticated(app: TestClient) -> None:
+    """Unauthenticated request to /logs should redirect to login."""
+    resp = app.get("/logs", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
+def test_logs_partial_redirects_unauthenticated(app: TestClient) -> None:
+    """Unauthenticated request to /api/logs/partial should redirect to login."""
+    resp = app.get("/api/logs/partial", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] in _AUTH_LOCATIONS
+
+
+# ---------------------------------------------------------------------------
+# GET /api/logs — empty state
+# ---------------------------------------------------------------------------
+
+
+def test_logs_empty_when_no_entries(app: TestClient) -> None:
+    """Returns an empty list when search_log has no rows."""
+    _login(app)
+    resp = app.get("/api/logs")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /api/logs — with seeded data (uses async DB fixture + sync app)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_logs_returns_all_rows(seeded_log: None, async_client: object) -> None:
+    """Returns all seeded rows with correct fields when no filter is applied."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    # Setup + login via the async client
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 5
+
+    # Newest first (by timestamp DESC)
+    actions = [r["action"] for r in data]
+    assert actions[0] == "error"  # 12:03
+    assert actions[-1] == "info"  # 11:59
+
+
+@pytest.mark.asyncio()
+async def test_logs_filter_by_instance_id(seeded_log: None, async_client: object) -> None:
+    """Filtering by instance_id returns only that instance's rows."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?instance_id=1&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    # instance 1 has 2 rows (101 searched, 102 skipped)
+    assert len(data) == 2
+    for row in data:
+        assert row["instance_id"] == 1
+
+
+@pytest.mark.asyncio()
+async def test_logs_filter_by_action(seeded_log: None, async_client: object) -> None:
+    """Filtering by action returns only rows with that action."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?action=searched&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    for row in data:
+        assert row["action"] == "searched"
+
+
+@pytest.mark.asyncio()
+async def test_logs_limit_restricts_rows(seeded_log: None, async_client: object) -> None:
+    """The limit param caps the number of rows returned."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?limit=2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+
+
+@pytest.mark.asyncio()
+async def test_logs_before_cursor_paginates(seeded_log: None, async_client: object) -> None:
+    """The 'before' cursor returns only rows older than the given timestamp."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    # All rows older than 12:02 → should be 12:01, 12:00, 11:59 (3 rows)
+    resp = await async_client.get("/api/logs?before=2024-01-01T12:02:00.000Z&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+    for row in data:
+        assert row["timestamp"] < "2024-01-01T12:02:00.000Z"
+
+
+# ---------------------------------------------------------------------------
+# GET /logs page
+# ---------------------------------------------------------------------------
+
+
+def test_logs_page_renders(app: TestClient) -> None:
+    """The /logs page renders 200 OK with the expected HTML structure."""
+    _login(app)
+    resp = app.get("/logs")
+    assert resp.status_code == 200
+    assert b"Search Logs" in resp.content
+    assert b"log-filter-form" in resp.content
+    assert b"log-tbody" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# GET /api/logs/partial — HTMX partial
+# ---------------------------------------------------------------------------
+
+
+def test_logs_partial_empty(app: TestClient) -> None:
+    """The HTMX partial returns the empty-state row when no logs exist."""
+    _login(app)
+    resp = app.get("/api/logs/partial")
+    assert resp.status_code == 200
+    assert b"No log entries found" in resp.content
+
+
+@pytest.mark.asyncio()
+async def test_logs_partial_returns_rows(seeded_log: None, async_client: object) -> None:
+    """The HTMX partial contains <tr> elements when rows exist."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs/partial?limit=200")
+    assert resp.status_code == 200
+    content = resp.text
+    assert "<tr" in content
+    # Should contain action badges
+    assert "searched" in content or "skipped" in content


### PR DESCRIPTION
## Summary

Implements the search log viewer (Plan #13, closes #41).

- **`GET /api/logs`** — paginated JSON from `search_log`; supports `instance_id`, `action`, `before` (cursor), `limit` (1–200, default 50) query params
- **`GET /api/logs/partial`** — server-rendered `<tbody>` HTMX partial for seamless filter swaps (no page reload)
- **`GET /logs`** — new page route with instance dropdown, action filter, row-limit selector; initial render is server-side
- **`logs.html`** — dark-themed table with color-coded action badges (green/yellow/red/slate), truncation with `title` tooltips, load-older pagination via `before` cursor
- **`partials/log_rows.html`** — reusable tbody partial; renders empty-state row when no entries
- **`app.py`** — registers logs API router
- **12 new tests** covering: auth guard (3), empty state, all-rows ordering, instance_id filter, action filter, limit cap, before-cursor pagination, page render, partial empty+rows

## Test count

170 passing (was 158).

## Checklist

- [x] `GET /api/logs` returns empty list when no logs
- [x] `GET /api/logs` filters by `instance_id`
- [x] `GET /api/logs` filters by `action`
- [x] Pagination via `limit` and `before` params works
- [x] `/logs` page renders 200 OK (authenticated)
- [x] HTMX partial returns `<tbody>` rows / empty state
- [x] All quality gates pass (ruff, mypy, bandit, pytest)