### PR TITLE
feat(logs): improve operator clarity with cycle/trigger columns and filters

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -82,6 +82,10 @@ exists and which rows belong to the same run:
 System lifecycle rows (for example, supervisor startup messages) are tagged
 `cycle_trigger=system` and keep `cycle_id` empty.
 
+In the Logs page, you can now filter by `search_kind` and `cycle_trigger`. The
+UI defaults to hiding system rows (`hide_system=true`) to keep operator-facing
+views focused on search activity.
+
 ## Status Control
 
 - **Enabled/Disabled**: controlled from the row toggle in Settings.

--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -22,6 +22,8 @@ router = APIRouter()
 
 _LOG_LIMIT_DEFAULT = 50
 _LOG_LIMIT_MAX = 500
+_SEARCH_KINDS = {"missing", "cutoff"}
+_CYCLE_TRIGGERS = {"scheduled", "run_now", "system"}
 
 
 def _parse_instance_id(raw: str | None) -> int | None:
@@ -44,6 +46,39 @@ def _parse_instance_id(raw: str | None) -> int | None:
         return int(raw)
     except ValueError as exc:  # pragma: no cover - defensive path
         raise HTTPException(status_code=422, detail="instance_id must be an integer") from exc
+
+
+def _parse_search_kind(raw: str | None) -> str | None:
+    """Parse optional search_kind query param."""
+    if raw is None or raw == "":
+        return None
+    if raw not in _SEARCH_KINDS:
+        raise HTTPException(status_code=422, detail="search_kind must be 'missing' or 'cutoff'")
+    return raw
+
+
+def _parse_cycle_trigger(raw: str | None) -> str | None:
+    """Parse optional cycle_trigger query param."""
+    if raw is None or raw == "":
+        return None
+    if raw not in _CYCLE_TRIGGERS:
+        raise HTTPException(
+            status_code=422,
+            detail="cycle_trigger must be 'scheduled', 'run_now', or 'system'",
+        )
+    return raw
+
+
+def _parse_hide_system(raw: str | None) -> bool:
+    """Parse hide_system checkbox/select values from query params."""
+    if raw is None or raw == "":
+        return False
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise HTTPException(status_code=422, detail="hide_system must be a boolean")
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +105,9 @@ def _get_templates() -> Jinja2Templates:
 async def _query_logs(
     instance_id: int | None,
     action: str | None,
+    search_kind: str | None,
+    cycle_trigger: str | None,
+    hide_system: bool,
     before: str | None,
     limit: int,
 ) -> list[dict[str, Any]]:
