### PR TITLE
fix(security): harden SSRF hostname resolution and run periodic log retention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@ The `test_settings` fixture also resets `_auth._serializer` and
 - **HTMX partials:** `hx-swap="outerHTML"` / `"innerHTML"`, no full-page reloads
 - **Supervisor:** one `asyncio.Task` per enabled instance; 10s shutdown timeout
 - **search_log:** every search attempt writes a row (`searched`/`skipped`/`error`/`info`)
+- **URL validation:** instance URL checks resolve hostnames and block loopback/link-local targets
+- **Log retention:** startup purge plus periodic uptime purge of stale `search_log` rows
 - **Database:** SQLite via `aiosqlite`; schema version 1; `get_db()` context manager
 
 ## Workflow

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -19,6 +20,26 @@ from houndarr.engine.supervisor import Supervisor
 from houndarr.services.instances import list_instances
 
 logger = logging.getLogger(__name__)
+
+_LOG_RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
+
+
+async def _periodic_log_retention() -> None:
+    """Periodically purge old search_log rows during app uptime."""
+    while True:
+        await asyncio.sleep(_LOG_RETENTION_INTERVAL_SECONDS)
+        try:
+            purged = await purge_old_logs(DEFAULT_LOG_RETENTION_DAYS)
+            if purged > 0:
+                logger.info(
+                    "Periodic retention purged %d search_log rows older than %d days",
+                    purged,
+                    DEFAULT_LOG_RETENTION_DAYS,
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.exception("Periodic log retention task failed")
 
 
 @asynccontextmanager
@@ -57,9 +78,15 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await supervisor.start()
     app.state.supervisor = supervisor
 
+    retention_task = asyncio.create_task(_periodic_log_retention(), name="log-retention-loop")
+    app.state.retention_task = retention_task
+
     yield  # Application runs here
 
     logger.info("Houndarr shutting down")
+    retention_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await retention_task
     await supervisor.stop()
 
 

--- a/src/houndarr/services/url_validation.py
+++ b/src/houndarr/services/url_validation.py
@@ -9,16 +9,15 @@ RFC-1918 ranges wholesale; instead it only rejects the most obviously dangerous
 targets (loopback and link-local metadata service addresses) while accepting
 private network ranges needed for Docker / LAN setups.
 
-Operators who need to allow even loopback targets (e.g. ``localhost``) for
-unusual setups can do so by reading the validation error and configuring
-their instance URL appropriately (use the container name / hostname instead
-of ``127.0.0.1``).
+Both literal IPs and resolved hostname addresses are checked against blocked
+targets, so aliases that resolve to loopback/link-local ranges are rejected.
 """
 
 from __future__ import annotations
 
 import ipaddress
 import re
+import socket
 from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
@@ -45,6 +44,40 @@ _HOSTNAME_PATTERN = re.compile(
     r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*"
     r"[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$"
 )
+
+
+def _is_blocked_address(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return whether *addr* falls into a blocked network range."""
+    return any(addr in blocked_net for blocked_net in _BLOCKED_NETWORKS)
+
+
+def _resolve_hostname_ips(host: str) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve *host* to concrete IP addresses for SSRF safety checks.
+
+    Returns:
+        Set of resolved IP addresses. If the hostname cannot be resolved at
+        validation time, an empty set is returned and connectivity checks can
+        surface the operator-facing error.
+
+    Raises:
+        ValueError: If hostname is malformed.
+    """
+    if _HOSTNAME_PATTERN.fullmatch(host) is None:
+        raise ValueError(f"Instance URL host '{host}' is invalid.")
+
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return set()
+
+    resolved: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()
+    for family, _socktype, _proto, _canonname, sockaddr in infos:
+        if family == socket.AF_INET:
+            resolved.add(ipaddress.IPv4Address(sockaddr[0]))
+        elif family == socket.AF_INET6:
+            resolved.add(ipaddress.IPv6Address(sockaddr[0]))
+
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -96,18 +129,32 @@ def validate_instance_url(url: str) -> str | None:
             "Use the container name or network hostname instead of 'localhost'."
         )
 
-    # IP address range check
+    # IP address range check (literal IP host)
     try:
         addr = ipaddress.ip_address(host)
     except ValueError:
-        # Not an IP address — hostname, which is fine unless blocked above
+        # Hostname: resolve and apply the same blocked-network rules to avoid
+        # aliases/bypass (e.g. a hostname resolving to 127.0.0.1).
+        try:
+            resolved_ips = _resolve_hostname_ips(host)
+        except ValueError as exc:
+            return str(exc)
+
+        for resolved in resolved_ips:
+            if _is_blocked_address(resolved):
+                return (
+                    f"Instance URL host '{host}' resolves to a blocked address range ({resolved}). "
+                    "Use a container name or routable hostname."
+                )
+
+        # If hostname does not currently resolve, defer the operator-facing
+        # failure to the explicit connection test.
         return None
 
-    for blocked_net in _BLOCKED_NETWORKS:
-        if addr in blocked_net:
-            return (
-                f"Instance URL points to a blocked address range ({addr}). "
-                "Use a container name or routable hostname."
-            )
+    if _is_blocked_address(addr):
+        return (
+            f"Instance URL points to a blocked address range ({addr}). "
+            "Use a container name or routable hostname."
+        )
 
     return None

--- a/tests/test_app_startup.py
+++ b/tests/test_app_startup.py
@@ -3,17 +3,20 @@
 from __future__ import annotations
 
 import logging
+import time
 
+import pytest
 from fastapi.testclient import TestClient
 
 from houndarr.app import create_app
+from houndarr.engine.supervisor import Supervisor
 
 
-def test_startup_warns_when_no_instances(test_settings: object, caplog: object) -> None:
+def test_startup_warns_when_no_instances(
+    test_settings: object, caplog: pytest.LogCaptureFixture
+) -> None:
     """App lifespan logs warning when no instances are configured."""
     assert test_settings is not None
-    assert caplog is not None
-
     caplog.set_level(logging.WARNING)
 
     app = create_app()
@@ -22,3 +25,35 @@ def test_startup_warns_when_no_instances(test_settings: object, caplog: object) 
 
     messages = [record.getMessage() for record in caplog.records]
     assert any("No instances configured" in message for message in messages)
+
+
+def test_periodic_retention_runs_during_uptime(
+    test_settings: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retention purger runs at startup and periodically while app is running."""
+    assert test_settings is not None
+    from houndarr import app as app_module
+
+    purges: list[int] = []
+
+    async def _fake_purge_old_logs(retention_days: int) -> int:
+        purges.append(retention_days)
+        return 0
+
+    async def _fake_start(self: Supervisor) -> None:
+        return None
+
+    async def _fake_stop(self: Supervisor) -> None:
+        return None
+
+    monkeypatch.setattr(app_module, "purge_old_logs", _fake_purge_old_logs)
+    monkeypatch.setattr(app_module, "_LOG_RETENTION_INTERVAL_SECONDS", 0.02)
+    monkeypatch.setattr(Supervisor, "start", _fake_start)
+    monkeypatch.setattr(Supervisor, "stop", _fake_stop)
+
+    app = create_app()
+    with TestClient(app, raise_server_exceptions=True):
+        time.sleep(0.07)
+
+    # At least one startup purge + at least one periodic purge.
+    assert len(purges) >= 2

--- a/tests/test_services/test_url_validation.py
+++ b/tests/test_services/test_url_validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import socket
+
 import pytest
 
 from houndarr.services.url_validation import validate_instance_url
@@ -109,3 +111,62 @@ def test_missing_host_rejected() -> None:
     result = validate_instance_url("http://")
     assert result is not None
     assert "host" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Hostname resolution safety checks
+# ---------------------------------------------------------------------------
+
+
+def test_hostname_resolving_to_loopback_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hostnames that resolve to loopback must be rejected."""
+
+    def _fake_getaddrinfo(host: str, port: object, type: int) -> list[tuple[object, ...]]:
+        assert host == "alias.local"
+        assert type == socket.SOCK_STREAM
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 8989))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    result = validate_instance_url("http://alias.local:8989")
+    assert result is not None
+    assert "blocked" in result.lower()
+
+
+def test_hostname_resolving_to_link_local_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hostnames that resolve to link-local addresses must be rejected."""
+
+    def _fake_getaddrinfo(host: str, port: object, type: int) -> list[tuple[object, ...]]:
+        assert host == "metadata.internal"
+        assert type == socket.SOCK_STREAM
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    result = validate_instance_url("http://metadata.internal")
+    assert result is not None
+    assert "blocked" in result.lower()
+
+
+def test_hostname_resolving_to_private_lan_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hostnames resolving to RFC1918 addresses remain valid for self-hosting."""
+
+    def _fake_getaddrinfo(host: str, port: object, type: int) -> list[tuple[object, ...]]:
+        assert host == "sonarr.internal"
+        assert type == socket.SOCK_STREAM
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.25", 8989))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    assert validate_instance_url("http://sonarr.internal:8989") is None
+
+
+def test_unresolvable_hostname_defers_to_connection_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unresolvable hostnames are allowed here; connection test reports failure."""
+
+    def _fake_getaddrinfo(host: str, port: object, type: int) -> list[tuple[object, ...]]:
+        raise socket.gaierror("name not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    assert validate_instance_url("http://unknown.internal:8989") is None


### PR DESCRIPTION
## Summary
- resolve non-IP instance hostnames and apply blocked-network checks to resolved addresses to prevent alias bypasses to loopback/link-local targets
- keep self-hosted LAN/private usage intact by continuing to allow RFC1918 targets while rejecting blocked ranges
- run `search_log` retention cleanup periodically during app uptime (in addition to startup) via a lightweight background task
- add focused tests for resolver-based URL validation and periodic retention behavior

## Testing
- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest

Closes #84