### PR TITLE
feat(dashboard): add operator-focused status enrichment

### DIFF
--- a/src/houndarr/routes/api/status.py
+++ b/src/houndarr/routes/api/status.py
@@ -84,6 +84,54 @@ async def _last_search_at(instance_id: int) -> str | None:
     return str(row["timestamp"]) if row else None
 
 
+async def _action_counts_last_24h(instance_id: int) -> dict[str, int]:
+    """Count searched/skipped/error rows in the past 24 hours."""
+    async with get_db() as db:
+        async with db.execute(
+            """
+            SELECT
+                SUM(CASE WHEN action = 'searched' THEN 1 ELSE 0 END) AS searched_count,
+                SUM(CASE WHEN action = 'skipped' THEN 1 ELSE 0 END) AS skipped_count,
+                SUM(CASE WHEN action = 'error' THEN 1 ELSE 0 END) AS error_count
+            FROM search_log
+            WHERE instance_id = ?
+              AND julianday(timestamp) >= julianday('now', '-24 hours')
+            """,
+            (instance_id,),
+        ) as cur:
+            row = await cur.fetchone()
+
+    searched_count = int(row["searched_count"] or 0) if row else 0
+    skipped_count = int(row["skipped_count"] or 0) if row else 0
+    error_count = int(row["error_count"] or 0) if row else 0
+    return {
+        "searched": searched_count,
+        "skipped": skipped_count,
+        "error": error_count,
+    }
+
+
+async def _last_activity(instance_id: int) -> tuple[str | None, str | None]:
+    """Return latest action/timestamp among searched/skipped/error rows."""
+    async with get_db() as db:
+        async with db.execute(
+            """
+            SELECT action, timestamp
+            FROM search_log
+            WHERE instance_id = ?
+              AND action IN ('searched', 'skipped', 'error')
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """,
+            (instance_id,),
+        ) as cur:
+            row = await cur.fetchone()
+
+    if row is None:
+        return None, None
+    return str(row["action"]), str(row["timestamp"])
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -98,6 +146,8 @@ async def get_status(request: Request) -> JSONResponse:
     results: list[dict[str, Any]] = []
     for inst in instances:
         last_at = await _last_search_at(inst.id)
+        action_counts_24h = await _action_counts_last_24h(inst.id)
+        last_activity_action, last_activity_at = await _last_activity(inst.id)
         results.append(
             {
                 "id": inst.id,
@@ -108,6 +158,18 @@ async def get_status(request: Request) -> JSONResponse:
                 "searches_last_hour": await _searches_last_hour(inst.id),
                 "searches_today": await _searches_today(inst.id),
                 "items_found_total": await _items_found_total(inst.id),
+                "searched_24h": action_counts_24h["searched"],
+                "skipped_24h": action_counts_24h["skipped"],
+                "errors_24h": action_counts_24h["error"],
+                "last_activity_action": last_activity_action,
+                "last_activity_at": last_activity_at,
+                "batch_size": inst.batch_size,
+                "sleep_interval_mins": inst.sleep_interval_mins,
+                "hourly_cap": inst.hourly_cap,
+                "cooldown_days": inst.cooldown_days,
+                "cutoff_enabled": inst.cutoff_enabled,
+                "cutoff_batch_size": inst.cutoff_batch_size,
+                "unreleased_delay_hrs": inst.unreleased_delay_hrs,
             }
         )
 

--- a/src/houndarr/templates/dashboard.html
+++ b/src/houndarr/templates/dashboard.html
@@ -124,6 +124,11 @@
   const RUN_NOW_ERROR_HOLD_MS = 1100;
   const previousMetrics = new Map();
 
