### PR TITLE
fix: add bounded fair scanning for missing and cutoff passes

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -58,6 +58,17 @@ Why this shape:
 
 Cutoff searches use separate cap/cooldown settings from missing searches so they do not consume the same budget.
 
+## Fair Backlog Scanning
+
+Houndarr does not stop at the first wanted page anymore. During each cycle, it can scan deeper pages when
+top candidates are repeatedly ineligible (cooldown, unreleased delay, or caps), but it stays bounded:
+
+- per-pass list paging has a hard cap (no unbounded page walks)
+- per-pass candidate evaluation has a hard scan budget
+- missing remains primary; cutoff remains separate and conservative
+
+This improves backlog rotation while preserving polite API behavior.
+
 ## Status Control
 
 - **Enabled/Disabled**: controlled from the row toggle in Settings.

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -26,6 +26,16 @@ logger = logging.getLogger(__name__)
 SearchKind = Literal["missing", "cutoff"]
 ItemType = Literal["episode", "movie"]
 
+_MAX_LIST_PAGES_PER_PASS = 3
+_MISSING_PAGE_SIZE_MIN = 10
+_MISSING_PAGE_SIZE_MAX = 50
+_MISSING_SCAN_BUDGET_MIN = 24
+_MISSING_SCAN_BUDGET_MAX = 120
+_CUTOFF_PAGE_SIZE_MIN = 5
+_CUTOFF_PAGE_SIZE_MAX = 25
+_CUTOFF_SCAN_BUDGET_MIN = 12
+_CUTOFF_SCAN_BUDGET_MAX = 60
+
 
 # ---------------------------------------------------------------------------
 # search_log helper
@@ -103,6 +113,31 @@ def _movie_label(item: MissingMovie) -> str:
     return title
 
 
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    """Clamp *value* to the [minimum, maximum] range."""
+    return max(minimum, min(value, maximum))
+
+
+def _missing_page_size(batch_size: int) -> int:
+    """Return list page size for the missing pass."""
+    return _clamp(batch_size * 4, _MISSING_PAGE_SIZE_MIN, _MISSING_PAGE_SIZE_MAX)
+
+
+def _cutoff_page_size(batch_size: int) -> int:
+    """Return list page size for the cutoff pass."""
+    return _clamp(batch_size * 4, _CUTOFF_PAGE_SIZE_MIN, _CUTOFF_PAGE_SIZE_MAX)
+
+
+def _missing_scan_budget(batch_size: int) -> int:
+    """Return max candidates to evaluate during one missing pass."""
+    return _clamp(batch_size * 12, _MISSING_SCAN_BUDGET_MIN, _MISSING_SCAN_BUDGET_MAX)
+
+
+def _cutoff_scan_budget(batch_size: int) -> int:
+    """Return max candidates to evaluate during one cutoff pass."""
+    return _clamp(batch_size * 12, _CUTOFF_SCAN_BUDGET_MIN, _CUTOFF_SCAN_BUDGET_MAX)
+
+
 async def _count_searches_last_hour(instance_id: int, search_kind: SearchKind) -> int:
     """Count successful searches in the last hour for one pass kind."""
     cutoff = datetime.now(UTC) - timedelta(hours=1)
@@ -157,6 +192,9 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
     )
 
     searched = 0
