### PR TITLE
fix(radarr): prevent MoviesSearch for unreleased titles

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -39,6 +39,10 @@ Why this shape:
 - **Unreleased Delay (hrs)**: minimum delay after release date before searching.
   - Default: `36`
   - If the item is still inside this window, Houndarr logs `unreleased delay (...)` and skips it.
+  - For Radarr, Houndarr evaluates release timing with fallback anchors in this order:
+    `digitalRelease` -> `physicalRelease` -> `releaseDate` -> `inCinemas`.
+  - For Radarr, unavailable or clearly pre-release titles may also be skipped using
+    availability signals (`isAvailable` / `status`) even when release dates are incomplete.
 
 ## Cutoff Upgrade Controls
 

--- a/src/houndarr/clients/radarr.py
+++ b/src/houndarr/clients/radarr.py
@@ -19,6 +19,12 @@ class MissingMovie:
     movie_id: int
     title: str
     year: int
+    status: str | None
+    minimum_availability: str | None
+    is_available: bool | None
+    in_cinemas: str | None
+    physical_release: str | None
+    release_date: str | None
     digital_release: str | None  # ISO-8601 date or None if unknown
 
 
@@ -110,6 +116,12 @@ def _parse_movie(record: dict[str, Any]) -> MissingMovie:
         movie_id=record["id"],
         title=record.get("title") or "",
         year=record.get("year", 0),
+        status=record.get("status"),
+        minimum_availability=record.get("minimumAvailability"),
+        is_available=record.get("isAvailable"),
+        in_cinemas=record.get("inCinemas"),
+        physical_release=record.get("physicalRelease"),
+        release_date=record.get("releaseDate"),
         digital_release=record.get("digitalRelease"),
     )
 

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -37,6 +37,7 @@ _CUTOFF_PAGE_SIZE_MIN = 5
 _CUTOFF_PAGE_SIZE_MAX = 25
 _CUTOFF_SCAN_BUDGET_MIN = 12
 _CUTOFF_SCAN_BUDGET_MAX = 60
