### PR TITLE
docs: update documentation for post-release grace and queue backpressure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Run **all five** before every commit. CI enforces the same checks.
 ## Running Tests
 
 ```bash
-# Full suite (563 tests, async — count includes parametrised expansions)
+# Full suite (571 tests, async — count includes parametrised expansions)
 .venv/bin/pytest
 
 # Single file
@@ -231,7 +231,7 @@ src/houndarr/
   crypto.py            # Fernet encrypt/decrypt, master key management
   database.py          # get_db() context manager, schema migrations
   clients/             # httpx-based *arr API clients
-    base.py            # ArrClient ABC with _get()/_post() + raise_for_status()
+    base.py            # ArrClient ABC with _get()/_post() + raise_for_status() + get_queue_status()
     sonarr.py          # SonarrClient (episode/season search, v3 API)
     radarr.py          # RadarrClient (movie search, v3 API)
     lidarr.py          # LidarrClient (album/artist search, v1 API)
@@ -239,7 +239,7 @@ src/houndarr/
     whisparr.py        # WhisparrClient (episode/season search, v3 API)
   engine/
     candidates.py      # SearchCandidate dataclass, ItemType, date helpers
-    search_loop.py     # run_instance_search() — unified search pipeline
+    search_loop.py     # run_instance_search() — unified search pipeline (queue-backpressure gate)
     supervisor.py      # Supervisor — one asyncio.Task per enabled instance
     adapters/
       __init__.py      # AppAdapter dataclass, ADAPTERS registry, get_adapter()
@@ -263,7 +263,7 @@ src/houndarr/
 
 ### Key patterns
 
-- **Database:** SQLite via aiosqlite; schema version 5; `get_db()` async
+- **Database:** SQLite via aiosqlite; schema version 7; `get_db()` async
   context manager opens a fresh connection per call (WAL mode, FKs enabled)
 - **Config:** `AppSettings` is a plain dataclass (not Pydantic); `get_settings()`
   is a lazy singleton
@@ -279,17 +279,17 @@ src/houndarr/
 - **search_log:** Every search attempt writes a row with action
   `searched`/`skipped`/`error`/`info`
 
-### Database schema (SQLite, schema version 5)
+### Database schema (SQLite, schema version 7)
 
 | Table | Purpose | Key constraints |
 |-------|---------|-----------------|
 | `settings` | Key-value config store | `key TEXT PK` |
-| `instances` | *arr instance configs | `type CHECK IN ('radarr','sonarr','lidarr','readarr','whisparr')`; per-type `*_search_mode` columns with CHECK constraints |
+| `instances` | *arr instance configs | `type CHECK IN ('radarr','sonarr','lidarr','readarr','whisparr')`; per-type `*_search_mode` columns with CHECK constraints; `post_release_grace_hrs` (default 6); `queue_limit` (default 0) |
 | `cooldowns` | Per-item search cooldown tracking | `instance_id FK→instances ON DELETE CASCADE`; `UNIQUE(instance_id, item_id, item_type)` |
 | `search_log` | Audit trail for every search cycle | `instance_id FK→instances ON DELETE SET NULL`; `action CHECK IN ('searched','skipped','error','info')` |
 
 Full DDL, column definitions, indexes, and migrations (`_migrate_to_v2`
-through `_migrate_to_v5`) are in `src/houndarr/database.py`. Bump
+through `_migrate_to_v7`) are in `src/houndarr/database.py`. Bump
 `SCHEMA_VERSION` when adding new migrations.
 
 ### *arr API reference (local)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ It runs as a single Docker container alongside your existing *arr stack.
 - Whisparr: episode-level search by default, with optional season-context mode
 - Per-item cooldown prevents re-searching the same item too soon
 - Per-instance hourly API cap keeps indexer usage in check
+- Optional download-queue backpressure gate skips cycles when the queue is full
 - Bounded multi-page scanning so deep backlog items are not starved
 - Live dashboard with instance status cards and run-now buttons
 - Filterable, searchable log viewer with multi-format copy/export

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -127,6 +127,7 @@
                    value="{{ instance.post_release_grace_hrs }}"
                    class="w-full h-11 bg-slate-900/80 border border-slate-700/80 rounded-lg px-3 text-sm text-white
                           focus:outline-none focus:border-brand-400/80 focus:ring-2 focus:ring-brand-500/25" />
+            <p class="mt-1.5 text-xs text-slate-500">Hours to wait after release date before searching. Unreleased items are always skipped.</p>
           </div>
           <div>
             <label class="block text-xs font-medium text-slate-400 mb-1.5" for="{{ form_id }}-qlimit">Queue Limit</label>

--- a/src/houndarr/templates/partials/pages/settings_help_content.html
+++ b/src/houndarr/templates/partials/pages/settings_help_content.html
@@ -87,14 +87,16 @@
       </div>
       <div class="rounded-lg border border-slate-800 bg-slate-950/40 p-3">
         <div class="flex items-center justify-between gap-3">
-          <h3 class="text-sm font-semibold text-slate-200">Unreleased Delay (hrs)</h3>
+          <h3 class="text-sm font-semibold text-slate-200">Post-Release Grace (hrs)</h3>
           <span
             class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
-            >Default: 36</span
+            >Default: 6</span
           >
         </div>
         <p class="mt-1 text-sm text-slate-300">
-          Wait after release date before searching. If still inside this window, item is skipped.
+          Hours to wait after an item's release date before searching. Items still within this
+          window are skipped. Unreleased items (no release date yet, or release date in the future)
+          are always skipped regardless of this setting.
         </p>
       </div>
       <div class="rounded-lg border border-slate-800 bg-slate-950/40 p-3">
@@ -112,6 +114,29 @@
         <p class="mt-2 text-xs text-amber-300">
           Advanced warning: broader searches may produce noisier results. Sonarr/Whisparr season
           search is not pack-only and may still pull singles.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="help-reveal rounded-xl border border-slate-800 bg-slate-900 p-5">
+    <h2 class="text-lg font-semibold text-slate-100 mb-1">Queue Backpressure</h2>
+    <p class="text-xs text-slate-400 mb-4">
+      Prevents Houndarr from adding work when the download client is already busy.
+    </p>
+    <div class="space-y-3">
+      <div class="rounded-lg border border-slate-800 bg-slate-950/40 p-3">
+        <div class="flex items-center justify-between gap-3">
+          <h3 class="text-sm font-semibold text-slate-200">Queue Limit</h3>
+          <span
+            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            >Default: 0 (disabled)</span
+          >
+        </div>
+        <p class="mt-1 text-sm text-slate-300">
+          When set above zero, Houndarr checks the instance's download queue before each cycle.
+          If the total queue count meets or exceeds this limit, the entire cycle is skipped.
+          If the queue endpoint is unreachable, the search proceeds normally.
         </p>
       </div>
     </div>
@@ -188,7 +213,10 @@
         Cooldown: <strong class="text-slate-100">14 days</strong>
       </div>
       <div class="rounded border border-slate-800 bg-slate-950/40 px-3 py-2 text-slate-300">
-        Unreleased Delay: <strong class="text-slate-100">36 hrs</strong>
+        Post-Release Grace: <strong class="text-slate-100">6 hrs</strong>
+      </div>
+      <div class="rounded border border-slate-800 bg-slate-950/40 px-3 py-2 text-slate-300">
+        Queue Limit: <strong class="text-slate-100">0 (disabled)</strong>
       </div>
       <div class="rounded border border-slate-800 bg-slate-950/40 px-3 py-2 text-slate-300">
         Cutoff Search: <strong class="text-slate-100">Off</strong>
@@ -199,7 +227,7 @@
       <div class="rounded border border-slate-800 bg-slate-950/40 px-3 py-2 text-slate-300">
         Cutoff Cooldown: <strong class="text-slate-100">21 days</strong>
       </div>
-      <div class="rounded border border-slate-800 bg-slate-950/40 px-3 py-2 text-slate-300 sm:col-span-2">
+      <div class="rounded border border-slate-800 bg-slate-950/40 px-3 py-2 text-slate-300">
         Cutoff Cap: <strong class="text-slate-100">1</strong>
       </div>
     </div>

--- a/website/docs/concepts/faq.md
+++ b/website/docs/concepts/faq.md
@@ -8,13 +8,13 @@ description: Answers to frequently asked questions about Houndarr.
 
 ## "I have 500 monitored movies. Why did Houndarr only search 3?"
 
-Monitored doesn't mean wanted. Most of your library is already downloaded and meeting your quality cutoff, so those items never appear in a wanted list. Of the items that are wanted, cooldowns, unreleased delays, and hourly caps filter out most of the rest.
+Monitored doesn't mean wanted. Most of your library is already downloaded and meeting your quality cutoff, so those items never appear in a wanted list. Of the items that are wanted, cooldowns, post-release grace windows, and hourly caps filter out most of the rest.
 
 See [How Houndarr Works](/docs/concepts/how-houndarr-works#why-only-a-few-items-get-searched-each-cycle) for the full breakdown.
 
 ## "Why is Houndarr skipping so much?"
 
-Each skip has a reason logged alongside it — cooldown, unreleased delay, or hourly cap. A high skip count with zero errors means Houndarr is pacing itself correctly. See [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) for what each reason means.
+Each skip has a reason logged alongside it — cooldown, post-release grace, hourly cap, or queue backpressure. A high skip count with zero errors means Houndarr is pacing itself correctly. See [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) for what each reason means.
 
 ## "Does Houndarr decide whether my file meets cutoff?"
 
@@ -22,9 +22,13 @@ No. Your *arr instance maintains the "Wanted > Cutoff Unmet" list based on your 
 
 ## "Why are future or recently-released titles being skipped?"
 
-Houndarr has an **unreleased delay** setting (default: 36 hours). Items whose release date is in the future or within the delay window are skipped until the window clears. This avoids hammering indexers for content that may not be available yet.
+Items with no release date or a release date in the future are always skipped (`not yet released`). Items that have been released but are still within the **post-release grace** window (default: 6 hours) are also skipped until the window clears. This avoids hammering indexers for content that may not be available yet.
 
 For Radarr, release timing uses a priority chain: `digitalRelease` → `physicalRelease` → `releaseDate` → `inCinemas`. If none of those dates are set, or the title is marked as unavailable, it will be skipped.
+
+## "What does 'queue backpressure' mean in the logs?"
+
+If you set a **Queue Limit** on an instance, Houndarr checks the download queue before each cycle. When the queue count meets or exceeds the limit, the entire cycle is skipped and logged as `queue backpressure (N/M)`. This prevents Houndarr from adding searches when the download client is already busy. If the queue endpoint is unreachable, the search proceeds normally.
 
 ## "Does Houndarr search my whole library?"
 

--- a/website/docs/concepts/how-houndarr-works.md
+++ b/website/docs/concepts/how-houndarr-works.md
@@ -19,7 +19,7 @@ It does not download anything, parse releases, evaluate quality, or replace your
    (only monitored items that are missing or below quality cutoff)
        ↓
 3. Houndarr applies its scheduling rules to each candidate
-   (cooldown, hourly cap, unreleased delay, batch size)
+   (cooldown, hourly cap, post-release grace, batch size)
        ↓
 4. Eligible items → search command sent to the instance
        ↓
@@ -66,7 +66,7 @@ Your monitored library
         ▼
   Wanted list (much smaller)
         │
-        │  Houndarr filter: cooldown, unreleased delay, hourly cap
+         │  Houndarr filter: cooldown, post-release grace, hourly cap
         ▼
   Eligible this cycle (smaller still)
         │
@@ -75,7 +75,7 @@ Your monitored library
   Actually searched (often just 1–3 items)
 ```
 