+    missing_target = max(0, instance.batch_size)
+    missing_page_size = _missing_page_size(missing_target)
+    missing_scan_budget = _missing_scan_budget(missing_target)
 
     if instance.type == InstanceType.sonarr:
         client: SonarrClient | RadarrClient = SonarrClient(
@@ -167,94 +205,127 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
         client = RadarrClient(url=instance.url, api_key=instance.api_key)
         item_type = "movie"
 
-    async with client:
-        items = await client.get_missing(page=1, page_size=instance.batch_size)
-
-    logger.debug("[%s] fetched %d missing %s(s)", instance.name, len(items), item_type)
-
-    for item in items:
-        if isinstance(item, MissingEpisode):
-            item_id = item.episode_id
-            item_label = _episode_label(item)
-            release_at = item.air_date_utc
-        else:
-            item_id = item.movie_id
-            item_label = _movie_label(item)
-            release_at = item.digital_release
-
-        if _is_within_unreleased_delay(release_at, instance.unreleased_delay_hrs):
-            reason = f"unreleased delay ({instance.unreleased_delay_hrs}h)"
-            await _write_log(
-                instance.id,
-                item_id,
-                item_type,
-                "skipped",
-                search_kind="missing",
-                item_label=item_label,
-                reason=reason,
-            )
-            continue
-
-        # --- hourly cap check ---
+    if missing_target > 0:
         searches_this_hour = await _count_searches_last_hour(instance.id, "missing")
-        if instance.hourly_cap > 0 and searches_this_hour >= instance.hourly_cap:
-            reason = f"hourly cap reached ({instance.hourly_cap})"
-            logger.info("[%s] %s — %s", instance.name, item_id, reason)
-            await _write_log(
-                instance.id,
-                item_id,
-                item_type,
-                "skipped",
-                search_kind="missing",
-                item_label=item_label,
-                reason=reason,
-            )
-            break
+        seen_item_ids: set[int] = set()
+        scanned = 0
+        page = 1
 
-        # --- cooldown check ---
-        if await is_on_cooldown(instance.id, item_id, item_type, instance.cooldown_days):
-            reason = f"on cooldown ({instance.cooldown_days}d)"
-            logger.debug("[%s] %s — %s", instance.name, item_id, reason)
-            await _write_log(
-                instance.id,
-                item_id,
-                item_type,
-                "skipped",
-                search_kind="missing",
-                item_label=item_label,
-                reason=reason,
-            )
-            continue
+        async with client:
+            for _ in range(_MAX_LIST_PAGES_PER_PASS):
+                if searched >= missing_target or scanned >= missing_scan_budget:
+                    break
 
-        # --- search ---
-        try:
-            async with client.__class__(url=instance.url, api_key=instance.api_key) as c:
-                await c.search(item_id)
-        except Exception as exc:  # noqa: BLE001
-            msg = str(exc)
-            logger.warning("[%s] search failed for %s: %s", instance.name, item_id, msg)
-            await _write_log(
-                instance.id,
-                item_id,
-                item_type,
-                "error",
-                search_kind="missing",
-                item_label=item_label,
-                message=msg,
-            )
-            continue
+                items = await client.get_missing(page=page, page_size=missing_page_size)
+                logger.debug(
+                    "[%s] fetched %d missing %s(s) from page %d",
+                    instance.name,
+                    len(items),
+                    item_type,
+                    page,
+                )
+                if not items:
+                    break
 
-        await record_search(instance.id, item_id, item_type)
-        await _write_log(
-            instance.id,
-            item_id,
-            item_type,
-            "searched",
-            search_kind="missing",
-            item_label=item_label,
-        )
-        searched += 1
-        logger.info("[%s] searched %s %s", instance.name, item_type, item_id)
+                stop_pass = False
+                for item in items:
+                    if searched >= missing_target or scanned >= missing_scan_budget:
+                        break
+
+                    if isinstance(item, MissingEpisode):
+                        item_id = item.episode_id
+                        item_label = _episode_label(item)
+                        release_at = item.air_date_utc
+                    else:
+                        item_id = item.movie_id
+                        item_label = _movie_label(item)
+                        release_at = item.digital_release
+
+                    if item_id in seen_item_ids:
+                        continue
+                    seen_item_ids.add(item_id)
+                    scanned += 1
+
+                    if _is_within_unreleased_delay(release_at, instance.unreleased_delay_hrs):
+                        reason = f"unreleased delay ({instance.unreleased_delay_hrs}h)"
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="missing",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        continue
+
+                    if instance.hourly_cap > 0 and searches_this_hour >= instance.hourly_cap:
+                        reason = f"hourly cap reached ({instance.hourly_cap})"
+                        logger.info("[%s] %s — %s", instance.name, item_id, reason)
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="missing",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        stop_pass = True
+                        break
+
+                    if await is_on_cooldown(
+                        instance.id, item_id, item_type, instance.cooldown_days
+                    ):
+                        reason = f"on cooldown ({instance.cooldown_days}d)"
+                        logger.debug("[%s] %s — %s", instance.name, item_id, reason)
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="missing",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        continue
+
+                    try:
+                        async with client.__class__(
+                            url=instance.url, api_key=instance.api_key
+                        ) as c:
+                            await c.search(item_id)
+                    except Exception as exc:  # noqa: BLE001
+                        msg = str(exc)
+                        logger.warning("[%s] search failed for %s: %s", instance.name, item_id, msg)
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "error",
+                            search_kind="missing",
+                            item_label=item_label,
+                            message=msg,
+                        )
+                        continue
+
+                    await record_search(instance.id, item_id, item_type)
+                    await _write_log(
+                        instance.id,
+                        item_id,
+                        item_type,
+                        "searched",
+                        search_kind="missing",
+                        item_label=item_label,
+                    )
+                    searched += 1
+                    searches_this_hour += 1
+                    logger.info("[%s] searched %s %s", instance.name, item_type, item_id)
+
+                if stop_pass:
+                    break
+
+                page += 1
 
     logger.info("[%s] cycle complete — %d searched", instance.name, searched)
 
