### PR TITLE
fix(security): block mapped-loopback and unspecified SSRF targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ The `test_settings` fixture also resets `_auth._serializer` and
 - **HTMX partials:** `hx-swap="outerHTML"` / `"innerHTML"`, no full-page reloads
 - **Supervisor:** one `asyncio.Task` per enabled instance; 10s shutdown timeout
 - **search_log:** every search attempt writes a row (`searched`/`skipped`/`error`/`info`)
-- **URL validation:** instance URL checks resolve hostnames and block loopback/link-local targets
+- **URL validation:** instance URL checks resolve hostnames and block localhost/loopback/link-local/unspecified targets
 - **Log retention:** startup purge plus periodic uptime purge of stale `search_log` rows
 - **Database:** SQLite via `aiosqlite`; schema version 1; `get_db()` context manager
 

--- a/src/houndarr/services/url_validation.py
+++ b/src/houndarr/services/url_validation.py
@@ -28,13 +28,6 @@ _ALLOWED_SCHEMES = frozenset(["http", "https"])
 
 # Loopback ranges blocked by default.  Private ranges (10/8, 172.16/12,
 # 192.168/16) are NOT blocked because Docker / LAN setups legitimately use them.
-_BLOCKED_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
-    ipaddress.IPv4Network("127.0.0.0/8"),  # IPv4 loopback
-    ipaddress.IPv6Network("::1/128"),  # IPv6 loopback
-    ipaddress.IPv4Network("169.254.0.0/16"),  # link-local / cloud metadata (e.g. 169.254.169.254)
-    ipaddress.IPv6Network("fe80::/10"),  # IPv6 link-local
-]
-
 # Hostnames that should never be used directly — operators must use container
 # names or FQDNs instead.
 _BLOCKED_HOSTNAMES: frozenset[str] = frozenset(["localhost"])
@@ -48,7 +41,7 @@ _HOSTNAME_PATTERN = re.compile(
 
 def _is_blocked_address(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return whether *addr* falls into a blocked network range."""
-    return any(addr in blocked_net for blocked_net in _BLOCKED_NETWORKS)
+    return addr.is_loopback or addr.is_link_local or addr.is_unspecified
 
 
 def _resolve_hostname_ips(host: str) -> set[ipaddress.IPv4Address | ipaddress.IPv6Address]:
@@ -92,8 +85,8 @@ def validate_instance_url(url: str) -> str | None:
     - Scheme must be ``http`` or ``https``
     - Host must be present and non-empty
     - Host must not be a blocked hostname (``localhost``)
-    - If the host is a numeric IP address, it must not be in a blocked range
-      (loopback, link-local)
+    - If the host is a numeric IP address, it must not be in a blocked class
+      (loopback, link-local, unspecified)
 
     Private IP ranges (RFC-1918) are intentionally allowed so that Docker /
     LAN deployments work without restriction.

--- a/tests/test_services/test_url_validation.py
+++ b/tests/test_services/test_url_validation.py
@@ -170,3 +170,39 @@ def test_unresolvable_hostname_defers_to_connection_check(monkeypatch: pytest.Mo
     monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
 
     assert validate_instance_url("http://unknown.internal:8989") is None
+
+
+def test_ipv4_mapped_ipv6_loopback_rejected() -> None:
+    """IPv4-mapped IPv6 loopback must be rejected as loopback."""
+    result = validate_instance_url("http://[::ffff:127.0.0.1]:8989")
+    assert result is not None
+    assert "blocked" in result.lower()
+
+
+def test_unspecified_ipv4_rejected() -> None:
+    """Unspecified IPv4 bind target must be rejected."""
+    result = validate_instance_url("http://0.0.0.0:8989")
+    assert result is not None
+    assert "blocked" in result.lower()
+
+
+def test_unspecified_ipv6_rejected() -> None:
+    """Unspecified IPv6 bind target must be rejected."""
+    result = validate_instance_url("http://[::]:8989")
+    assert result is not None
+    assert "blocked" in result.lower()
+
+
+def test_hostname_resolving_to_unspecified_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hostnames resolving to unspecified addresses must be rejected."""
+
+    def _fake_getaddrinfo(host: str, port: object, type: int) -> list[tuple[object, ...]]:
+        assert host == "bind-target.internal"
+        assert type == socket.SOCK_STREAM
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("0.0.0.0", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    result = validate_instance_url("http://bind-target.internal")
+    assert result is not None
+    assert "blocked" in result.lower()


### PR DESCRIPTION
## Summary
- close the final pre-#15 SSRF validation gap by blocking unsafe IP classes via `ipaddress` semantics rather than a narrow static CIDR list
- continue allowing self-hosted LAN/private targets while rejecting localhost, loopback, link-local, and unspecified bind targets for both literal IPs and resolved hostnames
- add focused tests covering IPv4-mapped IPv6 loopback, unspecified IPv4/IPv6 literals, and hostname resolution to unspecified addresses

## Root Cause
Validation relied on explicit blocked CIDR ranges, which missed semantically unsafe addresses such as IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1`) and unspecified bind targets (`0.0.0.0`, `::`).

## Testing
- `.venv/bin/python -m ruff check src/ tests/`
- `.venv/bin/python -m ruff format --check src/ tests/`
- `.venv/bin/python -m mypy src/`
- `.venv/bin/python -m bandit -r src/ -c pyproject.toml`
- `.venv/bin/pytest`

Closes #86