### PR TITLE
chore(deps): group GitHub Actions Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,7 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Linked Issue (required)

Closes #159

## Summary

Add a `groups` rule to the `github-actions` ecosystem block in `.github/dependabot.yml` so all GitHub Actions version bumps are batched into a single PR instead of arriving individually.

## Type of Change

- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [ ] Tests added/updated for all changes — N/A, YAML config only
- [x] No secrets or sensitive data committed