@@ -287,113 +358,261 @@ async def _run_cutoff_pass(instance: Instance) -> int:
     )
 
     searched = 0
-    cutoff_items: list[MissingEpisode] | list[MissingMovie]
+    cutoff_target = max(0, instance.cutoff_batch_size)
+    cutoff_page_size = _cutoff_page_size(cutoff_target)
+    cutoff_scan_budget = _cutoff_scan_budget(cutoff_target)
+
+    if cutoff_target == 0:
+        logger.info("[%s] cutoff pass complete — 0 searched", instance.name)
+        return 0
+
+    searches_this_hour = await _count_searches_last_hour(instance.id, "cutoff")
+    seen_item_ids: set[int] = set()
+    scanned = 0
+    page = 1
 
     if instance.type == InstanceType.sonarr:
         sonarr = SonarrClient(url=instance.url, api_key=instance.api_key)
         async with sonarr:
-            cutoff_items = await sonarr.get_cutoff_unmet(
-                page=1, page_size=instance.cutoff_batch_size
-            )
+            for _ in range(_MAX_LIST_PAGES_PER_PASS):
+                if searched >= cutoff_target or scanned >= cutoff_scan_budget:
+                    break
+
+                sonarr_items = await sonarr.get_cutoff_unmet(page=page, page_size=cutoff_page_size)
+                logger.debug(
+                    "[%s] fetched %d cutoff-unmet %s(s) from page %d",
+                    instance.name,
+                    len(sonarr_items),
+                    item_type,
+                    page,
+                )
+                if not sonarr_items:
+                    break
+
+                stop_pass = False
+                for episode_item in sonarr_items:
+                    if searched >= cutoff_target or scanned >= cutoff_scan_budget:
+                        break
+
+                    item_id = episode_item.episode_id
+                    if item_id in seen_item_ids:
+                        continue
+                    seen_item_ids.add(item_id)
+                    scanned += 1
+
+                    item_label = _episode_label(episode_item)
+                    if _is_within_unreleased_delay(
+                        episode_item.air_date_utc, instance.unreleased_delay_hrs
+                    ):
+                        reason = f"unreleased delay ({instance.unreleased_delay_hrs}h)"
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="cutoff",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        continue
+
+                    if (
+                        instance.cutoff_hourly_cap > 0
+                        and searches_this_hour >= instance.cutoff_hourly_cap
+                    ):
+                        reason = f"cutoff hourly cap reached ({instance.cutoff_hourly_cap})"
+                        logger.info("[%s] cutoff %s — %s", instance.name, item_id, reason)
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="cutoff",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        stop_pass = True
+                        break
+
+                    if await is_on_cooldown(
+                        instance.id,
+                        item_id,
+                        item_type,
+                        instance.cutoff_cooldown_days,
+                    ):
+                        reason = f"on cutoff cooldown ({instance.cutoff_cooldown_days}d)"
+                        logger.debug("[%s] cutoff %s — %s", instance.name, item_id, reason)
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="cutoff",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        continue
+
+                    try:
+                        async with SonarrClient(url=instance.url, api_key=instance.api_key) as c:
+                            await c.search(item_id)
+                    except Exception as exc:  # noqa: BLE001
+                        msg = str(exc)
+                        logger.warning(
+                            "[%s] cutoff search failed for %s: %s",
+                            instance.name,
+                            item_id,
+                            msg,
+                        )
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "error",
+                            search_kind="cutoff",
+                            item_label=item_label,
+                            message=msg,
+                        )
+                        continue
+
+                    await record_search(instance.id, item_id, item_type)
+                    await _write_log(
+                        instance.id,
+                        item_id,
+                        item_type,
+                        "searched",
+                        search_kind="cutoff",
+                        item_label=item_label,
+                    )
+                    searched += 1
+                    searches_this_hour += 1
+                    logger.info("[%s] cutoff searched %s %s", instance.name, item_type, item_id)
+
+                if stop_pass:
+                    break
+
+                page += 1
     else:
         radarr = RadarrClient(url=instance.url, api_key=instance.api_key)
         async with radarr:
