### PR TITLE
feat(logs): add cycle and trigger context to search_log

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -69,6 +69,19 @@ top candidates are repeatedly ineligible (cooldown, unreleased delay, or caps), 
 
 This improves backlog rotation while preserving polite API behavior.
 
+## Log Context Fields
+
+Search log rows now include cycle context so operators can distinguish why a row
+exists and which rows belong to the same run:
+
+- `cycle_id`: one ID per `run_instance_search(...)` invocation for one instance;
+  shared by both missing and cutoff passes in that invocation.
+- `cycle_trigger`: one of `scheduled`, `run_now`, or `system`.
+- `search_kind`: `missing` or `cutoff` for item rows; `NULL` for system rows.
+
+System lifecycle rows (for example, supervisor startup messages) are tagged
+`cycle_trigger=system` and keep `cycle_id` empty.
+
 ## Status Control
 
 - **Enabled/Disabled**: controlled from the row toggle in Settings.

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Schema version — bump when adding new migrations
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -62,6 +62,8 @@ CREATE TABLE IF NOT EXISTS search_log (
     item_id     INTEGER,
     item_type   TEXT    CHECK(item_type IN ('episode', 'movie')),
     search_kind TEXT,
+    cycle_id    TEXT,
+    cycle_trigger TEXT CHECK(cycle_trigger IN ('scheduled', 'run_now', 'system')),
     item_label  TEXT,
     action      TEXT    NOT NULL CHECK(action IN ('searched', 'skipped', 'error', 'info')),
     reason      TEXT,
@@ -123,18 +125,23 @@ async def init_db() -> None:
                 "INSERT INTO settings (key, value) VALUES ('schema_version', ?)",
                 (str(SCHEMA_VERSION),),
             )
+            await _ensure_v3_indexes(db)
             await db.commit()
             logger.info("Database initialized at schema version %d", SCHEMA_VERSION)
         else:
             current = int(row["value"])
             if current < SCHEMA_VERSION:
                 await _run_migrations(db, current)
+            await _ensure_v3_indexes(db)
+            await db.commit()
 
 
 async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
     """Apply incremental migrations from from_version to SCHEMA_VERSION."""
     if from_version < 2:
         await _migrate_to_v2(db)
+    if from_version < 3:
+        await _migrate_to_v3(db)
 
     logger.info("Migrated database from schema version %d to %d", from_version, SCHEMA_VERSION)
     await db.execute(
@@ -161,6 +168,22 @@ async def _migrate_to_v2(db: aiosqlite.Connection) -> None:
         await db.execute(
             "ALTER TABLE instances ADD COLUMN cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1"
         )
+
+
+async def _migrate_to_v3(db: aiosqlite.Connection) -> None:
+    """Add v3 columns for cycle and trigger log context."""
+    if not await _column_exists(db, "search_log", "cycle_id"):
+        await db.execute("ALTER TABLE search_log ADD COLUMN cycle_id TEXT")
+
+    if not await _column_exists(db, "search_log", "cycle_trigger"):
+        await db.execute("ALTER TABLE search_log ADD COLUMN cycle_trigger TEXT")
+
+
+async def _ensure_v3_indexes(db: aiosqlite.Connection) -> None:
+    """Create v3 indexes that depend on post-v2 columns."""
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_search_log_cycle ON search_log(cycle_id, timestamp DESC)"
+    )
 
 
 async def _column_exists(db: aiosqlite.Connection, table_name: str, column_name: str) -> bool:

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Literal
+from uuid import uuid4
 
 from houndarr.clients.radarr import MissingMovie, RadarrClient
 from houndarr.clients.sonarr import MissingEpisode, SonarrClient
@@ -24,6 +25,7 @@ from houndarr.services.instances import Instance, InstanceType
 logger = logging.getLogger(__name__)
 
 SearchKind = Literal["missing", "cutoff"]
+CycleTrigger = Literal["scheduled", "run_now", "system"]
 ItemType = Literal["episode", "movie"]
 
 _MAX_LIST_PAGES_PER_PASS = 3
