### PR TITLE
fix(website): use dark logo for favicon and light mode navbar

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 const config: Config = {
   title: 'Houndarr',
   tagline: 'Polite, automated media searching for Sonarr and Radarr',
-  favicon: 'img/houndarr-logo.png',
+  favicon: 'img/houndarr-logo-dark.png',
 
   future: {
     v4: true,
@@ -58,7 +58,7 @@ const config: Config = {
       title: 'Houndarr',
       logo: {
         alt: 'Houndarr logo',
-        src: 'img/houndarr-logo.png',
+        src: 'img/houndarr-logo-dark.png',
         srcDark: 'img/houndarr-logo-dark.png',
       },
       items: [


### PR DESCRIPTION
## Summary

- Point `favicon` to `houndarr-logo-dark.png` so the browser tab icon is visible on all backgrounds.
- Point `navbar.logo.src` (light mode) to `houndarr-logo-dark.png` so the navbar logo is visible in light mode.
- `navbar.logo.srcDark` was already correct and is unchanged.

## Changes

- `website/docusaurus.config.ts`: two one-line changes (`favicon` and `logo.src`).

## Checklist

- [x] Linked issue has `type:*` and `priority:*` labels
- [x] Change is scoped to the linked issue only
- [x] No version bump or CHANGELOG edit (docs/website-only change)

Closes #165