### PR TITLE
fix: use dark logo variant for favicon visibility

### DIFF
--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -8,9 +8,9 @@
   <meta name="apple-mobile-web-app-title" content="Houndarr" />
   <meta name="theme-color" content="#020617" />
   <meta name="color-scheme" content="dark" />
-  <link rel="icon" type="image/png" href="/static/img/houndarr-logo.png" />
-  <link rel="shortcut icon" href="/static/img/houndarr-logo.png" />
-  <link rel="apple-touch-icon" href="/static/img/houndarr-logo.png" />
+  <link rel="icon" type="image/png" href="/static/img/houndarr-logo-dark.png" />
+  <link rel="shortcut icon" href="/static/img/houndarr-logo-dark.png" />
+  <link rel="apple-touch-icon" href="/static/img/houndarr-logo-dark.png" />
   <title>{% block title %}Houndarr{% endblock %}</title>
 
   <!-- Tailwind CSS via CDN play script -->

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -233,12 +233,16 @@ def test_login_page_includes_browser_identity_metadata(app: TestClient) -> None:
     assert b'<meta name="theme-color" content="#020617" />' in response.content
     assert b'<meta name="color-scheme" content="dark" />' in response.content
     assert (
-        b'<link rel="icon" type="image/png" href="/static/img/houndarr-logo.png" />'
+        b'<link rel="icon" type="image/png" href="/static/img/houndarr-logo-dark.png" />'
         in response.content
     )
-    assert b'<link rel="shortcut icon" href="/static/img/houndarr-logo.png" />' in response.content
     assert (
-        b'<link rel="apple-touch-icon" href="/static/img/houndarr-logo.png" />' in response.content
+        b'<link rel="shortcut icon" href="/static/img/houndarr-logo-dark.png" />'
+        in response.content
+    )
+    assert (
+        b'<link rel="apple-touch-icon" href="/static/img/houndarr-logo-dark.png" />'
+        in response.content
     )
 
 


### PR DESCRIPTION
## Summary

- Swap favicon references in `base.html` from `houndarr-logo.png` (light variant) to `houndarr-logo-dark.png` for better visibility on light browser chrome / tab bars
- Update corresponding test assertion in `test_auth.py`

## Changes

| File | Change |
|------|--------|
| `src/houndarr/templates/base.html` | 3 `<link>` tags updated to reference `-dark.png` |
| `tests/test_auth.py` | Test assertion updated to match new favicon path |

Closes #109