### PR TITLE
docs: fix four false claims found in documentation truth audit

### DIFF
--- a/website/docs/concepts/how-houndarr-works.md
+++ b/website/docs/concepts/how-houndarr-works.md
@@ -137,7 +137,6 @@ Every item Houndarr considers but does not search is logged with an action of `s
 | `cooldown (N days remaining)` | Item was searched recently; waiting to retry |
 | `unreleased delay (N hrs remaining)` | Release date is too recent or in the future |
 | `hourly cap reached` | This instance has hit its per-hour search limit |
-| `not in wanted list` | Item is monitored but Sonarr/Radarr do not report it as missing or cutoff-unmet |
 
 A high skip count with zero errors is a **strong signal of health**. It means Houndarr is examining candidates, finding most of them ineligible under your rules, and waiting patiently for them to become eligible.
 

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -16,7 +16,7 @@ Houndarr is configured primarily through environment variables set in your
 | `HOUNDARR_DATA_DIR` | `/data` | Directory for persistent data (SQLite DB and master key) |
 | `HOUNDARR_HOST` | `0.0.0.0` | Host address to bind the web server to |
 | `HOUNDARR_PORT` | `8877` | Port to bind the web server to |
-| `HOUNDARR_DEV` | `false` | Enable development mode (auto-reload, API docs at `/docs`) |
+| `HOUNDARR_DEV` | `false` | Enable development mode (auto-reload, API docs at `/api/docs`) |
 | `HOUNDARR_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warning`, `error` |
 
 ## Security settings
@@ -48,7 +48,7 @@ stack. A warning will be printed to stdout at startup as a reminder.
 Setting `HOUNDARR_DEV=true` enables:
 
 - Auto-reload on code changes
-- FastAPI Swagger UI at `/docs`
+- FastAPI Swagger UI at `/api/docs`
 
 :::warning
 Do not run with `HOUNDARR_DEV=true` in production. It exposes the Swagger UI

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -73,8 +73,10 @@ Season-context mode sends at most one `SeasonSearch` per `(series, season)` per 
 Season search is not pack-only in Sonarr and may still produce singles or noisier behavior.
 
 :::info
-Cooldown in season-context mode is tracked through the representative missing episode
-that triggered that season search.
+Cooldown in season-context mode is tracked at the season level using a stable synthetic
+identifier derived from the series ID and season number — not through any individual
+episode. This ensures cooldown history is consistent across cycles regardless of which
+episode happens to appear first on the wanted list.
 :::
 
 ## Cutoff upgrade controls

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -19,7 +19,7 @@ docker pull ghcr.io/av1155/houndarr:latest
 Or pin to a specific version:
 
 ```bash
-docker pull ghcr.io/av1155/houndarr:v1.0.6
+docker pull ghcr.io/av1155/houndarr:v1.0.8
 ```
 
 Available architectures: `linux/amd64` and `linux/arm64`.
@@ -52,7 +52,7 @@ The dev server will be available at `http://localhost:8877`.
 - Python 3.12 or later
 - pip
 
-Development mode enables auto-reload and exposes the FastAPI Swagger UI at `/docs`.
+Development mode enables auto-reload and exposes the FastAPI Swagger UI at `/api/docs`.
 
 ## Container details
 


### PR DESCRIPTION
## Summary

Fix four incorrect claims in user-facing documentation by cross-referencing against the codebase.

Closes #186

## Changes

- **Swagger UI URL** — Three locations had `/docs`; actual dev-mode URL is `/api/docs` (set in `app.py`).
- **Stale version example** — Pinned pull example updated from `v1.0.6` to `v1.0.8` (current `VERSION` file).
- **Season-context cooldown** — Rewrote stale description that described pre-v1.0.5 behavior. Cooldown now tracks at season level via stable synthetic ID, not through any individual episode.
- **Phantom log reason** — Removed `"not in wanted list"` row from skip-reasons table in `how-houndarr-works.md`. Houndarr never writes this to `search_log`; items not on the wanted list are simply never fetched.

No source code modified — docs-only change.