### PR TITLE
fix: start/stop supervisor tasks on create-toggle-delete and gate run-now by enabled state

### DIFF
--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import suppress
+from functools import partial
+from typing import Literal
 
 from houndarr.engine.search_loop import _write_log, run_instance_search
-from houndarr.services.instances import list_instances
+from houndarr.services.instances import Instance, get_instance, list_instances
 
 logger = logging.getLogger(__name__)
 
 _SHUTDOWN_TIMEOUT = 10  # seconds to wait for tasks to finish on stop()
+RunNowStatus = Literal["accepted", "not_found", "disabled"]
 
 
 class Supervisor:
@@ -34,6 +38,8 @@ class Supervisor:
     def __init__(self, master_key: bytes) -> None:
         self._master_key = master_key
         self._tasks: dict[int, asyncio.Task[None]] = {}
+        self._manual_runs: dict[int, asyncio.Task[None]] = {}
+        self._run_locks: dict[int, asyncio.Lock] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -44,19 +50,12 @@ class Supervisor:
         instances = await list_instances(master_key=self._master_key)
         enabled = [i for i in instances if i.enabled]
 
-        if not enabled:
+        for instance in enabled:
+            await self.start_instance_task(instance.id, instance=instance)
+
+        if not self._tasks:
             logger.warning("Supervisor: no enabled instances configured — nothing to do")
             return
