### PR TITLE
chore: polish web metadata and browser identity

### DIFF
--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -3,6 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="A focused, self-hosted companion for Sonarr and Radarr." />
+  <meta name="application-name" content="Houndarr" />
+  <meta name="apple-mobile-web-app-title" content="Houndarr" />
+  <meta name="theme-color" content="#020617" />
+  <meta name="color-scheme" content="dark" />
+  <link rel="icon" type="image/png" href="/static/img/houndarr-logo.png" />
+  <link rel="shortcut icon" href="/static/img/houndarr-logo.png" />
+  <link rel="apple-touch-icon" href="/static/img/houndarr-logo.png" />
   <title>{% block title %}Houndarr{% endblock %}</title>
 
   <!-- Tailwind CSS via CDN play script -->

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -181,6 +181,67 @@ def test_login_page_renders_after_setup(app: TestClient) -> None:
     assert b"Houndarr" in response.content
 
 
+def test_full_pages_render_consistent_titles(app: TestClient) -> None:
+    """Full HTML pages should render '<Page> - Houndarr' title format."""
+    setup_resp = app.get("/setup")
+    assert setup_resp.status_code == 200
+    assert b"<title>Setup \xe2\x80\x94 Houndarr</title>" in setup_resp.content
+
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+
+    login_resp = app.get("/login")
+    assert login_resp.status_code == 200
+    assert b"<title>Login \xe2\x80\x94 Houndarr</title>" in login_resp.content
+
+    app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    dashboard_resp = app.get("/")
+    assert dashboard_resp.status_code == 200
+    assert b"<title>Dashboard \xe2\x80\x94 Houndarr</title>" in dashboard_resp.content
+
+    settings_resp = app.get("/settings")
+    assert settings_resp.status_code == 200
+    assert b"<title>Settings \xe2\x80\x94 Houndarr</title>" in settings_resp.content
+
+    logs_resp = app.get("/logs")
+    assert logs_resp.status_code == 200
+    assert b"<title>Logs \xe2\x80\x94 Houndarr</title>" in logs_resp.content
+
+    help_resp = app.get("/settings/help")
+    assert help_resp.status_code == 200
+    assert b"<title>Settings Help \xe2\x80\x94 Houndarr</title>" in help_resp.content
+
+
+def test_login_page_includes_browser_identity_metadata(app: TestClient) -> None:
+    """Shared head metadata should be present on full HTML pages."""
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+
+    response = app.get("/login")
+    assert response.status_code == 200
+    assert (
+        b'<meta name="description" content="A focused, self-hosted companion for '
+        b'Sonarr and Radarr." />' in response.content
+    )
+    assert b'<meta name="application-name" content="Houndarr" />' in response.content
+    assert b'<meta name="apple-mobile-web-app-title" content="Houndarr" />' in response.content
+    assert b'<meta name="theme-color" content="#020617" />' in response.content
+    assert b'<meta name="color-scheme" content="dark" />' in response.content
+    assert (
+        b'<link rel="icon" type="image/png" href="/static/img/houndarr-logo.png" />'
+        in response.content
+    )
+    assert b'<link rel="shortcut icon" href="/static/img/houndarr-logo.png" />' in response.content
+    assert (
+        b'<link rel="apple-touch-icon" href="/static/img/houndarr-logo.png" />' in response.content
+    )
+
+
 def test_login_wrong_password(app: TestClient) -> None:
     """Wrong password should return 401."""
     app.post(


### PR DESCRIPTION
## Summary
- add shared browser-facing metadata defaults to the base template head (description, app name, apple title, theme color, color-scheme)
- add favicon/browser identity link tags using existing static logo assets
- add targeted route tests that verify full-page title consistency and shared metadata presence

## Why
This keeps release polish focused and minimal while improving tab identity, favicon behavior, and metadata defaults before final release/docs work.

## Testing
- .venv/bin/python -m ruff check src/ tests/
- .venv/bin/python -m ruff format --check src/ tests/
- .venv/bin/python -m mypy src/
- .venv/bin/python -m bandit -r src/ -c pyproject.toml
- .venv/bin/pytest

Closes #90