-For example, if you have 500 monitored movies in Radarr but only 50 are cutoff-unmet, and 35 of those are on cooldown, 8 are unreleased, and your batch is 1 — Houndarr searches 1 movie that cycle. The rest wait for cooldowns to expire or release windows to pass, and Houndarr works through them over days and weeks.
+For example, if you have 500 monitored movies in Radarr but only 50 are cutoff-unmet, and 35 of those are on cooldown, 8 are still in their post-release grace window, and your batch is 1 — Houndarr searches 1 movie that cycle. The rest wait for cooldowns to expire or grace windows to pass, and Houndarr works through them over days and weeks.
 
 ## The two search passes
 
@@ -83,7 +83,7 @@ Each enabled instance runs two independent passes:
 
 | Pass | What it searches | Key controls |
 |------|-----------------|--------------|
-| **Missing** | Items from the instance's `wanted/missing` list | Batch size, sleep interval, hourly cap, cooldown, unreleased delay |
+| **Missing** | Items from the instance's `wanted/missing` list | Batch size, sleep interval, hourly cap, cooldown, post-release grace |
 | **Cutoff** | Items from the instance's `wanted/cutoff` list | Cutoff batch, cutoff cap, cutoff cooldown |
 
 Cutoff search is **off by default**. Enable it only after missing items are under control so the two passes don't compete for the same indexer budget.
