### PR TITLE
ci: fix release.yml backtick substitution and update release docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,10 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.notes }}
         run: |
+          echo "$RELEASE_NOTES" > /tmp/release-notes.md
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
-            --notes "${{ steps.notes.outputs.notes }}" \
+            --notes-file /tmp/release-notes.md \
             --latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,9 +292,17 @@ Do not use `Improved`, `Updated`, `Refactored`, `Internal`, or any other heading
 
 ### `release.yml` workflow
 
-- Triggers on `push: tags: ["v*"]` only — not a required PR check
-- Extracts the `## [X.Y.Z]` block from `CHANGELOG.md` using the tag version
-- Runs `gh release create --latest` with those notes
+- Triggers on `push: tags: ["v*"]` only — **not** a required PR check
+- Extracts the `## [X.Y.Z]` block from `CHANGELOG.md` using `awk`
+  (the `## [X.Y.Z]` heading line itself is stripped — the release title is
+  already `vX.Y.Z`)
+- Writes extracted notes to a temp file and passes `--notes-file` to
+  `gh release create` — this is intentional: passing notes via `--notes`
+  would cause shell command substitution of any backticks in the markdown,
+  silently stripping inline code formatting
+- The notes content flows through a GitHub Actions `env:` variable
+  (`RELEASE_NOTES`), not inline `${{ }}` interpolation in the `run:` script,
+  so backticks and other shell metacharacters survive intact
 - Requires `permissions: contents: write`
 
 ## Workflow


### PR DESCRIPTION
## Summary

- Fix `release.yml` to pass CHANGELOG notes through an `env:` variable and `--notes-file` instead of inline `--notes`, preventing shell command substitution of backticks in release body markdown
- Expand `AGENTS.md` release workflow documentation to explain the `--notes-file` mechanism, why it exists, and how `awk` extraction works

## Problem

The `release.yml` workflow passed notes via `--notes "${{ steps.notes.outputs.notes }}"`, which caused bash to interpret backticks (e.g. `` `INFO` ``, `` `WARNING` ``) as command substitution. The v1.0.4 release body has mangled formatting as a result — inline code markers were silently stripped.

## Fix

1. **`release.yml`**: Set notes as a `RELEASE_NOTES` env variable (GitHub Actions expands `${{ }}` safely into env values), write to a temp file with `echo "$RELEASE_NOTES"` (double-quoted — no command substitution), then pass `--notes-file /tmp/release-notes.md` to `gh release create`
2. **`AGENTS.md`**: Expanded the `release.yml` workflow subsection to document the `--notes-file` approach, the `awk` extraction logic, heading stripping, and the env variable mechanism

## Testing

- No Python code changes — `ruff check`, `ruff format --check`, `mypy`, `bandit`, and all 303 `pytest` tests pass unchanged
- This PR only touches `.yml` and `.md` files; `ci-skip.yml` provides the required no-op check jobs

## Post-merge follow-up

After merge, the v1.0.4 release body will be manually patched via `gh release edit v1.0.4 --notes-file` to restore the correct markdown with backticks intact.

Closes #129