### PR TITLE
fix(supervisor): deduplicate connect-error log rows and add startup grace delay

### DIFF
--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 _SHUTDOWN_TIMEOUT = 10  # seconds to wait for tasks to finish on stop()
 _CONNECT_RETRY_SECS = 30  # back-off interval when a connection error occurs
+_STARTUP_GRACE_SECS = 10  # one-time delay before the first cycle fires per instance
 RunNowStatus = Literal["accepted", "not_found", "disabled"]
 
 
@@ -188,9 +189,23 @@ class Supervisor:
     # ------------------------------------------------------------------
 
     async def _instance_loop(self, instance_id: int) -> None:
-        """Run search cycles for one instance until cancelled."""
+        """Run search cycles for one instance until cancelled.
+
+        A one-time startup grace delay gives co-located services (Sonarr, Radarr)
+        time to become ready before the first cycle fires.  Connection errors are
+        logged to ``search_log`` only on state transitions (first failure and
+        recovery) to avoid inflating the dashboard error counter with retry noise.
+        """
         logger.debug("Supervisor: loop started for instance id=%d", instance_id)
         _in_connect_retry = False
+
+        logger.info(
+            "Supervisor: waiting %d s startup grace for instance id=%d",
+            _STARTUP_GRACE_SECS,
+            instance_id,
+        )
+        await asyncio.sleep(_STARTUP_GRACE_SECS)
+
         try:
             while True:
                 instance = await get_instance(instance_id, master_key=self._master_key)
@@ -213,14 +228,33 @@ class Supervisor:
                 )
 
                 if got_connect_error:
+                    if not _in_connect_retry:
+                        # First failure — write one error row and enter retry state.
+                        await _write_log(
+                            instance_id=instance.id,
+                            item_id=None,
+                            item_type=None,
+                            action="error",
+                            cycle_trigger="scheduled",
+                            message=f"Could not reach {instance.url}",
+                        )
                     _in_connect_retry = True
                     await asyncio.sleep(_CONNECT_RETRY_SECS)
                 else:
                     if _in_connect_retry:
+                        # Recovery — write one info row and leave retry state.
                         logger.info(
                             "Supervisor: %r (%s) is reachable again",
                             instance.name,
                             instance.url,
+                        )
+                        await _write_log(
+                            instance_id=instance.id,
+                            item_id=None,
+                            item_type=None,
+                            action="info",
+                            cycle_trigger="scheduled",
+                            message=f"{instance.name!r} ({instance.url}) is reachable again",
                         )
                         _in_connect_retry = False
                     await asyncio.sleep(instance.sleep_interval_mins * 60)
@@ -260,15 +294,6 @@ class Supervisor:
                     instance.name,
                     instance.url,
                     _CONNECT_RETRY_SECS,
-                )
-                await _write_log(
-                    instance_id=instance.id,
-                    item_id=None,
-                    item_type=None,
-                    action="error",
-                    cycle_id=cycle_id,
-                    cycle_trigger=cycle_trigger,
-                    message=f"Could not reach {instance.url}",
                 )
                 return True
             except Exception as exc:  # noqa: BLE001

--- a/tests/test_e2e/test_search_cycle.py
+++ b/tests/test_e2e/test_search_cycle.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -18,6 +19,7 @@ import respx
 from cryptography.fernet import Fernet
 
 from houndarr.database import get_db
+from houndarr.engine import supervisor as _supervisor_mod
 from houndarr.engine.search_loop import run_instance_search
 from houndarr.engine.supervisor import Supervisor
 from houndarr.services.cooldown import record_search
@@ -334,13 +336,14 @@ async def test_supervisor_runs_both_instances(
         return_value=httpx.Response(201, json={"id": 2})
     )
 
-    sup = Supervisor(master_key=master_key)
-    await sup.start()
-    assert len(sup._tasks) == 2  # noqa: SLF001
+    with patch.object(_supervisor_mod, "_STARTUP_GRACE_SECS", 0):
+        sup = Supervisor(master_key=master_key)
+        await sup.start()
+        assert len(sup._tasks) == 2  # noqa: SLF001
 