+  function toNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
   function setRunNowButtonState(button, state) {
     const label = button.querySelector('[data-run-now-label]');
     const icon = button.querySelector('[data-run-now-icon]');
@@ -225,11 +230,56 @@
 
     const isInitialHydration = evt.detail.target.dataset.hydrated !== 'true';
 
+    const fleetSummary = data.reduce(function(acc, inst) {
+      const enabled = Boolean(inst.enabled);
+      acc.totalInstances += 1;
+      if (enabled) {
+        acc.enabledInstances += 1;
+      }
+      acc.searched24h += toNumber(inst.searched_24h);
+      acc.skipped24h += toNumber(inst.skipped_24h);
+      acc.errors24h += toNumber(inst.errors_24h);
+      return acc;
+    }, {
+      totalInstances: 0,
+      enabledInstances: 0,
+      searched24h: 0,
+      skipped24h: 0,
+      errors24h: 0,
+    });
+
+    const fleetSummaryMarkup = `
+      <section class="mb-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5" aria-label="Fleet summary">
+        <div class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3">
+          <p class="text-[11px] uppercase tracking-wide text-slate-500">Fleet summary</p>
+          <p class="mt-1 text-sm font-semibold text-white">${fleetSummary.enabledInstances}/${fleetSummary.totalInstances} enabled</p>
+        </div>
+        <div class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3">
+          <p class="text-[11px] uppercase tracking-wide text-slate-500">24h searched</p>
+          <p class="mt-1 text-sm font-semibold text-emerald-300">${fleetSummary.searched24h}</p>
+        </div>
+        <div class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3">
+          <p class="text-[11px] uppercase tracking-wide text-slate-500">24h skipped</p>
+          <p class="mt-1 text-sm font-semibold text-amber-300">${fleetSummary.skipped24h}</p>
+        </div>
+        <div class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3">
+          <p class="text-[11px] uppercase tracking-wide text-slate-500">24h errors</p>
+          <p class="mt-1 text-sm font-semibold text-rose-300">${fleetSummary.errors24h}</p>
+        </div>
+        <div class="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3">
+          <p class="text-[11px] uppercase tracking-wide text-slate-500">Auto-refresh</p>
+          <p class="mt-1 text-sm font-semibold text-slate-200">Every 15s</p>
+        </div>
+      </section>`;
+
     const cards = data.map((inst, index) => {
       const previous = previousMetrics.get(inst.id);
       const lastHourChanged = previous && previous.searches_last_hour !== inst.searches_last_hour;
       const todayChanged = previous && previous.searches_today !== inst.searches_today;
       const totalChanged = previous && previous.items_found_total !== inst.items_found_total;
+      const searched24hChanged = previous && previous.searched_24h !== toNumber(inst.searched_24h);
+      const skipped24hChanged = previous && previous.skipped_24h !== toNumber(inst.skipped_24h);
+      const errors24hChanged = previous && previous.errors_24h !== toNumber(inst.errors_24h);
 
       const badge = inst.enabled
         ? `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-900/60 text-green-300">
@@ -247,12 +297,37 @@
         ? formatLocalTimestamp(inst.last_search_at)
         : "Never";
 
+      const activityLabelMap = {
+        searched: 'Searched',
+        skipped: 'Skipped',
+        error: 'Error',
+      };
+      const lastActivity = inst.last_activity_at
+        ? `${activityLabelMap[inst.last_activity_action] || 'Activity'} at ${formatLocalTimestamp(inst.last_activity_at)}`
+        : 'No activity in recent history';
+
+      const policyChips = [
+        `Every ${toNumber(inst.sleep_interval_mins)}m`,
+        `Batch ${toNumber(inst.batch_size)}`,
+        `Cap/h ${toNumber(inst.hourly_cap)}`,
+        `Cooldown ${toNumber(inst.cooldown_days)}d`,
+        `Delay ${toNumber(inst.unreleased_delay_hrs)}h`,
+        inst.cutoff_enabled
+          ? `Cutoff on (${toNumber(inst.cutoff_batch_size)})`
+          : 'Cutoff off',
+      ].map(function(label) {
+        return `<span class="rounded-md border border-slate-700 bg-slate-800/60 px-2 py-1 text-[11px] text-slate-300">${label}</span>`;
+      }).join('');
+
       const animationDelay = Math.min(index * 40, 220);
 
       previousMetrics.set(inst.id, {
         searches_last_hour: inst.searches_last_hour,
         searches_today: inst.searches_today,
         items_found_total: inst.items_found_total,
+        searched_24h: toNumber(inst.searched_24h),
+        skipped_24h: toNumber(inst.skipped_24h),
+        errors_24h: toNumber(inst.errors_24h),
       });
 
       const entryClass = isInitialHydration ? ' is-entering' : '';
@@ -302,14 +377,33 @@
             </div>
           </dl>
 
-          <!-- Last search -->
-          <p class="text-xs text-slate-500">
-            Last search: <span class="text-slate-400">${lastSearch}</span>
-          </p>
+          <dl class="grid grid-cols-1 sm:grid-cols-3 gap-3 text-center">
+            <div class="bg-emerald-950/35 rounded-lg px-3 py-2 border border-emerald-900/40 ${searched24hChanged ? 'metric-changed' : ''}">
+              <dt class="text-[11px] text-emerald-300/80 uppercase tracking-wide">24h searched</dt>
+              <dd class="text-lg font-bold text-emerald-200 mt-0.5">${toNumber(inst.searched_24h)}</dd>
+            </div>
+            <div class="bg-amber-950/30 rounded-lg px-3 py-2 border border-amber-900/40 ${skipped24hChanged ? 'metric-changed' : ''}">
+              <dt class="text-[11px] text-amber-300/80 uppercase tracking-wide">24h skipped</dt>
+              <dd class="text-lg font-bold text-amber-200 mt-0.5">${toNumber(inst.skipped_24h)}</dd>
+            </div>
+            <div class="bg-rose-950/30 rounded-lg px-3 py-2 border border-rose-900/40 ${errors24hChanged ? 'metric-changed' : ''}">
+              <dt class="text-[11px] text-rose-300/80 uppercase tracking-wide">24h errors</dt>
+              <dd class="text-lg font-bold text-rose-200 mt-0.5">${toNumber(inst.errors_24h)}</dd>
+            </div>
+          </dl>
+
+          <div class="space-y-1.5 text-xs text-slate-400">
+            <p>Last activity: <span class="text-slate-300">${lastActivity}</span></p>
+            <p>Last searched: <span class="text-slate-300">${lastSearch}</span></p>
+          </div>
+
+          <div class="flex flex-wrap gap-1.5">
+            ${policyChips}
+          </div>
         </div>`;
     }).join("");
 
-    evt.detail.serverResponse = `<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">${cards}</div>`;
+    evt.detail.serverResponse = `${fleetSummaryMarkup}<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">${cards}</div>`;
     evt.detail.target.dataset.hydrated = 'true';
   });
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -229,6 +229,8 @@ def test_dashboard_accessible_after_login(app: TestClient) -> None:
     assert b'id="instance-grid"' in response.content
     assert b'data-hydrated="false"' in response.content
     assert b'hx-trigger="load, every 15s"' in response.content