@@ -48,6 +50,8 @@ async def _write_log(
     item_type: str | None,
     action: str,
     search_kind: SearchKind | None = None,
+    cycle_id: str | None = None,
+    cycle_trigger: CycleTrigger | None = None,
     item_label: str | None = None,
     reason: str | None = None,
     message: str | None = None,
@@ -57,10 +61,32 @@ async def _write_log(
         await db.execute(
             """
             INSERT INTO search_log
-                (instance_id, item_id, item_type, search_kind, item_label, action, reason, message)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                (
+                    instance_id,
+                    item_id,
+                    item_type,
+                    search_kind,
+                    cycle_id,
+                    cycle_trigger,
+                    item_label,
+                    action,
+                    reason,
+                    message
+                )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (instance_id, item_id, item_type, search_kind, item_label, action, reason, message),
+            (
+                instance_id,
+                item_id,
+                item_type,
+                search_kind,
+                cycle_id,
+                cycle_trigger,
+                item_label,
+                action,
+                reason,
+                message,
+            ),
         )
         await db.commit()
 
@@ -165,7 +191,13 @@ async def _count_searches_last_hour(instance_id: int, search_kind: SearchKind) -
 # ---------------------------------------------------------------------------
 
 
-async def run_instance_search(instance: Instance, master_key: bytes) -> int:
+async def run_instance_search(
+    instance: Instance,
+    master_key: bytes,
+    *,
+    cycle_id: str | None = None,
+    cycle_trigger: CycleTrigger = "scheduled",
+) -> int:
     """Execute one search cycle for *instance*.
 
     Steps:
@@ -192,6 +224,7 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
     )
 
     searched = 0
+    cycle_id_value = cycle_id or str(uuid4())
     missing_target = max(0, instance.batch_size)
     missing_page_size = _missing_page_size(missing_target)
     missing_scan_budget = _missing_scan_budget(missing_target)
@@ -254,6 +287,8 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
                             item_type,
                             "skipped",
                             search_kind="missing",
+                            cycle_id=cycle_id_value,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -268,6 +303,8 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
                             item_type,
                             "skipped",
                             search_kind="missing",
+                            cycle_id=cycle_id_value,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -285,6 +322,8 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
                             item_type,
                             "skipped",
                             search_kind="missing",
+                            cycle_id=cycle_id_value,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -304,6 +343,8 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
                             item_type,
                             "error",
                             search_kind="missing",
+                            cycle_id=cycle_id_value,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             message=msg,
                         )
@@ -316,6 +357,8 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
                         item_type,
                         "searched",
                         search_kind="missing",
+                        cycle_id=cycle_id_value,
+                        cycle_trigger=cycle_trigger,
                         item_label=item_label,
                     )
                     searched += 1
@@ -333,12 +376,21 @@ async def run_instance_search(instance: Instance, master_key: bytes) -> int:
     # Cutoff-unmet pass (only when enabled)
     # -----------------------------------------------------------------------
     if instance.cutoff_enabled:
-        searched += await _run_cutoff_pass(instance)
+        searched += await _run_cutoff_pass(
+            instance,
+            cycle_id=cycle_id_value,
+            cycle_trigger=cycle_trigger,
+        )
 
     return searched
 
 
