### PR TITLE
fix: standardize app ordering to Radarr-first and update search mode docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,10 +55,10 @@ body:
       required: true
 
   - type: input
-    id: sonarr-radarr-version
+    id: arr-version
     attributes:
-      label: Sonarr / Radarr Version
-      placeholder: "e.g., Sonarr 4.0.8, Radarr 5.11.0"
+      label: Radarr / Sonarr / Lidarr / Readarr / Whisparr Version
+      placeholder: "e.g., Radarr 5.11.0, Sonarr 4.0.8"
 
   - type: input
     id: docker-version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
         ## Scope Check
 
         Houndarr is a **single-purpose tool** that searches for missing and cutoff-unmet
-        media in Sonarr, Radarr, Lidarr, Readarr, and Whisparr, in controlled batches.
+        media in Radarr, Sonarr, Lidarr, Readarr, and Whisparr, in controlled batches.
 
         Before submitting, please confirm your feature is within scope.
 

--- a/.github/workflows/api-snapshot-refresh.yml
+++ b/.github/workflows/api-snapshot-refresh.yml
@@ -54,7 +54,7 @@ jobs:
           api_dir = repo / "docs" / "api"
           tests_file = repo / "tests" / "test_docs_api.py"
 
-          SPECS = ["sonarr", "radarr", "whisparr", "lidarr", "readarr"]
+          SPECS = ["radarr", "sonarr", "lidarr", "readarr", "whisparr"]
 
           changed = False
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This file is the primary source of truth for autonomous agents operating here.
 
 ## Project Overview
 
-Houndarr is a self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and
+Houndarr is a self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and
 Whisparr that automatically searches for missing and cutoff-unmet media in
 small, rate-limited batches. It runs as a single Docker container alongside
 an existing *arr stack.
@@ -111,7 +111,7 @@ identical check names so branch protection is satisfied.
 | `release.yml` | `v*` tag push | Validates VERSION == tag, extracts CHANGELOG block, creates GitHub Release |
 | `dockerfile-lint.yml` | Changes to `Dockerfile` | `hadolint Dockerfile` |
 | `workflow-lint.yml` | Changes to `.github/workflows/**` | `actionlint` via reviewdog |
-| `api-snapshot-refresh.yml` | Weekly (Monday 10:00 UTC) + manual | Fetches upstream Sonarr/Radarr/Whisparr/Lidarr/Readarr OpenAPI specs, updates `docs/api/` snapshots and `tests/test_docs_api.py` hashes, opens a PR if changed |
+| `api-snapshot-refresh.yml` | Weekly (Monday 10:00 UTC) + manual | Fetches upstream Radarr/Sonarr/Whisparr/Lidarr/Readarr OpenAPI specs, updates `docs/api/` snapshots and `tests/test_docs_api.py` hashes, opens a PR if changed |
 | `pages.yml` | Pushes to `main` touching `website/**` | Deploys docs site to GitHub Pages |
 | `test-deploy.yml` | PRs touching `website/**` | Tests Docusaurus build without deploying |
 | `cleanup-actions-cache.yml` | Daily (05:00 UTC) + manual | Prunes stale GitHub Actions caches |
@@ -284,7 +284,7 @@ src/houndarr/
 | Table | Purpose | Key constraints |
 |-------|---------|-----------------|
 | `settings` | Key-value config store | `key TEXT PK` |
