### PR TITLE
chore: extend row limits to 1000/All and remove legacy/unknown cycle stats from logs summary

### DIFF
--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _LOG_LIMIT_DEFAULT = 50
-_LOG_LIMIT_MAX = 500
+_LOG_LIMIT_MAX = 5000
+_LOG_LIMIT_ALL = 5000
 _LOG_LOAD_MORE_CHUNK_MAX = 100
 _SEARCH_KINDS = {"missing", "cutoff"}
 _CYCLE_TRIGGERS = {"scheduled", "run_now", "system"}
@@ -39,7 +40,6 @@ def _summarize_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
     skipped_rows = 0
     error_rows = 0
     info_rows = 0
-    legacy_rows = 0
 
     cycle_outcomes: dict[str, str] = {}
     for row in rows:
@@ -55,7 +55,6 @@ def _summarize_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
 
         cycle_id = row.get("cycle_id")
         if cycle_id is None:
-            legacy_rows += 1
             continue
 
         cycle_id_str = str(cycle_id)
@@ -64,13 +63,10 @@ def _summarize_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
         if existing == "progress" or cycle_progress == "progress":
             cycle_outcomes[cycle_id_str] = "progress"
         elif existing is None:
-            cycle_outcomes[cycle_id_str] = cycle_progress or "unknown"
+            cycle_outcomes[cycle_id_str] = cycle_progress or "no_progress"
 
     searched_cycles = sum(1 for value in cycle_outcomes.values() if value == "progress")
     skip_only_cycles = sum(1 for value in cycle_outcomes.values() if value == "no_progress")
-    unknown_cycles = sum(
-        1 for value in cycle_outcomes.values() if value not in {"progress", "no_progress"}
-    )
 
     return {
         "total_rows": len(rows),
@@ -78,11 +74,9 @@ def _summarize_rows(rows: list[dict[str, Any]]) -> dict[str, int]:
         "skipped_rows": skipped_rows,
         "error_rows": error_rows,
         "info_rows": info_rows,
-        "legacy_rows": legacy_rows,
         "total_cycles": len(cycle_outcomes),
         "searched_cycles": searched_cycles,
         "skip_only_cycles": skip_only_cycles,
-        "unknown_cycles": unknown_cycles,
     }
 
 

--- a/src/houndarr/templates/partials/log_summary.html
+++ b/src/houndarr/templates/partials/log_summary.html
@@ -4,8 +4,6 @@
     <span>cycles <span id="summary-total-cycles">{{ summary.total_cycles }}</span></span>
     <span class="text-green-300">searched cycles <span id="summary-searched-cycles">{{ summary.searched_cycles }}</span></span>
     <span class="text-zinc-300">skip-only cycles <span id="summary-skip-cycles">{{ summary.skip_only_cycles }}</span></span>
-    <span class="text-slate-500">unknown cycles <span id="summary-unknown-cycles">{{ summary.unknown_cycles }}</span></span>
-    <span class="text-slate-500">legacy rows <span id="summary-legacy-rows">{{ summary.legacy_rows }}</span></span>
     <span class="text-slate-500">rows: searched <span id="summary-searched-rows">{{ summary.searched_rows }}</span> · skipped <span id="summary-skipped-rows">{{ summary.skipped_rows }}</span> · error <span id="summary-error-rows">{{ summary.error_rows }}</span> · info <span id="summary-info-rows">{{ summary.info_rows }}</span></span>
   </div>
 </div>

--- a/src/houndarr/templates/partials/pages/logs_content.html
+++ b/src/houndarr/templates/partials/pages/logs_content.html
@@ -148,6 +148,8 @@
       <option value="200">200</option>
       <option value="300">300</option>
       <option value="500">500</option>
+      <option value="1000">1000</option>
+      <option value="5000">All</option>
     </select>
   </div>
 
@@ -469,11 +471,9 @@
       skippedRows: 0,
       errorRows: 0,
       infoRows: 0,
-      legacyRows: 0,
       totalCycles: 0,
       searchedCycles: 0,
       skipOnlyCycles: 0,
-      unknownCycles: 0,
       cycleProgressById: new Map(),
     };
 
@@ -496,7 +496,6 @@
         summaryState.skipOnlyCycles += delta;
         return;
       }
-      summaryState.unknownCycles += delta;
     }
 
     function accountSummaryRow(row) {
@@ -521,7 +520,6 @@
       const cycleId = row.getAttribute('data-cycle-id') || '';
       const cycleProgress = row.getAttribute('data-cycle-progress') || '';
       if (!cycleId) {
-        summaryState.legacyRows += 1;
         return;
       }
 
@@ -546,8 +544,6 @@
       setSummaryValue('summary-total-cycles', summaryState.totalCycles);
       setSummaryValue('summary-searched-cycles', summaryState.searchedCycles);
       setSummaryValue('summary-skip-cycles', summaryState.skipOnlyCycles);
-      setSummaryValue('summary-unknown-cycles', summaryState.unknownCycles);
-      setSummaryValue('summary-legacy-rows', summaryState.legacyRows);
       setSummaryValue('summary-searched-rows', summaryState.searchedRows);
       setSummaryValue('summary-skipped-rows', summaryState.skippedRows);
       setSummaryValue('summary-error-rows', summaryState.errorRows);
@@ -560,11 +556,9 @@
       summaryState.skippedRows = 0;
       summaryState.errorRows = 0;
       summaryState.infoRows = 0;
-      summaryState.legacyRows = 0;
       summaryState.totalCycles = 0;
       summaryState.searchedCycles = 0;
       summaryState.skipOnlyCycles = 0;
-      summaryState.unknownCycles = 0;
       summaryState.cycleProgressById.clear();
     }
 