-            cutoff_items = await radarr.get_cutoff_unmet(
-                page=1, page_size=instance.cutoff_batch_size
-            )
+            for _ in range(_MAX_LIST_PAGES_PER_PASS):
+                if searched >= cutoff_target or scanned >= cutoff_scan_budget:
+                    break
 
-    logger.debug("[%s] fetched %d cutoff-unmet %s(s)", instance.name, len(cutoff_items), item_type)
+                radarr_items = await radarr.get_cutoff_unmet(page=page, page_size=cutoff_page_size)
+                logger.debug(
+                    "[%s] fetched %d cutoff-unmet %s(s) from page %d",
+                    instance.name,
+                    len(radarr_items),
+                    item_type,
+                    page,
+                )
+                if not radarr_items:
+                    break
 
-    for item in cutoff_items:
-        item_id: int = item.episode_id if isinstance(item, MissingEpisode) else item.movie_id
-        item_label = (
-            _episode_label(item) if isinstance(item, MissingEpisode) else _movie_label(item)
-        )
+                stop_pass = False
+                for movie_item in radarr_items:
+                    if searched >= cutoff_target or scanned >= cutoff_scan_budget:
+                        break
 
-        release_at = item.air_date_utc if isinstance(item, MissingEpisode) else item.digital_release
+                    item_id = movie_item.movie_id
+                    if item_id in seen_item_ids:
+                        continue
+                    seen_item_ids.add(item_id)
+                    scanned += 1
 
-        if _is_within_unreleased_delay(release_at, instance.unreleased_delay_hrs):
-            reason = f"unreleased delay ({instance.unreleased_delay_hrs}h)"
-            await _write_log(
-                instance.id,
-                item_id,
-                item_type,
-                "skipped",
-                search_kind="cutoff",
-                item_label=item_label,
-                reason=reason,
-            )
-            continue
+                    item_label = _movie_label(movie_item)
+                    if _is_within_unreleased_delay(
+                        movie_item.digital_release, instance.unreleased_delay_hrs
+                    ):
+                        reason = f"unreleased delay ({instance.unreleased_delay_hrs}h)"
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="cutoff",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        continue
 
-        # --- hourly cap check ---
-        searches_this_hour = await _count_searches_last_hour(instance.id, "cutoff")
-        if instance.cutoff_hourly_cap > 0 and searches_this_hour >= instance.cutoff_hourly_cap:
-            reason = f"cutoff hourly cap reached ({instance.cutoff_hourly_cap})"
-            logger.info("[%s] cutoff %s — %s", instance.name, item_id, reason)
-            await _write_log(
-                instance.id,
-                item_id,
-                item_type,
-                "skipped",
-                search_kind="cutoff",
-                item_label=item_label,
-                reason=reason,
-            )
-            break
+                    if (
+                        instance.cutoff_hourly_cap > 0
+                        and searches_this_hour >= instance.cutoff_hourly_cap
+                    ):
+                        reason = f"cutoff hourly cap reached ({instance.cutoff_hourly_cap})"
+                        logger.info("[%s] cutoff %s — %s", instance.name, item_id, reason)
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="cutoff",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        stop_pass = True
+                        break
 