+_RADARR_UNRELEASED_STATUSES = {"tba", "announced"}
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +121,34 @@ def _is_within_unreleased_delay(release_at: str | None, unreleased_delay_hrs: in
         return False
 
     return datetime.now(UTC) < (release_dt + timedelta(hours=unreleased_delay_hrs))
+
+
+def _radarr_release_anchor(movie: MissingMovie) -> str | None:
+    """Return preferred Radarr release anchor in fallback order."""
+    return movie.digital_release or movie.physical_release or movie.release_date or movie.in_cinemas
+
+
+def _radarr_unreleased_reason(movie: MissingMovie, unreleased_delay_hrs: int) -> str | None:
+    """Return skip reason when a Radarr movie should be treated as unreleased."""
+    release_anchor = _radarr_release_anchor(movie)
+    if _is_within_unreleased_delay(release_anchor, unreleased_delay_hrs):
+        return f"unreleased delay ({unreleased_delay_hrs}h)"
+
+    if movie.is_available is False:
+        return "radarr reports not available"
+
+    status = (movie.status or "").lower()
+    if status in _RADARR_UNRELEASED_STATUSES and movie.is_available is not True:
+        return "radarr status indicates unreleased"
+
+    if (
+        movie.year > datetime.now(UTC).year
+        and movie.is_available is not True
+        and status != "released"
+    ):
+        return "future title not yet available"
+
+    return None
 
 
 def _episode_label(item: MissingEpisode) -> str:
@@ -268,19 +297,26 @@ async def run_instance_search(
                     if isinstance(item, MissingEpisode):
                         item_id = item.episode_id
                         item_label = _episode_label(item)
-                        release_at = item.air_date_utc
+                        unreleased_reason = (
+                            f"unreleased delay ({instance.unreleased_delay_hrs}h)"
+                            if _is_within_unreleased_delay(
+                                item.air_date_utc, instance.unreleased_delay_hrs
+                            )
+                            else None
+                        )
                     else:
                         item_id = item.movie_id
                         item_label = _movie_label(item)
-                        release_at = item.digital_release
+                        unreleased_reason = _radarr_unreleased_reason(
+                            item, instance.unreleased_delay_hrs
+                        )
 
                     if item_id in seen_item_ids:
                         continue
                     seen_item_ids.add(item_id)
                     scanned += 1
 
-                    if _is_within_unreleased_delay(release_at, instance.unreleased_delay_hrs):
-                        reason = f"unreleased delay ({instance.unreleased_delay_hrs}h)"
+                    if unreleased_reason is not None:
                         await _write_log(
                             instance.id,
                             item_id,
@@ -290,7 +326,7 @@ async def run_instance_search(
                             cycle_id=cycle_id_value,
                             cycle_trigger=cycle_trigger,
                             item_label=item_label,
-                            reason=reason,
+                            reason=unreleased_reason,
                         )
                         continue
 
@@ -584,10 +620,10 @@ async def _run_cutoff_pass(
                     scanned += 1
 
                     item_label = _movie_label(movie_item)
-                    if _is_within_unreleased_delay(
-                        movie_item.digital_release, instance.unreleased_delay_hrs
-                    ):
-                        reason = f"unreleased delay ({instance.unreleased_delay_hrs}h)"
+                    unreleased_reason = _radarr_unreleased_reason(
+                        movie_item, instance.unreleased_delay_hrs
+                    )
+                    if unreleased_reason is not None:
                         await _write_log(
                             instance.id,
                             item_id,
@@ -597,7 +633,7 @@ async def _run_cutoff_pass(
                             cycle_id=cycle_id,
                             cycle_trigger=cycle_trigger,
                             item_label=item_label,
-                            reason=reason,
+                            reason=unreleased_reason,
                         )
                         continue
 

--- a/tests/test_clients/test_radarr.py
+++ b/tests/test_clients/test_radarr.py
@@ -57,6 +57,12 @@ _MOVIE_RECORD = {
     "id": 201,
     "title": "Great Film",
     "year": 2022,
+    "status": "released",
+    "minimumAvailability": "released",
+    "isAvailable": True,
+    "inCinemas": "2022-10-15T00:00:00Z",
+    "physicalRelease": "2022-12-05T00:00:00Z",
+    "releaseDate": "2022-12-01T00:00:00Z",
     "digitalRelease": "2022-12-01",
 }
 
@@ -76,6 +82,12 @@ async def test_get_missing_returns_movies(client: RadarrClient) -> None:
     assert movie.movie_id == 201
     assert movie.title == "Great Film"
     assert movie.year == 2022
+    assert movie.status == "released"
+    assert movie.minimum_availability == "released"
+    assert movie.is_available is True
+    assert movie.in_cinemas == "2022-10-15T00:00:00Z"
+    assert movie.physical_release == "2022-12-05T00:00:00Z"
+    assert movie.release_date == "2022-12-01T00:00:00Z"
     assert movie.digital_release == "2022-12-01"
     request = route.calls[0].request
     assert request.url.params["monitored"] == "true"
@@ -102,6 +114,33 @@ async def test_get_missing_null_digital_release(client: RadarrClient) -> None:
     )
     results = await client.get_missing()
     assert results[0].digital_release is None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_missing_parses_release_eligibility_fields(client: RadarrClient) -> None:
+    record = {
+        **_MOVIE_RECORD,
+        "status": "announced",
+        "minimumAvailability": "released",
+        "isAvailable": False,
+        "inCinemas": "2026-07-29T00:00:00Z",
+        "physicalRelease": None,
+        "releaseDate": "2026-10-27T00:00:00Z",
+        "digitalRelease": None,
+    }
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [record]})
+    )
+
+    result = (await client.get_missing())[0]
+    assert result.status == "announced"
+    assert result.minimum_availability == "released"
+    assert result.is_available is False
+    assert result.in_cinemas == "2026-07-29T00:00:00Z"
+    assert result.physical_release is None
+    assert result.release_date == "2026-10-27T00:00:00Z"
+    assert result.digital_release is None
 
 
 @pytest.mark.asyncio()

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -38,6 +38,12 @@ _MOVIE_RECORD: dict[str, Any] = {
     "id": 201,
     "title": "My Movie",
     "year": 2023,
+    "status": "released",
+    "minimumAvailability": "released",
+    "isAvailable": True,
+    "inCinemas": "2023-01-01T00:00:00Z",
+    "physicalRelease": "2023-02-01T00:00:00Z",
+    "releaseDate": "2023-02-01T00:00:00Z",
     "digitalRelease": None,
 }
 
@@ -172,6 +178,144 @@ async def test_radarr_item_is_searched(seeded_instances: None) -> None:
     assert rows[0]["search_kind"] == "missing"
     assert rows[0]["cycle_id"]
     assert rows[0]["cycle_trigger"] == "scheduled"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_announced_unavailable_with_null_digital_release_is_skipped(
+    seeded_instances: None,
+) -> None:
+    """Radarr movies flagged unavailable should not be searched."""
+    unreleased_movie = {
+        **_MOVIE_RECORD,
+        "id": 226,
+        "title": "Spider-Man: Brand New Day",
+        "year": 2026,
+        "status": "announced",
+        "isAvailable": False,
+        "releaseDate": "2026-10-27T00:00:00Z",
+        "inCinemas": "2026-07-29T00:00:00Z",
+        "physicalRelease": None,
+        "digitalRelease": None,
+    }
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [unreleased_movie]})
+    )
+    search_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+
+    instance = _make_instance(instance_id=2, itype=InstanceType.radarr, url=RADARR_URL)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert not search_route.called
+    rows = await _get_log_rows()
+    assert rows[0]["action"] == "skipped"
+    assert rows[0]["reason"] == "unreleased delay (24h)"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_release_anchor_falls_back_to_physical_release_for_delay(
+    seeded_instances: None,
+) -> None:
+    """When digitalRelease is missing, physicalRelease should enforce delay."""
+    movie = {
+        **_MOVIE_RECORD,
+        "id": 350,
+        "status": "released",
+        "isAvailable": True,
+        "digitalRelease": None,
+        "physicalRelease": "2999-01-01T00:00:00Z",
+        "releaseDate": None,
+        "inCinemas": None,
+    }
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [movie]})
+    )
+    search_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+
+    instance = _make_instance(
+        instance_id=2,
+        itype=InstanceType.radarr,
+        url=RADARR_URL,
+        unreleased_delay_hrs=36,
+    )
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert not search_route.called
+    rows = await _get_log_rows()
+    assert rows[0]["reason"] == "unreleased delay (36h)"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_weak_release_metadata_fails_conservatively(seeded_instances: None) -> None:
+    """Future-year movies with weak metadata should be treated as unreleased."""
+    weak_movie = {
+        **_MOVIE_RECORD,
+        "id": 351,
+        "title": "Mystery Future Film",
+        "year": 2999,
+        "status": None,
+        "minimumAvailability": None,
+        "isAvailable": None,
+        "inCinemas": None,
+        "physicalRelease": None,
+        "releaseDate": None,
+        "digitalRelease": None,
+    }
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [weak_movie]})
+    )
+    search_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+
+    instance = _make_instance(instance_id=2, itype=InstanceType.radarr, url=RADARR_URL)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert not search_route.called
+    rows = await _get_log_rows()
+    assert rows[0]["reason"] == "future title not yet available"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_available_movie_still_searches(seeded_instances: None) -> None:
+    """Available Radarr movies should still be searched."""
+    available_movie = {
+        **_MOVIE_RECORD,
+        "id": 352,
+        "title": "Already Released",
+        "year": 2024,
+        "status": "released",
+        "minimumAvailability": "released",
+        "isAvailable": True,
+        "digitalRelease": "2024-01-15T00:00:00Z",
+    }
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": [available_movie]})
+    )
+    search_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+
+    instance = _make_instance(
+        instance_id=2,
+        itype=InstanceType.radarr,
+        url=RADARR_URL,
+        unreleased_delay_hrs=36,
+    )
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
 
 
 # ---------------------------------------------------------------------------
