### PR TITLE
fix(website): consistent spacing between homepage feature card rows

### DIFF
--- a/website/src/components/HomepageFeatures/styles.module.css
+++ b/website/src/components/HomepageFeatures/styles.module.css
@@ -4,3 +4,17 @@
   padding: 2rem 0;
   width: 100%;
 }
+
+/* Ensure consistent vertical spacing between wrapped rows of cards */
+.features :global(.row) {
+  row-gap: 1rem;
+}
+
+/* Stretch cards to equal height within each row */
+.features :global(.col) {
+  display: flex;
+}
+
+.features :global(.col) > * {
+  flex: 1;
+}


### PR DESCRIPTION
## Linked Issue (required)

Closes #156

## Summary

Add `row-gap` to the feature grid and make cards stretch to equal height within each row. Fixes inconsistent vertical spacing between homepage feature card rows.

## Type of Change

- [x] Bug fix (`fix:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Branch name matches issue scope
- [ ] Tests added/updated for all changes — N/A, CSS-only change
- [ ] Type check passes (`mypy src/`) — N/A, no Python changes
- [x] No secrets or sensitive data committed