### PR TITLE
docs: remove unimplemented quiet hours mention from README and homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ below your quality cutoff. Their built-in "Search All Missing" button fires
 every item at once, overwhelming indexer API limits.
 
 Houndarr searches **slowly, politely, and automatically**: small batches,
-configurable sleep intervals, per-item cooldowns, hourly API caps, and quiet
-hours. It runs as a single Docker container alongside your existing *arr stack.
+configurable sleep intervals, per-item cooldowns, and hourly API caps.
+It runs as a single Docker container alongside your existing *arr stack.
 
 **Key capabilities:**
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -94,8 +94,8 @@ function WhatItDoes() {
             <p>
               <strong>Houndarr searches slowly, politely, and automatically:</strong>{' '}
               small batches, configurable sleep intervals, per-item cooldowns,
-              hourly API caps, and quiet hours. It runs as a single Docker
-              container alongside your existing *arr stack.
+              and hourly API caps. It runs as a single Docker container alongside
+              your existing *arr stack.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Remove two occurrences of "quiet hours" from user-facing copy (README and homepage) — it was listed as a real feature but has no implementation anywhere.

Existing controls (interval, batch size, hourly caps, cooldowns, unreleased delay, cutoff-specific throttling) already provide polite operation.

## Changes

- `README.md`: remove ", and quiet hours" from the feature description
- `website/src/pages/index.tsx`: same removal from the homepage

Closes #178