-        # --- cooldown check ---
-        if await is_on_cooldown(
-            instance.id,
-            item_id,
-            item_type,
-            instance.cutoff_cooldown_days,
-        ):
-            reason = f"on cutoff cooldown ({instance.cutoff_cooldown_days}d)"
-            logger.debug("[%s] cutoff %s — %s", instance.name, item_id, reason)
-            await _write_log(
-                instance.id,
-                item_id,
-                item_type,
-                "skipped",
-                search_kind="cutoff",
-                item_label=item_label,
-                reason=reason,
-            )
-            continue
+                    if await is_on_cooldown(
+                        instance.id,
+                        item_id,
+                        item_type,
+                        instance.cutoff_cooldown_days,
+                    ):
+                        reason = f"on cutoff cooldown ({instance.cutoff_cooldown_days}d)"
+                        logger.debug("[%s] cutoff %s — %s", instance.name, item_id, reason)
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "skipped",
+                            search_kind="cutoff",
+                            item_label=item_label,
+                            reason=reason,
+                        )
+                        continue
 
-        # --- search ---
-        try:
-            if instance.type == InstanceType.sonarr:
-                async with SonarrClient(url=instance.url, api_key=instance.api_key) as c:
-                    await c.search(item_id)
-            else:
-                async with RadarrClient(url=instance.url, api_key=instance.api_key) as c:
-                    await c.search(item_id)
-        except Exception as exc:  # noqa: BLE001
-            msg = str(exc)
-            logger.warning("[%s] cutoff search failed for %s: %s", instance.name, item_id, msg)
-            await _write_log(
-                instance.id,
-                item_id,
-                item_type,
-                "error",
-                search_kind="cutoff",
-                item_label=item_label,
-                message=msg,
-            )
-            continue
+                    try:
+                        async with RadarrClient(url=instance.url, api_key=instance.api_key) as c:
+                            await c.search(item_id)
+                    except Exception as exc:  # noqa: BLE001
+                        msg = str(exc)
+                        logger.warning(
+                            "[%s] cutoff search failed for %s: %s",
+                            instance.name,
+                            item_id,
+                            msg,
+                        )
+                        await _write_log(
+                            instance.id,
+                            item_id,
+                            item_type,
+                            "error",
+                            search_kind="cutoff",
+                            item_label=item_label,
+                            message=msg,
+                        )
+                        continue
 
-        await record_search(instance.id, item_id, item_type)
-        await _write_log(
-            instance.id,
-            item_id,
-            item_type,
-            "searched",
-            search_kind="cutoff",
-            item_label=item_label,
-        )
-        searched += 1
-        logger.info("[%s] cutoff searched %s %s", instance.name, item_type, item_id)
+                    await record_search(instance.id, item_id, item_type)
+                    await _write_log(
+                        instance.id,
+                        item_id,
+                        item_type,
+                        "searched",
+                        search_kind="cutoff",
+                        item_label=item_label,
+                    )
+                    searched += 1
+                    searches_this_hour += 1
+                    logger.info("[%s] cutoff searched %s %s", instance.name, item_type, item_id)
+
+                if stop_pass:
+                    break
+
+                page += 1
 
     logger.info("[%s] cutoff pass complete — %d searched", instance.name, searched)
     return searched

--- a/tests/test_e2e/test_search_cycle.py
+++ b/tests/test_e2e/test_search_cycle.py
@@ -20,6 +20,7 @@ from cryptography.fernet import Fernet
 from houndarr.database import get_db
 from houndarr.engine.search_loop import run_instance_search
 from houndarr.engine.supervisor import Supervisor
+from houndarr.services.cooldown import record_search
 from houndarr.services.instances import Instance, InstanceType, create_instance
 
 # ---------------------------------------------------------------------------
