### PR TITLE
fix: clipboard copy fallback for plain HTTP (non-secure context)

### DIFF
--- a/src/houndarr/templates/partials/pages/logs_content.html
+++ b/src/houndarr/templates/partials/pages/logs_content.html
@@ -693,14 +693,33 @@
       if (text === null) {
         return;
       }
-      navigator.clipboard
-        .writeText(text)
-        .then(() => {
+      // navigator.clipboard is only available in secure contexts (HTTPS or localhost).
+      // Fall back to the legacy textarea + execCommand approach for plain HTTP access.
+      if (navigator.clipboard) {
+        navigator.clipboard
+          .writeText(text)
+          .then(() => {
+            flashCopyButtonState('success');
+          })
+          .catch(() => {
+            flashCopyButtonState('error');
+          });
+      } else {
+        try {
+          const ta = document.createElement('textarea');
+          ta.value = text;
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.focus();
+          ta.select();
+          document.execCommand('copy');
+          document.body.removeChild(ta);
           flashCopyButtonState('success');
-        })
-        .catch(() => {
+        } catch {
           flashCopyButtonState('error');
-        });
+        }
+      }
     }
 
     // Main button: copy TSV immediately, also close dropdown if open.


### PR DESCRIPTION
## Summary

- Add `textarea` + `document.execCommand('copy')` fallback in `performCopy` for when `navigator.clipboard` is unavailable (plain HTTP over LAN/IP)
- Primary `navigator.clipboard.writeText()` path unchanged — still used on HTTPS/localhost
- Success/error button flash feedback preserved for both paths

## Root Cause

`navigator.clipboard` is a Secure Context API — `undefined` on plain `http://`. The copy button silently did nothing for any self-hosted user accessing Houndarr over HTTP without a reverse proxy.

## Testing

All quality gates pass (ruff, mypy, bandit, pytest — 303 tests).

Closes #115