@@ -78,6 +116,9 @@ async def _query_logs(
     Args:
         instance_id: Restrict to a specific instance (None = all).
         action: One of ``searched``, ``skipped``, ``error``, ``info`` (None = all).
+        search_kind: ``missing`` or ``cutoff`` (None = all).
+        cycle_trigger: ``scheduled``, ``run_now``, or ``system`` (None = all).
+        hide_system: When True, hide system lifecycle rows from results.
         before: ISO-8601 timestamp cursor — return rows older than this value.
         limit: Maximum number of rows to return.
 
@@ -98,6 +139,20 @@ async def _query_logs(
     if action is not None:
         conditions.append("sl.action = ?")
         params.append(action)
+
+    if search_kind is not None:
+        conditions.append("sl.search_kind = ?")
+        params.append(search_kind)
+
+    if cycle_trigger is not None:
+        conditions.append("sl.cycle_trigger = ?")
+        params.append(cycle_trigger)
+
+    if hide_system:
+        conditions.append(
+            "NOT (COALESCE(sl.cycle_trigger, '') = 'system' "
+            "OR (sl.instance_id IS NULL AND sl.action = 'info'))"
+        )
 
     if before is not None:
         conditions.append("sl.timestamp < ?")
@@ -123,6 +178,16 @@ async def _query_logs(
             sl.action,
             sl.reason,
             sl.message,
+            CASE
+                WHEN sl.cycle_id IS NULL THEN NULL
+                WHEN EXISTS (
+                    SELECT 1
+                    FROM search_log sl2
+                    WHERE sl2.cycle_id = sl.cycle_id
+                      AND sl2.action = 'searched'
+                ) THEN 'progress'
+                ELSE 'no_progress'
+            END AS cycle_progress,
             sl.timestamp
         FROM search_log sl
         LEFT JOIN instances i ON i.id = sl.instance_id
@@ -148,6 +213,9 @@ async def _query_logs(
 async def get_logs(
     instance_id: str | None = Query(default=None),
     action: str | None = Query(default=None),
+    search_kind: str | None = Query(default=None),
+    cycle_trigger: str | None = Query(default=None),
+    hide_system: str | None = Query(default=None),
     before: str | None = Query(default=None),
     limit: int = Query(default=_LOG_LIMIT_DEFAULT, ge=1, le=_LOG_LIMIT_MAX),
 ) -> JSONResponse:
@@ -156,6 +224,9 @@ async def get_logs(
     Args:
         instance_id: Filter to a specific instance ID.
         action: Filter by action (``searched``, ``skipped``, ``error``, ``info``).
+        search_kind: Filter by search pass kind (``missing`` or ``cutoff``).
+        cycle_trigger: Filter by cycle trigger (``scheduled``, ``run_now``, ``system``).
+        hide_system: When true, hide system lifecycle rows.
         before: Timestamp cursor — only return rows older than this ISO-8601 value.
         limit: Max rows (1–500, default 50).
 
@@ -164,7 +235,18 @@ async def get_logs(
     """
     parsed_instance_id = _parse_instance_id(instance_id)
     parsed_action = action or None
-    rows = await _query_logs(parsed_instance_id, parsed_action, before, limit)
+    parsed_search_kind = _parse_search_kind(search_kind)
+    parsed_cycle_trigger = _parse_cycle_trigger(cycle_trigger)
+    parsed_hide_system = _parse_hide_system(hide_system)
+    rows = await _query_logs(
+        parsed_instance_id,
+        parsed_action,
+        parsed_search_kind,
+        parsed_cycle_trigger,
+        parsed_hide_system,
+        before,
+        limit,
+    )
     return JSONResponse(rows)
 
 
@@ -173,6 +255,9 @@ async def get_logs_partial(
     request: Request,
     instance_id: str | None = Query(default=None),
     action: str | None = Query(default=None),
+    search_kind: str | None = Query(default=None),
+    cycle_trigger: str | None = Query(default=None),
+    hide_system: str | None = Query(default=None),
     before: str | None = Query(default=None),
     limit: int = Query(default=_LOG_LIMIT_DEFAULT, ge=1, le=_LOG_LIMIT_MAX),
 ) -> HTMLResponse:
@@ -182,6 +267,9 @@ async def get_logs_partial(
         request: FastAPI request (required for template rendering).
         instance_id: Filter to a specific instance ID.
         action: Filter by action.
+        search_kind: Filter by search pass kind.
+        cycle_trigger: Filter by trigger type.
+        hide_system: Whether to hide system lifecycle rows.
         before: Timestamp cursor.
         limit: Max rows.
 
@@ -190,7 +278,18 @@ async def get_logs_partial(
     """
     parsed_instance_id = _parse_instance_id(instance_id)
     parsed_action = action or None
-    rows = await _query_logs(parsed_instance_id, parsed_action, before, limit)
+    parsed_search_kind = _parse_search_kind(search_kind)
+    parsed_cycle_trigger = _parse_cycle_trigger(cycle_trigger)
+    parsed_hide_system = _parse_hide_system(hide_system)
+    rows = await _query_logs(
+        parsed_instance_id,
+        parsed_action,
+        parsed_search_kind,
+        parsed_cycle_trigger,
+        parsed_hide_system,
+        before,
+        limit,
+    )
 
     return _get_templates().TemplateResponse(
         request=request,
@@ -200,6 +299,9 @@ async def get_logs_partial(
             # Pass back current filter values so the partial can render pagination
             "instance_id": parsed_instance_id,
             "action": parsed_action,
+            "search_kind": parsed_search_kind,
+            "cycle_trigger": parsed_cycle_trigger,
+            "hide_system": parsed_hide_system,
             "before": before,
             "limit": limit,
         },

--- a/src/houndarr/routes/pages.py
+++ b/src/houndarr/routes/pages.py
@@ -192,6 +192,9 @@ async def logs_page(request: Request) -> HTMLResponse:
     rows = await _query_logs(
         instance_id=None,
         action=None,
+        search_kind=None,
+        cycle_trigger=None,
+        hide_system=True,
         before=None,
         limit=50,
     )
@@ -203,6 +206,14 @@ async def logs_page(request: Request) -> HTMLResponse:
         limit=50,
         selected_instance_id=None,
         selected_action=None,
+        selected_search_kind=None,
+        selected_cycle_trigger=None,
+        selected_hide_system=True,
+        instance_id=None,
+        action=None,
+        search_kind=None,
+        cycle_trigger=None,
+        hide_system=True,
         before=None,
     )
 

--- a/src/houndarr/templates/logs.html
+++ b/src/houndarr/templates/logs.html
@@ -99,6 +99,42 @@
     </select>
   </div>
 
+  {# Search kind filter #}
+  <div class="flex flex-col gap-1">
+    <label for="filter-search-kind" class="text-xs text-slate-400 font-medium">Kind</label>
+    <select id="filter-search-kind" name="search_kind"
+            class="bg-slate-800 border border-slate-700 text-slate-200 text-sm rounded-lg px-3 py-2
+                   focus:outline-none focus:ring-1 focus:ring-brand-500 focus:border-brand-500">
+      <option value="">All kinds</option>
+      <option value="missing" {% if selected_search_kind == "missing" %}selected{% endif %}>Missing</option>
+      <option value="cutoff" {% if selected_search_kind == "cutoff" %}selected{% endif %}>Cutoff</option>
+    </select>
+  </div>
+
+  {# Trigger filter #}
+  <div class="flex flex-col gap-1">
+    <label for="filter-cycle-trigger" class="text-xs text-slate-400 font-medium">Trigger</label>
+    <select id="filter-cycle-trigger" name="cycle_trigger"
+            class="bg-slate-800 border border-slate-700 text-slate-200 text-sm rounded-lg px-3 py-2
+                   focus:outline-none focus:ring-1 focus:ring-brand-500 focus:border-brand-500">
+      <option value="">All triggers</option>
+      <option value="scheduled" {% if selected_cycle_trigger == "scheduled" %}selected{% endif %}>Scheduled</option>
+      <option value="run_now" {% if selected_cycle_trigger == "run_now" %}selected{% endif %}>Run now</option>
+      <option value="system" {% if selected_cycle_trigger == "system" %}selected{% endif %}>System</option>
+    </select>
+  </div>
+
+  {# Hide system rows toggle #}
+  <div class="flex items-center gap-2 pb-2">
+    <input id="filter-hide-system"
+           name="hide_system"
+           type="checkbox"
+           value="true"
+           {% if selected_hide_system %}checked{% endif %}
+           class="w-4 h-4 rounded border-slate-600 bg-slate-800 text-brand-500 focus:ring-brand-500 focus:ring-offset-0">
+    <label for="filter-hide-system" class="text-xs text-slate-300 font-medium">Hide system rows</label>
+  </div>
+
   <div class="w-full sm:w-auto sm:ml-auto flex items-center sm:justify-end gap-2 pb-0.5">
     <button id="copy-visible-logs-btn"
             type="button"
@@ -128,6 +164,10 @@
         <th class="px-3 py-2.5 font-medium">Instance</th>
         <th class="px-3 py-2.5 font-medium">Action</th>
         <th class="px-3 py-2.5 font-medium">Type</th>
+        <th class="px-3 py-2.5 font-medium">Kind</th>
+        <th class="px-3 py-2.5 font-medium">Trigger</th>
+        <th class="px-3 py-2.5 font-medium">Cycle</th>
+        <th class="px-3 py-2.5 font-medium">Progress</th>
         <th class="px-3 py-2.5 font-medium">Media</th>
         <th class="px-3 py-2.5 font-medium">Reason / Message</th>
       </tr>
@@ -180,8 +220,8 @@
       return;
     }
 
-    const header = ['Timestamp (Local)', 'Instance', 'Action', 'Type', 'Media', 'Reason / Message'];
-    const divider = ['---', '---', '---', '---', '---', '---'];
+    const header = ['Timestamp (Local)', 'Instance', 'Action', 'Type', 'Kind', 'Trigger', 'Cycle', 'Progress', 'Media', 'Reason / Message'];
+    const divider = ['---', '---', '---', '---', '---', '---', '---', '---', '---', '---'];
     const lines = [
       `| ${header.join(' | ')} |`,
       `| ${divider.join(' | ')} |`,
@@ -193,6 +233,10 @@
         row.querySelector('[data-col="instance"]')?.textContent?.trim() || '—',
         row.querySelector('[data-col="action"]')?.textContent?.trim() || '—',
         row.querySelector('[data-col="type"]')?.textContent?.trim() || '—',
+        row.querySelector('[data-col="kind"]')?.textContent?.trim() || '—',
+        row.querySelector('[data-col="trigger"]')?.textContent?.trim() || '—',
+        row.querySelector('[data-col="cycle"]')?.textContent?.trim() || '—',
+        row.querySelector('[data-col="progress"]')?.textContent?.trim() || '—',
         row.querySelector('[data-col="media"]')?.textContent?.replace(/\s+/g, ' ').trim() || '—',
         row.querySelector('[data-col="reason"]')?.textContent?.trim() || '—',
       ].map(escapePipes);

--- a/src/houndarr/templates/partials/log_rows.html
+++ b/src/houndarr/templates/partials/log_rows.html
@@ -30,6 +30,50 @@
       {{ row.item_type or "—" }}
     </td>
 
+    {# Search kind #}
+    <td class="px-3 py-2.5" data-col="kind">
+      {% if row.search_kind == "missing" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-sky-900/50 text-sky-300">missing</span>
+      {% elif row.search_kind == "cutoff" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-amber-900/50 text-amber-300">cutoff</span>
+      {% else %}
+        <span class="text-slate-500">—</span>
+      {% endif %}
+    </td>
+
+    {# Cycle trigger #}
+    <td class="px-3 py-2.5" data-col="trigger">
+      {% if row.cycle_trigger == "scheduled" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-blue-900/50 text-blue-300">scheduled</span>
+      {% elif row.cycle_trigger == "run_now" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-emerald-900/50 text-emerald-300">run_now</span>
+      {% elif row.cycle_trigger == "system" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-slate-700 text-slate-300">system</span>
+      {% else %}
+        <span class="text-slate-500">—</span>
+      {% endif %}
+    </td>
+
+    {# Cycle id #}
+    <td class="px-3 py-2.5 text-xs text-slate-300 font-mono" data-col="cycle" title="{{ row.cycle_id or '' }}">
+      {% if row.cycle_id %}
+        {{ row.cycle_id[:8] }}
+      {% else %}
+        <span class="text-slate-500">—</span>
+      {% endif %}
+    </td>
+
+    {# Cycle progress #}
+    <td class="px-3 py-2.5" data-col="progress">
+      {% if row.cycle_progress == "progress" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-green-900/50 text-green-300">progress</span>
+      {% elif row.cycle_progress == "no_progress" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium bg-zinc-700 text-zinc-300">no progress</span>
+      {% else %}
+        <span class="text-slate-500">—</span>
+      {% endif %}
+    </td>
+
     {# Media label + ID fallback #}
     <td class="px-3 py-2.5 text-xs text-slate-300 max-w-[320px] truncate"
         data-col="media"
@@ -58,9 +102,9 @@
   {# Pagination: "Load older" link — only show if we got a full page #}
   {% if rows | length >= limit %}
   <tr id="pagination-row">
-    <td colspan="6" class="px-3 py-3 text-center">
+    <td colspan="10" class="px-3 py-3 text-center">
       <button
-        hx-get="/api/logs/partial?limit={{ limit }}{% if instance_id %}&instance_id={{ instance_id }}{% endif %}{% if action %}&action={{ action }}{% endif %}&before={{ rows[-1].timestamp }}"
+        hx-get="/api/logs/partial?limit={{ limit }}{% if instance_id %}&instance_id={{ instance_id }}{% endif %}{% if action %}&action={{ action }}{% endif %}{% if search_kind %}&search_kind={{ search_kind }}{% endif %}{% if cycle_trigger %}&cycle_trigger={{ cycle_trigger }}{% endif %}&hide_system={{ 'true' if hide_system else 'false' }}&before={{ rows[-1].timestamp }}"
         hx-target="#pagination-row"
         hx-swap="outerHTML"
         class="text-xs text-brand-400 hover:text-brand-300 transition-colors underline-offset-2 hover:underline">
@@ -72,7 +116,7 @@
 
 {% else %}
   <tr id="log-empty-row">
-    <td colspan="6" class="px-3 py-12 text-center text-slate-500 text-sm">
+    <td colspan="10" class="px-3 py-12 text-center text-slate-500 text-sm">
       No log entries found.
     </td>
   </tr>

--- a/tests/test_routes/test_logs.py
+++ b/tests/test_routes/test_logs.py
@@ -91,7 +91,7 @@ async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[mi
                     1,
                     102,
                     "episode",
-                    "missing",
+                    "cutoff",
                     "cycle-a",
                     "scheduled",
                     "My Show - S01E02 - Next",
@@ -216,6 +216,7 @@ async def test_logs_returns_all_rows(seeded_log: None, async_client: object) -> 
     assert data[0]["search_kind"] == "missing"
     assert data[0]["cycle_id"] == "cycle-b"
     assert data[0]["cycle_trigger"] == "run_now"
+    assert data[0]["cycle_progress"] == "progress"
 
 
 @pytest.mark.asyncio()
@@ -279,6 +280,94 @@ async def test_logs_filter_by_action(seeded_log: None, async_client: object) -> 
     assert len(data) == 2
     for row in data:
         assert row["action"] == "searched"
+
+
+@pytest.mark.asyncio()
+async def test_logs_filter_by_search_kind(seeded_log: None, async_client: object) -> None:
+    """Filtering by search_kind returns only rows with that kind."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?search_kind=cutoff&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["search_kind"] == "cutoff"
+
+
+@pytest.mark.asyncio()
+async def test_logs_filter_by_cycle_trigger(seeded_log: None, async_client: object) -> None:
+    """Filtering by cycle_trigger returns only rows with that trigger."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?cycle_trigger=run_now&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    assert all(row["cycle_trigger"] == "run_now" for row in data)
+
+
+@pytest.mark.asyncio()
+async def test_logs_hide_system_rows_filter(seeded_log: None, async_client: object) -> None:
+    """hide_system=true should remove system lifecycle rows from results."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?hide_system=true&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 4
+    assert all(row["cycle_trigger"] != "system" for row in data)
+
+
+@pytest.mark.asyncio()
+async def test_logs_filters_compose_with_existing_filters(
+    seeded_log: None, async_client: object
+) -> None:
+    """Existing and new filters should compose deterministically."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get(
+        "/api/logs?instance_id=1&action=skipped&search_kind=cutoff&cycle_trigger=scheduled&hide_system=true&limit=200"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    row = data[0]
+    assert row["instance_id"] == 1
+    assert row["action"] == "skipped"
+    assert row["search_kind"] == "cutoff"
+    assert row["cycle_trigger"] == "scheduled"
 
 
 @pytest.mark.asyncio()
@@ -380,6 +469,13 @@ def test_logs_page_renders(app: TestClient) -> None:
     assert b"log-tbody" in resp.content
     assert b"Media" in resp.content
     assert b"Timestamp (Local)" in resp.content
+    assert b"Kind" in resp.content
+    assert b"Trigger" in resp.content
+    assert b"Cycle" in resp.content
+    assert b"Progress" in resp.content
+    assert b"Hide system rows" in resp.content
+    assert b'id="filter-hide-system"' in resp.content
+    assert b"checked" in resp.content
     assert b"Copy visible rows" in resp.content
     assert b'<option value="500">500</option>' in resp.content
 
@@ -417,6 +513,8 @@ async def test_logs_partial_returns_rows(seeded_log: None, async_client: object)
     # Should contain action badges
     assert "searched" in content or "skipped" in content
     assert "My Show - S01E01 - Pilot" in content
+    assert "run_now" in content
+    assert "progress" in content
 
 
 @pytest.mark.asyncio()
@@ -437,6 +535,26 @@ async def test_logs_partial_empty_instance_id_treated_as_all(
     resp = await async_client.get("/api/logs/partial?instance_id=&limit=200")
     assert resp.status_code == 200
     assert "<tr" in resp.text
+
+
+@pytest.mark.asyncio()
+async def test_logs_partial_hide_system_rows_excludes_system_entries(
+    seeded_log: None, async_client: object
+) -> None:
+    """Partial endpoint should hide system rows when hide_system=true."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs/partial?hide_system=true&limit=200")
+    assert resp.status_code == 200
+    assert "Supervisor started" not in resp.text
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- Add logs API filtering for `search_kind`, `cycle_trigger`, and `hide_system`, while preserving existing filters and compatibility.
- Improve logs table clarity with new Kind, Trigger, Cycle, and Progress columns plus compact badges and cycle-context rendering.
- Default the logs page UI to hide system rows, keep system row emission behavior unchanged, and align "Copy visible rows" export with visible columns.

## Testing
- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest

Closes #62