@@ -47,6 +48,7 @@ _MOVIE: dict[str, Any] = {
 _MISSING_SONARR_1 = {"records": [_EPISODE]}
 _MISSING_RADARR_1 = {"records": [_MOVIE]}
 _MISSING_EMPTY = {"records": []}
+_FUTURE_AIR_DATE = "2999-01-01T00:00:00Z"
 
 _CMD_OK = {"id": 1, "name": "EpisodeSearch"}
 
@@ -347,3 +349,72 @@ async def test_supervisor_runs_both_instances(
     instance_ids = {r["instance_id"] for r in searched}
     assert sonarr_instance.id in instance_ids
     assert radarr_instance.id in instance_ids
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_pass_reaches_deeper_page_when_top_items_are_ineligible(
+    sonarr_instance: Instance, master_key: bytes
+) -> None:
+    """Fair scanning should reach page 2 when page 1 candidates are blocked."""
+    await record_search(sonarr_instance.id, 601, "episode")
+
+    page_1 = {
+        "records": [
+            {**_EPISODE, "id": 600, "airDateUtc": _FUTURE_AIR_DATE},
+            {**_EPISODE, "id": 601, "airDateUtc": "2023-09-01T00:00:00Z"},
+        ]
+    }
+    page_2 = {"records": [{**_EPISODE, "id": 602, "title": "Deeper candidate"}]}
+
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page_1),
+            httpx.Response(200, json=page_2),
+        ]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_CMD_OK)
+    )
+
+    # Use a small target to ensure we stop once we find one eligible candidate.
+    sonarr_instance.batch_size = 1
+    count = await run_instance_search(sonarr_instance, master_key)
+
+    assert count == 1
+    assert missing_route.call_count == 2
+    assert search_route.call_count == 1
+
+    logs = await _log_rows()
+    assert any(row["item_id"] == 602 and row["action"] == "searched" for row in logs)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_list_calls_are_bounded_per_cycle(
+    sonarr_instance: Instance, master_key: bytes
+) -> None:
+    """Fair scanning keeps missing list-page fetches under a hard cap."""
+    payloads = [
+        {
+            "records": [
+                {**_EPISODE, "id": i, "airDateUtc": _FUTURE_AIR_DATE}
+                for i in range(start, start + 10)
+            ]
+        }
+        for start in (900, 1000, 1100, 1200)
+    ]
+
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[httpx.Response(200, json=payload) for payload in payloads]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_CMD_OK)
+    )
+
+    sonarr_instance.batch_size = 2
+    count = await run_instance_search(sonarr_instance, master_key)
+
+    assert count == 0
+    assert missing_route.call_count == 3
+    assert not search_route.called

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -44,6 +44,7 @@ _MOVIE_RECORD: dict[str, Any] = {
 _MISSING_SONARR = {"page": 1, "pageSize": 10, "totalRecords": 1, "records": [_EPISODE_RECORD]}
 _MISSING_RADARR = {"page": 1, "pageSize": 10, "totalRecords": 1, "records": [_MOVIE_RECORD]}
 _COMMAND_RESP = {"id": 1, "name": "EpisodeSearch"}
+_FUTURE_AIR_DATE = "2999-01-01T00:00:00Z"
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +259,174 @@ async def test_hourly_cap_zero_means_unlimited(seeded_instances: None) -> None:
     count = await run_instance_search(instance, MASTER_KEY)
 
     assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_scans_next_pages_when_first_page_items_ineligible(
+    seeded_instances: None,
+) -> None:
+    """Missing pass should continue to later pages when page 1 items are ineligible."""
+    from houndarr.services.cooldown import record_search
+
+    await record_search(1, 1002, "episode")
+
+    page_1 = {
+        "records": [
+            {**_EPISODE_RECORD, "id": 1001, "airDateUtc": _FUTURE_AIR_DATE},
+            {**_EPISODE_RECORD, "id": 1002, "airDateUtc": "2023-09-01T00:00:00Z"},
+        ]
+    }
+    page_2 = {"records": [{**_EPISODE_RECORD, "id": 1003, "title": "Eligible"}]}
+
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page_1),
+            httpx.Response(200, json=page_2),
+        ]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(batch_size=1, cooldown_days=7, unreleased_delay_hrs=36)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert missing_route.call_count == 2
+    assert search_route.call_count == 1
+
+    rows = await _get_log_rows()
+    assert any(r["item_id"] == 1001 and r["action"] == "skipped" for r in rows)
+    assert any(r["item_id"] == 1002 and r["action"] == "skipped" for r in rows)
+    assert any(r["item_id"] == 1003 and r["action"] == "searched" for r in rows)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_list_page_calls_are_hard_bounded(seeded_instances: None) -> None:
+    """Missing pass should not fetch more than three list pages per cycle."""
+    page_payloads = [
+        {
+            "records": [
+                {
+                    **_EPISODE_RECORD,
+                    "id": i,
+                    "airDateUtc": _FUTURE_AIR_DATE,
+                }
+                for i in range(start, start + 10)
+            ]
+        }
+        for start in (1000, 2000, 3000, 4000)
+    ]
+
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[httpx.Response(200, json=p) for p in page_payloads]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(batch_size=2, unreleased_delay_hrs=36)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert missing_route.call_count == 3
+    assert not search_route.called
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_stops_fetching_pages_when_target_is_reached(seeded_instances: None) -> None:
+    """Once missing batch target is reached, no additional pages should be fetched."""
+    page_1 = {"records": [{**_EPISODE_RECORD, "id": 1101, "title": "First"}]}
+    page_2 = {"records": [{**_EPISODE_RECORD, "id": 1102, "title": "Second"}]}
+
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page_1),
+            httpx.Response(200, json=page_2),
+        ]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(batch_size=1, cooldown_days=0, unreleased_delay_hrs=0)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert missing_route.call_count == 1
+    assert search_route.call_count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_deduplicates_items_across_pages(seeded_instances: None) -> None:
+    """Duplicate item IDs returned on later pages should be ignored within one pass."""
+    page_1 = {"records": [{**_EPISODE_RECORD, "id": 1201, "title": "One"}]}
+    page_2 = {
+        "records": [
+            {**_EPISODE_RECORD, "id": 1201, "title": "One duplicate"},
+            {**_EPISODE_RECORD, "id": 1202, "title": "Two"},
+        ]
+    }
+
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page_1),
+            httpx.Response(200, json=page_2),
+        ]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(batch_size=2, cooldown_days=0, unreleased_delay_hrs=0)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 2
+    assert missing_route.call_count == 2
+    assert search_route.call_count == 2
+
+    rows = await _get_log_rows()
+    assert [row["item_id"] for row in rows if row["action"] == "searched"] == [1201, 1202]
+    assert not any(row["item_id"] == 1201 and row["action"] == "skipped" for row in rows)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_hourly_cap_stops_additional_page_fetches(seeded_instances: None) -> None:
+    """When missing hourly cap is reached, the pass should stop without extra page fetches."""
+    async with get_db() as conn:
+        await conn.execute(
+            """
+            INSERT INTO search_log (instance_id, item_id, item_type, search_kind, action, timestamp)
+            VALUES (?, ?, 'episode', 'missing', 'searched', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            """,
+            (1, 9999),
+        )
+        await conn.commit()
+
+    page_1 = {"records": [{**_EPISODE_RECORD, "id": 1301}]}
+    page_2 = {"records": [{**_EPISODE_RECORD, "id": 1302}]}
+
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page_1),
+            httpx.Response(200, json=page_2),
+        ]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(hourly_cap=1, cooldown_days=0, unreleased_delay_hrs=0)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert missing_route.call_count == 1
+    assert not search_route.called
 
 
 # ---------------------------------------------------------------------------