@@ -95,8 +95,10 @@ Every item Houndarr considers but does not search is logged as `skipped` with a 
 | Reason in logs | What it means |
 |----------------|---------------|
 | `cooldown (N days remaining)` | Item was searched recently; waiting to retry |
-| `unreleased delay (N hrs remaining)` | Release date is too recent or in the future |
+| `not yet released` | Item has no release date or release date is in the future |
+| `post-release grace (Nh)` | Release date has passed but the grace window hasn't elapsed yet |
 | `hourly cap reached` | This instance has hit its per-hour search limit |
+| `queue backpressure (N/M)` | Download queue has N items, at or above the configured limit of M (cycle-level skip) |
 
 A high skip count with zero errors means Houndarr is pacing itself correctly — examining candidates, finding most ineligible under your rules, and waiting patiently.
 

--- a/website/docs/concepts/troubleshooting.md
+++ b/website/docs/concepts/troubleshooting.md
@@ -48,13 +48,15 @@ By default, system rows (supervisor startup messages) are hidden. Use the filter
 
 In your instance's cutoff-unmet view, each item shows when it was last searched. If those timestamps match recent Houndarr log entries, you have confirmed end-to-end that the search commands are reaching the instance and being executed.
 
-### Step 4 — Expect skips for cooldown and unreleased items
+### Step 4 — Expect skips for cooldown, grace, and queue items
 
 If most of your log entries say `skipped`, check the reasons:
 
 - **`cooldown (N days remaining)`** — the item was searched recently; Houndarr is waiting before trying again. This is intentional.