-| `instances` | *arr instance configs | `type CHECK IN ('sonarr','radarr','lidarr','readarr','whisparr')`; per-type `*_search_mode` columns with CHECK constraints |
+| `instances` | *arr instance configs | `type CHECK IN ('radarr','sonarr','lidarr','readarr','whisparr')`; per-type `*_search_mode` columns with CHECK constraints |
 | `cooldowns` | Per-item search cooldown tracking | `instance_id FK→instances ON DELETE CASCADE`; `UNIQUE(instance_id, item_id, item_type)` |
 | `search_log` | Audit trail for every search cycle | `instance_id FK→instances ON DELETE SET NULL`; `action CHECK IN ('searched','skipped','error','info')` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Connection errors now write exactly one `action="error"` log row per outage instead of one per retry, preventing the dashboard *24h errors* counter from inflating during startup races or service restarts (#140)
 - A recovery `action="info"` row is now written to `search_log` when an unreachable instance becomes reachable again, making the recovery event visible on the Logs page (#140)
-- A 10-second startup grace delay before the first search cycle gives co-located Sonarr/Radarr services time to become ready (#140)
+- A 10-second startup grace delay before the first search cycle gives co-located *arr services time to become ready (#140)
 
 ---
 
@@ -117,7 +117,7 @@ First stable public release.
 ### Added
 
 #### Core
-- Automated missing-media search engine for Sonarr and Radarr instances
+- Automated missing-media search engine for Radarr and Sonarr instances
 - Episode-level search for Sonarr (`EpisodeSearch` + `episodeIds`) with optional
   season-context mode (`SeasonSearch`)
 - Movie-level search for Radarr (`MoviesSearch` + `movieIds`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in improving Houndarr.
 
 ## Scope
 
-Houndarr is a focused tool for controlled *arr search automation (Sonarr, Radarr, Lidarr, Readarr, Whisparr).
+Houndarr is a focused tool for controlled *arr search automation (Radarr, Sonarr, Lidarr, Readarr, Whisparr).
 Please keep changes aligned with the project goal and avoid scope expansion.
 
 ## Development setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG HOUNDARR_VERSION=dev
 
 # OCI labels
 LABEL org.opencontainers.image.title="Houndarr" \
-      org.opencontainers.image.description="Focused self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and Whisparr" \
+      org.opencontainers.image.description="Focused self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr" \
       org.opencontainers.image.url="https://github.com/av1155/houndarr" \
       org.opencontainers.image.source="https://github.com/av1155/houndarr" \
       org.opencontainers.image.licenses="MIT"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="src/houndarr/static/img/houndarr-logo-dark.png" alt="Houndarr logo" width="220" />
 </p>
 
-> A focused, self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches.
+> A focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches.
 >
 > **[Documentation](https://av1155.github.io/houndarr/)** | **[Quick Start](https://av1155.github.io/houndarr/docs/getting-started/quick-start)**
 
@@ -12,7 +12,7 @@
 
 ## What Houndarr Does
 
-Sonarr, Radarr, Lidarr, Readarr, and Whisparr monitor RSS feeds for new
+Radarr, Sonarr, Lidarr, Readarr, and Whisparr monitor RSS feeds for new
 releases, but they do not go back and actively search for content already in
 your library that is missing or below your quality cutoff. Their built-in
 "Search All Missing" button fires every item at once, overwhelming indexer
@@ -24,11 +24,11 @@ It runs as a single Docker container alongside your existing *arr stack.
 
 **Key capabilities:**
 
-- Connects to one or more Sonarr, Radarr, Lidarr, Readarr, and Whisparr instances
+- Connects to one or more Radarr, Sonarr, Lidarr, Readarr, and Whisparr instances
 - Searches for **missing** episodes, movies, albums, and books in small, configurable batches
 - Searches for **cutoff-unmet** items (below your quality profile) separately
-- Sonarr: episode-level search by default, with optional season-context mode
 - Radarr: movie-level search
+- Sonarr: episode-level search by default, with optional season-context mode
 - Lidarr: album-level search by default, with optional artist-context mode
 - Readarr: book-level search by default, with optional author-context mode
 - Whisparr: episode-level search by default, with optional season-context mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "houndarr"
 dynamic = ["version"]
-description = "A focused, self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches."
+description = "A focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches."
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.12"
 authors = [{ name = "Andrea A. Venti Fuentes", email = "av1155.dev@gmail.com" }]
-keywords = ["sonarr", "radarr", "lidarr", "readarr", "whisparr", "media", "automation", "self-hosted"]
+keywords = ["radarr", "sonarr", "lidarr", "readarr", "whisparr", "media", "automation", "self-hosted"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: End Users/Desktop",

--- a/src/houndarr/__init__.py
+++ b/src/houndarr/__init__.py
@@ -1,4 +1,4 @@
-"""Houndarr — focused, self-hosted companion for Sonarr and Radarr."""
+"""Houndarr — focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr."""
 
 from pathlib import Path
 

--- a/src/houndarr/__main__.py
+++ b/src/houndarr/__main__.py
@@ -76,7 +76,7 @@ def cli(
     secure_cookies: bool,
     trusted_proxies: str,
 ) -> None:
-    """Houndarr — search for missing media in Sonarr and Radarr, politely.
+    """Houndarr — search for missing media in your *arr stack, politely.
 
     A focused self-hosted companion that automatically triggers searches for
     missing and cutoff-unmet media in controlled batches, keeping your

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -94,7 +94,9 @@ def create_app() -> FastAPI:
 
     app = FastAPI(
         title="Houndarr",
-        description="A focused, self-hosted companion for Sonarr and Radarr.",
+        description=(
+            "A focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr."
+        ),
         version=__version__,
         docs_url="/api/docs" if settings.dev else None,
         redoc_url=None,

--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -86,7 +86,7 @@ class ArrClient(ABC):
         """Return ``True`` if the instance is reachable and healthy.
 
         Uses the system/status endpoint at :attr:`_SYSTEM_STATUS_PATH`.
-        Defaults to ``/api/v3/system/status`` (Sonarr, Radarr, Whisparr);
+        Defaults to ``/api/v3/system/status`` (Radarr, Sonarr, Whisparr);
         Lidarr and Readarr override to ``/api/v1/system/status``.
         """
         try:

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -18,7 +18,7 @@ SCHEMA_VERSION = 5
 # ---------------------------------------------------------------------------
 # DDL
 # ---------------------------------------------------------------------------
-_INSTANCE_TYPES = "'sonarr', 'radarr', 'lidarr', 'readarr', 'whisparr'"
+_INSTANCE_TYPES = "'radarr', 'sonarr', 'lidarr', 'readarr', 'whisparr'"
 _ITEM_TYPES = "'episode', 'movie', 'album', 'book', 'whisparr_episode'"
 
 _SCHEMA_SQL = f"""

--- a/src/houndarr/engine/adapters/__init__.py
+++ b/src/houndarr/engine/adapters/__init__.py
@@ -36,17 +36,17 @@ class AppAdapter:
 
 
 ADAPTERS: dict[InstanceType, AppAdapter] = {
-    InstanceType.sonarr: AppAdapter(
-        adapt_missing=sonarr.adapt_missing,
-        adapt_cutoff=sonarr.adapt_cutoff,
-        dispatch_search=sonarr.dispatch_search,
-        make_client=sonarr.make_client,
-    ),
     InstanceType.radarr: AppAdapter(
         adapt_missing=radarr.adapt_missing,
         adapt_cutoff=radarr.adapt_cutoff,
         dispatch_search=radarr.dispatch_search,
         make_client=radarr.make_client,
+    ),
+    InstanceType.sonarr: AppAdapter(
+        adapt_missing=sonarr.adapt_missing,
+        adapt_cutoff=sonarr.adapt_cutoff,
+        dispatch_search=sonarr.dispatch_search,
+        make_client=sonarr.make_client,
     ),
     InstanceType.lidarr: AppAdapter(
         adapt_missing=lidarr.adapt_missing,

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -191,8 +191,8 @@ class Supervisor:
     async def _instance_loop(self, instance_id: int) -> None:
         """Run search cycles for one instance until cancelled.
 
-        A one-time startup grace delay gives co-located services (Sonarr, Radarr)
-        time to become ready before the first cycle fires.  Connection errors are
+        A one-time startup grace delay gives co-located *arr services time
+        to become ready before the first cycle fires.  Connection errors are
         logged to ``search_log`` only on state transitions (first failure and
         recovery) to avoid inflating the dashboard error counter with retry noise.
         """

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -97,7 +97,7 @@ def _blank_instance() -> Instance:
     return Instance(
         id=0,
         name="",
-        type=InstanceType.sonarr,
+        type=InstanceType.radarr,
         url="",
         api_key="",
         enabled=True,
@@ -120,8 +120,8 @@ def _blank_instance() -> Instance:
 
 
 _CLIENT_CONSTRUCTORS: dict[InstanceType, type[ArrClient]] = {
-    InstanceType.sonarr: SonarrClient,
     InstanceType.radarr: RadarrClient,
+    InstanceType.sonarr: SonarrClient,
     InstanceType.lidarr: LidarrClient,
     InstanceType.readarr: ReadarrClient,
     InstanceType.whisparr: WhisparrClient,
@@ -353,7 +353,7 @@ async def instance_test_connection(
     api_key: Annotated[str, Form()],
     instance_id: Annotated[str, Form()] = "",
 ) -> HTMLResponse:
-    """Test Sonarr/Radarr connectivity and return a status snippet.
+    """Test *arr instance connectivity and return a status snippet.
 
     When testing from the edit form, ``api_key`` may be the unchanged sentinel
     value (``__UNCHANGED__``).  In that case the existing stored key is

--- a/src/houndarr/services/cooldown.py
+++ b/src/houndarr/services/cooldown.py
@@ -39,8 +39,8 @@ async def is_on_cooldown(
 
     Args:
         instance_id: Owning instance primary key.
-        item_id: Sonarr episode ID or Radarr movie ID.
-        item_type: ``"episode"`` or ``"movie"``.
+        item_id: Item identifier (e.g. episode, movie, album, or book ID).
+        item_type: ``"episode"``, ``"movie"``, ``"album"``, ``"book"``, or ``"whisparr_episode"``.
         cooldown_days: Number of days before the same item can be re-searched.
             Pass ``0`` to disable cooldowns entirely.
 
@@ -79,8 +79,8 @@ async def record_search(
 
     Args:
         instance_id: Owning instance primary key.
-        item_id: Sonarr episode ID or Radarr movie ID.
-        item_type: ``"episode"`` or ``"movie"``.
+        item_id: Item identifier (e.g. episode, movie, album, or book ID).
+        item_type: ``"episode"``, ``"movie"``, ``"album"``, ``"book"``, or ``"whisparr_episode"``.
     """
     now = _iso(_now_utc())
     async with get_db() as db:

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -31,8 +31,8 @@ from houndarr.database import get_db
 class InstanceType(StrEnum):
     """Supported *arr application types."""
 
-    sonarr = "sonarr"
     radarr = "radarr"
+    sonarr = "sonarr"
     lidarr = "lidarr"
     readarr = "readarr"
     whisparr = "whisparr"
@@ -161,7 +161,7 @@ async def create_instance(
     Args:
         master_key: Fernet key used to encrypt *api_key* before storage.
         name: Human-readable label for the instance.
-        type: One of ``sonarr``, ``radarr``, ``lidarr``, ``readarr``, ``whisparr``.
+        type: One of ``radarr``, ``sonarr``, ``lidarr``, ``readarr``, ``whisparr``.
         url: Base URL of the *arr instance (e.g. ``http://sonarr:8989``).
         api_key: Plaintext API key — will be encrypted before being written.
         enabled: Whether the search engine should process this instance.

--- a/src/houndarr/services/url_validation.py
+++ b/src/houndarr/services/url_validation.py
@@ -2,7 +2,8 @@
 
 Self-hosted context notes
 --------------------------
-Houndarr is designed to talk to Sonarr and Radarr instances that commonly run
+Houndarr is designed to talk to Radarr, Sonarr, Lidarr, Readarr, and Whisparr
+instances that commonly run
 on the same Docker network or LAN as Houndarr itself.  Private IP ranges are
 therefore *legitimate and expected* targets.  This module does **not** block
 RFC-1918 ranges wholesale; instead it only rejects the most obviously dangerous

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="A focused, self-hosted companion for Sonarr and Radarr." />
+  <meta name="description" content="A focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr." />
   <meta name="application-name" content="Houndarr" />
   <meta name="apple-mobile-web-app-title" content="Houndarr" />
   <meta name="theme-color" content="#020617" />

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -55,8 +55,8 @@
                     data-instance-field="type"
                     class="w-full h-11 bg-slate-900/80 border border-slate-700/80 rounded-lg px-3 text-sm text-white
                            focus:outline-none focus:border-brand-400/80 focus:ring-2 focus:ring-brand-500/25">
-              <option value="sonarr" {% if is_edit and instance.type.value == 'sonarr' %}selected{% endif %}>Sonarr</option>
               <option value="radarr" {% if is_edit and instance.type.value == 'radarr' %}selected{% endif %}>Radarr</option>
+              <option value="sonarr" {% if is_edit and instance.type.value == 'sonarr' %}selected{% endif %}>Sonarr</option>
               <option value="lidarr" {% if is_edit and instance.type.value == 'lidarr' %}selected{% endif %}>Lidarr</option>
               <option value="readarr" {% if is_edit and instance.type.value == 'readarr' %}selected{% endif %}>Readarr</option>
               <option value="whisparr" {% if is_edit and instance.type.value == 'whisparr' %}selected{% endif %}>Whisparr</option>
@@ -72,7 +72,7 @@
                    data-readarr-placeholder="http://readarr:8787"
                    data-whisparr-placeholder="http://whisparr:6969"
                    value="{{ instance.url if is_edit else '' }}"
-                   placeholder="http://sonarr:8989"
+                   placeholder="http://radarr:7878"
                    class="w-full h-11 bg-slate-900/80 border border-slate-700/80 rounded-lg px-3 text-sm text-white placeholder:text-slate-500
                           focus:outline-none focus:border-brand-400/80 focus:ring-2 focus:ring-brand-500/25" />
           </div>

--- a/src/houndarr/templates/partials/pages/settings_help_content.html
+++ b/src/houndarr/templates/partials/pages/settings_help_content.html
@@ -99,18 +99,19 @@
       </div>
       <div class="rounded-lg border border-slate-800 bg-slate-950/40 p-3">
         <div class="flex items-center justify-between gap-3">
-          <h3 class="text-sm font-semibold text-slate-200">Sonarr Missing Search Mode</h3>
+          <h3 class="text-sm font-semibold text-slate-200">Missing Search Mode</h3>
           <span class="text-[11px] px-2 py-0.5 rounded-full bg-slate-800 text-slate-300 border border-slate-700"
-            >Default: Episode</span
+            >Per-app setting</span
           >
         </div>
         <p class="mt-1 text-sm text-slate-300">
-          Sonarr only. Choose episode-level default or advanced season-context mode for the missing
-          pass.
+          Sonarr, Lidarr, Readarr, and Whisparr each offer an advanced search mode alongside
+          their default item-level search. The advanced mode groups items by a parent context
+          (season, artist, author) to issue fewer, broader commands.
         </p>
         <p class="mt-2 text-xs text-amber-300">
-          Advanced warning: Sonarr season search is not pack-only and may still produce
-          singles/noisier behavior.
+          Advanced warning: broader searches may produce noisier results. Sonarr/Whisparr season
+          search is not pack-only and may still pull singles.
         </p>
       </div>
     </div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -226,7 +226,7 @@ def test_login_page_includes_browser_identity_metadata(app: TestClient) -> None:
     assert response.status_code == 200
     assert (
         b'<meta name="description" content="A focused, self-hosted companion for '
-        b'Sonarr and Radarr." />' in response.content
+        b'Radarr, Sonarr, Lidarr, Readarr, and Whisparr." />' in response.content
     )
     assert b'<meta name="application-name" content="Houndarr" />' in response.content
     assert b'<meta name="apple-mobile-web-app-title" content="Houndarr" />' in response.content

--- a/tests/test_e2e/test_search_cycle.py
+++ b/tests/test_e2e/test_search_cycle.py
@@ -339,7 +339,7 @@ async def test_supervisor_no_instances_starts_cleanly(db: None, master_key: byte
 
 
 # ---------------------------------------------------------------------------
-# Test 5 — Both Sonarr and Radarr instances run concurrently via supervisor
+# Test 5 — Both Radarr and Sonarr instances run concurrently via supervisor
 # ---------------------------------------------------------------------------
 
 
@@ -350,7 +350,7 @@ async def test_supervisor_runs_both_instances(
     radarr_instance: Instance,
     master_key: bytes,
 ) -> None:
-    """Supervisor spawns separate tasks for Sonarr and Radarr instances."""
+    """Supervisor spawns separate tasks for Radarr and Sonarr instances."""
     # Sonarr: returns one episode then empty (second cycle won't fire, but mock it anyway)
     respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
         return_value=httpx.Response(200, json=_MISSING_SONARR_1)

--- a/tests/test_routes/test_status.py
+++ b/tests/test_routes/test_status.py
@@ -184,7 +184,7 @@ def test_status_returns_multiple_instances(app: TestClient) -> None:
     data = resp.json()
     assert len(data) == 2
     names = {d["name"] for d in data}
-    assert names == {"My Sonarr", "My Radarr"}
+    assert names == {"My Radarr", "My Sonarr"}
 
 
 def test_status_includes_24h_outcomes_and_last_activity(app: TestClient) -> None:

--- a/website/docs/concepts/how-houndarr-works.md
+++ b/website/docs/concepts/how-houndarr-works.md
@@ -6,7 +6,7 @@ description: What Houndarr does, how it decides what to search, and why most ite
 
 # How Houndarr Works
 
-Houndarr is a search scheduler for Sonarr, Radarr, Lidarr, Readarr, and Whisparr. It triggers search commands in small, rate-limited batches so you don't have to hit "Search All Missing" and overwhelm your indexers.
+Houndarr is a search scheduler for Radarr, Sonarr, Lidarr, Readarr, and Whisparr. It triggers search commands in small, rate-limited batches so you don't have to hit "Search All Missing" and overwhelm your indexers.
 
 It does not download anything, parse releases, evaluate quality, or replace your *arr instances. It only decides **when** to ask them to search and **how many** items to include per batch.
 

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -12,10 +12,10 @@ indexer/API pressure and avoid bans.
 
 ## Search command contract
 
+- **Radarr:** Sends movie-level commands (`MoviesSearch` with `movieIds`).
 - **Sonarr (default):** Sends episode-level commands (`EpisodeSearch` with `episodeIds`).
 - **Sonarr (advanced):** Missing pass can use season-context commands
   (`SeasonSearch` with `seriesId` + `seasonNumber`) when enabled per instance.
-- **Radarr:** Sends movie-level commands (`MoviesSearch` with `movieIds`).
 - **Lidarr (default):** Sends album-level commands (`AlbumSearch` with `albumIds`).
 - **Lidarr (advanced):** Missing pass can use artist-context commands
   (`ArtistSearch` with `artistId`) when enabled per instance.

--- a/website/docs/getting-started/first-run-setup.md
+++ b/website/docs/getting-started/first-run-setup.md
@@ -26,8 +26,8 @@ Go to **Settings** and click **Add Instance** to connect your *arr instances.
 
 For each instance you need:
 
-- **Name** — a friendly label (e.g., "Sonarr 4K", "Radarr Movies", "Lidarr Music")
-- **Type** — Sonarr, Radarr, Lidarr, Readarr, or Whisparr
+- **Name** — a friendly label (e.g., "Radarr Movies", "Sonarr 4K", "Lidarr Music")
+- **Type** — Radarr, Sonarr, Lidarr, Readarr, or Whisparr
 - **URL** — the base URL of the instance (e.g., `http://sonarr:8989`)
 - **API Key** — found in your *arr instance under Settings > General
 

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -11,7 +11,7 @@ Get Houndarr running in under five minutes.
 ## Prerequisites
 
 - Docker and Docker Compose installed on your host
-- At least one running Sonarr, Radarr, Lidarr, Readarr, or Whisparr instance with an API key
+- At least one running Radarr, Sonarr, Lidarr, Readarr, or Whisparr instance with an API key
 
 ## Docker Compose
 

--- a/website/docs/security/trust-and-security.md
+++ b/website/docs/security/trust-and-security.md
@@ -21,8 +21,8 @@ version polling, no usage reporting, no crash reporting, and no beacons.
 ### What the server connects to
 
 The only outbound HTTP connections are to **your own *arr instances**
-(Sonarr, Radarr, Lidarr, Readarr, Whisparr), using their standard REST API
-(v3 for Sonarr/Radarr/Whisparr, v1 for Lidarr/Readarr). Each request includes:
+(Radarr, Sonarr, Lidarr, Readarr, Whisparr), using their standard REST API
+(v3 for Radarr/Sonarr/Whisparr, v1 for Lidarr/Readarr). Each request includes:
 
 - An `X-Api-Key` header (the API key you configured for that instance)
 - An `Accept: application/json` header

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -33,7 +33,7 @@ const FeatureList: FeatureItem[] = [
     title: 'Multi-Instance',
     description: (
       <>
-        Connect one or more Sonarr, Radarr, Lidarr, Readarr, and Whisparr
+        Connect one or more Radarr, Sonarr, Lidarr, Readarr, and Whisparr
         instances, each with their own batch size, sleep interval, cooldown,
         and hourly cap settings.
       </>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -85,7 +85,7 @@ function WhatItDoes() {
               Why Houndarr?
             </Heading>
             <p>
-              Sonarr, Radarr, Lidarr, Readarr, and Whisparr monitor RSS feeds
+              Radarr, Sonarr, Lidarr, Readarr, and Whisparr monitor RSS feeds
               for new releases, but they do not go back and actively search for
               content already in your library that is missing or below your
               quality cutoff. Their built-in "Search All Missing" button fires
@@ -131,7 +131,7 @@ export default function Home(): ReactNode {
   return (
     <Layout
       title="Polite media searching for your *arr stack"
-      description="A self-hosted companion for Sonarr, Radarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches.">
+      description="A self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Be concise. -->

Standardizes all *arr app listings to Radarr, Sonarr, Lidarr, Readarr, Whisparr and expands the settings help panel to describe search modes for all four apps that support them.

Closes #210

## Changes

<!-- Bullet the specific changes. Lead with user-facing impact. -->

- Instance form dropdown now lists Radarr first; default blank instance type changed to Radarr
- Settings help panel "Sonarr Missing Search Mode" section replaced with a general "Missing Search Mode" section covering Sonarr, Lidarr, Readarr, and Whisparr
- `InstanceType` enum, `ADAPTERS` dict, `_CLIENT_CONSTRUCTORS` dict, `_INSTANCE_TYPES`, and `_blank_instance()` all list Radarr first
- All prose listings across README, AGENTS.md, CONTRIBUTING.md, CHANGELOG.md, pyproject.toml, Dockerfile, source docstrings, HTML templates, website docs, and website components reordered
- Bug report template field updated from "Sonarr / Radarr Version" to "Radarr / Sonarr / Lidarr / Readarr / Whisparr Version"
- Cooldown docstrings updated to reference all item types instead of only episode/movie
- Test assertions updated to match new meta description and comment ordering

## Testing <!-- If applicable -->

All checks pass locally — ruff lint, ruff format, mypy strict, bandit SAST, and pytest (563 tests).

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [ ] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way