### PR TITLE
fix(logs): prevent high-limit load-more freezes with chunked pagination and lighter client processing

### DIFF
--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -22,8 +22,15 @@ router = APIRouter()
 
 _LOG_LIMIT_DEFAULT = 50
 _LOG_LIMIT_MAX = 500
+_LOG_LOAD_MORE_CHUNK_MAX = 100
 _SEARCH_KINDS = {"missing", "cutoff"}
 _CYCLE_TRIGGERS = {"scheduled", "run_now", "system"}
+
+
+def _compute_load_more_limit(limit: int) -> int:
+    """Return a bounded per-request chunk size for load-more pagination."""
+    bounded_limit = min(max(1, limit), _LOG_LIMIT_MAX)
+    return min(bounded_limit, _LOG_LOAD_MORE_CHUNK_MAX)
 
 
 def _summarize_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
@@ -361,6 +368,7 @@ async def get_logs_partial(
     parsed_search_kind = _parse_search_kind(search_kind)
     parsed_cycle_trigger = _parse_cycle_trigger(cycle_trigger)
     parsed_hide_system = _parse_hide_system(hide_system)
+    load_more_limit = _compute_load_more_limit(limit)
     rows = await _query_logs(
         parsed_instance_id,
         parsed_action,
@@ -383,5 +391,6 @@ async def get_logs_partial(
             "hide_system": parsed_hide_system,
             "before": before,
             "limit": limit,
+            "load_more_limit": load_more_limit,
         },
     )

--- a/src/houndarr/routes/pages.py
+++ b/src/houndarr/routes/pages.py
@@ -192,7 +192,7 @@ async def dashboard(request: Request) -> HTMLResponse:
 @router.get("/logs", response_class=HTMLResponse)
 async def logs_page(request: Request) -> HTMLResponse:
     """Search log viewer page — initial render with no filters applied."""
-    from houndarr.routes.api.logs import _query_logs, _summarize_rows
+    from houndarr.routes.api.logs import _compute_load_more_limit, _query_logs, _summarize_rows
 
     master_key: bytes = request.app.state.master_key
     instances = await list_instances(master_key=master_key)
@@ -213,6 +213,7 @@ async def logs_page(request: Request) -> HTMLResponse:
         rows=rows,
         summary=summary,
         limit=50,
+        load_more_limit=_compute_load_more_limit(50),
         selected_instance_id=None,
         selected_action=None,
         selected_search_kind=None,

--- a/src/houndarr/templates/logs.html
+++ b/src/houndarr/templates/logs.html
@@ -206,10 +206,14 @@
     }).format(parsed);
   }
 
