### PR TITLE
fix: remove enabled toggle from instance modal

### DIFF
--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -184,7 +184,6 @@ async def instance_create(
     type: Annotated[str, Form()],  # noqa: A002
     url: Annotated[str, Form()],
     api_key: Annotated[str, Form()],
-    enabled: Annotated[str, Form()] = "on",
     batch_size: Annotated[int, Form()] = DEFAULT_BATCH_SIZE,
     sleep_interval_mins: Annotated[int, Form()] = DEFAULT_SLEEP_INTERVAL_MINUTES,
     hourly_cap: Annotated[int, Form()] = DEFAULT_HOURLY_CAP,
@@ -212,7 +211,7 @@ async def instance_create(
         type=instance_type,
         url=url.rstrip("/"),
         api_key=api_key,
-        enabled=enabled == "on",
+        enabled=True,
         batch_size=batch_size,
         sleep_interval_mins=sleep_interval_mins,
         hourly_cap=hourly_cap,
@@ -253,7 +252,6 @@ async def instance_update(
     type: Annotated[str, Form()],  # noqa: A002
     url: Annotated[str, Form()],
     api_key: Annotated[str, Form()],
-    enabled: Annotated[str, Form()] = "on",
     batch_size: Annotated[int, Form()] = DEFAULT_BATCH_SIZE,
     sleep_interval_mins: Annotated[int, Form()] = DEFAULT_SLEEP_INTERVAL_MINUTES,
     hourly_cap: Annotated[int, Form()] = DEFAULT_HOURLY_CAP,
@@ -275,6 +273,10 @@ async def instance_update(
     if not await _connection_ok(instance_type, url.rstrip("/"), api_key):
         return _connection_guard_response("Connection test failed. Re-test before saving changes.")
 
+    current = await get_instance(instance_id, master_key=_master_key(request))
+    if current is None:
+        return HTMLResponse(content="Not found", status_code=404)
+
     updated = await update_instance(
         instance_id,
         master_key=_master_key(request),
@@ -282,7 +284,7 @@ async def instance_update(
         type=instance_type,
         url=url.rstrip("/"),
         api_key=api_key,
-        enabled=enabled == "on",
+        enabled=current.enabled,
         batch_size=batch_size,
         sleep_interval_mins=sleep_interval_mins,
         hourly_cap=hourly_cap,

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -141,17 +141,6 @@
         </div>
       </div>
 
-      {# Enabled toggle #}
-      <div class="flex items-center">
-        <label class="flex items-center gap-2 cursor-pointer select-none">
-          <input type="checkbox" name="enabled" value="on"
-                 {% if not is_edit or instance.enabled %}checked{% endif %}
-                 class="rounded border-slate-600 bg-slate-900 text-brand-500
-                        focus:ring-brand-500 focus:ring-offset-slate-950" />
-          <span class="text-xs text-slate-300">Enabled</span>
-        </label>
-      </div>
-
       {# Buttons — span full width #}
       <div class="sm:col-span-2 flex items-center gap-3 pt-2">
         <button type="button"

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -136,6 +136,13 @@ def test_create_instance_radarr(app: TestClient) -> None:
     assert b"Radarr" in resp.content
 
 
+def test_create_instance_defaults_to_enabled(app: TestClient) -> None:
+    _login(app)
+    resp = app.post("/settings/instances", data=_VALID_FORM)
+    assert resp.status_code == 200
+    assert b"Search enabled" in resp.content
+
+
 def test_create_instance_invalid_type_returns_422(app: TestClient) -> None:
     _login(app)
     form = {**_VALID_FORM, "type": "plex"}
@@ -179,6 +186,7 @@ def test_edit_form_returns_partial(app: TestClient) -> None:
     assert b"Save Changes" in resp.content
     assert b"<tr" not in resp.content
     assert b'data-form-mode="edit"' in resp.content
+    assert b'name="enabled"' not in resp.content
 
 
 def test_edit_form_not_found(app: TestClient) -> None:
@@ -199,6 +207,20 @@ def test_update_instance(app: TestClient) -> None:
     resp = app.post("/settings/instances/1", data=updated_form)
     assert resp.status_code == 200
     assert b"Renamed Sonarr" in resp.content
+
+
+def test_update_instance_preserves_enabled_state(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM)
+    app.post("/settings/instances/1/toggle-enabled")
+
+    updated_form = {**_VALID_FORM, "name": "Still Disabled"}
+    resp = app.post("/settings/instances/1", data=updated_form)
+
+    assert resp.status_code == 200
+    assert b"Still Disabled" in resp.content
+    assert b"Search disabled" in resp.content
+    assert b"Enable" in resp.content
 
 
 def test_update_instance_requires_successful_test(app: TestClient) -> None:
@@ -275,6 +297,7 @@ def test_add_form_partial_renders(app: TestClient) -> None:
     resp = app.get("/settings/instances/add-form")
     assert resp.status_code == 200
     assert b"Add Instance" in resp.content
+    assert b'name="enabled"' not in resp.content
 
 
 def test_connection_check_endpoint_success(app: TestClient) -> None:


### PR DESCRIPTION
## Summary
- remove the redundant `enabled` checkbox from the add/edit instance modal and keep enable/disable control in the row-level toggle only
- make instance creation always default to `enabled=True`
- preserve the existing enabled state during modal edits, and add route tests for create/edit behavior

## Testing
- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest