### PR TITLE
chore: codify Sonarr episode-level and Radarr movie-level search contract

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,6 +4,20 @@ This guide explains each Add/Edit Instance setting in Houndarr, with safe defaul
 
 Houndarr is a polite backlog orchestrator. Keep settings conservative to reduce indexer/API pressure and avoid bans.
 
+## Search Command Contract (v0.1)
+
+- **Sonarr:** Houndarr sends episode-level commands (`EpisodeSearch` with `episodeIds`).
+- **Radarr:** Houndarr sends movie-level commands (`MoviesSearch` with `movieIds`).
+- Wanted-list reads are explicitly restricted to monitored items (`monitored=true`) for both
+  missing and cutoff passes.
+
+Why this shape:
+
+- Episode/movie-level commands map cleanly to Houndarr's cooldown, cap, and batch controls.
+- It keeps retries predictable and avoids broad one-shot bursts that can over-pressure indexers.
+- Season-level Sonarr search is intentionally out of scope for v0.1 to keep behavior simple,
+  controlled, and observable.
+
 ## Missing Search Controls
 
 - **Batch Size**: maximum number of missing items considered per cycle.

--- a/src/houndarr/clients/radarr.py
+++ b/src/houndarr/clients/radarr.py
@@ -49,6 +49,7 @@ class RadarrClient(ArrClient):
             pageSize=page_size,
             sortKey="inCinemas",
             sortDirection="ascending",
+            monitored="true",
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_movie(r) for r in records]
@@ -89,6 +90,7 @@ class RadarrClient(ArrClient):
             pageSize=page_size,
             sortKey="inCinemas",
             sortDirection="ascending",
+            monitored="true",
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_movie(r) for r in records]

--- a/src/houndarr/clients/sonarr.py
+++ b/src/houndarr/clients/sonarr.py
@@ -52,6 +52,7 @@ class SonarrClient(ArrClient):
             sortKey="airDateUtc",
             sortDirection="ascending",
             includeSeries="true",
+            monitored="true",
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_episode(r) for r in records]
@@ -92,6 +93,7 @@ class SonarrClient(ArrClient):
             page=page,
             pageSize=page_size,
             includeSeries="true",
+            monitored="true",
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_episode(r) for r in records]

--- a/tests/test_clients/test_radarr.py
+++ b/tests/test_clients/test_radarr.py
@@ -66,7 +66,7 @@ _MISSING_RESPONSE = {"page": 1, "pageSize": 10, "totalRecords": 1, "records": [_
 @pytest.mark.asyncio()
 @respx.mock
 async def test_get_missing_returns_movies(client: RadarrClient) -> None:
-    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+    route = respx.get(f"{BASE}/api/v3/wanted/missing").mock(
         return_value=httpx.Response(200, json=_MISSING_RESPONSE)
     )
     results = await client.get_missing(page=1, page_size=10)
@@ -77,6 +77,8 @@ async def test_get_missing_returns_movies(client: RadarrClient) -> None:
     assert movie.title == "Great Film"
     assert movie.year == 2022
     assert movie.digital_release == "2022-12-01"
+    request = route.calls[0].request
+    assert request.url.params["monitored"] == "true"
 
 
 @pytest.mark.asyncio()
@@ -171,7 +173,7 @@ _CUTOFF_RESPONSE = {
 @pytest.mark.asyncio()
 @respx.mock
 async def test_get_cutoff_unmet_returns_movies(client: RadarrClient) -> None:
-    respx.get(f"{BASE}/api/v3/wanted/cutoff").mock(
+    route = respx.get(f"{BASE}/api/v3/wanted/cutoff").mock(
         return_value=httpx.Response(200, json=_CUTOFF_RESPONSE)
     )
     results = await client.get_cutoff_unmet(page=1, page_size=10)
@@ -180,6 +182,8 @@ async def test_get_cutoff_unmet_returns_movies(client: RadarrClient) -> None:
     assert isinstance(movie, MissingMovie)
     assert movie.movie_id == 201
     assert movie.title == "My Movie"
+    request = route.calls[0].request
+    assert request.url.params["monitored"] == "true"
 
 
 @pytest.mark.asyncio()

--- a/tests/test_clients/test_sonarr.py
+++ b/tests/test_clients/test_sonarr.py
@@ -68,7 +68,7 @@ _MISSING_RESPONSE = {"page": 1, "pageSize": 10, "totalRecords": 1, "records": [_
 @pytest.mark.asyncio()
 @respx.mock
 async def test_get_missing_returns_episodes(client: SonarrClient) -> None:
-    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+    route = respx.get(f"{BASE}/api/v3/wanted/missing").mock(
         return_value=httpx.Response(200, json=_MISSING_RESPONSE)
     )
     results = await client.get_missing(page=1, page_size=10)
@@ -81,6 +81,8 @@ async def test_get_missing_returns_episodes(client: SonarrClient) -> None:
     assert ep.season == 1
     assert ep.episode == 1
     assert ep.air_date_utc == "2023-09-01T00:00:00Z"
+    request = route.calls[0].request
+    assert request.url.params["monitored"] == "true"
 
 
 @pytest.mark.asyncio()
@@ -168,7 +170,7 @@ _CUTOFF_RESPONSE = {
 @pytest.mark.asyncio()
 @respx.mock
 async def test_get_cutoff_unmet_returns_episodes(client: SonarrClient) -> None:
-    respx.get(f"{BASE}/api/v3/wanted/cutoff").mock(
+    route = respx.get(f"{BASE}/api/v3/wanted/cutoff").mock(
         return_value=httpx.Response(200, json=_CUTOFF_RESPONSE)
     )
     results = await client.get_cutoff_unmet(page=1, page_size=10)
@@ -177,6 +179,8 @@ async def test_get_cutoff_unmet_returns_episodes(client: SonarrClient) -> None:
     assert isinstance(ep, MissingEpisode)
     assert ep.episode_id == 101
     assert ep.series_title == "My Show"
+    request = route.calls[0].request
+    assert request.url.params["monitored"] == "true"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- keep Sonarr search dispatch episode-scoped (`EpisodeSearch` + `episodeIds`) and Radarr movie-scoped (`MoviesSearch` + `movieIds`)
- make `monitored=true` explicit for Sonarr/Radarr wanted missing and cutoff list reads
- add client tests asserting the monitored query parameter and update settings docs with the v0.1 contract and season-scope rationale

## Why this is right for v0.1
Houndarr's guardrails (batch size, caps, cooldowns) are item-level. Episode-level (Sonarr) and movie-level (Radarr) commands align with those controls and keep behavior predictable for self-hosted operators. Season-level Sonarr search is intentionally out of scope for now because it broadens blast radius and would need separate product semantics/testing.

## Validation
- `.venv/bin/python -m ruff check src/ tests/`
- `.venv/bin/python -m ruff format --check src/ tests/`
- `.venv/bin/python -m mypy src/`
- `.venv/bin/python -m bandit -r src/ -c pyproject.toml`
- `.venv/bin/pytest`

Closes #54