@@ -739,3 +908,117 @@ async def test_cutoff_pass_radarr(seeded_instances: None) -> None:
     assert rows[0]["action"] == "searched"
     assert rows[0]["item_id"] == 201
     assert rows[0]["item_type"] == "movie"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cutoff_scans_next_pages_when_first_page_items_ineligible(
+    seeded_instances: None,
+) -> None:
+    """Cutoff pass should continue to later pages when page 1 items are ineligible."""
+    from houndarr.services.cooldown import record_search
+
+    await record_search(1, 2202, "episode")
+
+    page_1 = {
+        "records": [
+            {**_EPISODE_RECORD, "id": 2201, "airDateUtc": _FUTURE_AIR_DATE},
+            {**_EPISODE_RECORD, "id": 2202, "airDateUtc": "2023-09-01T00:00:00Z"},
+        ]
+    }
+    page_2 = {"records": [{**_EPISODE_RECORD, "id": 2203, "title": "Eligible cutoff"}]}
+
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": []})
+    )
+    cutoff_route = respx.get(f"{SONARR_URL}/api/v3/wanted/cutoff").mock(
+        side_effect=[
+            httpx.Response(200, json=page_1),
+            httpx.Response(200, json=page_2),
+        ]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_cutoff_instance(cutoff_enabled=True, cutoff_batch_size=1)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert cutoff_route.call_count == 2
+    assert search_route.call_count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cutoff_list_page_calls_are_hard_bounded(seeded_instances: None) -> None:
+    """Cutoff pass should not fetch more than three list pages per cycle."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": []})
+    )
+
+    page_payloads = [
+        {
+            "records": [
+                {
+                    **_EPISODE_RECORD,
+                    "id": i,
+                    "airDateUtc": _FUTURE_AIR_DATE,
+                }
+                for i in range(start, start + 10)
+            ]
+        }
+        for start in (5000, 6000, 7000, 8000)
+    ]
+
+    cutoff_route = respx.get(f"{SONARR_URL}/api/v3/wanted/cutoff").mock(
+        side_effect=[httpx.Response(200, json=p) for p in page_payloads]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_cutoff_instance(cutoff_enabled=True, cutoff_batch_size=1)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert cutoff_route.call_count <= 3
+    assert not search_route.called
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cutoff_hourly_cap_stops_additional_page_fetches(seeded_instances: None) -> None:
+    """When cutoff hourly cap is reached, the pass should stop without extra page fetches."""
+    async with get_db() as conn:
+        await conn.execute(
+            """
+            INSERT INTO search_log (instance_id, item_id, item_type, search_kind, action, timestamp)
+            VALUES (?, ?, 'episode', 'cutoff', 'searched', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            """,
+            (1, 9100),
+        )
+        await conn.commit()
+
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": []})
+    )
+    page_1 = {"records": [{**_EPISODE_RECORD, "id": 2301}]}
+    page_2 = {"records": [{**_EPISODE_RECORD, "id": 2302}]}
+
+    cutoff_route = respx.get(f"{SONARR_URL}/api/v3/wanted/cutoff").mock(
+        side_effect=[
+            httpx.Response(200, json=page_1),
+            httpx.Response(200, json=page_2),
+        ]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_cutoff_instance(cutoff_enabled=True, cutoff_batch_size=1, cutoff_hourly_cap=1)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert cutoff_route.call_count == 1
+    assert not search_route.called


### PR DESCRIPTION
## Summary
- implement bounded multi-page scanning for missing and cutoff passes instead of page-1-only processing
- enforce strict per-pass limits for page fetches and candidate evaluation to keep API usage polite and predictable
- preserve missing-first behavior with separate cutoff budget semantics and existing cooldown/hourly-cap/unreleased guardrails
- add engine and e2e coverage for page-depth fairness, hard bounds, deduping across pages, and cap-driven early stop

## Fairness model
- missing target remains `batch_size`; cutoff target remains `cutoff_batch_size`
- missing list page size: `clamp(batch_size * 4, 10, 50)`
- cutoff list page size: `clamp(cutoff_batch_size * 4, 5, 25)`
- missing scan budget: `clamp(batch_size * 12, 24, 120)` candidates
- cutoff scan budget: `clamp(cutoff_batch_size * 12, 12, 60)` candidates
- hard list-page bound per pass per cycle: `3`
- duplicates across pages are ignored within a pass

## Why
Runtime evidence showed repeated skip patterns around top-of-list candidates. This change provides principled fairness and backlog rotation without turning cycles into unbounded scans.

## Scope boundary
This PR intentionally does not include major logs/UI redesign work; those remain separate issues.

## Validation
- `.venv/bin/python -m ruff check src/ tests/`
- `.venv/bin/python -m ruff format --check src/ tests/`
- `.venv/bin/python -m mypy src/`
- `.venv/bin/python -m bandit -r src/ -c pyproject.toml`
- `.venv/bin/pytest`

Closes #58