### PR TITLE
docs: update documentation and metadata for multi-arr support

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
         ## Scope Check
 
         Houndarr is a **single-purpose tool** that searches for missing and cutoff-unmet
-        media in Sonarr and Radarr, in controlled batches.
+        media in Sonarr, Radarr, Lidarr, Readarr, and Whisparr, in controlled batches.
 
         Before submitting, please confirm your feature is within scope.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,10 @@ This file is the primary source of truth for autonomous agents operating here.
 
 ## Project Overview
 
-Houndarr is a self-hosted companion for Sonarr and Radarr that automatically
-searches for missing and cutoff-unmet media in small, rate-limited batches.
-It runs as a single Docker container alongside an existing *arr stack.
+Houndarr is a self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and
+Whisparr that automatically searches for missing and cutoff-unmet media in
+small, rate-limited batches. It runs as a single Docker container alongside
+an existing *arr stack.
 
 **Tech stack:** Python 3.12 / FastAPI / aiosqlite (SQLite) / Jinja2 / HTMX /
 Tailwind CSS CDN. Published to GHCR at `ghcr.io/av1155/houndarr`.
@@ -53,7 +54,7 @@ Run **all five** before every commit. CI enforces the same checks.
 ## Running Tests
 
 ```bash
-# Full suite (401 tests, async — count includes parametrised expansions)
+# Full suite (408 tests, async — count includes parametrised expansions)
 .venv/bin/pytest
 
 # Single file
@@ -111,6 +112,9 @@ identical check names so branch protection is satisfied.
 | `dockerfile-lint.yml` | Changes to `Dockerfile` | `hadolint Dockerfile` |
 | `workflow-lint.yml` | Changes to `.github/workflows/**` | `actionlint` via reviewdog |
 | `api-snapshot-refresh.yml` | Weekly (Monday 10:00 UTC) + manual | Fetches upstream Sonarr/Radarr/Whisparr/Lidarr/Readarr OpenAPI specs, updates `docs/api/` snapshots and `tests/test_docs_api.py` hashes, opens a PR if changed |
+| `pages.yml` | Pushes to `main` touching `website/**` | Deploys docs site to GitHub Pages |
+| `test-deploy.yml` | PRs touching `website/**` | Tests Docusaurus build without deploying |
+| `cleanup-actions-cache.yml` | Daily (05:00 UTC) + manual | Prunes stale GitHub Actions caches |
 
 ### Branch protection on `main`
 
@@ -174,7 +178,7 @@ from houndarr.database import get_db
 | Constants | UPPER_SNAKE_CASE | `SESSION_MAX_AGE_SECONDS`, `SCHEMA_VERSION` |
 | Module-level state | `_leading_underscore` | `_db_path`, `_runtime_settings` |
 | Enums | `StrEnum`, lowercase values | `InstanceType.sonarr` |
-| Type aliases | PascalCase or Literal | `ItemType = Literal["episode", "movie"]` |
+| Type aliases | PascalCase or Literal | `ItemType = Literal["episode", "movie", "album", "book", "whisparr_episode"]` |
 
 ### Docstrings
 
@@ -207,9 +211,10 @@ No alternative logging libraries (structlog, loguru) are used.
 | `B008` | FastAPI `Depends()` in function defaults |
 | `S608` + `nosec B608` | Dynamic SQL with explicit column allowlist (3 files) |
 | `BLE001` | Broad exception in background loops (always with logging) |
-| `SLF001` | Test fixtures accessing private module state for reset |
+| `A002` | Parameter names `type`/`id` shadowing builtins (FastAPI form/function signature convention) |
+| `SLF001` | Test fixtures and `__main__.py` accessing private module state |
 | `PLW0603` | Module-level global reassignment (singletons) — note: the `PLW` rule family is not currently selected in ruff config, so these comments are defensive/inert |
-| `S101` | Defensive assert for non-None `series_id` in Sonarr adapter (1 location) |
+| `S101` | Defensive assert in adapters and instance validation — also globally ignored in ruff config; per-file comments are defensive |
 
 ---
 
@@ -225,10 +230,13 @@ src/houndarr/
   config.py            # AppSettings dataclass, get_settings() singleton
   crypto.py            # Fernet encrypt/decrypt, master key management
   database.py          # get_db() context manager, schema migrations
-  clients/             # httpx-based Sonarr/Radarr API clients
-    base.py            # BaseClient with _get()/_post() + raise_for_status()
-    sonarr.py          # SonarrClient (episode/season search)
-    radarr.py          # RadarrClient (movie search)
+  clients/             # httpx-based *arr API clients
+    base.py            # ArrClient ABC with _get()/_post() + raise_for_status()
+    sonarr.py          # SonarrClient (episode/season search, v3 API)
+    radarr.py          # RadarrClient (movie search, v3 API)
+    lidarr.py          # LidarrClient (album/artist search, v1 API)
+    readarr.py         # ReadarrClient (book/author search, v1 API)
+    whisparr.py        # WhisparrClient (episode/season search, v3 API)
   engine/
     candidates.py      # SearchCandidate dataclass, ItemType, date helpers
     search_loop.py     # run_instance_search() — unified search pipeline
@@ -237,8 +245,11 @@ src/houndarr/
       __init__.py      # AppAdapter dataclass, ADAPTERS registry, get_adapter()
       sonarr.py        # Sonarr adapter: candidate conversion + dispatch
       radarr.py        # Radarr adapter: candidate conversion + dispatch
+      lidarr.py        # Lidarr adapter: candidate conversion + dispatch
+      readarr.py       # Readarr adapter: candidate conversion + dispatch
+      whisparr.py      # Whisparr adapter: candidate conversion + dispatch
   routes/
-    pages.py           # Dashboard, Logs, Settings page routes
+    pages.py           # Setup, Login, Dashboard, Logs, Settings page routes
     settings.py        # Settings CRUD (instance add/edit/delete/toggle)
     health.py          # GET /api/health (Docker HEALTHCHECK)
     api/
@@ -252,7 +263,7 @@ src/houndarr/
 
 ### Key patterns
 
-- **Database:** SQLite via aiosqlite; schema version 4; `get_db()` async
+- **Database:** SQLite via aiosqlite; schema version 5; `get_db()` async
   context manager opens a fresh connection per call (WAL mode, FKs enabled)
 - **Config:** `AppSettings` is a plain dataclass (not Pydantic); `get_settings()`
   is a lazy singleton
@@ -268,14 +279,15 @@ src/houndarr/
 - **search_log:** Every search attempt writes a row with action
   `searched`/`skipped`/`error`/`info`
 
-### Database schema (SQLite, schema version 4)
+### Database schema (SQLite, schema version 5)
 
 ```sql
 settings    (key TEXT PK, value TEXT NOT NULL)
 
 instances   (id INTEGER PK AUTOINCREMENT,
-             name, type CHECK IN ('sonarr','radarr'), url,
-             encrypted_api_key DEFAULT '',
+             name, type CHECK IN ('sonarr','radarr','lidarr',
+                                   'readarr','whisparr'),
+             url, encrypted_api_key DEFAULT '',
              batch_size DEFAULT 2, sleep_interval_mins DEFAULT 30,
              hourly_cap DEFAULT 4, cooldown_days DEFAULT 14,
              unreleased_delay_hrs DEFAULT 36,
@@ -283,18 +295,28 @@ instances   (id INTEGER PK AUTOINCREMENT,
              cutoff_cooldown_days DEFAULT 21, cutoff_hourly_cap DEFAULT 1,
              sonarr_search_mode DEFAULT 'episode'
                  CHECK IN ('episode','season_context'),
+             lidarr_search_mode DEFAULT 'album'
+                 CHECK IN ('album','artist_context'),
+             readarr_search_mode DEFAULT 'book'
+                 CHECK IN ('book','author_context'),
+             whisparr_search_mode DEFAULT 'episode'
+                 CHECK IN ('episode','season_context'),
              enabled DEFAULT 1, created_at, updated_at)
 
 cooldowns   (id INTEGER PK AUTOINCREMENT,
              instance_id FK→instances ON DELETE CASCADE,
-             item_id, item_type CHECK IN ('episode','movie'),
+             item_id,
+             item_type CHECK IN ('episode','movie','album',
+                                  'book','whisparr_episode'),
              searched_at,
              UNIQUE(instance_id, item_id, item_type))
              -- index: idx_cooldowns_lookup(instance_id, item_type, searched_at)
 
 search_log  (id INTEGER PK AUTOINCREMENT,
              instance_id FK→instances ON DELETE SET NULL,
-             item_id, item_type CHECK IN ('episode','movie'),
+             item_id,
+             item_type CHECK IN ('episode','movie','album',
+                                  'book','whisparr_episode'),
              search_kind, cycle_id,
              cycle_trigger CHECK IN ('scheduled','run_now','system'),
              item_label,
@@ -306,7 +328,7 @@ search_log  (id INTEGER PK AUTOINCREMENT,
 ```
 
 Full DDL is in `src/houndarr/database.py`. Migrations are incremental
-(`_migrate_to_v2` through `_migrate_to_v4`); bump `SCHEMA_VERSION` when
+(`_migrate_to_v2` through `_migrate_to_v5`); bump `SCHEMA_VERSION` when
 adding new ones.
 
 ### *arr API reference (local)
@@ -323,9 +345,7 @@ Full upstream OpenAPI specs are vendored locally and kept current:
 code. They document every endpoint, parameter, request body, and response
 schema. See `docs/api-context.md` for usage guidelines.
 
-Sonarr and Radarr specs are actively used by `clients/sonarr.py` and
-`clients/radarr.py`. The Whisparr, Lidarr, and Readarr specs are vendored
-as reference material for future client development.
+All five specs are actively used by their respective clients in `clients/`.
 
 **Freshness:** `api-snapshot-refresh.yml` auto-fetches all five upstream
 specs weekly (Monday 10:00 UTC) and opens a PR if changed — local specs
@@ -366,15 +386,18 @@ first via the `seeded_instances` fixture (defined locally in
 async def seeded_instances(db: None) -> AsyncGenerator[None, None]:
     async with get_db() as conn:
         await conn.executemany(
-            "INSERT INTO instances (id, name, type, url) VALUES (?, ?, ?, ?)",
-            [(1, "Sonarr Test", "sonarr", "http://sonarr:8989"),
-             (2, "Radarr Test", "radarr", "http://radarr:7878")],
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+            " VALUES (?, ?, ?, ?, ?)",
+            [(1, "Sonarr Test", "sonarr", "http://sonarr:8989", _ENC_KEY),
+             (2, "Radarr Test", "radarr", "http://radarr:7878", _ENC_KEY)],
         )
         await conn.commit()
     yield
 ```
 
-Engine tests also set `encrypted_api_key` to a valid Fernet-encrypted value.
+Engine tests set `encrypted_api_key` to a valid Fernet-encrypted value
+(`_ENC_KEY`). The simpler 4-column form (without `encrypted_api_key`)
+is used in `test_cooldown.py` where only FK constraints matter.
 
 ### Login helper for route tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in improving Houndarr.
 
 ## Scope
 
-Houndarr is a focused tool for controlled Sonarr/Radarr search automation.
+Houndarr is a focused tool for controlled *arr search automation (Sonarr, Radarr, Lidarr, Readarr, Whisparr).
 Please keep changes aligned with the project goal and avoid scope expansion.
 
 ## Development setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG HOUNDARR_VERSION=dev
 
 # OCI labels
 LABEL org.opencontainers.image.title="Houndarr" \
-      org.opencontainers.image.description="Focused self-hosted companion for Sonarr and Radarr" \
+      org.opencontainers.image.description="Focused self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and Whisparr" \
       org.opencontainers.image.url="https://github.com/av1155/houndarr" \
       org.opencontainers.image.source="https://github.com/av1155/houndarr" \
       org.opencontainers.image.licenses="MIT"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="src/houndarr/static/img/houndarr-logo-dark.png" alt="Houndarr logo" width="220" />
 </p>
 
-> A focused, self-hosted companion for Sonarr and Radarr that automatically searches for missing media in polite, controlled batches.
+> A focused, self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches.
 >
 > **[Documentation](https://av1155.github.io/houndarr/)** | **[Quick Start](https://av1155.github.io/houndarr/docs/getting-started/quick-start)**
 
@@ -12,10 +12,11 @@
 
 ## What Houndarr Does
 
-Sonarr and Radarr monitor RSS feeds for new releases, but they do not go back
-and actively search for content already in your library that is missing or
-below your quality cutoff. Their built-in "Search All Missing" button fires
-every item at once, overwhelming indexer API limits.
+Sonarr, Radarr, Lidarr, Readarr, and Whisparr monitor RSS feeds for new
+releases, but they do not go back and actively search for content already in
+your library that is missing or below your quality cutoff. Their built-in
+"Search All Missing" button fires every item at once, overwhelming indexer
+API limits.
 
 Houndarr searches **slowly, politely, and automatically**: small batches,
 configurable sleep intervals, per-item cooldowns, and hourly API caps.
@@ -23,11 +24,14 @@ It runs as a single Docker container alongside your existing *arr stack.
 
 **Key capabilities:**
 
-- Connects to one or more Sonarr and Radarr instances
-- Searches for **missing** episodes and movies in small, configurable batches
+- Connects to one or more Sonarr, Radarr, Lidarr, Readarr, and Whisparr instances
+- Searches for **missing** episodes, movies, albums, and books in small, configurable batches
 - Searches for **cutoff-unmet** items (below your quality profile) separately
 - Sonarr: episode-level search by default, with optional season-context mode
 - Radarr: movie-level search
+- Lidarr: album-level search by default, with optional artist-context mode
+- Readarr: book-level search by default, with optional author-context mode
+- Whisparr: episode-level search by default, with optional season-context mode
 - Per-item cooldown prevents re-searching the same item too soon
 - Per-instance hourly API cap keeps indexer usage in check
 - Bounded multi-page scanning so deep backlog items are not starved
@@ -37,7 +41,7 @@ It runs as a single Docker container alongside your existing *arr stack.
 
 ## What Houndarr Does Not Do
 
-- **No download-client integration** — it triggers searches in Sonarr/Radarr, which handle downloads
+- **No download-client integration** — it triggers searches in your *arr instances, which handle downloads
 - **No Prowlarr/indexer management** — your *arr instances manage their own indexers
 - **No request workflows** — no Overseerr/Ombi-style request handling
 - **No multi-user support** — single admin username and password
@@ -137,7 +141,7 @@ If you run Houndarr behind a reverse proxy (Nginx, Caddy, Traefik, etc.):
 1. Navigate to `http://<your-host>:8877`.
 2. Create an admin username and password on the setup screen.
 3. Log in with your new credentials.
-4. Go to **Settings** and add your Sonarr/Radarr instances (URL + API key).
+4. Go to **Settings** and add your *arr instances (URL + API key).
 5. Enable each instance — Houndarr will begin searching on the configured schedule.
 
 For detailed per-instance configuration options, see the
@@ -175,7 +179,7 @@ Houndarr is designed for self-hosters who care about what runs on their
 network:
 
 - **No telemetry, no call-home.** The only outbound connections are to your
-  configured Sonarr/Radarr instances. There are no analytics, update checks, or
+  configured *arr instances. There are no analytics, update checks, or
   crash reporting.
 - **API keys are encrypted at rest** using Fernet symmetric encryption
   (AES-128-CBC + HMAC-SHA256) and are never sent back to the browser.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "houndarr"
 dynamic = ["version"]
-description = "A focused, self-hosted companion for Sonarr and Radarr that automatically searches for missing media in polite, controlled batches."
+description = "A focused, self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches."
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.12"
 authors = [{ name = "Andrea A. Venti Fuentes", email = "av1155.dev@gmail.com" }]
-keywords = ["sonarr", "radarr", "media", "automation", "self-hosted"]
+keywords = ["sonarr", "radarr", "lidarr", "readarr", "whisparr", "media", "automation", "self-hosted"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: End Users/Desktop",

--- a/src/houndarr/engine/candidates.py
+++ b/src/houndarr/engine/candidates.py
@@ -1,9 +1,10 @@
 """Normalized search candidate model for the engine pipeline.
 
 :class:`SearchCandidate` is the unified representation that adapter functions
-produce from app-specific client models (``MissingEpisode``, ``MissingMovie``).
-The engine pipeline operates solely on ``SearchCandidate`` instances, removing
-the need for ``isinstance`` checks or per-app branching.
+produce from app-specific client models (``MissingEpisode``, ``MissingMovie``,
+``MissingAlbum``, ``MissingBook``, ``MissingWhisparrEpisode``).  The engine
+pipeline operates solely on ``SearchCandidate`` instances, removing the need
+for ``isinstance`` checks or per-app branching.
 """
 
 from __future__ import annotations
@@ -21,16 +22,19 @@ class SearchCandidate:
 
     Adapter functions convert app-specific models into this common shape.
     The engine sees only ``SearchCandidate`` — it never inspects the
-    original ``MissingEpisode`` or ``MissingMovie``.
+    original app-specific model.
 
     Attributes:
-        item_id: Episode ID, movie ID, or synthetic season ID.
-        item_type: ``"episode"`` or ``"movie"``.
+        item_id: Episode ID, movie ID, album ID, book ID, or synthetic
+            season/artist/author ID.
+        item_type: One of ``"episode"``, ``"movie"``, ``"album"``,
+            ``"book"``, or ``"whisparr_episode"``.
         label: Human-readable label for logging.
         unreleased_reason: ``None`` when eligible; a skip-reason string
             when the item should be treated as unreleased.
-        group_key: ``(series_id, season)`` for season-context dedup, or
-            ``None`` for episode-mode and Radarr.
+        group_key: ``(series_id, season)`` for season-context dedup,
+            ``(artist_id,)`` for artist-context, ``(author_id,)`` for
+            author-context, or ``None`` for item-level modes.
         search_payload: Opaque data consumed only by the adapter's
             ``dispatch_search`` function.
     """

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -279,7 +279,8 @@ async def update_instance(
             ``cooldown_days``, ``unreleased_delay_hrs``,
             ``cutoff_enabled``, ``cutoff_batch_size``,
             ``cutoff_cooldown_days``, ``cutoff_hourly_cap``,
-            ``sonarr_search_mode``.
+            ``sonarr_search_mode``, ``lidarr_search_mode``,
+            ``readarr_search_mode``, ``whisparr_search_mode``.
 
     Returns:
         Updated :class:`Instance`, or ``None`` if *id* does not exist.

--- a/website/docs/concepts/faq.md
+++ b/website/docs/concepts/faq.md
@@ -18,7 +18,7 @@ Each skip has a reason logged alongside it — cooldown, unreleased delay, or ho
 
 ## "Does Houndarr decide whether my file meets cutoff?"
 
-No. Sonarr and Radarr maintain the "Wanted > Cutoff Unmet" list based on your quality profiles. Houndarr reads that list and schedules searches for items on it. If something should be in the cutoff list but isn't, check the quality profile in Sonarr/Radarr directly.
+No. Your *arr instance maintains the "Wanted > Cutoff Unmet" list based on your quality profiles. Houndarr reads that list and schedules searches for items on it. If something should be in the cutoff list but isn't, check the quality profile in your instance directly.
 
 ## "Why are future or recently-released titles being skipped?"
 
@@ -28,22 +28,22 @@ For Radarr, release timing uses a priority chain: `digitalRelease` → `physical
 
 ## "Does Houndarr search my whole library?"
 
-No. It only acts on what Sonarr/Radarr report as wanted — items from `wanted/missing` and `wanted/cutoff`. Everything else in your library is invisible to Houndarr.
+No. It only acts on what your *arr instances report as wanted — items from `wanted/missing` and `wanted/cutoff`. Everything else in your library is invisible to Houndarr.
 
 ## "Why is Houndarr searching so slowly?"
 
 The defaults are conservative on purpose — batch size 2, hourly cap 4, 14-day cooldown. With a large backlog, clearing it takes weeks. You can increase throughput gradually; see [Increasing throughput](/docs/configuration/instance-settings#increasing-throughput).
 
-## "Sonarr/Radarr show many cutoff-unmet items. Why is Houndarr only searching a few per day?"
+## "My *arr instance shows many cutoff-unmet items. Why is Houndarr only searching a few per day?"
 
 The cutoff controls (batch 1, cap 1, cooldown 21 days) are more conservative than missing controls because quality upgrades are lower priority than acquiring missing content. With a cap of 1, that's roughly 24 cutoff searches per day. Increase **Cutoff Cap** and **Cutoff Batch** gradually if you want faster progress.
 
 ## "I enabled Houndarr but I don't see any activity"
 
-Check in order: is the instance enabled (green toggle)? Has at least one sleep interval passed (default: 30 min)? Does Sonarr/Radarr actually have items in their wanted lists? Are there `error` entries in the Logs page?
+Check in order: is the instance enabled (green toggle)? Has at least one sleep interval passed (default: 30 min)? Does your *arr instance actually have items in its wanted lists? Are there `error` entries in the Logs page?
 
 See [Troubleshooting](/docs/concepts/troubleshooting) for a step-by-step guide.
 
-## "Can Houndarr search for things that aren't in Sonarr/Radarr yet?"
+## "Can Houndarr search for things that aren't in my *arr instance yet?"
 
-No. Houndarr only triggers searches within Sonarr/Radarr for items already tracked there. For request workflows, use Overseerr or Jellyseerr alongside your *arr stack.
+No. Houndarr only triggers searches within your *arr instances for items already tracked there. For request workflows, use Overseerr or Jellyseerr alongside your *arr stack.

--- a/website/docs/concepts/how-houndarr-works.md
+++ b/website/docs/concepts/how-houndarr-works.md
@@ -6,33 +6,33 @@ description: What Houndarr does, how it decides what to search, and why most ite
 
 # How Houndarr Works
 
-Houndarr is a search scheduler for Sonarr and Radarr. It triggers search commands in small, rate-limited batches so you don't have to hit "Search All Missing" and overwhelm your indexers.
+Houndarr is a search scheduler for Sonarr, Radarr, Lidarr, Readarr, and Whisparr. It triggers search commands in small, rate-limited batches so you don't have to hit "Search All Missing" and overwhelm your indexers.
 
-It does not download anything, parse releases, evaluate quality, or replace Sonarr/Radarr. It only decides **when** to ask them to search and **how many** items to include per batch.
+It does not download anything, parse releases, evaluate quality, or replace your *arr instances. It only decides **when** to ask them to search and **how many** items to include per batch.
 
 ## The search cycle
 
 ```
-1. Houndarr asks Sonarr/Radarr: "What items are missing or cutoff-unmet?"
+1. Houndarr asks your *arr instance: "What items are missing or cutoff-unmet?"
        ↓
-2. Sonarr/Radarr respond with their wanted lists
+2. The instance responds with its wanted list
    (only monitored items that are missing or below quality cutoff)
        ↓
 3. Houndarr applies its scheduling rules to each candidate
    (cooldown, hourly cap, unreleased delay, batch size)
        ↓
-4. Eligible items → search command sent to Sonarr/Radarr
+4. Eligible items → search command sent to the instance
        ↓
 5. Ineligible items → logged as "skipped", retried next cycle
 ```
 
-Sonarr and Radarr do all the actual searching. Houndarr controls the pacing.
+Your *arr instances do all the actual searching. Houndarr controls the pacing.
 
 ## Monitored vs. wanted
 
-A **monitored** item in Sonarr/Radarr just means the software is tracking it. If the item is already downloaded at a quality that meets your cutoff, it won't appear in any wanted list, and Houndarr will never touch it.
+A **monitored** item in your *arr instance just means the software is tracking it. If the item is already downloaded at a quality that meets your cutoff, it won't appear in any wanted list, and Houndarr will never touch it.
 
-| Item state in Sonarr/Radarr | Will Houndarr search it? |
+| Item state | Will Houndarr search it? |
 |-----------------------------|--------------------------|
 | Monitored + missing | Yes, if eligible under scheduling rules |
 | Monitored + downloaded + cutoff met | **No** — not in any wanted list |
@@ -41,12 +41,12 @@ A **monitored** item in Sonarr/Radarr just means the software is tracking it. If
 
 ## Who decides "cutoff unmet"?
 
-Sonarr and Radarr — not Houndarr. They populate the `wanted/cutoff` API list based on your quality profile settings. Houndarr reads that list and applies its scheduling rules on top.
+Your *arr instance — not Houndarr. It populates the `wanted/cutoff` API list based on your quality profile settings. Houndarr reads that list and applies its scheduling rules on top.
 
-If cutoff searches aren't happening, check whether the item actually appears in Sonarr/Radarr's own "Wanted > Cutoff Unmet" view first.
+If cutoff searches aren't happening, check whether the item actually appears in your instance's own "Wanted > Cutoff Unmet" view first.
 
-:::tip Quality profiles are managed in Sonarr/Radarr — not Houndarr
-Houndarr works best when your Sonarr/Radarr instances are already configured with
+:::tip Quality profiles are managed in your *arr instance — not Houndarr
+Houndarr works best when your *arr instances are already configured with
 quality profiles you trust. It does not manage quality profiles or custom formats.
 
 If you manage multiple instances or want help keeping quality settings consistent,
@@ -62,7 +62,7 @@ Think of it as a funnel:
 ```
 Your monitored library
         │
-        │  Sonarr/Radarr filter: only missing or cutoff-unmet items
+        │  *arr instance filter: only missing or cutoff-unmet items
         ▼
   Wanted list (much smaller)
         │
@@ -83,8 +83,8 @@ Each enabled instance runs two independent passes:
 
 | Pass | What it searches | Key controls |
 |------|-----------------|--------------|
-| **Missing** | Items in Sonarr/Radarr's `wanted/missing` list | Batch size, sleep interval, hourly cap, cooldown, unreleased delay |
-| **Cutoff** | Items in Sonarr/Radarr's `wanted/cutoff` list | Cutoff batch, cutoff cap, cutoff cooldown |
+| **Missing** | Items from the instance's `wanted/missing` list | Batch size, sleep interval, hourly cap, cooldown, unreleased delay |
+| **Cutoff** | Items from the instance's `wanted/cutoff` list | Cutoff batch, cutoff cap, cutoff cooldown |
 
 Cutoff search is **off by default**. Enable it only after missing items are under control so the two passes don't compete for the same indexer budget.
 

--- a/website/docs/concepts/troubleshooting.md
+++ b/website/docs/concepts/troubleshooting.md
@@ -10,10 +10,12 @@ description: How to verify Houndarr is working correctly, interpret logs, and di
 
 If you are unsure whether Houndarr is actually doing anything, follow these steps before assuming something is broken.
 
-### Step 1 — Open Sonarr/Radarr's own wanted pages
+### Step 1 — Open your *arr instance's own wanted pages
 
-In Sonarr: **Wanted → Missing** and **Wanted → Cutoff Unmet**  
-In Radarr: **Movies → Discover** or use the **Wanted** filter
+In Sonarr/Whisparr: **Wanted → Missing** and **Wanted → Cutoff Unmet**  
+In Radarr: **Movies → Discover** or use the **Wanted** filter  
+In Lidarr: **Wanted → Missing** and **Wanted → Cutoff Unmet**  
+In Readarr: **Wanted → Missing** and **Wanted → Cutoff Unmet**
 
 If those pages are empty, Houndarr has nothing to search.
 
@@ -25,10 +27,10 @@ Open Houndarr's **Logs** page and look at recent activity. Each row shows:
 |-------|-------------------|
 | **Action** | `searched` — a search command was sent; `skipped` — item was ineligible this cycle; `error` — something went wrong |
 | **Reason** | Why the item was skipped or what kind of search was triggered |
-| **Item label** | The series/movie title and episode info |
+| **Item label** | The series/movie/album/book title and relevant details |
 | **Timestamp** | When the action occurred |
 
-If you see `searched` entries for items that also appear in Sonarr/Radarr's wanted views, Houndarr is working correctly.
+If you see `searched` entries for items that also appear in your *arr instance's wanted views, Houndarr is working correctly.
 
 #### Log context fields
 
@@ -42,9 +44,9 @@ The Logs page groups rows by cycle when metadata exists and shows a **Cycle outc
 
 By default, system rows (supervisor startup messages) are hidden. Use the filter controls to show them if needed.
 
-### Step 3 — Check "Last Searched" timestamps in Sonarr/Radarr
+### Step 3 — Check "Last Searched" timestamps in your *arr instance
 
-In Sonarr's cutoff-unmet view, each episode shows when it was last searched. If those timestamps match recent Houndarr log entries, you have confirmed end-to-end that the search commands are reaching Sonarr and being executed.
+In your instance's cutoff-unmet view, each item shows when it was last searched. If those timestamps match recent Houndarr log entries, you have confirmed end-to-end that the search commands are reaching the instance and being executed.
 
 ### Step 4 — Expect skips for cooldown and unreleased items
 
@@ -76,20 +78,20 @@ See [Instance Settings](/docs/configuration/instance-settings#increasing-through
 
 ## Common issues
 
-### Houndarr is not connecting to Sonarr/Radarr
+### Houndarr is not connecting to your *arr instance
 
 **Symptoms:** `error` entries in logs with connection refused or timeout messages.
 
 **Checks:**
-1. Verify the instance URL is reachable from the Houndarr container (try `curl <url>/api/v3/system/status?apikey=<key>` from inside the container).
+1. Verify the instance URL is reachable from the Houndarr container. Try `curl <url>/api/v3/system/status?apikey=<key>` from inside the container (use `/api/v1/` for Lidarr and Readarr instead of `/api/v3/`).
 2. Confirm the API key is correct in Houndarr's Settings page.
-3. If Sonarr/Radarr are in the same Docker Compose stack, use the container service name as the hostname (e.g., `http://sonarr:8989`), not `localhost`.
+3. If your *arr instance is in the same Docker Compose stack, use the container service name as the hostname (e.g., `http://sonarr:8989`, `http://lidarr:8686`), not `localhost`.
 4. Check that the URL does not have a trailing slash.
 
 ### An instance is enabled but nothing is happening
 
 **Checks:**
-1. Open Sonarr/Radarr's wanted pages. If they are empty, there is nothing for Houndarr to search.
+1. Open your *arr instance's wanted pages. If they are empty, there is nothing for Houndarr to search.
 2. Check the Houndarr Logs page for the instance. Look at the most recent entries — if you see `skipped` with reason `hourly cap reached`, wait until the next hour window.
 3. Confirm the instance is enabled (green toggle in Settings).
 4. Check that the sleep interval has elapsed since the last cycle. With a 30-minute sleep, Houndarr runs approximately twice per hour.
@@ -98,17 +100,17 @@ See [Instance Settings](/docs/configuration/instance-settings#increasing-through
 
 **Checks:**
 1. Confirm **Cutoff search** is enabled for the instance (it is off by default).
-2. Open Sonarr/Radarr's "Wanted → Cutoff Unmet" view. If it is empty, there is nothing to search.
-3. Check your quality profiles in Sonarr/Radarr. An item only appears in the cutoff-unmet list if the file you have does not meet the profile's cutoff quality.
+2. Open your *arr instance's "Wanted → Cutoff Unmet" view. If it is empty, there is nothing to search.
+3. Check your quality profiles in your *arr instance. An item only appears in the cutoff-unmet list if the file you have does not meet the profile's cutoff quality.
 4. Note that cutoff search uses a separate hourly cap (default: 1 per hour). With a cap of 1, you may only see one cutoff search per hour.
 
 ### I see errors in the logs
 
 `error` log entries include a message field explaining what went wrong. Common causes:
 
-- **HTTP 401** — API key is wrong or has been rotated in Sonarr/Radarr.
-- **HTTP 404** — The item was removed from Sonarr/Radarr between the time Houndarr read the wanted list and the time it issued the search.
-- **Connection refused / timeout** — Sonarr/Radarr is unreachable (see connection troubleshooting above).
+- **HTTP 401** — API key is wrong or has been rotated in your *arr instance.
+- **HTTP 404** — The item was removed from the instance between the time Houndarr read the wanted list and the time it issued the search.
+- **Connection refused / timeout** — the instance is unreachable (see connection troubleshooting above).
 
 Occasional 404 errors are harmless. A stream of connection errors suggests a network or configuration issue.
 

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -6,8 +6,8 @@ description: Detailed guide to all per-instance search settings in Houndarr.
 
 # Instance Settings
 
-This guide explains each setting available when adding or editing a Sonarr/Radarr
-instance in Houndarr. The defaults are conservative — keep settings low to reduce
+This guide explains each setting available when adding or editing an instance
+in Houndarr. The defaults are conservative — keep settings low to reduce
 indexer/API pressure and avoid bans.
 
 ## Search command contract
@@ -16,8 +16,17 @@ indexer/API pressure and avoid bans.
 - **Sonarr (advanced):** Missing pass can use season-context commands
   (`SeasonSearch` with `seriesId` + `seasonNumber`) when enabled per instance.
 - **Radarr:** Sends movie-level commands (`MoviesSearch` with `movieIds`).
+- **Lidarr (default):** Sends album-level commands (`AlbumSearch` with `albumIds`).
+- **Lidarr (advanced):** Missing pass can use artist-context commands
+  (`ArtistSearch` with `artistId`) when enabled per instance.
+- **Readarr (default):** Sends book-level commands (`BookSearch` with `bookIds`).
+- **Readarr (advanced):** Missing pass can use author-context commands
+  (`AuthorSearch` with `authorId`) when enabled per instance.
+- **Whisparr (default):** Sends episode-level commands (`EpisodeSearch` with `episodeIds`).
+- **Whisparr (advanced):** Missing pass can use season-context commands
+  (`SeasonSearch` with `seriesId` + `seasonNumber`) when enabled per instance.
 - Wanted-list reads are restricted to monitored items (`monitored=true`) for both
-  missing and cutoff passes.
+  missing and cutoff passes across all app types.
 
 ## Missing search controls
 
@@ -56,11 +65,12 @@ Minimum delay after release date before searching.
 - **Default:** `36`
 - If the item is still inside this window, Houndarr logs `unreleased delay (...)` and skips it.
 
-For Radarr, Houndarr evaluates release timing with fallback anchors in this order:
-`digitalRelease` → `physicalRelease` → `releaseDate` → `inCinemas`.
+Release date evaluation varies by app type:
 
-For Radarr, unavailable or clearly pre-release titles may also be skipped using
-availability signals (`isAvailable` / `status`) even when release dates are incomplete.
+- **Radarr:** Fallback anchors in order: `digitalRelease` → `physicalRelease` → `releaseDate` → `inCinemas`. Unavailable or pre-release titles may also be skipped using availability signals (`isAvailable` / `status`).
+- **Sonarr / Whisparr:** Uses `airDateUtc` (Sonarr) or the `DateOnly` year/month/day object (Whisparr).
+- **Lidarr:** Uses the album `releaseDate` field.
+- **Readarr:** Uses the book `releaseDate` field.
 
 ### Sonarr Missing Search Mode
 
@@ -70,7 +80,6 @@ Strategy for Sonarr missing-pass commands.
 - **Advanced:** `Season-context search (advanced)`
 
 Season-context mode sends at most one `SeasonSearch` per `(series, season)` per pass.
-Season search is not pack-only in Sonarr and may still produce singles or noisier behavior.
 
 :::info
 Cooldown in season-context mode is tracked at the season level using a stable synthetic
@@ -78,6 +87,33 @@ identifier derived from the series ID and season number — not through any indi
 episode. This ensures cooldown history is consistent across cycles regardless of which
 episode happens to appear first on the wanted list.
 :::
+
+### Lidarr Missing Search Mode
+
+Strategy for Lidarr missing-pass commands.
+
+- **Default:** `Album search (default)`
+- **Advanced:** `Artist-context search (advanced)`
+
+Artist-context mode sends at most one `ArtistSearch` per artist per pass.
+
+### Readarr Missing Search Mode
+
+Strategy for Readarr missing-pass commands.
+
+- **Default:** `Book search (default)`
+- **Advanced:** `Author-context search (advanced)`
+
+Author-context mode sends at most one `AuthorSearch` per author per pass.
+
+### Whisparr Missing Search Mode
+
+Strategy for Whisparr missing-pass commands.
+
+- **Default:** `Episode search (default)`
+- **Advanced:** `Season-context search (advanced)`
+
+Season-context mode sends at most one `SeasonSearch` per `(series, season)` per pass, same as Sonarr's season-context mode.
 
 ## Cutoff upgrade controls
 

--- a/website/docs/getting-started/first-run-setup.md
+++ b/website/docs/getting-started/first-run-setup.md
@@ -22,14 +22,14 @@ After creating your account, log in with your new credentials.
 
 ## 3. Add your instances
 
-Go to **Settings** and click **Add Instance** to connect your Sonarr or Radarr instances.
+Go to **Settings** and click **Add Instance** to connect your *arr instances.
 
 For each instance you need:
 
-- **Name** — a friendly label (e.g., "Sonarr 4K", "Radarr Movies")
-- **Type** — Sonarr or Radarr
+- **Name** — a friendly label (e.g., "Sonarr 4K", "Radarr Movies", "Lidarr Music")
+- **Type** — Sonarr, Radarr, Lidarr, Readarr, or Whisparr
 - **URL** — the base URL of the instance (e.g., `http://sonarr:8989`)
-- **API Key** — found in your Sonarr/Radarr instance under Settings > General
+- **API Key** — found in your *arr instance under Settings > General
 
 :::tip
 API keys are encrypted at rest using Fernet symmetric encryption and are never

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -11,7 +11,7 @@ Get Houndarr running in under five minutes.
 ## Prerequisites
 
 - Docker and Docker Compose installed on your host
-- At least one running Sonarr or Radarr instance with an API key
+- At least one running Sonarr, Radarr, Lidarr, Readarr, or Whisparr instance with an API key
 
 ## Docker Compose
 
@@ -46,13 +46,13 @@ prompted to create an admin username and password.
 
 1. Create your admin account on the setup screen.
 2. Log in and go to **Settings**.
-3. Add your Sonarr/Radarr instances (URL + API key).
+3. Add your *arr instances (URL + API key).
 4. Enable each instance — Houndarr begins searching on the configured schedule.
 
 For more details, see [First-Run Setup](first-run-setup.md).
 
 :::tip Good to know
-Houndarr does not search your entire library — only items that Sonarr/Radarr report as missing or below your quality cutoff, in small batches. See [How Houndarr Works](/docs/concepts/how-houndarr-works) for details.
+Houndarr does not search your entire library — only items that your *arr instances report as missing or below your quality cutoff, in small batches. See [How Houndarr Works](/docs/concepts/how-houndarr-works) for details.
 :::
 
 ## Using `docker run`

--- a/website/docs/security/trust-and-security.md
+++ b/website/docs/security/trust-and-security.md
@@ -20,8 +20,9 @@ version polling, no usage reporting, no crash reporting, and no beacons.
 
 ### What the server connects to
 
-The only outbound HTTP connections are to **your own Sonarr and Radarr
-instances**, using their standard v3 API. Each request includes:
+The only outbound HTTP connections are to **your own *arr instances**
+(Sonarr, Radarr, Lidarr, Readarr, Whisparr), using their standard REST API
+(v3 for Sonarr/Radarr/Whisparr, v1 for Lidarr/Readarr). Each request includes:
 
 - An `X-Api-Key` header (the API key you configured for that instance)
 - An `Accept: application/json` header
@@ -247,7 +248,7 @@ When adding or editing an instance URL, Houndarr validates the target:
 - **Blocked:** `localhost`, loopback IPs (`127.0.0.0/8`, `::1`), link-local
   (`169.254.0.0/16`), and unspecified addresses (`0.0.0.0`)
 - **Allowed:** RFC-1918 private ranges (`10.0.0.0/8`, `172.16.0.0/12`,
-  `192.168.0.0/16`) because Sonarr/Radarr typically run on the same LAN or
+  `192.168.0.0/16`) because *arr instances typically run on the same LAN or
   Docker network
 
 Hostnames are resolved via DNS and each resolved IP is checked against the
@@ -307,7 +308,7 @@ unavailable, the UI will not render correctly. Both are loaded by the browser,
 not the server.
 
 **Private network ranges allowed.** Instance URL validation intentionally
-permits RFC-1918 private addresses because Sonarr and Radarr are typically on
+permits RFC-1918 private addresses because *arr instances are typically on
 the same LAN or Docker network. This means Houndarr can be directed at any
 reachable host on your private network.
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Houndarr',
-  tagline: 'Polite, automated media searching for Sonarr and Radarr',
+  tagline: 'Polite, automated media searching for your *arr stack',
   favicon: 'img/houndarr-logo-dark.png',
 
   future: {

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -23,9 +23,9 @@ const FeatureList: FeatureItem[] = [
     title: 'Missing & Cutoff',
     description: (
       <>
-        Automatically searches for missing episodes and movies, plus items
-        below your quality cutoff. Each search type has independent controls
-        and budgets.
+        Automatically searches for missing episodes, movies, albums, and
+        books, plus items below your quality cutoff. Each search type has
+        independent controls and budgets.
       </>
     ),
   },
@@ -33,8 +33,9 @@ const FeatureList: FeatureItem[] = [
     title: 'Multi-Instance',
     description: (
       <>
-        Connect one or more Sonarr and Radarr instances, each with their own
-        batch size, sleep interval, cooldown, and hourly cap settings.
+        Connect one or more Sonarr, Radarr, Lidarr, Readarr, and Whisparr
+        instances, each with their own batch size, sleep interval, cooldown,
+        and hourly cap settings.
       </>
     ),
   },
@@ -44,7 +45,7 @@ const FeatureList: FeatureItem[] = [
       <>
         Zero outbound connections to analytics, error tracking, or
         developer-controlled servers. The only network traffic goes to your
-        own Sonarr/Radarr instances.
+        own *arr instances.
       </>
     ),
   },

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -85,11 +85,11 @@ function WhatItDoes() {
               Why Houndarr?
             </Heading>
             <p>
-              Sonarr and Radarr monitor RSS feeds for new releases, but they do
-              not go back and actively search for content already in your library
-              that is missing or below your quality cutoff. Their built-in
-              "Search All Missing" button fires every item at once, overwhelming
-              indexer API limits.
+              Sonarr, Radarr, Lidarr, Readarr, and Whisparr monitor RSS feeds
+              for new releases, but they do not go back and actively search for
+              content already in your library that is missing or below your
+              quality cutoff. Their built-in "Search All Missing" button fires
+              every item at once, overwhelming indexer API limits.
             </p>
             <p>
               <strong>Houndarr searches slowly, politely, and automatically:</strong>{' '}
@@ -114,7 +114,7 @@ function WhatItDoesNot() {
               Focused by Design
             </Heading>
             <ul>
-              <li><strong>No download-client integration</strong> — it triggers searches in Sonarr/Radarr, which handle downloads</li>
+              <li><strong>No download-client integration</strong> — it triggers searches in your *arr instances, which handle downloads</li>
               <li><strong>No Prowlarr/indexer management</strong> — your *arr instances manage their own indexers</li>
               <li><strong>No request workflows</strong> — no Overseerr/Ombi-style request handling</li>
               <li><strong>No multi-user support</strong> — single admin username and password</li>
@@ -130,8 +130,8 @@ function WhatItDoesNot() {
 export default function Home(): ReactNode {
   return (
     <Layout
-      title="Polite media searching for Sonarr & Radarr"
-      description="A self-hosted companion for Sonarr and Radarr that automatically searches for missing media in polite, controlled batches.">
+      title="Polite media searching for your *arr stack"
+      description="A self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
## Summary

- Update all documentation, metadata, and source docstrings to reflect five supported *arr applications (previously only Sonarr and Radarr)
- Add missing search command and search mode documentation for Lidarr, Readarr, and Whisparr
- Fix factually incorrect API version claims in troubleshooting and security docs

Closes #202

## Changes

**AGENTS.md** — Source layout (add 3 clients + 3 adapters, fix `BaseClient` → `ArrClient`), schema DDL (v4→v5, expanded CHECK constraints, 3 new search mode columns), test count (401→408), noqa table (add `A002`, update `S101`/`SLF001`), CI workflows table (add 3 missing workflows), API reference (all five specs actively used), `ItemType` example.

**README.md** — Tagline, feature list (add Lidarr/Readarr/Whisparr search modes), security section, first-run setup.

**CONTRIBUTING.md** — Scope description.

**pyproject.toml** — Description, keywords (add `lidarr`, `readarr`, `whisparr`).

**Dockerfile** — OCI image description.

**.github/ISSUE_TEMPLATE/feature_request.yml** — Scope check body.

**Source docstrings** — `candidates.py` (`SearchCandidate` attributes), `instances.py` (`update_instance` accepted fields).

**Website docs** (8 files) — Generalize ~70 "Sonarr/Radarr" references; add search command contract entries for Lidarr/Readarr/Whisparr; add search mode sections for Lidarr/Readarr/Whisparr; fix `curl` example to note `/api/v1/` for Lidarr/Readarr; correct "standard v3 API" claim in trust-and-security.

**Website components** (3 files) — Tagline, homepage copy, feature cards.

## Checklist

- [x] Linked issue has `type:` and `priority:` labels
- [x] All quality gates pass locally (ruff, mypy, bandit, pytest — 408 tests)
- [x] Website builds successfully (`npm run build`)
- [x] No VERSION or CHANGELOG changes (docs-only PR)