### PR TITLE
fix(security): allow safe logout for stale sessions and align CSRF guarantees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,10 @@ def _login(client: TestClient) -> None:
 
 ### CSRF helper for route tests
 
-All mutating route tests (POST, DELETE) require a valid CSRF token after login.
+Mutating authenticated route tests generally require a valid CSRF token after login.
+Current intentional exemptions:
+- `POST /logout` (allows stale legacy sessions to be cleared safely)
+- Public auth/setup routes (`/login`, `/setup`)
 Use the helpers from `tests/conftest.py`:
 
 ```python

--- a/src/houndarr/auth.py
+++ b/src/houndarr/auth.py
@@ -47,6 +47,11 @@ _PUBLIC_PATHS = frozenset(
     ]
 )
 
+# Logout is a safe, destructive-free action (session invalidation only). We
+# allow it without CSRF/session validation so stale legacy sessions can always
+# be cleared after upgrades.
+_LOGOUT_PATH = "/logout"
+
 
 # ---------------------------------------------------------------------------
 # Password hashing
@@ -357,10 +362,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
         first-run setup has not been completed).
 
     CSRF protection:
-        All state-changing requests (POST, PUT, PATCH, DELETE) on authenticated
+        State-changing requests (POST, PUT, PATCH, DELETE) on authenticated
         routes must carry a valid CSRF token in either the ``X-CSRF-Token``
-        header or the ``csrf_token`` form field.  The token is validated
-        against the value embedded in the signed session cookie.
+        header or the ``csrf_token`` form field, except ``POST /logout``
+        which is intentionally exempt so stale legacy sessions can always be
+        cleared safely. The token is validated against the value embedded in
+        the signed session cookie.
     """
 
     def __init__(self, app: ASGIApp) -> None:
@@ -368,6 +375,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Callable[..., Any]) -> Any:
         path = request.url.path
+
+        # Always allow logout requests so stale/broken sessions can be cleared
+        # after upgrades. This endpoint only invalidates local cookies.
+        if path == _LOGOUT_PATH and request.method == "POST":
+            return await call_next(request)
 
         # Always allow public paths and static files
         if any(path.startswith(p) for p in _PUBLIC_PATHS):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -248,26 +251,38 @@ def test_logout_clears_session(app: TestClient) -> None:
 
 
 def test_csrf_protection_rejects_missing_token(app: TestClient) -> None:
-    """POST to protected route without CSRF token should return 403."""
-    app.post(
-        "/setup",
-        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
-    )
-    app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
-    # POST logout without CSRF token — should be rejected
-    response = app.post("/logout", follow_redirects=False)
-    assert response.status_code == 403
-
-
-def test_csrf_protection_rejects_wrong_token(app: TestClient) -> None:
-    """POST to protected route with a wrong CSRF token should return 403."""
+    """POST to protected authenticated route without CSRF token should return 403."""
     app.post(
         "/setup",
         data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
     )
     app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
     response = app.post(
-        "/logout",
+        "/settings/account/password",
+        data={
+            "current_password": "ValidPass1!",
+            "new_password": "BetterPass2!",
+            "new_password_confirm": "BetterPass2!",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 403
+
+
+def test_csrf_protection_rejects_wrong_token(app: TestClient) -> None:
+    """Wrong CSRF token on protected authenticated route should return 403."""
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+    response = app.post(
+        "/settings/account/password",
+        data={
+            "current_password": "ValidPass1!",
+            "new_password": "BetterPass2!",
+            "new_password_confirm": "BetterPass2!",
+        },
         follow_redirects=False,
         headers={"X-CSRF-Token": "invalid-token-value"},
     )
@@ -290,6 +305,34 @@ def test_csrf_protection_via_form_field(app: TestClient) -> None:
         follow_redirects=False,
     )
     assert response.status_code == 303
+
+
+def test_logout_allows_legacy_session_without_csrf(app: TestClient) -> None:
+    """Legacy pre-CSRF sessions should still be able to logout cleanly."""
+    from houndarr.auth import SESSION_COOKIE_NAME, _get_serializer
+
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    serializer = asyncio.run(_get_serializer())
+    legacy_token = serializer.dumps({"ts": int(time.time())})
+    app.cookies.set(SESSION_COOKIE_NAME, legacy_token)
+    app.cookies.pop("houndarr_csrf", None)
+
+    response = app.post("/logout", follow_redirects=False)
+    assert response.status_code == 303
+    assert "/login" in response.headers["location"]
+
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    assert any(
+        "houndarr_session=" in header and "Max-Age=0" in header for header in set_cookie_headers
+    )
+    assert any(
+        "houndarr_csrf=" in header and "Max-Age=0" in header for header in set_cookie_headers
+    )
 
 
 def test_rate_limiter_uses_direct_ip_by_default(app: TestClient) -> None:


### PR DESCRIPTION
## Summary
- exempt only `POST /logout` from auth/CSRF middleware checks so stale pre-hardening sessions can always be invalidated
- keep CSRF enforcement on other authenticated mutating routes, and move regression tests to a protected settings route
- align `AGENTS.md` CSRF guidance with the real protection boundary and explicit exemptions

## Testing
- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest

Closes #82