-async def _run_cutoff_pass(instance: Instance) -> int:
+async def _run_cutoff_pass(
+    instance: Instance,
+    *,
+    cycle_id: str,
+    cycle_trigger: CycleTrigger,
+) -> int:
     """Execute the cutoff-unmet search pass for *instance*.
 
     Fetches one page of cutoff-unmet items and searches each eligible one,
@@ -411,6 +463,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                             item_type,
                             "skipped",
                             search_kind="cutoff",
+                            cycle_id=cycle_id,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -428,6 +482,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                             item_type,
                             "skipped",
                             search_kind="cutoff",
+                            cycle_id=cycle_id,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -448,6 +504,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                             item_type,
                             "skipped",
                             search_kind="cutoff",
+                            cycle_id=cycle_id,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -470,6 +528,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                             item_type,
                             "error",
                             search_kind="cutoff",
+                            cycle_id=cycle_id,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             message=msg,
                         )
@@ -482,6 +542,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                         item_type,
                         "searched",
                         search_kind="cutoff",
+                        cycle_id=cycle_id,
+                        cycle_trigger=cycle_trigger,
                         item_label=item_label,
                     )
                     searched += 1
@@ -532,6 +594,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                             item_type,
                             "skipped",
                             search_kind="cutoff",
+                            cycle_id=cycle_id,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -549,6 +613,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                             item_type,
                             "skipped",
                             search_kind="cutoff",
+                            cycle_id=cycle_id,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -569,6 +635,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                             item_type,
                             "skipped",
                             search_kind="cutoff",
+                            cycle_id=cycle_id,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             reason=reason,
                         )
@@ -591,6 +659,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                             item_type,
                             "error",
                             search_kind="cutoff",
+                            cycle_id=cycle_id,
+                            cycle_trigger=cycle_trigger,
                             item_label=item_label,
                             message=msg,
                         )
@@ -603,6 +673,8 @@ async def _run_cutoff_pass(instance: Instance) -> int:
                         item_type,
                         "searched",
                         search_kind="cutoff",
+                        cycle_id=cycle_id,
+                        cycle_trigger=cycle_trigger,
                         item_label=item_label,
                     )
                     searched += 1

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -13,8 +13,9 @@ import logging
 from contextlib import suppress
 from functools import partial
 from typing import Literal
+from uuid import uuid4
 
-from houndarr.engine.search_loop import _write_log, run_instance_search
+from houndarr.engine.search_loop import CycleTrigger, _write_log, run_instance_search
 from houndarr.services.instances import Instance, get_instance, list_instances
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,7 @@ class Supervisor:
             item_id=None,
             item_type=None,
             action="info",
+            cycle_trigger="system",
             message=f"Supervisor started {len(self._tasks)} task(s)",
         )
 
@@ -202,7 +204,7 @@ class Supervisor:
                     )
                     return
 
-                await self._run_search_cycle(instance)
+                await self._run_search_cycle(instance, cycle_trigger="scheduled")
 
                 await asyncio.sleep(instance.sleep_interval_mins * 60)
 
@@ -216,14 +218,20 @@ class Supervisor:
         if instance is None or not instance.enabled:
             return
 
-        await self._run_search_cycle(instance)
+        await self._run_search_cycle(instance, cycle_trigger="run_now")
 
-    async def _run_search_cycle(self, instance: Instance) -> None:
+    async def _run_search_cycle(self, instance: Instance, *, cycle_trigger: CycleTrigger) -> None:
         """Run exactly one cycle for *instance* under the per-instance lock."""
         lock = self._run_locks.setdefault(instance.id, asyncio.Lock())
         async with lock:
+            cycle_id = str(uuid4())
             try:
-                await run_instance_search(instance, self._master_key)
+                await run_instance_search(
+                    instance,
+                    self._master_key,
+                    cycle_id=cycle_id,
+                    cycle_trigger=cycle_trigger,
+                )
             except Exception as exc:  # noqa: BLE001
                 logger.error(
                     "Supervisor: unhandled error in search loop for %r: %s",
@@ -235,6 +243,8 @@ class Supervisor:
                     item_id=None,
                     item_type=None,
                     action="error",
+                    cycle_id=cycle_id,
+                    cycle_trigger=cycle_trigger,
                     message=str(exc),
                 )
 

--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -83,7 +83,8 @@ async def _query_logs(
 
     Returns:
         List of dicts with keys: id, instance_id, instance_name, item_id,
-        item_type, item_label, action, reason, message, timestamp.
+        item_type, search_kind, cycle_id, cycle_trigger, item_label, action,
+        reason, message, timestamp.
     """
     limit = min(max(1, limit), _LOG_LIMIT_MAX)
 