+    assert b"Fleet summary" in response.content
+    assert b"24h searched" in response.content
 
 
 def test_logout_clears_session(app: TestClient) -> None:

--- a/tests/test_routes/test_status.py
+++ b/tests/test_routes/test_status.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime, timedelta
+
 import httpx
 import pytest
 import respx
 from fastapi.testclient import TestClient
 
 from houndarr.clients.base import ArrClient
+from houndarr.database import get_db
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -38,6 +42,56 @@ def _login(client: TestClient) -> None:
         data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
     )
     client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+
+async def _seed_status_activity_logs(instance_id: int) -> None:
+    """Seed mixed recent/old log actions for status aggregate assertions."""
+    now = datetime.now(UTC)
+    rows = [
+        (
+            instance_id,
+            101,
+            "episode",
+            "missing",
+            "searched",
+            (now - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        ),
+        (
+            instance_id,
+            102,
+            "episode",
+            "missing",
+            "skipped",
+            (now - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        ),
+        (
+            instance_id,
+            103,
+            "episode",
+            "missing",
+            "error",
+            (now - timedelta(minutes=10)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        ),
+        (
+            instance_id,
+            104,
+            "episode",
+            "missing",
+            "searched",
+            (now - timedelta(hours=30)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        ),
+    ]
+
+    async with get_db() as conn:
+        await conn.execute("DELETE FROM search_log WHERE instance_id = ?", (instance_id,))
+        await conn.executemany(
+            """
+            INSERT INTO search_log (instance_id, item_id, item_type, search_kind, action, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        await conn.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +146,18 @@ def test_status_returns_correct_shape(app: TestClient) -> None:
     assert item["searches_last_hour"] == 0
     assert item["searches_today"] == 0
     assert item["items_found_total"] == 0
+    assert item["searched_24h"] == 0
+    assert item["skipped_24h"] == 0
+    assert item["errors_24h"] == 0
+    assert item["last_activity_action"] is None
+    assert item["last_activity_at"] is None
+    assert item["batch_size"] == 2
+    assert item["sleep_interval_mins"] == 30
+    assert item["hourly_cap"] == 4
+    assert item["cooldown_days"] == 14
+    assert item["cutoff_enabled"] is False
+    assert item["cutoff_batch_size"] == 1
+    assert item["unreleased_delay_hrs"] == 36
 
 
 def test_status_returns_multiple_instances(app: TestClient) -> None:
@@ -108,6 +174,29 @@ def test_status_returns_multiple_instances(app: TestClient) -> None:
     assert len(data) == 2
     names = {d["name"] for d in data}
     assert names == {"My Sonarr", "My Radarr"}
+
+
+def test_status_includes_24h_outcomes_and_last_activity(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data={**_VALID_FORM, "name": "Seeded Sonarr"})
+    created = app.get("/api/status").json()
+    inst_id = int(created[0]["id"])
+    app.post(f"/settings/instances/{inst_id}/toggle-enabled")
+    asyncio.run(_seed_status_activity_logs(inst_id))
+
+    resp = app.get("/api/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+
+    item = data[0]
+    assert item["name"] == "Seeded Sonarr"
+    assert item["searched_24h"] == 1
+    assert item["skipped_24h"] == 1
+    assert item["errors_24h"] == 1
+    assert item["last_activity_action"] == "error"
+    assert isinstance(item["last_activity_at"], str)
+    assert item["last_search_at"] is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Enrich dashboard cards with operator-oriented signals for low-instance setups
- Add a compact fleet summary strip for enabled and 24h outcome totals
- Add per-instance 24h searched/skipped/errors, last activity, and read-only policy chips
- Keep existing run-now behavior and motion behavior intact
- Extend /api/status with additive fields only

## Testing
- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest

Closes #72