### PR TITLE
docs: tighten website copy and reduce cross-page repetition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -589,3 +589,122 @@ Currently known minor discrepancies:
   rule family is not selected in the ruff config. The `# noqa: PLW0603`
   comments in source are defensive/inert. **Leave them in place but do not
   rely on `PLW` rules being enforced.**
+
+---
+
+## Public-Facing Voice
+
+All text posted to GitHub under the maintainer's account must read as if a
+human wrote it. Agents ghostwrite — they do not narrate, report, or
+self-identify.
+
+### Prohibited in all GitHub-visible text
+
+This applies to issue titles, issue bodies, PR titles, PR bodies, PR/issue
+comments, commit messages, CHANGELOG entries, and release notes.
+
+Never include:
+
+- References to AGENTS.md, CLAUDE.md, or any instruction file
+  (`"I have read AGENTS.md"`, `"per AGENTS.md"`, `"scope discipline"`)
+- Agent compliance declarations
+  (`"this change is within scope"`, `"I verified"`, `"I audited"`)
+- Audit/verification narration
+  (`"truth audit"`, `"verified TRUE"`, `"confirmed against the codebase"`,
+  `"cross-reference audit"`, `"code-grounded"`, `"release-readiness
+  verification"`)
+- Finding-ID numbering schemes (`SEC-1`, `F-1`, `FINDING-1`)
+- Process theater
+  (`"post-fix verification"`, `"remediation plan"`, `"close the remaining
+  gaps"`, `"completed housekeeping"`, `"this task is now complete"`)
+- Exhaustive negative-finding enumerations (listing every file where
+  something was NOT found)
+- Quality-gate recitation with exact tool names and test counts
+  (`"All 5 quality gates pass: ruff check, ruff format, mypy strict,
+  bandit SAST, pytest (312 tests)"` — just say `"all checks pass"`)
+- grep/search verification as proof (`"grep -ri returns zero matches"`)
+- Post-merge instruction lists in PR bodies
+- `"Follow-up recommendations (not in this PR)"` sections
+- Item-count narration (`"9 Q&A entries covering every misconception"`)
+- Prompt-shaped headings (`"Success criteria"`, `"Evidence"`, `"Decision"`)
+- Layer-by-layer audit tables in issue bodies
+
+### Required voice
+
+- Write as the maintainer would: concise, direct, technical.
+- Issue bodies: state the problem and what needs to change. A few sentences
+  for routine issues, more detail for complex ones.
+- PR bodies: say what changed and why. Use the PR template. Do not add
+  custom compliance checklists beyond the template.
+- PR template checklist: only check items that actually apply. Leave
+  inapplicable items unchecked or mark `N/A`.
+- Comments: short and human (`"Done"`, `"Fixed in abc1234"`, `"Merged"`).
+- Commit messages: follow Conventional Commits. Body optional — if present,
+  explain why, not what the agent did.
+- CHANGELOG: follow existing bullet rules (already defined above).
+
+### Internal-only text
+
+References to agents, prompts, instruction files, and workflow mechanics
+belong only in:
+
+- `AGENTS.md` itself
+- `.claude/` or `.cursor/` directories
+- Git-ignored local files
+
+They must never appear in any GitHub-visible artifact.
+
+### Documentation voice
+
+All user-facing documentation (website pages, README, CONTRIBUTING, SECURITY,
+in-app help text) must read as if a single human maintainer wrote it — direct,
+concise, and conversational. Documentation should feel authored, not assembled.
+
+**Prohibited in documentation:**
+
+- `"Mental model"` as a framing device or callout label
+- Defensive credibility claims about the document itself
+  (`"every claim is based on the source code"`,
+  `"where limitations exist, they are stated plainly"`,
+  `"these are honest trade-offs"`)
+- Summary sections that restate the page's content bullet-by-bullet
+- Worked examples that read like textbook exercises (step-by-step arithmetic
+  with bold emphasis on each subtraction)
+- Exhaustive enumeration of things that are absent (listing many specific
+  analytics services that are not used — just say "no analytics or error
+  tracking")
+- FAQ questions that feel reverse-engineered from a prompt rather than
+  sourced from real user confusion
+- The same concept explained in near-identical phrasing on more than two pages
+
+**Cross-page repetition rule:**
+
+Each concept (e.g. "skips are normal", "monitored does not mean wanted",
+"conservative defaults are slow by design") should have ONE authoritative
+explanation on one page. Other pages that mention the concept should use a
+brief statement (one sentence) and link to the authority page. Never repeat
+the same reassurance formula verbatim across pages.
+
+**Reassurance discipline:**
+
+Avoid repeating reassurance phrases (`"this is expected"`,
+`"this does not mean Houndarr is stuck"`, `"a high skip count is healthy"`)
+more than once across the entire documentation set. State the fact once,
+clearly, and trust the reader.
+
+**FAQ rules:**
+
+- Keep answers to 2–4 sentences. Link to concept pages for detail.
+- Do not re-explain the full search funnel in every FAQ entry.
+- Write questions in the voice of a real user, not as preemptive
+  corrections of anticipated misconceptions.
+
+**Required voice:**
+
+- Write as a maintainer explaining their own tool to a peer.
+- Be concise. Prefer short paragraphs and direct statements.
+- Vary phrasing across pages — do not use the same sentence structure
+  to explain similar concepts.
+- Use callouts and admonitions sparingly.
+- Headings should be descriptive or action-oriented, not reassuring
+  (`"Check the error count"` not `"Zero errors is a strong health signal"`).

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ network:
   protection, and login rate limiting.
 - **The container runs as a non-root user** after PUID/PGID remapping.
 
-For a detailed, code-grounded explanation of how Houndarr handles credentials,
+For a detailed explanation of how Houndarr handles credentials,
 network behavior, and trust boundaries, see
 [Trust & Security](https://av1155.github.io/houndarr/docs/security/trust-and-security).
 

--- a/website/docs/concepts/faq.md
+++ b/website/docs/concepts/faq.md
@@ -1,97 +1,49 @@
 ---
 sidebar_position: 3
 title: FAQ
-description: Answers to frequently asked questions and common misconceptions about Houndarr.
+description: Answers to frequently asked questions about Houndarr.
 ---
 
 # FAQ
 
 ## "I have 500 monitored movies. Why did Houndarr only search 3?"
 
-Because **monitored** does not mean **wanted**.
+Monitored doesn't mean wanted. Most of your library is already downloaded and meeting your quality cutoff, so those items never appear in a wanted list. Of the items that are wanted, cooldowns, unreleased delays, and hourly caps filter out most of the rest.
 
-Houndarr only searches items that Sonarr or Radarr report as missing or cutoff-unmet. Of your 500 monitored movies, the vast majority are likely already downloaded and meeting your quality cutoff — so they do not appear in any wanted list, and Houndarr will not touch them.
-
-Of the items that do appear in a wanted list, most will be filtered further by cooldowns, unreleased delays, and hourly caps. The result is often just 1–3 searches per cycle.
-
-This is expected. See [How Houndarr Works](/docs/concepts/how-houndarr-works#the-search-funnel--why-your-search-count-is-small) for a detailed walkthrough.
+See [How Houndarr Works](/docs/concepts/how-houndarr-works#why-only-a-few-items-get-searched-each-cycle) for the full breakdown.
 
 ## "Why is Houndarr skipping so much?"
 
-Skips are normal. Each skip has a reason logged alongside it:
-
-- **Cooldown** — the item was searched recently; Houndarr will retry after the cooldown window expires.
-- **Unreleased delay** — the title has not been available long enough. Houndarr will retry once the delay clears.
-- **Hourly cap reached** — the per-hour search limit for this instance has been hit.
-
-A high skip count with zero errors is a **healthy sign**. It means Houndarr is examining candidates, applying its safety rules, and waiting patiently. It is not stuck.
+Each skip has a reason logged alongside it — cooldown, unreleased delay, or hourly cap. A high skip count with zero errors means Houndarr is pacing itself correctly. See [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) for what each reason means.
 
 ## "Does Houndarr decide whether my file meets cutoff?"
 
-No. Houndarr never evaluates file quality itself.
-
-Sonarr and Radarr maintain a "Wanted → Cutoff Unmet" list based on your quality profiles. An item appears there when the file you have does not meet the profile's cutoff quality. Houndarr reads that list and schedules search commands for items on it.
-
-If you think something should be in the cutoff list but is not, check the quality profile and the file's current quality in Sonarr/Radarr directly.
+No. Sonarr and Radarr maintain the "Wanted > Cutoff Unmet" list based on your quality profiles. Houndarr reads that list and schedules searches for items on it. If something should be in the cutoff list but isn't, check the quality profile in Sonarr/Radarr directly.
 
 ## "Why are future or recently-released titles being skipped?"
 
-Houndarr has an **unreleased delay** setting (default: 36 hours). Items whose release date is in the future, or within the delay window of having been released, are skipped until the window clears.
+Houndarr has an **unreleased delay** setting (default: 36 hours). Items whose release date is in the future or within the delay window are skipped until the window clears. This avoids hammering indexers for content that may not be available yet.
 
-This prevents Houndarr from immediately hammering indexers for content that may not be available yet. Once the delay window passes, the item becomes eligible on the next cycle.
-
-For Radarr, Houndarr evaluates release timing using a priority chain: `digitalRelease` → `physicalRelease` → `releaseDate` → `inCinemas`. If none of those dates are set, or the title is marked as unavailable, it will be skipped.
+For Radarr, release timing uses a priority chain: `digitalRelease` → `physicalRelease` → `releaseDate` → `inCinemas`. If none of those dates are set, or the title is marked as unavailable, it will be skipped.
 
 ## "Does Houndarr search my whole library?"
 
-No. Houndarr **only** acts on what Sonarr/Radarr report as wanted. It queries two endpoints per instance:
-
-- `wanted/missing` — items that are monitored and not yet downloaded
-- `wanted/cutoff` — items that are monitored but downloaded at a quality below the cutoff
-
-Everything else in your library is invisible to Houndarr.
-
-## "Is a lot of skipped activity a bug?"
-
-No. Skips are logged because transparency matters — you can see exactly why each item was not searched. The ratio of skips to searches depends on:
-
-- How large your wanted lists are
-- How recently items were searched (cooldowns)
-- Whether items are inside the unreleased delay window
-- How conservative your batch size and hourly cap are
-
-If you have zero errors and occasional `searched` entries, Houndarr is operating exactly as designed.
+No. It only acts on what Sonarr/Radarr report as wanted — items from `wanted/missing` and `wanted/cutoff`. Everything else in your library is invisible to Houndarr.
 
 ## "Why is Houndarr searching so slowly?"
 
-The default settings are deliberately conservative to protect your indexers:
-
-- **Batch size 2** + **hourly cap 4** means at most 4–8 searches per hour under default settings.
-- **Cooldown 14 days** means the same item is not searched twice within a two-week period.
-
-If you want to work through your backlog faster, increase the batch size or hourly cap one step at a time and watch your indexer health for a day before increasing further. See [Increasing throughput](/docs/configuration/instance-settings#increasing-throughput).
+The defaults are conservative on purpose — batch size 2, hourly cap 4, 14-day cooldown. With a large backlog, clearing it takes weeks. You can increase throughput gradually; see [Increasing throughput](/docs/configuration/instance-settings#increasing-throughput).
 
 ## "Sonarr/Radarr show many cutoff-unmet items. Why is Houndarr only searching a few per day?"
 
-This is by design. The cutoff controls (batch 1, cap 1, cooldown 21 days) are even more conservative than the missing controls, because quality upgrades are lower priority than acquiring missing content.
-
-With a cutoff cap of 1, Houndarr will search at most 1 cutoff item per hour per instance. That is roughly 24 cutoff searches per day — enough to make steady progress without flooding indexers with upgrade requests.
-
-If you have many cutoff-unmet items and want to work through them faster, increase the **Cutoff Cap** and **Cutoff Batch** settings gradually.
+The cutoff controls (batch 1, cap 1, cooldown 21 days) are more conservative than missing controls because quality upgrades are lower priority than acquiring missing content. With a cap of 1, that's roughly 24 cutoff searches per day. Increase **Cutoff Cap** and **Cutoff Batch** gradually if you want faster progress.
 
 ## "I enabled Houndarr but I don't see any activity"
 
-Check these things in order:
+Check in order: is the instance enabled (green toggle)? Has at least one sleep interval passed (default: 30 min)? Does Sonarr/Radarr actually have items in their wanted lists? Are there `error` entries in the Logs page?
 
-1. Is the instance enabled (green toggle in Settings)?
-2. Has at least one full sleep interval passed? (default: 30 minutes)
-3. Does Sonarr/Radarr actually have anything in their wanted lists?
-4. Are there any `error` entries in the Logs page?
-
-If the wanted lists are empty, Houndarr has nothing to do. If there are errors, the error message will point to the cause.
-
-See [Troubleshooting](/docs/concepts/troubleshooting) for a step-by-step verification guide.
+See [Troubleshooting](/docs/concepts/troubleshooting) for a step-by-step guide.
 
 ## "Can Houndarr search for things that aren't in Sonarr/Radarr yet?"
 
-No. Houndarr only triggers searches within Sonarr/Radarr for items that are already tracked in those applications. It has no ability to add new titles, browse indexers, or handle requests. For request workflows, use Overseerr or Jellyseerr alongside your *arr stack.
+No. Houndarr only triggers searches within Sonarr/Radarr for items already tracked there. For request workflows, use Overseerr or Jellyseerr alongside your *arr stack.

--- a/website/docs/concepts/how-houndarr-works.md
+++ b/website/docs/concepts/how-houndarr-works.md
@@ -1,32 +1,16 @@
 ---
 sidebar_position: 1
 title: How Houndarr Works
-description: A plain-English explanation of what Houndarr does, how it decides what to search, and why low search counts are normal.
+description: What Houndarr does, how it decides what to search, and why most items get skipped each cycle.
 ---
 
 # How Houndarr Works
 
-Understanding Houndarr's mental model will save you hours of confusion. This page explains what Houndarr does, what it does not do, and why seeing many skips and few searches is usually a sign that everything is working correctly.
+Houndarr is a search scheduler for Sonarr and Radarr. It triggers search commands in small, rate-limited batches so you don't have to hit "Search All Missing" and overwhelm your indexers.
 
-## What Houndarr is
+It does not download anything, parse releases, evaluate quality, or replace Sonarr/Radarr. It only decides **when** to ask them to search and **how many** items to include per batch.
 
-Houndarr is a **scheduler and orchestrator**. Its job is to trigger search commands in Sonarr and Radarr in a slow, polite, and automatic way — preventing the indexer overload that happens when you hit "Search All Missing" manually.
-
-It is:
-
-- A lightweight companion that sits alongside your existing Sonarr/Radarr stack.
-- A rate-limited search scheduler with per-item cooldowns, hourly caps, and configurable batch sizes.
-- A tool that gently works through your backlog over time.
-
-It is **not**:
-
-- A downloader — it does not fetch files itself.
-- An indexer or release parser — it has no knowledge of what releases exist.
-- A quality decision engine — it does not decide whether a file meets your cutoff.
-- A Sonarr/Radarr replacement — it only triggers searches that Sonarr/Radarr then handle.
-- A tool that blindly searches every monitored item in your library.
-
-## How it works — step by step
+## The search cycle
 
 ```
 1. Houndarr asks Sonarr/Radarr: "What items are missing or cutoff-unmet?"
@@ -34,7 +18,7 @@ It is **not**:
 2. Sonarr/Radarr respond with their wanted lists
    (only monitored items that are missing or below quality cutoff)
        ↓
-3. Houndarr reviews each candidate and applies its scheduling rules
+3. Houndarr applies its scheduling rules to each candidate
    (cooldown, hourly cap, unreleased delay, batch size)
        ↓
 4. Eligible items → search command sent to Sonarr/Radarr
@@ -42,19 +26,11 @@ It is **not**:
 5. Ineligible items → logged as "skipped", retried next cycle
 ```
 
-Sonarr and Radarr do all the actual searching. Houndarr only decides **when** to ask them to search, and **how many** items to ask about at once.
+Sonarr and Radarr do all the actual searching. Houndarr controls the pacing.
 
-## "Monitored" does not mean "will be searched"
+## Monitored vs. wanted
 
-This is the most common source of confusion.
-
-A **monitored** item in Sonarr or Radarr simply means you want the software to track it. It does **not** mean:
-
-- The item is missing.
-- The item is below your quality cutoff.
-- Houndarr will search for it.
-
-Houndarr only acts on items that Sonarr or Radarr **report as wanted** — that is, items that appear in their missing or cutoff-unmet lists. If an item is monitored but already downloaded at a quality that meets your cutoff, Sonarr/Radarr will not include it in either wanted list, and Houndarr will never touch it.
+A **monitored** item in Sonarr/Radarr just means the software is tracking it. If the item is already downloaded at a quality that meets your cutoff, it won't appear in any wanted list, and Houndarr will never touch it.
 
 | Item state in Sonarr/Radarr | Will Houndarr search it? |
 |-----------------------------|--------------------------|
@@ -65,11 +41,9 @@ Houndarr only acts on items that Sonarr or Radarr **report as wanted** — that 
 
 ## Who decides "cutoff unmet"?
 
-**Sonarr and Radarr decide this — not Houndarr.**
+Sonarr and Radarr — not Houndarr. They populate the `wanted/cutoff` API list based on your quality profile settings. Houndarr reads that list and applies its scheduling rules on top.
 
-Houndarr reads the `wanted/cutoff` API endpoint from each instance. Sonarr and Radarr populate that list based on your quality profile settings: if the file you have does not meet the profile's cutoff quality, the item appears there. Houndarr simply reads that list and applies its own scheduling rules on top.
-
-If you are not seeing cutoff searches happen, the first thing to check is whether the item actually appears in Sonarr/Radarr's own "Wanted → Cutoff Unmet" view.
+If cutoff searches aren't happening, check whether the item actually appears in Sonarr/Radarr's own "Wanted > Cutoff Unmet" view first.
 
 :::tip Quality profiles are managed in Sonarr/Radarr — not Houndarr
 Houndarr works best when your Sonarr/Radarr instances are already configured with
@@ -81,9 +55,9 @@ can sync profiles and custom formats across instances. These tools are optional 
 fully independent of Houndarr.
 :::
 
-## The search funnel — why your search count is small
+## Why only a few items get searched each cycle
 
-Think of it as a funnel. At each stage, items are filtered out:
+Think of it as a funnel:
 
 ```
 Your monitored library
@@ -101,36 +75,22 @@ Your monitored library
   Actually searched (often just 1–3 items)
 ```
 
-### Worked example
-
-Say you have:
-
-- **500 monitored movies** in Radarr
-- **50** are cutoff-unmet (Radarr's wanted/cutoff list)
-- **35** of those 50 were searched recently and are on a **21-day cooldown**
-- **8** of the remaining 15 are future/unreleased films inside the **36-hour unreleased delay**
-- **7** are eligible — but your **hourly cap is 1** and **batch is 1**
-
-In a single pass, Houndarr searches **1 movie**. The other 499 are either not in the wanted list, on cooldown, or skipped for another reason.
-
-**This is expected. This does not mean Houndarr is stuck.**
-
-Over days and weeks, as cooldowns expire and releases become available, Houndarr steadily works through the eligible items. Conservative defaults trade aggressiveness for indexer politeness — which is the entire point.
+For example, if you have 500 monitored movies in Radarr but only 50 are cutoff-unmet, and 35 of those are on cooldown, 8 are unreleased, and your batch is 1 — Houndarr searches 1 movie that cycle. The rest wait for cooldowns to expire or release windows to pass, and Houndarr works through them over days and weeks.
 
 ## The two search passes
 
-Each enabled instance runs two independent passes on a configurable schedule:
+Each enabled instance runs two independent passes:
 
 | Pass | What it searches | Key controls |
 |------|-----------------|--------------|
 | **Missing** | Items in Sonarr/Radarr's `wanted/missing` list | Batch size, sleep interval, hourly cap, cooldown, unreleased delay |
 | **Cutoff** | Items in Sonarr/Radarr's `wanted/cutoff` list | Cutoff batch, cutoff cap, cutoff cooldown |
 
-Cutoff search is **off by default**. Enable it only after missing items are under control, so the two passes do not compete for the same indexer budget.
+Cutoff search is **off by default**. Enable it only after missing items are under control so the two passes don't compete for the same indexer budget.
 
 ## What "skipped" means in the logs
 
-Every item Houndarr considers but does not search is logged with an action of `skipped` and a reason. Common reasons:
+Every item Houndarr considers but does not search is logged as `skipped` with a reason:
 
 | Reason in logs | What it means |
 |----------------|---------------|
@@ -138,14 +98,6 @@ Every item Houndarr considers but does not search is logged with an action of `s
 | `unreleased delay (N hrs remaining)` | Release date is too recent or in the future |
 | `hourly cap reached` | This instance has hit its per-hour search limit |
 
-A high skip count with zero errors is a **strong signal of health**. It means Houndarr is examining candidates, finding most of them ineligible under your rules, and waiting patiently for them to become eligible.
+A high skip count with zero errors means Houndarr is pacing itself correctly — examining candidates, finding most ineligible under your rules, and waiting patiently.
 
-## Summary
-
-- Houndarr reads Sonarr/Radarr wanted lists — it does not scan your whole library.
-- Sonarr/Radarr decide what is missing and what is cutoff-unmet.
-- Houndarr adds a scheduling layer: cooldowns, caps, delays, and batch limits.
-- Low search counts and many skips are normal and expected.
-- A high skip count with zero errors means Houndarr is working correctly.
-
-See [FAQ](/docs/concepts/faq) for answers to specific questions, and [Troubleshooting](/docs/concepts/troubleshooting) for steps to verify Houndarr is working as expected.
+See [FAQ](/docs/concepts/faq) for answers to specific questions, and [Troubleshooting](/docs/concepts/troubleshooting) if you want to verify everything is connected and running.

--- a/website/docs/concepts/troubleshooting.md
+++ b/website/docs/concepts/troubleshooting.md
@@ -15,7 +15,7 @@ If you are unsure whether Houndarr is actually doing anything, follow these step
 In Sonarr: **Wanted → Missing** and **Wanted → Cutoff Unmet**  
 In Radarr: **Movies → Discover** or use the **Wanted** filter
 
-If those pages are empty, Houndarr has nothing to search. A Houndarr with an empty wanted list will log `skipped` for every item it considers, and that is completely correct behavior.
+If those pages are empty, Houndarr has nothing to search.
 
 ### Step 2 — Compare items to Houndarr logs
 
@@ -54,19 +54,13 @@ If most of your log entries say `skipped`, check the reasons:
 - **`unreleased delay (N hrs remaining)`** — the release date is too recent or in the future. Houndarr will search once the delay window clears.
 - **`hourly cap reached`** — your per-hour search limit has been hit for this cycle.
 
-None of these are errors. They are all normal scheduling behavior.
+These are all normal scheduling behavior.
 
-### Step 5 — Zero errors is a strong health signal
+### Step 5 — Check the error count
 
-Look at your logs. If you see:
+Look at your logs. If you see many `skipped` entries, some `searched` entries, and zero `error` entries, Houndarr is connected and running correctly. Errors mean something is wrong with the connection or API key — skips do not.
 
-- Many `skipped` entries
-- Some `searched` entries
-- **Zero `error` entries**
-
-Houndarr is healthy. It is examining candidates, applying its rules, and issuing searches at the configured rate. The absence of errors means it is connecting to Sonarr/Radarr successfully and the search commands are being accepted.
-
-### Step 6 — Understand that conservative settings progress slowly but correctly
+### Step 6 — Conservative defaults are slow by design
 
 The default settings are intentionally conservative:
 
@@ -74,7 +68,7 @@ The default settings are intentionally conservative:
 - **Hourly cap 4** — maximum 4 searches per hour
 - **Cooldown 14 days** — no item is searched more than once every two weeks
 
-With these defaults, Houndarr might search 4–8 items in a day. If your backlog has hundreds of items, clearing it will take weeks. That is by design. You can increase throughput by raising the batch size or hourly cap, but do so gradually and monitor your indexer health.
+With these defaults, Houndarr might search 4–8 items in a day. If your backlog has hundreds of items, clearing it takes weeks. You can increase throughput by raising the batch size or hourly cap, but do so gradually and monitor your indexer health.
 
 See [Instance Settings](/docs/configuration/instance-settings#increasing-throughput) for the recommended order of adjustments.
 

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -123,12 +123,7 @@ delay, or caps), but it stays bounded:
 This improves backlog rotation while preserving polite API behavior.
 
 :::tip Why am I seeing mostly skips?
-A high skip count is normal. Houndarr only searches items that Sonarr/Radarr report
-as missing or cutoff-unmet — it does not search your whole library. Each skipped item
-has a reason (cooldown, unreleased delay, hourly cap) logged alongside it. Zero errors
-and occasional `searched` entries means everything is working correctly.
-
-See [How Houndarr Works](/docs/concepts/how-houndarr-works) and the [FAQ](/docs/concepts/faq) for a detailed explanation.
+Skips are normal — see [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) and the [FAQ](/docs/concepts/faq) for details.
 :::
 
 ## Recommended starting profile

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -51,8 +51,8 @@ prompted to create an admin username and password.
 
 For more details, see [First-Run Setup](first-run-setup.md).
 
-:::info Mental model
-Houndarr does not search your entire library. It asks Sonarr/Radarr which items are **missing** or **below your quality cutoff**, then searches for those items in small, rate-limited batches. Seeing many skips and few searches is normal and expected. See [How Houndarr Works](/docs/concepts/how-houndarr-works) for a full explanation.
+:::tip Good to know
+Houndarr does not search your entire library — only items that Sonarr/Radarr report as missing or below your quality cutoff, in small batches. See [How Houndarr Works](/docs/concepts/how-houndarr-works) for details.
 :::
 
 ## Using `docker run`

--- a/website/docs/security/trust-and-security.md
+++ b/website/docs/security/trust-and-security.md
@@ -6,9 +6,8 @@ description: How Houndarr handles credentials, network behavior, and trust bound
 
 # Trust & Security
 
-This document explains how Houndarr handles sensitive credentials, network
-behavior, and trust boundaries. Every claim is based on the actual source code.
-Where limitations exist, they are stated plainly.
+This document covers how Houndarr handles credentials, network behavior,
+and trust boundaries.
 
 If you find a discrepancy between this document and the code, please
 [report it](https://github.com/av1155/houndarr/security/advisories/new).
@@ -34,11 +33,9 @@ is present in the source tree.
 
 ### What the server does not connect to
 
-- No analytics services (Google Analytics, Mixpanel, Amplitude, Segment, etc.)
-- No error tracking services (Sentry, Bugsnag, Datadog, etc.)
+- No analytics, error tracking, or telemetry services
 - No developer-controlled servers
 - No package registries, update servers, or version-check endpoints
-- No webhooks or notification services
 
 ### Browser-side CDN resources
 
@@ -289,9 +286,6 @@ The persistent data directory (default `/data` in Docker) contains:
 - [ ] Keep the Docker image updated for security patches
 
 ## Known limitations
-
-These are honest trade-offs in the current implementation. They are appropriate
-for the single-admin self-hosted deployment model but should be understood.
 
 **Stateless sessions.** Sessions are signed tokens with no server-side session
 store. Logout deletes the cookie client-side, but a stolen token remains valid


### PR DESCRIPTION
## Linked Issue (required)

Closes #188

## Summary

Consolidates repeated explanations across the documentation website. Each
concept (skip behavior, conservative defaults, search funnel) now has one
authoritative page; other pages link to it instead of re-explaining inline.

Pages edited: how-houndarr-works, faq, trust-and-security, quick-start,
troubleshooting, instance-settings, README, AGENTS.md.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A (docs only)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way — N/A (docs only)