@@ -115,6 +116,9 @@ async def _query_logs(
             END AS instance_name,
             sl.item_id,
             sl.item_type,
+            sl.search_kind,
+            sl.cycle_id,
+            sl.cycle_trigger,
             sl.item_label,
             sl.action,
             sl.reason,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,12 +29,12 @@ async def test_schema_created(db: None) -> None:
 async def test_schema_version_set(db: None) -> None:
     """Schema version should be set after init."""
     version = await get_setting("schema_version")
-    assert version == "2"
+    assert version == "3"
 
 
 @pytest.mark.asyncio()
-async def test_search_log_and_instance_v2_columns_exist(db: None) -> None:
-    """v2 schema adds log labels and cutoff-specific throttling columns."""
+async def test_search_log_and_instance_v3_columns_exist(db: None) -> None:
+    """v3 schema includes cycle context plus cutoff-specific throttling columns."""
     async with (
         get_db() as conn,
         conn.execute("PRAGMA table_info(search_log)") as search_log_cur,
@@ -45,13 +45,15 @@ async def test_search_log_and_instance_v2_columns_exist(db: None) -> None:
 
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
+    assert "cycle_id" in search_log_columns
+    assert "cycle_trigger" in search_log_columns
     assert "cutoff_cooldown_days" in instance_columns
     assert "cutoff_hourly_cap" in instance_columns
 
 
 @pytest.mark.asyncio()
-async def test_init_db_migrates_v1_schema_to_v2(tmp_path: Path) -> None:
-    """init_db should migrate existing schema_version=1 databases to v2."""
+async def test_init_db_migrates_v1_schema_to_v3(tmp_path: Path) -> None:
+    """init_db should migrate existing schema_version=1 databases to v3."""
     db_path = tmp_path / "migrate-v1.db"
 
     async with aiosqlite.connect(str(db_path)) as conn:
@@ -103,11 +105,72 @@ async def test_init_db_migrates_v1_schema_to_v2(tmp_path: Path) -> None:
         search_log_columns = {row[1] async for row in search_log_cur}
         instance_columns = {row[1] async for row in instances_cur}
 
-    assert await get_setting("schema_version") == "2"
+    assert await get_setting("schema_version") == "3"
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
+    assert "cycle_id" in search_log_columns
+    assert "cycle_trigger" in search_log_columns
     assert "cutoff_cooldown_days" in instance_columns
     assert "cutoff_hourly_cap" in instance_columns
+
+
+@pytest.mark.asyncio()
+async def test_init_db_migrates_v2_schema_to_v3(tmp_path: Path) -> None:
+    """init_db should migrate existing schema_version=2 databases to v3."""
+    db_path = tmp_path / "migrate-v2.db"
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await conn.executescript(
+            """
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO settings (key, value) VALUES ('schema_version', '2');
+
+            CREATE TABLE instances (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL,
+                url TEXT NOT NULL,
+                encrypted_api_key TEXT NOT NULL DEFAULT '',
+                batch_size INTEGER NOT NULL DEFAULT 2,
+                sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+                hourly_cap INTEGER NOT NULL DEFAULT 4,
+                cooldown_days INTEGER NOT NULL DEFAULT 14,
+                unreleased_delay_hrs INTEGER NOT NULL DEFAULT 36,
+                cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+                cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+                cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+                cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE search_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER,
+                item_id INTEGER,
+                item_type TEXT,
+                search_kind TEXT,
+                item_label TEXT,
+                action TEXT NOT NULL,
+                reason TEXT,
+                message TEXT,
+                timestamp TEXT NOT NULL
+            );
+            """
+        )
+        await conn.commit()
+
+    set_db_path(str(db_path))
+    await init_db()
+
+    async with get_db() as conn:
+        async with conn.execute("PRAGMA table_info(search_log)") as cur:
+            search_log_columns = {row[1] async for row in cur}
+
+    assert await get_setting("schema_version") == "3"
+    assert "cycle_id" in search_log_columns
+    assert "cycle_trigger" in search_log_columns
 
 
 @pytest.mark.asyncio()

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -145,6 +145,8 @@ async def test_item_is_searched_when_not_on_cooldown(seeded_instances: None) -> 
     assert rows[0]["item_type"] == "episode"
     assert rows[0]["item_label"] == "My Show - S01E01 - Pilot"
     assert rows[0]["search_kind"] == "missing"
+    assert rows[0]["cycle_id"]
+    assert rows[0]["cycle_trigger"] == "scheduled"
 
 
 @pytest.mark.asyncio()
@@ -168,6 +170,8 @@ async def test_radarr_item_is_searched(seeded_instances: None) -> None:
     assert rows[0]["item_type"] == "movie"
     assert rows[0]["item_label"] == "My Movie (2023)"
     assert rows[0]["search_kind"] == "missing"
+    assert rows[0]["cycle_id"]
+    assert rows[0]["cycle_trigger"] == "scheduled"
 
 
 # ---------------------------------------------------------------------------
@@ -456,6 +460,8 @@ async def test_search_log_row_written_on_success(seeded_instances: None) -> None
     assert row["item_type"] == "episode"
     assert row["item_label"] == "My Show - S01E01 - Pilot"
     assert row["search_kind"] == "missing"
+    assert row["cycle_id"]
+    assert row["cycle_trigger"] == "scheduled"
     assert row["action"] == "searched"
     assert row["reason"] is None
     assert row["timestamp"] is not None
@@ -506,6 +512,91 @@ async def test_search_log_row_written_on_error(seeded_instances: None) -> None:
     assert len(rows) == 1
     assert rows[0]["action"] == "error"
     assert rows[0]["item_id"] == 101
+    assert rows[0]["cycle_id"]
+    assert rows[0]["cycle_trigger"] == "scheduled"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cycle_id_is_shared_between_missing_and_cutoff_passes(seeded_instances: None) -> None:
+    """One run_instance_search invocation should reuse cycle_id across both passes."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [{**_EPISODE_RECORD, "id": 501}]})
+    )
+    respx.get(f"{SONARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json={"records": [{**_EPISODE_RECORD, "id": 502}]})
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_cutoff_instance(
+        cutoff_enabled=True,
+        cutoff_batch_size=1,
+        cooldown_days=0,
+        cutoff_cooldown_days=0,
+        unreleased_delay_hrs=0,
+    )
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 2
+    rows = await _get_log_rows()
+    searched_rows = [row for row in rows if row["action"] == "searched"]
+    assert len(searched_rows) == 2
+    assert searched_rows[0]["search_kind"] == "missing"
+    assert searched_rows[1]["search_kind"] == "cutoff"
+    assert searched_rows[0]["cycle_id"] == searched_rows[1]["cycle_id"]
+    assert searched_rows[0]["cycle_trigger"] == "scheduled"
+    assert searched_rows[1]["cycle_trigger"] == "scheduled"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cycle_id_changes_across_distinct_invocations(seeded_instances: None) -> None:
+    """Separate run_instance_search invocations should use different cycle IDs."""
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json={"records": [{**_EPISODE_RECORD, "id": 701}]}),
+            httpx.Response(200, json={"records": [{**_EPISODE_RECORD, "id": 702}]}),
+        ]
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(cooldown_days=0, unreleased_delay_hrs=0, batch_size=1)
+    first_count = await run_instance_search(instance, MASTER_KEY)
+    second_count = await run_instance_search(instance, MASTER_KEY)
+
+    assert first_count == 1
+    assert second_count == 1
+    assert missing_route.call_count == 2
+
+    rows = await _get_log_rows()
+    searched_rows = [row for row in rows if row["action"] == "searched"]
+    assert len(searched_rows) == 2
+    assert searched_rows[0]["cycle_id"] != searched_rows[1]["cycle_id"]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_run_now_trigger_is_persisted_in_log_rows(seeded_instances: None) -> None:
+    """Manual trigger context should persist as cycle_trigger='run_now'."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [{**_EPISODE_RECORD, "id": 801}]})
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(cooldown_days=0, unreleased_delay_hrs=0, batch_size=1)
+    count = await run_instance_search(instance, MASTER_KEY, cycle_trigger="run_now")
+
+    assert count == 1
+    rows = await _get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["cycle_id"]
+    assert rows[0]["cycle_trigger"] == "run_now"
 
 
 @pytest.mark.asyncio()
@@ -540,6 +631,26 @@ async def test_supervisor_starts_and_stops_cleanly(db: None) -> None:
     await sup.start()
     await sup.stop()
     assert sup._tasks == {}  # noqa: SLF001
+
+
+@pytest.mark.asyncio()
+async def test_supervisor_start_logs_system_row_with_null_cycle_id(seeded_instances: None) -> None:
+    """Supervisor lifecycle rows are classified as system and keep cycle_id NULL."""
+    from houndarr.engine.supervisor import Supervisor
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        new=AsyncMock(return_value=0),
+    ):
+        sup = Supervisor(master_key=MASTER_KEY)
+        await sup.start()
+        await sup.stop()
+
+    rows = await _get_log_rows()
+    info_rows = [row for row in rows if row["action"] == "info"]
+    assert info_rows
+    assert info_rows[0]["cycle_trigger"] == "system"
+    assert info_rows[0]["cycle_id"] is None
 
 
 @pytest.mark.asyncio()
@@ -688,6 +799,61 @@ async def test_trigger_run_now_deduplicates_pending_manual_runs(
         assert status_1 == "accepted"
         assert status_2 == "accepted"
         assert len(sup._manual_runs) == 1  # noqa: SLF001
+
+        gate.set()
+        await asyncio.sleep(0)
+        await sup.stop()
+
+
+@pytest.mark.asyncio()
+async def test_supervisor_scheduled_cycles_pass_scheduled_trigger(seeded_instances: None) -> None:
+    """Scheduled supervisor loop should call engine with cycle_trigger='scheduled'."""
+    import asyncio
+
+    from houndarr.engine.supervisor import Supervisor
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        new=AsyncMock(return_value=0),
+    ) as run_mock:
+        sup = Supervisor(master_key=MASTER_KEY)
+        await sup.start()
+        await asyncio.sleep(0.05)
+        await sup.stop()
+
+    assert run_mock.call_count >= 1
+    trigger_values = [call.kwargs.get("cycle_trigger") for call in run_mock.call_args_list]
+    assert "scheduled" in trigger_values
+    assert all(call.kwargs.get("cycle_id") for call in run_mock.call_args_list)
+
+
+@pytest.mark.asyncio()
+async def test_supervisor_run_now_passes_run_now_trigger(seeded_instances: None) -> None:
+    """Run-now should call engine with cycle_trigger='run_now'."""
+    import asyncio
+
+    from houndarr.engine.supervisor import Supervisor
+
+    gate = asyncio.Event()
+
+    async def _block(*_: object, **__: object) -> int:
+        await gate.wait()
+        return 0
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        new=AsyncMock(side_effect=_block),
+    ) as run_mock:
+        sup = Supervisor(master_key=MASTER_KEY)
+        status = await sup.trigger_run_now(1)
+        assert status == "accepted"
+        await asyncio.sleep(0.05)
+
+        called_with_run_now = any(
+            call.kwargs.get("cycle_trigger") == "run_now" for call in run_mock.call_args_list
+        )
+        assert called_with_run_now
+        assert all(call.kwargs.get("cycle_id") for call in run_mock.call_args_list)
 
         gate.set()
         await asyncio.sleep(0)