@@ -1074,6 +1218,50 @@ async def test_cutoff_pass_radarr(seeded_instances: None) -> None:
     assert rows[0]["action"] == "searched"
     assert rows[0]["item_id"] == 201
     assert rows[0]["item_type"] == "movie"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cutoff_pass_radarr_skips_unreleased_announced_titles(seeded_instances: None) -> None:
+    """Cutoff pass should apply the same Radarr unreleased gate as missing pass."""
+    unreleased_movie = {
+        **_MOVIE_RECORD,
+        "id": 319,
+        "title": "Shrek 5",
+        "year": 2027,
+        "status": "announced",
+        "minimumAvailability": "released",
+        "isAvailable": False,
+        "inCinemas": "2027-06-30T00:00:00Z",
+        "physicalRelease": None,
+        "releaseDate": "2027-09-28T00:00:00Z",
+        "digitalRelease": None,
+    }
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": []})
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json={"records": [unreleased_movie]})
+    )
+    search_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+
+    instance = _make_cutoff_instance(
+        instance_id=2,
+        itype=InstanceType.radarr,
+        url=RADARR_URL,
+        cutoff_enabled=True,
+    )
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    assert not search_route.called
+    rows = await _get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["search_kind"] == "cutoff"
+    assert rows[0]["action"] == "skipped"
+    assert rows[0]["reason"] == "unreleased delay (24h)"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- expand Radarr wanted-item parsing to include availability and release-status fields used for eligibility decisions
- harden Radarr missing/cutoff eligibility to skip clearly unreleased titles using conservative checks and release-anchor fallback (`digitalRelease` -> `physicalRelease` -> `releaseDate` -> `inCinemas`)
- add regression coverage for announced/unavailable movies, fallback anchor behavior, conservative weak-metadata handling, and cutoff-path parity
- document the Radarr unreleased gating behavior in settings guidance

## Validation
- `.venv/bin/python -m ruff check src/ tests/`
- `.venv/bin/python -m ruff format --check src/ tests/`
- `.venv/bin/python -m mypy src/`
- `.venv/bin/python -m bandit -r src/ -c pyproject.toml`
- `.venv/bin/pytest`

Closes #74