### PR TITLE
fix(website): reduce spacing between screenshots and scope sections

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -30,7 +30,7 @@
 }
 
 .screenshots {
-  padding: 3rem 0;
+  padding: 3rem 0 1rem;
 }
 
 .whatItDoes {
@@ -46,5 +46,5 @@
 }
 
 .scopeSection {
-  padding: 2rem 0 3rem;
+  padding: 0 0 3rem;
 }


### PR DESCRIPTION
## Summary

- Decrease bottom padding on `.screenshots` from `3rem 0` to `3rem 0 1rem`
- Remove top padding on `.scopeSection` from `2rem 0 3rem` to `0 0 3rem`

These two adjustments bring the \"See It in Action\" images and the \"Focused by Design\" section visually closer together on the landing page.

Closes #163