-    # Let both tasks complete their first search cycle before stopping
-    await asyncio.sleep(0.2)
-    await sup.stop()
+        # Let both tasks complete their first search cycle before stopping
+        await asyncio.sleep(0.2)
+        await sup.stop()
 
     # Both instances must have a 'searched' log entry
     logs = await _log_rows()

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -1219,12 +1219,16 @@ async def test_supervisor_scheduled_cycles_pass_scheduled_trigger(seeded_instanc
     """Scheduled supervisor loop should call engine with cycle_trigger='scheduled'."""
     import asyncio
 
+    import houndarr.engine.supervisor as _sup_mod
     from houndarr.engine.supervisor import Supervisor
 
-    with patch(
-        "houndarr.engine.supervisor.run_instance_search",
-        new=AsyncMock(return_value=0),
-    ) as run_mock:
+    with (
+        patch.object(_sup_mod, "_STARTUP_GRACE_SECS", 0),
+        patch(
+            "houndarr.engine.supervisor.run_instance_search",
+            new=AsyncMock(return_value=0),
+        ) as run_mock,
+    ):
         sup = Supervisor(master_key=MASTER_KEY)
         await sup.start()
         await asyncio.sleep(0.05)

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -1,0 +1,273 @@
+"""Tests for the Supervisor engine — connection-error deduplication and startup grace."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.fernet import Fernet
+
+from houndarr.database import get_db
+from houndarr.engine import supervisor as _supervisor_mod
+from houndarr.engine.supervisor import Supervisor
+from houndarr.services.instances import Instance, InstanceType, SonarrSearchMode
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+SONARR_URL = "http://sonarr:8989"
+MASTER_KEY: bytes = Fernet.generate_key()
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_instance(
+    *,
+    instance_id: int = 1,
+    url: str = SONARR_URL,
+    enabled: bool = True,
+    sleep_interval_mins: int = 30,
+) -> Instance:
+    return Instance(
+        id=instance_id,
+        name="Test Sonarr",
+        type=InstanceType.sonarr,
+        url=url,
+        api_key="test-api-key",
+        enabled=enabled,
+        batch_size=2,
+        sleep_interval_mins=sleep_interval_mins,
+        hourly_cap=4,
+        cooldown_days=14,
+        unreleased_delay_hrs=36,
+        cutoff_enabled=False,
+        cutoff_batch_size=1,
+        cutoff_cooldown_days=21,
+        cutoff_hourly_cap=1,
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        sonarr_search_mode=SonarrSearchMode.episode,
+    )
+
+
+@pytest_asyncio.fixture()
+async def seeded_instances(db: None) -> AsyncGenerator[None, None]:
+    """Seed FK-required instance rows so search_log can reference them."""
+    from houndarr.crypto import encrypt
+
+    encrypted = encrypt("test-api-key", MASTER_KEY)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
+            (1, "Test Sonarr", "sonarr", SONARR_URL, encrypted),
+        )
+        await conn.commit()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helper: fetch all search_log rows
+# ---------------------------------------------------------------------------
+
+
+async def _get_log_rows() -> list[dict[str, Any]]:
+    async with get_db() as conn:
+        async with conn.execute("SELECT * FROM search_log ORDER BY id ASC") as cur:
+            rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Tests — startup grace delay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_instance_loop_waits_startup_grace_before_first_cycle(
+    seeded_instances: None,
+) -> None:
+    """_instance_loop sleeps _STARTUP_GRACE_SECS before the first search cycle."""
+    from houndarr.engine.supervisor import _STARTUP_GRACE_SECS
+
+    instance = _make_instance()
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(secs: float) -> None:
+        sleep_calls.append(secs)
+        # Cancel after the first sleep so the loop exits cleanly.
+        raise asyncio.CancelledError
+
+    with (
+        patch.object(_supervisor_mod, "_STARTUP_GRACE_SECS", 10),
+        patch("houndarr.engine.supervisor.get_instance", return_value=instance),
+        patch("houndarr.engine.supervisor.asyncio.sleep", side_effect=fake_sleep),
+        patch(
+            "houndarr.engine.supervisor.run_instance_search",
+            new_callable=AsyncMock,
+        ) as mock_search,
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        with pytest.raises(asyncio.CancelledError):  # noqa: PT012
+            await supervisor._instance_loop(instance.id)  # noqa: SLF001
+
+    # The very first sleep must be the startup grace, not the inter-cycle sleep.
+    assert sleep_calls, "expected at least one asyncio.sleep call"
+    assert sleep_calls[0] == _STARTUP_GRACE_SECS
+    # No search should have run because CancelledError fires in the first sleep.
+    mock_search.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests — state-transition error logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_first_connect_error_writes_exactly_one_error_row(
+    seeded_instances: None,
+) -> None:
+    """The first TransportError in a sequence writes exactly one error log row."""
+    instance = _make_instance()
+    call_count = 0
+
+    async def fail_once_then_cancel(*_: Any, **__: Any) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.TransportError("refused")
+        raise asyncio.CancelledError
+
+    with (
+        patch.object(_supervisor_mod, "_STARTUP_GRACE_SECS", 0),
+        patch("houndarr.engine.supervisor.get_instance", return_value=instance),
+        patch("houndarr.engine.supervisor.asyncio.sleep", new_callable=AsyncMock),
+        patch(
+            "houndarr.engine.supervisor.run_instance_search",
+            side_effect=fail_once_then_cancel,
+        ),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        with pytest.raises(asyncio.CancelledError):
+            await supervisor._instance_loop(instance.id)  # noqa: SLF001
+
+    rows = await _get_log_rows()
+    error_rows = [r for r in rows if r["action"] == "error"]
+    assert len(error_rows) == 1
+    assert SONARR_URL in (error_rows[0]["message"] or "")
+
+
+@pytest.mark.asyncio()
+async def test_repeated_connect_errors_write_only_one_error_row(
+    seeded_instances: None,
+) -> None:
+    """Multiple consecutive TransportErrors produce exactly one error log row."""
+    instance = _make_instance()
+    call_count = 0
+
+    async def fail_three_then_cancel(*_: Any, **__: Any) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 3:
+            raise httpx.TransportError("refused")
+        raise asyncio.CancelledError
+
+    with (
+        patch.object(_supervisor_mod, "_STARTUP_GRACE_SECS", 0),
+        patch("houndarr.engine.supervisor.get_instance", return_value=instance),
+        patch("houndarr.engine.supervisor.asyncio.sleep", new_callable=AsyncMock),
+        patch(
+            "houndarr.engine.supervisor.run_instance_search",
+            side_effect=fail_three_then_cancel,
+        ),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        with pytest.raises(asyncio.CancelledError):
+            await supervisor._instance_loop(instance.id)  # noqa: SLF001
+
+    rows = await _get_log_rows()
+    error_rows = [r for r in rows if r["action"] == "error"]
+    assert len(error_rows) == 1, (
+        f"expected 1 error row for {call_count} retries, got {len(error_rows)}"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_recovery_after_connect_error_writes_info_row(
+    seeded_instances: None,
+) -> None:
+    """After reconnecting, exactly one action='info' recovery row is written."""
+    instance = _make_instance()
+    call_count = 0
+
+    async def fail_once_then_succeed(*_: Any, **__: Any) -> int:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.TransportError("refused")
+        if call_count == 2:
+            return 0  # success — triggers recovery path
+        raise asyncio.CancelledError
+
+    with (
+        patch.object(_supervisor_mod, "_STARTUP_GRACE_SECS", 0),
+        patch("houndarr.engine.supervisor.get_instance", return_value=instance),
+        patch("houndarr.engine.supervisor.asyncio.sleep", new_callable=AsyncMock),
+        patch(
+            "houndarr.engine.supervisor.run_instance_search",
+            side_effect=fail_once_then_succeed,
+        ),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        with pytest.raises(asyncio.CancelledError):
+            await supervisor._instance_loop(instance.id)  # noqa: SLF001
+
+    rows = await _get_log_rows()
+    info_rows = [r for r in rows if r["action"] == "info"]
+    assert any("reachable" in (r["message"] or "") for r in info_rows), (
+        f"expected a recovery info row, got: {rows}"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_no_extra_log_rows_during_retry_sequence(
+    seeded_instances: None,
+) -> None:
+    """Retries between first failure and recovery produce no additional log rows."""
+    instance = _make_instance()
+    call_count = 0
+
+    async def fail_twice_then_succeed(*_: Any, **__: Any) -> int:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise httpx.TransportError("refused")
+        if call_count == 3:
+            return 0  # recovery
+        raise asyncio.CancelledError
+
+    with (
+        patch.object(_supervisor_mod, "_STARTUP_GRACE_SECS", 0),
+        patch("houndarr.engine.supervisor.get_instance", return_value=instance),
+        patch("houndarr.engine.supervisor.asyncio.sleep", new_callable=AsyncMock),
+        patch(
+            "houndarr.engine.supervisor.run_instance_search",
+            side_effect=fail_twice_then_succeed,
+        ),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        with pytest.raises(asyncio.CancelledError):
+            await supervisor._instance_loop(instance.id)  # noqa: SLF001
+
+    rows = await _get_log_rows()
+    # Expect exactly: 1 error (first failure) + 1 info (recovery) = 2 rows total
+    assert len(rows) == 2, f"expected 2 log rows (1 error + 1 recovery), got: {rows}"
+    assert rows[0]["action"] == "error"
+    assert rows[1]["action"] == "info"


### PR DESCRIPTION
## Summary

- Adds a 10 s startup grace delay before the first search cycle fires per instance, giving co-located Sonarr/Radarr services time to become ready.
- Moves `search_log` writes for `TransportError` from `_run_search_cycle` to `_instance_loop`, gated on state transitions: one `action="error"` row on the first failure, one `action="info"` recovery row when the instance becomes reachable again — subsequent retries produce only a stdout `WARNING`.
- Adds `tests/test_engine/test_supervisor.py` with five regression tests covering the startup grace, first-failure deduplication, multi-retry deduplication, recovery row, and the combined error+recovery row count.
- Updates two existing tests (`test_supervisor_scheduled_cycles_pass_scheduled_trigger`, `test_supervisor_runs_both_instances`) to patch `_STARTUP_GRACE_SECS=0` so they are not affected by the grace delay.

## Checklist

- [x] Linked issue has `type:*` and `priority:*` labels
- [x] All five quality gates pass (ruff, mypy, bandit, pytest — 311 tests)
- [x] No changes to `VERSION` or `CHANGELOG.md` (version bump is a separate PR)

Closes #140