### PR TITLE
fix: configure root logger so application INFO messages appear in stdout

### DIFF
--- a/src/houndarr/__main__.py
+++ b/src/houndarr/__main__.py
@@ -1,5 +1,7 @@
 """Entry point: python -m houndarr."""
 
+from __future__ import annotations
+
 import click
 
 from houndarr import __version__
@@ -80,9 +82,20 @@ def cli(
     missing and cutoff-unmet media in controlled batches, keeping your
     indexers happy.
     """
+    import logging
+
     import uvicorn
 
     from houndarr.config import AppSettings
+
+    # Configure the root logger so that application loggers (houndarr.*)
+    # respect --log-level.  Without this, only uvicorn's own loggers are
+    # configured and all houndarr.* INFO messages are silently dropped
+    # (Python's root logger defaults to WARNING).
+    logging.basicConfig(
+        level=getattr(logging, log_level.upper()),
+        format="%(levelname)s:     %(message)s",
+    )
 
     settings = AppSettings(
         data_dir=data_dir,


### PR DESCRIPTION
## Summary

- Configure `logging.basicConfig()` before `uvicorn.run()` so all `houndarr.*` loggers respect the `--log-level` / `HOUNDARR_LOG_LEVEL` setting
- Previously, only uvicorn's own loggers were configured; Python's root logger defaulted to `WARNING`, silently dropping all application `INFO` messages (startup, search cycles, supervisor recovery)

## Root Cause

`uvicorn.run(log_level="info")` only configures `uvicorn`, `uvicorn.error`, and `uvicorn.access` loggers. The `houndarr.*` loggers created via `logging.getLogger(__name__)` inherit from the root logger, which Python defaults to `WARNING`. This made the v1.0.3 recovery message (`"is reachable again"`) invisible in container stdout even though it was being emitted correctly at `INFO` level.

## Changes

- `src/houndarr/__main__.py`: Add `logging.basicConfig(level=..., format=...)` before `uvicorn.run()`, using the user's `--log-level` setting. Format matches uvicorn's visual style. Also adds the missing `from __future__ import annotations` import.

## Testing

- All 303 tests pass
- All quality gates green (ruff, mypy, bandit)
- Manually verified that `basicConfig` + uvicorn's `dictConfig` coexist without duplicate handlers (uvicorn loggers set `propagate: false`)

Closes #125