-  function formatVisibleLogTimestamps() {
-    document.querySelectorAll('[data-log-ts]').forEach((el) => {
+  function formatVisibleLogTimestamps(root = document) {
+    root.querySelectorAll('[data-log-ts]').forEach((el) => {
+      if (el.getAttribute('data-ts-formatted') === 'true') {
+        return;
+      }
       const ts = el.getAttribute('data-log-ts') || '';
       el.textContent = formatLocalTimestamp(ts);
+      el.setAttribute('data-ts-formatted', 'true');
     });
   }
 
@@ -265,63 +269,129 @@
     el.textContent = String(value);
   }
 
-  function refreshSummaryFromVisibleRows() {
-    const rows = Array.from(document.querySelectorAll('#log-tbody tr[data-log-row="true"]'));
-    const cycleProgressById = new Map();
-    let searchedRows = 0;
-    let skippedRows = 0;
-    let errorRows = 0;
-    let infoRows = 0;
-    let legacyRows = 0;
+  const summaryState = {
+    totalRows: 0,
+    searchedRows: 0,
+    skippedRows: 0,
+    errorRows: 0,
+    infoRows: 0,
+    legacyRows: 0,
+    totalCycles: 0,
+    searchedCycles: 0,
+    skipOnlyCycles: 0,
+    unknownCycles: 0,
+    cycleProgressById: new Map(),
+  };
 
-    rows.forEach((row) => {
-      const action = row.querySelector('[data-col="action"]')?.textContent?.trim().toLowerCase() || '';
-      if (action === 'searched') {
-        searchedRows += 1;
-      } else if (action === 'skipped') {
-        skippedRows += 1;
-      } else if (action === 'error') {
-        errorRows += 1;
-      } else if (action === 'info') {
-        infoRows += 1;
-      }
-
-      const cycleId = row.getAttribute('data-cycle-id') || '';
-      const cycleProgress = row.getAttribute('data-cycle-progress') || '';
-      if (!cycleId) {
-        legacyRows += 1;
-        return;
-      }
-
-      const existing = cycleProgressById.get(cycleId) || '';
-      if (existing === 'progress' || cycleProgress === 'progress') {
-        cycleProgressById.set(cycleId, 'progress');
-      } else if (!existing) {
-        cycleProgressById.set(cycleId, cycleProgress || 'unknown');
-      }
-    });
-
-    const cycleProgressValues = Array.from(cycleProgressById.values());
-    const searchedCycles = cycleProgressValues.filter((value) => value === 'progress').length;
-    const skipOnlyCycles = cycleProgressValues.filter((value) => value === 'no_progress').length;
-    const unknownCycles = cycleProgressValues.filter(
-      (value) => value !== 'progress' && value !== 'no_progress'
-    ).length;
-
-    setSummaryValue('summary-total-rows', rows.length);
-    setSummaryValue('summary-total-cycles', cycleProgressById.size);
-    setSummaryValue('summary-searched-cycles', searchedCycles);
-    setSummaryValue('summary-skip-cycles', skipOnlyCycles);
-    setSummaryValue('summary-unknown-cycles', unknownCycles);
-    setSummaryValue('summary-legacy-rows', legacyRows);
-    setSummaryValue('summary-searched-rows', searchedRows);
-    setSummaryValue('summary-skipped-rows', skippedRows);
-    setSummaryValue('summary-error-rows', errorRows);
-    setSummaryValue('summary-info-rows', infoRows);
+  function mergeCycleProgress(current, incoming) {
+    if (current === 'progress' || incoming === 'progress') {
+      return 'progress';
+    }
+    if (current) {
+      return current;
+    }
+    return incoming || 'unknown';
   }
 
-  formatVisibleLogTimestamps();
-  refreshSummaryFromVisibleRows();
+  function adjustCycleBucket(status, delta) {
+    if (status === 'progress') {
+      summaryState.searchedCycles += delta;
+      return;
+    }
+    if (status === 'no_progress') {
+      summaryState.skipOnlyCycles += delta;
+      return;
+    }
+    summaryState.unknownCycles += delta;
+  }
+
+  function accountSummaryRow(row) {
+    if (row.getAttribute('data-summary-accounted') === 'true') {
+      return;
+    }
+
+    row.setAttribute('data-summary-accounted', 'true');
+    summaryState.totalRows += 1;
+
+    const action = (row.getAttribute('data-action') || '').toLowerCase();
+    if (action === 'searched') {
+      summaryState.searchedRows += 1;
+    } else if (action === 'skipped') {
+      summaryState.skippedRows += 1;
+    } else if (action === 'error') {
+      summaryState.errorRows += 1;
+    } else if (action === 'info') {
+      summaryState.infoRows += 1;
+    }
+
+    const cycleId = row.getAttribute('data-cycle-id') || '';
+    const cycleProgress = row.getAttribute('data-cycle-progress') || '';
+    if (!cycleId) {
+      summaryState.legacyRows += 1;
+      return;
+    }
+
+    const previous = summaryState.cycleProgressById.get(cycleId) || '';
+    const next = mergeCycleProgress(previous, cycleProgress);
+    if (!previous) {
+      summaryState.totalCycles += 1;
+      summaryState.cycleProgressById.set(cycleId, next);
+      adjustCycleBucket(next, 1);
+      return;
+    }
+
+    if (previous !== next) {
+      summaryState.cycleProgressById.set(cycleId, next);
+      adjustCycleBucket(previous, -1);
+      adjustCycleBucket(next, 1);
+    }
+  }
+
+  function renderSummaryState() {
+    setSummaryValue('summary-total-rows', summaryState.totalRows);
+    setSummaryValue('summary-total-cycles', summaryState.totalCycles);
+    setSummaryValue('summary-searched-cycles', summaryState.searchedCycles);
+    setSummaryValue('summary-skip-cycles', summaryState.skipOnlyCycles);
+    setSummaryValue('summary-unknown-cycles', summaryState.unknownCycles);
+    setSummaryValue('summary-legacy-rows', summaryState.legacyRows);
+    setSummaryValue('summary-searched-rows', summaryState.searchedRows);
+    setSummaryValue('summary-skipped-rows', summaryState.skippedRows);
+    setSummaryValue('summary-error-rows', summaryState.errorRows);
+    setSummaryValue('summary-info-rows', summaryState.infoRows);
+  }
+
+  function resetSummaryState() {
+    summaryState.totalRows = 0;
+    summaryState.searchedRows = 0;
+    summaryState.skippedRows = 0;
+    summaryState.errorRows = 0;
+    summaryState.infoRows = 0;
+    summaryState.legacyRows = 0;
+    summaryState.totalCycles = 0;
+    summaryState.searchedCycles = 0;
+    summaryState.skipOnlyCycles = 0;
+    summaryState.unknownCycles = 0;
+    summaryState.cycleProgressById.clear();
+  }
+
+  function rebuildSummaryFromVisibleRows() {
+    resetSummaryState();
+    document.querySelectorAll('#log-tbody tr[data-log-row="true"]').forEach((row) => {
+      row.removeAttribute('data-summary-accounted');
+      accountSummaryRow(row);
+    });
+    renderSummaryState();
+  }
+
+  function updateSummaryForAppendedRows(rows) {
+    rows.forEach((row) => {
+      accountSummaryRow(row);
+    });
+    renderSummaryState();
+  }
+
+  formatVisibleLogTimestamps(document);
+  rebuildSummaryFromVisibleRows();
 
   const copyBtn = document.getElementById('copy-visible-logs-btn');
   const copyBtnLabel = document.getElementById('copy-visible-logs-label');
@@ -389,9 +459,22 @@
       return;
     }
 
-    if (target.id === 'log-tbody' || target.id === 'pagination-row') {
-      formatVisibleLogTimestamps();
-      refreshSummaryFromVisibleRows();
+    if (target.id === 'log-tbody') {
+      formatVisibleLogTimestamps(target);
+      rebuildSummaryFromVisibleRows();
+      return;
+    }
+
+    if (target.id === 'pagination-row') {
+      const appendedRows = Array.from(
+        document.querySelectorAll('#log-tbody tr[data-log-row="true"].htmx-added')
+      );
+      formatVisibleLogTimestamps(document);
+      if (appendedRows.length > 0) {
+        updateSummaryForAppendedRows(appendedRows);
+      } else {
+        rebuildSummaryFromVisibleRows();
+      }
     }
   });
 

--- a/src/houndarr/templates/partials/log_rows.html
+++ b/src/houndarr/templates/partials/log_rows.html
@@ -26,6 +26,7 @@
 
   <tr class="border-b border-slate-800 hover:bg-slate-800/40 transition-colors"
       data-log-row="true"
+      data-action="{{ row.action or '' }}"
       data-cycle-id="{{ row.cycle_id or '' }}"
       data-cycle-progress="{{ row.cycle_progress or '' }}">
     {# Timestamp #}
@@ -132,10 +133,11 @@
 
   {# Pagination: "Load older" link — only show if we got a full page #}
   {% if rows | length >= limit %}
+  {% set next_limit = load_more_limit if load_more_limit is defined else limit %}
   <tr id="pagination-row">
     <td colspan="10" class="px-3 py-3 text-center">
       <button
-        hx-get="/api/logs/partial?limit={{ limit }}{% if instance_id %}&instance_id={{ instance_id }}{% endif %}{% if action %}&action={{ action }}{% endif %}{% if search_kind %}&search_kind={{ search_kind }}{% endif %}{% if cycle_trigger %}&cycle_trigger={{ cycle_trigger }}{% endif %}&hide_system={{ 'true' if hide_system else 'false' }}&before={{ rows[-1].timestamp }}"
+        hx-get="/api/logs/partial?limit={{ next_limit }}{% if instance_id %}&instance_id={{ instance_id }}{% endif %}{% if action %}&action={{ action }}{% endif %}{% if search_kind %}&search_kind={{ search_kind }}{% endif %}{% if cycle_trigger %}&cycle_trigger={{ cycle_trigger }}{% endif %}&hide_system={{ 'true' if hide_system else 'false' }}&before={{ rows[-1].timestamp }}"
         hx-target="#pagination-row"
         hx-swap="outerHTML"
         class="text-xs text-brand-400 hover:text-brand-300 transition-colors underline-offset-2 hover:underline">

--- a/tests/test_routes/test_logs.py
+++ b/tests/test_routes/test_logs.py
@@ -42,6 +42,53 @@ def _login(client: TestClient) -> None:
     client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
 
 
+async def _insert_extra_logs(count: int, *, start_index: int = 0) -> None:
+    """Insert many deterministic rows for pagination behavior tests."""
+    rows: list[tuple[object, ...]] = []
+    for index in range(start_index, start_index + count):
+        hour = (index // 3600) % 24
+        minute = (index // 60) % 60
+        second = index % 60
+        rows.append(
+            (
+                1,
+                10000 + index,
+                "episode",
+                "missing",
+                f"cycle-bulk-{index // 5}",
+                "scheduled",
+                f"Bulk row {index}",
+                "skipped",
+                "bulk",
+                None,
+                f"2024-01-02T{hour:02d}:{minute:02d}:{second:02d}.000Z",
+            )
+        )
+
+    async with get_db() as conn:
+        await conn.executemany(
+            """
+            INSERT INTO search_log
+                (
+                    instance_id,
+                    item_id,
+                    item_type,
+                    search_kind,
+                    cycle_id,
+                    cycle_trigger,
+                    item_label,
+                    action,
+                    reason,
+                    message,
+                    timestamp
+                )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        await conn.commit()
+
+
 @pytest_asyncio.fixture()
 async def seeded_log(db: None) -> AsyncGenerator[None, None]:  # type: ignore[misc]
     """Seed search_log with rows across two instances for filter/pagination tests."""
@@ -591,6 +638,49 @@ async def test_logs_partial_pagination_uses_append_swap(
     assert resp.status_code == 200
     assert 'hx-target="#pagination-row"' in resp.text
     assert 'hx-swap="outerHTML"' in resp.text
+
+
+@pytest.mark.asyncio()
+async def test_logs_partial_load_more_caps_chunk_size_for_high_limits(
+    seeded_log: None, async_client: object
+) -> None:
+    """High selected row counts should paginate in bounded chunks."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await _insert_extra_logs(620)
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs/partial?limit=500&hide_system=true")
+    assert resp.status_code == 200
+    assert "limit=100" in resp.text
+    assert 'hx-target="#pagination-row"' in resp.text
+
+
+@pytest.mark.asyncio()
+async def test_logs_partial_load_more_preserves_small_limits(
+    seeded_log: None, async_client: object
+) -> None:
+    """Smaller limits should keep their original pagination chunk size."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await _insert_extra_logs(80, start_index=1000)
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs/partial?limit=50&hide_system=true")
+    assert resp.status_code == 200
+    assert "limit=50" in resp.text
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- cap each load-more request to a bounded chunk (100 rows max) while keeping the selected visible row limit options unchanged
- keep pagination/filter/cursor semantics and append behavior intact
- reduce client-side load-more work by formatting timestamps once and incrementally updating summary stats for appended rows instead of rescanning the whole table
- add focused logs route tests for capped chunking and preserved small-limit semantics

## Root Cause
The logs page could become unresponsive at high limits because each load-more action appended a very large HTML fragment and then triggered full-table client-side reprocessing (timestamp formatting + summary recomputation over all visible rows).

## Testing
- `.venv/bin/python -m ruff check src/ tests/`
- `.venv/bin/python -m ruff format --check src/ tests/`
- `.venv/bin/python -m mypy src/`
- `.venv/bin/python -m bandit -r src/ -c pyproject.toml`
- `.venv/bin/pytest`

## Manual verification note
- On local/live data, confirmed `/api/logs/partial?limit=500` renders pagination links with `limit=100`.
- Successive load-more requests fetched ~229KB chunks (vs ~1.15MB full-500 fragments), with fast response times in the tested runtime.

Closes #88