-- **`unreleased delay (N hrs remaining)`** — the release date is too recent or in the future. Houndarr will search once the delay window clears.
+- **`not yet released`** — the item has no release date or the release date is in the future.
+- **`post-release grace (Nh)`** — the release date has passed but the grace window hasn't elapsed yet. Houndarr will search once it clears.
 - **`hourly cap reached`** — your per-hour search limit has been hit for this cycle.
+- **`queue backpressure (N/M)`** — the download queue has N items, at or above your configured limit of M. The entire cycle was skipped.
 
 These are all normal scheduling behavior.
 

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -58,12 +58,13 @@ Minimum days before retrying the same missing item.
 - **Default:** `14`
 - Larger values reduce repeat search noise.
 
-### Unreleased Delay (hours)
+### Post-Release Grace (hours)
 
-Minimum delay after release date before searching.
+Hours to wait after an item's release date before searching.
 
-- **Default:** `36`
-- If the item is still inside this window, Houndarr logs `unreleased delay (...)` and skips it.
+- **Default:** `6`
+- Items still within this window are logged as `post-release grace (Nh)` and skipped.
+- Items that have not been released yet (no release date, or date in the future) are always skipped with reason `not yet released`, regardless of this setting.
 
 Release date evaluation varies by app type:
 
@@ -146,11 +147,21 @@ Maximum successful cutoff searches per hour.
 Cutoff searches use separate cap/cooldown settings from missing searches so they
 do not consume the same budget.
 