--- a/tests/test_routes/test_logs.py
+++ b/tests/test_routes/test_logs.py
@@ -537,6 +537,8 @@ def test_logs_page_renders(app: TestClient) -> None:
     assert b'id="filter-hide-system"' in resp.content
     assert b"checked" in resp.content
     assert b'<option value="500">500</option>' in resp.content
+    assert b'<option value="1000">1000</option>' in resp.content
+    assert b'<option value="5000">All</option>' in resp.content
     # Split-button copy dropdown must be present.
     assert b"Copy as TSV" in resp.content
     assert b"Copy as Markdown" in resp.content
@@ -800,3 +802,86 @@ async def test_logs_partial_cycle_group_headers_include_cycle_context(
     assert "trigger run_now" in resp.text
     assert "searched 1" in resp.text
     assert "skipped 1" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Row-limit extensions: 1000 and All (5000)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_logs_limit_1000_accepted(seeded_log: None, async_client: object) -> None:
+    """limit=1000 must be accepted and return available rows."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?limit=1000")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 6
+
+
+@pytest.mark.asyncio()
+async def test_logs_limit_all_accepted(seeded_log: None, async_client: object) -> None:
+    """limit=5000 (the 'All' sentinel) must be accepted and return available rows."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?limit=5000")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 6
+
+
+@pytest.mark.asyncio()
+async def test_logs_limit_above_max_rejected(seeded_log: None, async_client: object) -> None:
+    """limit above _LOG_LIMIT_MAX (5000) must be rejected with 422."""
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs?limit=5001")
+    assert resp.status_code == 422
+
+
+def test_logs_page_renders_all_limit_options(app: TestClient) -> None:
+    """The /logs page must include the 1000 and All (5000) options in the Rows selector."""
+    _login(app)
+    resp = app.get("/logs")
+    assert resp.status_code == 200
+    assert b'<option value="1000">1000</option>' in resp.content
+    assert b'<option value="5000">All</option>' in resp.content
+
+
+def test_logs_summary_no_legacy_rows_in_html(app: TestClient) -> None:
+    """The /logs summary bar must not contain a 'legacy rows' label."""
+    _login(app)
+    resp = app.get("/logs")
+    assert resp.status_code == 200
+    assert b"legacy rows" not in resp.content
+
+
+def test_logs_summary_no_unknown_cycles_in_html(app: TestClient) -> None:
+    """The /logs summary bar must not contain an 'unknown cycles' label."""
+    _login(app)
+    resp = app.get("/logs")
+    assert resp.status_code == 200
+    assert b"unknown cycles" not in resp.content


### PR DESCRIPTION
## Summary

Closes #98

Three tightly-scoped logs page polish changes for release readiness:

- **Extend row-limit selector** — adds 1000 and All options alongside the existing 25/50/100/200/300/500 set. "All" maps to the bounded sentinel value `_LOG_LIMIT_ALL = 5000` so no query is ever truly unbounded. Load-more chunk size (`_LOG_LOAD_MORE_CHUNK_MAX = 100`) is unchanged.

- **Remove "legacy rows" from summary** — rows with `cycle_id IS NULL` (system info rows / pre-cycle-id data) were labelled as "legacy rows" in the summary bar. This internal migration artifact has no meaning to end users and creates noise before release.

- **Remove "unknown cycles" from summary** — always 0 in practice under the current schema (the SQL `cycle_progress` subquery only ever returns `progress` or `no_progress` for rows with a non-NULL `cycle_id`). Removed from both Python and JS.

## Files changed

| File | Change |
|------|--------|
| `src/houndarr/routes/api/logs.py` | `_LOG_LIMIT_MAX` → 5000; add `_LOG_LIMIT_ALL = 5000`; remove `legacy_rows`/`unknown_cycles` from `_summarize_rows` |
| `src/houndarr/templates/partials/log_summary.html` | Remove legacy rows and unknown cycles `<span>` lines |
| `src/houndarr/templates/partials/pages/logs_content.html` | Add `1000` and `All` options to Rows selector; strip `legacyRows`/`unknownCycles` from JS `summaryState`, `resetSummaryState`, `accountSummaryRow`, `adjustCycleBucket`, `renderSummaryState` |
| `tests/test_routes/test_logs.py` | Update existing option assertion; add 6 new tests |

## Tests

- Updated: `test_logs_page_renders` — asserts 500, 1000, and All options are all present
- Added: `test_logs_limit_1000_accepted`
- Added: `test_logs_limit_all_accepted`
- Added: `test_logs_limit_above_max_rejected`
- Added: `test_logs_page_renders_all_limit_options`
- Added: `test_logs_summary_no_legacy_rows_in_html`
- Added: `test_logs_summary_no_unknown_cycles_in_html`

## Quality gates

All green locally: ruff check, ruff format --check, mypy, bandit, pytest (303 passed)