-
-        for instance in enabled:
-            task = asyncio.create_task(
-                self._instance_loop(instance.id),
-                name=f"search-loop-{instance.id}",
-            )
-            self._tasks[instance.id] = task
-            logger.info(
-                "Supervisor: started task for instance %r (id=%d)", instance.name, instance.id
-            )
 
         await _write_log(
             instance_id=None,
@@ -68,14 +67,22 @@ class Supervisor:
 
     async def stop(self) -> None:
         """Cancel all running tasks and wait up to 10 s for clean exit."""
-        if not self._tasks:
+        self._prune_scheduled_tasks()
+        self._prune_manual_tasks()
+
+        if not self._tasks and not self._manual_runs:
             return
+
+        for task in self._manual_runs.values():
+            task.cancel()
 
         for task in self._tasks.values():
             task.cancel()
 
+        all_tasks = [*self._tasks.values(), *self._manual_runs.values()]
+
         done, pending = await asyncio.wait(
-            list(self._tasks.values()),
+            all_tasks,
             timeout=_SHUTDOWN_TIMEOUT,
         )
 
@@ -90,7 +97,86 @@ class Supervisor:
                 logger.error("Supervisor: task raised unexpected exception: %s", exc)
 
         self._tasks.clear()
+        self._manual_runs.clear()
         logger.info("Supervisor: all tasks stopped")
+
+    async def start_instance_task(
+        self, instance_id: int, *, instance: Instance | None = None
+    ) -> bool:
+        """Ensure the scheduled loop task exists for *instance_id* when enabled."""
+        self._prune_scheduled_tasks()
+
+        existing = self._tasks.get(instance_id)
+        if existing is not None and not existing.done():
+            return False
+
+        current = instance
+        if current is None:
+            current = await get_instance(instance_id, master_key=self._master_key)
+        if current is None or not current.enabled:
+            return False
+
+        task = asyncio.create_task(
+            self._instance_loop(instance_id),
+            name=f"search-loop-{instance_id}",
+        )
+        task.add_done_callback(partial(self._on_scheduled_task_done, instance_id))
+        self._tasks[instance_id] = task
+        logger.info("Supervisor: started task for instance %r (id=%d)", current.name, current.id)
+        return True
+
+    async def stop_instance_task(self, instance_id: int) -> bool:
+        """Cancel scheduled and manual tasks for *instance_id*."""
+        self._prune_scheduled_tasks()
+        self._prune_manual_tasks()
+
+        stopped = False
+
+        scheduled = self._tasks.pop(instance_id, None)
+        if scheduled is not None and not scheduled.done():
+            scheduled.cancel()
+            with suppress(asyncio.CancelledError):
+                await scheduled
+            stopped = True
+
+        manual = self._manual_runs.pop(instance_id, None)
+        if manual is not None and not manual.done():
+            manual.cancel()
+            with suppress(asyncio.CancelledError):
+                await manual
+            stopped = True
+
+        return stopped
+
+    async def reconcile_instance(self, instance_id: int) -> None:
+        """Start or stop tasks to match the instance's current enabled state."""
+        instance = await get_instance(instance_id, master_key=self._master_key)
+        if instance is None or not instance.enabled:
+            await self.stop_instance_task(instance_id)
+            return
+
+        await self.start_instance_task(instance_id, instance=instance)
+
+    async def trigger_run_now(self, instance_id: int) -> RunNowStatus:
+        """Queue one immediate search cycle for *instance_id* if active."""
+        self._prune_manual_tasks()
+
+        instance = await get_instance(instance_id, master_key=self._master_key)
+        if instance is None:
+            return "not_found"
+        if not instance.enabled:
+            return "disabled"
+
+        existing = self._manual_runs.get(instance_id)
+        if existing is not None and not existing.done():
+            return "accepted"
+
+        task = asyncio.create_task(
+            self._run_manual_once(instance_id), name=f"run-now-{instance_id}"
+        )
+        task.add_done_callback(partial(self._on_manual_task_done, instance_id))
+        self._manual_runs[instance_id] = task
+        return "accepted"
 
     # ------------------------------------------------------------------
     # Internal
@@ -101,9 +187,6 @@ class Supervisor:
         logger.debug("Supervisor: loop started for instance id=%d", instance_id)
         try:
             while True:
-                # Re-fetch the instance on each cycle so config changes take effect
-                from houndarr.services.instances import get_instance
-
                 instance = await get_instance(instance_id, master_key=self._master_key)
                 if instance is None:
                     logger.warning(
@@ -114,28 +197,91 @@ class Supervisor:
 
                 if not instance.enabled:
                     logger.info(
-                        "Supervisor: instance %r disabled — sleeping until re-enabled",
+                        "Supervisor: instance %r disabled — stopping loop",
                         instance.name,
                     )
-                else:
-                    try:
-                        await run_instance_search(instance, self._master_key)
-                    except Exception as exc:  # noqa: BLE001
-                        logger.error(
-                            "Supervisor: unhandled error in search loop for %r: %s",
-                            instance.name,
-                            exc,
-                        )
-                        await _write_log(
-                            instance_id=instance_id,
-                            item_id=None,
-                            item_type=None,
-                            action="error",
-                            message=str(exc),
-                        )
+                    return
+
+                await self._run_search_cycle(instance)
 
                 await asyncio.sleep(instance.sleep_interval_mins * 60)
 
         except asyncio.CancelledError:
             logger.debug("Supervisor: loop cancelled for instance id=%d", instance_id)
             raise
+
+    async def _run_manual_once(self, instance_id: int) -> None:
+        """Run one ad-hoc cycle, serialized with the scheduled loop."""
+        instance = await get_instance(instance_id, master_key=self._master_key)
+        if instance is None or not instance.enabled:
+            return
+
+        await self._run_search_cycle(instance)
+
+    async def _run_search_cycle(self, instance: Instance) -> None:
+        """Run exactly one cycle for *instance* under the per-instance lock."""
+        lock = self._run_locks.setdefault(instance.id, asyncio.Lock())
+        async with lock:
+            try:
+                await run_instance_search(instance, self._master_key)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "Supervisor: unhandled error in search loop for %r: %s",
+                    instance.name,
+                    exc,
+                )
+                await _write_log(
+                    instance_id=instance.id,
+                    item_id=None,
+                    item_type=None,
+                    action="error",
+                    message=str(exc),
+                )
+
+    def _on_scheduled_task_done(self, instance_id: int, task: asyncio.Task[None]) -> None:
+        """Remove finished scheduled task references."""
+        current = self._tasks.get(instance_id)
+        if current is task:
+            self._tasks.pop(instance_id, None)
+
+        if task.cancelled():
+            return
+
+        exc = task.exception()
+        if exc is not None:
+            logger.error("Supervisor: scheduled task for id=%d failed: %s", instance_id, exc)
+
+    def _on_manual_task_done(self, instance_id: int, task: asyncio.Task[None]) -> None:
+        """Remove finished run-now task references."""
+        current = self._manual_runs.get(instance_id)
+        if current is task:
+            self._manual_runs.pop(instance_id, None)
+
+        if task.cancelled():
+            return
+
+        exc = task.exception()
+        if exc is not None:
+            logger.error("Supervisor: run-now task for id=%d failed: %s", instance_id, exc)
+
+    def _prune_scheduled_tasks(self) -> None:
+        """Drop references to done scheduled tasks."""
+        done_ids = [instance_id for instance_id, task in self._tasks.items() if task.done()]
+        for instance_id in done_ids:
+            task = self._tasks.pop(instance_id)
+            if task.cancelled():
+                continue
+            exc = task.exception()
+            if exc is not None:
+                logger.error("Supervisor: scheduled task for id=%d failed: %s", instance_id, exc)
+
+    def _prune_manual_tasks(self) -> None:
+        """Drop references to done manual run-now tasks."""
+        done_ids = [instance_id for instance_id, task in self._manual_runs.items() if task.done()]
+        for instance_id in done_ids:
+            task = self._manual_runs.pop(instance_id)
+            if task.cancelled():
+                continue
+            exc = task.exception()
+            if exc is not None:
+                logger.error("Supervisor: run-now task for id=%d failed: %s", instance_id, exc)

--- a/src/houndarr/routes/api/status.py
+++ b/src/houndarr/routes/api/status.py
@@ -6,7 +6,6 @@ POST /api/instances/{id}/run-now → trigger an immediate search cycle (202)
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any
 
@@ -14,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from houndarr.database import get_db
+from houndarr.engine.supervisor import Supervisor
 from houndarr.services.instances import list_instances
 
 logger = logging.getLogger(__name__)
@@ -116,22 +116,16 @@ async def get_status(request: Request) -> JSONResponse:
 
 @router.post("/api/instances/{instance_id}/run-now", status_code=202)
 async def run_now(instance_id: int, request: Request) -> JSONResponse:
-    """Trigger an immediate search cycle for the given instance (non-blocking).
+    """Trigger an immediate search cycle for the given enabled instance."""
+    supervisor = getattr(request.app.state, "supervisor", None)
+    if not isinstance(supervisor, Supervisor):
+        raise HTTPException(status_code=503, detail="Supervisor unavailable")
 
-    Schedules ``run_instance_search`` as a background asyncio task so the
-    HTTP response returns immediately (202 Accepted).
-    """
-    from houndarr.engine.search_loop import run_instance_search
-    from houndarr.services.instances import get_instance
-
-    master_key: bytes = request.app.state.master_key
-    instance = await get_instance(instance_id, master_key=master_key)
-    if instance is None:
+    status = await supervisor.trigger_run_now(instance_id)
+    if status == "not_found":
         raise HTTPException(status_code=404, detail="Instance not found")
+    if status == "disabled":
+        raise HTTPException(status_code=409, detail="Instance is disabled")
 
-    asyncio.create_task(
-        run_instance_search(instance, master_key),
-        name=f"run-now-{instance_id}",
-    )
-    logger.info("run-now triggered for instance %r (id=%d)", instance.name, instance_id)
+    logger.info("run-now accepted for instance id=%d", instance_id)
     return JSONResponse({"status": "accepted", "instance_id": instance_id}, status_code=202)

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -24,6 +24,7 @@ from houndarr.config import (
     DEFAULT_SLEEP_INTERVAL_MINUTES,
     DEFAULT_UNRELEASED_DELAY_HOURS,
 )
+from houndarr.engine.supervisor import Supervisor
 from houndarr.services.instances import (
     Instance,
     InstanceType,
@@ -298,7 +299,7 @@ async def instance_create(
     if not await _connection_ok(instance_type, url.rstrip("/"), api_key):
         return _connection_guard_response("Connection test failed. Re-test before adding.")
 
-    await create_instance(
+    instance = await create_instance(
         master_key=_master_key(request),
         name=name,
         type=instance_type,
@@ -315,6 +316,11 @@ async def instance_create(
         cutoff_cooldown_days=cutoff_cooldown_days,
         cutoff_hourly_cap=cutoff_hourly_cap,
     )
+
+    supervisor = getattr(request.app.state, "supervisor", None)
+    if isinstance(supervisor, Supervisor):
+        await supervisor.reconcile_instance(instance.id)
+
     instances = await list_instances(master_key=_master_key(request))
     # HTMX: return just the refreshed table body partial
     return _render(request, "partials/instance_table_body.html", instances=instances)
@@ -415,6 +421,10 @@ async def instance_update(
 @router.delete("/settings/instances/{instance_id}")
 async def instance_delete(request: Request, instance_id: int) -> Response:
     """Delete an instance; returns empty 200 so HTMX removes the row."""
+    supervisor = getattr(request.app.state, "supervisor", None)
+    if isinstance(supervisor, Supervisor):
+        await supervisor.stop_instance_task(instance_id)
+
     await delete_instance(instance_id)
     # Return an empty 200 — HTMX hx-swap="outerHTML" with empty content
     # removes the row from the DOM.
@@ -448,5 +458,9 @@ async def instance_toggle_enabled(request: Request, instance_id: int) -> HTMLRes
     )
     if updated is None:
         return HTMLResponse(content="Not found", status_code=404)
+
+    supervisor = getattr(request.app.state, "supervisor", None)
+    if isinstance(supervisor, Supervisor):
+        await supervisor.reconcile_instance(updated.id)
 
     return _render(request, "partials/instance_row.html", instance=updated)

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -429,6 +429,102 @@ async def test_supervisor_stop_completes_within_timeout(seeded_instances: None) 
     assert sup._tasks == {}  # noqa: SLF001
 
 
+@pytest.mark.asyncio()
+async def test_supervisor_reconcile_starts_task_for_enabled_instance(db: None) -> None:
+    """reconcile_instance() should start a task when an enabled instance is added."""
+    from houndarr.crypto import encrypt
+    from houndarr.engine.supervisor import Supervisor
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        new=AsyncMock(return_value=0),
+    ):
+        sup = Supervisor(master_key=MASTER_KEY)
+        await sup.start()
+        assert sup._tasks == {}  # noqa: SLF001
+
+        encrypted = encrypt("test-api-key", MASTER_KEY)
+        async with get_db() as conn:
+            await conn.execute(
+                """
+                INSERT INTO instances (id, name, type, url, encrypted_api_key, enabled)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (1, "Sonarr Test", "sonarr", SONARR_URL, encrypted, 1),
+            )
+            await conn.commit()
+
+        await sup.reconcile_instance(1)
+        assert 1 in sup._tasks  # noqa: SLF001
+
+        await sup.stop()
+
+
+@pytest.mark.asyncio()
+async def test_supervisor_reconcile_stops_task_when_instance_disabled(
+    seeded_instances: None,
+) -> None:
+    """reconcile_instance() should cancel an existing task after disable."""
+    import asyncio
+
+    from houndarr.engine.supervisor import Supervisor
+
+    async def _block(*_: object, **__: object) -> int:
+        await asyncio.sleep(9999)
+        return 0
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        new=AsyncMock(side_effect=_block),
+    ):
+        sup = Supervisor(master_key=MASTER_KEY)
+        await sup.start()
+        assert 1 in sup._tasks  # noqa: SLF001
+
+        async with get_db() as conn:
+            await conn.execute("UPDATE instances SET enabled = 0 WHERE id = ?", (1,))
+            await conn.commit()
+
+        await sup.reconcile_instance(1)
+        assert 1 not in sup._tasks  # noqa: SLF001
+
+        await sup.stop()
+
+
+@pytest.mark.asyncio()
+async def test_trigger_run_now_deduplicates_pending_manual_runs(
+    seeded_instances: None,
+) -> None:
+    """trigger_run_now() should keep at most one pending manual run per instance."""
+    import asyncio
+
+    from houndarr.engine.supervisor import Supervisor
+
+    gate = asyncio.Event()
+
+    async def _block(*_: object, **__: object) -> int:
+        await gate.wait()
+        return 0
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        new=AsyncMock(side_effect=_block),
+    ):
+        sup = Supervisor(master_key=MASTER_KEY)
+        await sup.start()
+
+        status_1 = await sup.trigger_run_now(1)
+        status_2 = await sup.trigger_run_now(1)
+
+        assert status_1 == "accepted"
+        assert status_2 == "accepted"
+        assert len(sup._manual_runs) == 1  # noqa: SLF001
+
+        gate.set()
+        await asyncio.sleep(0)
+        await sup.stop()
+
+
 # ---------------------------------------------------------------------------
 # Tests — cutoff-unmet pass
 # ---------------------------------------------------------------------------

--- a/tests/test_routes/test_status.py
+++ b/tests/test_routes/test_status.py
@@ -140,3 +140,16 @@ def test_run_now_404_for_unknown_instance(app: TestClient) -> None:
     _login(app)
     resp = app.post("/api/instances/9999/run-now")
     assert resp.status_code == 404
+
+
+def test_run_now_409_for_disabled_instance(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM)
+
+    status = app.get("/api/status").json()
+    inst_id = status[0]["id"]
+
+    app.post(f"/settings/instances/{inst_id}/toggle-enabled")
+
+    resp = app.post(f"/api/instances/{inst_id}/run-now")
+    assert resp.status_code == 409


### PR DESCRIPTION
## Summary
- reconcile supervisor tasks at runtime when instances are created, toggled, or deleted
- route `run-now` through supervisor orchestration, reject disabled instances with `409`, and deduplicate concurrent manual runs per instance
- add supervisor and route tests that verify runtime reconciliation and disabled/manual-run behavior

## Why
This aligns runtime behavior with self-hosted operator expectations: enabled instances start working without restart, disabled/deleted instances stop promptly, and manual runs do not overlap unpredictably.

## Validation
- `.venv/bin/python -m ruff check src/ tests/`
- `.venv/bin/python -m ruff format --check src/ tests/`
- `.venv/bin/python -m mypy src/`
- `.venv/bin/python -m bandit -r src/ -c pyproject.toml`
- `.venv/bin/pytest`

Closes #52