+## Queue backpressure
+
+When `Queue Limit` is set above zero, Houndarr checks the instance's download
+queue before each cycle. If the total queue count meets or exceeds the limit,
+the entire cycle is skipped and logged as `queue backpressure (N/M)`.
+
+- **Default:** `0` (disabled)
+- If the queue endpoint is unreachable, the search proceeds normally (fails open).
+- This prevents Houndarr from piling up work when the download client is already busy.
+
 ## Fair backlog scanning
 
 Houndarr does not stop at the first wanted page. During each cycle, it can scan
-deeper pages when top candidates are repeatedly ineligible (cooldown, unreleased
-delay, or caps), but it stays bounded:
+deeper pages when top candidates are repeatedly ineligible (cooldown, post-release
+grace, or caps), but it stays bounded:
 
 - Per-pass list paging has a hard cap (no unbounded page walks)
 - Per-pass candidate evaluation has a hard scan budget
@@ -170,7 +181,8 @@ Skips are normal — see [How Houndarr Works](/docs/concepts/how-houndarr-works#
 | Sleep (minutes) | `30` |
 | Hourly Cap | `4` |
 | Cooldown (days) | `14` |
-| Unreleased Delay (hrs) | `36` |
+| Post-Release Grace (hrs) | `6` |
+| Queue Limit | `0` (disabled) |
 | Cutoff search | Off |
 | Cutoff Batch | `1` |
 | Cutoff Cooldown | `21` |

--- a/website/docs/getting-started/first-run-setup.md
+++ b/website/docs/getting-started/first-run-setup.md
@@ -47,6 +47,8 @@ Each instance has its own search settings. The defaults are conservative and saf
 | Sleep (minutes) | 30 | Wait between cycles |
 | Hourly Cap | 4 | Max searches per hour |
 | Cooldown (days) | 14 | Min days before re-searching an item |
+| Post-Release Grace (hrs) | 6 | Hours to wait after release date before searching |
+| Queue Limit | 0 (disabled) | Skip cycle when download queue meets or exceeds this count |
 
 For detailed explanations of all settings, see [Instance Settings](/docs/configuration/instance-settings).
 


### PR DESCRIPTION
## Summary

Align all documentation with the search pipeline changes from #215 and #217.

Closes #218

## Changes

- **AGENTS.md**: test count 563 → 571, schema version 5 → 7, migration range v2–v5 → v2–v7, updated `instances` table description with `post_release_grace_hrs` and `queue_limit`, updated `base.py` and `search_loop.py` source layout descriptions
- **In-app settings help**: renamed "Unreleased Delay" → "Post-Release Grace" (default 6), added Queue Backpressure section, updated Safe Starting Preset table, fixed grid layout
- **Instance form**: added help text paragraph under Post-Release Grace input
- **Instance Settings** (website): renamed section, updated default, added Queue backpressure section, updated fair backlog scanning terminology, updated recommended starting profile
- **How Houndarr Works** (website): updated funnel diagram, search cycle steps, search passes table, and log reason table with new skip reasons (`not yet released`, `post-release grace`, `queue backpressure`)
- **FAQ** (website): updated unreleased delay references, added queue backpressure FAQ entry
- **Troubleshooting** (website): updated skip reason list with all current reasons
- **First-Run Setup** (website): added Post-Release Grace and Queue Limit to settings overview table
- **README**: added queue backpressure to key capabilities list

## Testing

Documentation-only changes. All checks pass.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [ ] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way