--- a/tests/test_routes/test_logs.py
+++ b/tests/test_routes/test_logs.py
@@ -63,13 +63,15 @@ async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[mi
                     item_id,
                     item_type,
                     search_kind,
+                    cycle_id,
+                    cycle_trigger,
                     item_label,
                     action,
                     reason,
                     message,
                     timestamp
                 )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
@@ -77,6 +79,8 @@ async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[mi
                     101,
                     "episode",
                     "missing",
+                    "cycle-a",
+                    "scheduled",
                     "My Show - S01E01 - Pilot",
                     "searched",
                     None,
@@ -88,6 +92,8 @@ async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[mi
                     102,
                     "episode",
                     "missing",
+                    "cycle-a",
+                    "scheduled",
                     "My Show - S01E02 - Next",
                     "skipped",
                     "on cooldown (7d)",
@@ -99,6 +105,8 @@ async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[mi
                     201,
                     "movie",
                     "missing",
+                    "cycle-b",
+                    "run_now",
                     "My Movie (2023)",
                     "searched",
                     None,
@@ -110,6 +118,8 @@ async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[mi
                     202,
                     "movie",
                     "missing",
+                    "cycle-b",
+                    "run_now",
                     "Another Movie (2024)",
                     "error",
                     None,
@@ -121,6 +131,8 @@ async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[mi
                     None,
                     None,
                     None,
+                    None,
+                    "system",
                     None,
                     "info",
                     None,
@@ -201,6 +213,9 @@ async def test_logs_returns_all_rows(seeded_log: None, async_client: object) -> 
     assert actions[0] == "error"  # 12:03
     assert actions[-1] == "info"  # 11:59
     assert data[0]["item_label"] == "Another Movie (2024)"
+    assert data[0]["search_kind"] == "missing"
+    assert data[0]["cycle_id"] == "cycle-b"
+    assert data[0]["cycle_trigger"] == "run_now"
 
 
 @pytest.mark.asyncio()
@@ -305,6 +320,8 @@ async def test_logs_system_rows_render_as_system_label(
     assert len(data) == 1
     assert data[0]["instance_id"] is None
     assert data[0]["instance_name"] == "System"
+    assert data[0]["cycle_id"] is None
+    assert data[0]["cycle_trigger"] == "system"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- Add schema v3 log context columns (`cycle_id`, `cycle_trigger`) with additive migrations from v1/v2 and a compatible index creation path.
- Wire cycle metadata through producer paths: one cycle ID per `run_instance_search(...)` invocation, shared across missing+cutoff passes; classify lifecycle rows as `cycle_trigger=system` with `cycle_id` null.
- Expose `search_kind`, `cycle_id`, and `cycle_trigger` in logs API query results; add tests and a small docs note.

## Testing
- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest

Closes #60