### PR TITLE
feat(search): add release-aware missing cooldown retry

### DIFF
--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -257,16 +257,13 @@ async def _run_search_pass(  # noqa: C901
 
             candidate = adapt_fn(item, instance)
 
-            # Group-key dedup (season-context mode).
-            if candidate.group_key is not None:
-                if candidate.group_key in seen_group_keys:
+            # Item-level modes can dedup immediately. Context modes defer dedup
+            # until after release-timing checks so a temporarily blocked record
+            # does not hide a later eligible record from the same group.
+            if candidate.group_key is None:
+                if candidate.item_id in seen_item_ids:
                     continue
-                seen_group_keys.add(candidate.group_key)
-
-            # Item-id dedup across pages.
-            if candidate.item_id in seen_item_ids:
-                continue
-            seen_item_ids.add(candidate.item_id)
+                seen_item_ids.add(candidate.item_id)
 
             # Unreleased / post-release grace checks.
             # Pre-release gate is unconditional; post-release grace is
@@ -286,6 +283,18 @@ async def _run_search_pass(  # noqa: C901
                         reason=candidate.unreleased_reason,
                     )
                     continue
+
+            # Context-mode dedup happens after release-timing checks so a later
+            # eligible record in the same season/artist/author can still drive
+            # the group search when an earlier record was temporarily blocked.
+            if candidate.group_key is not None:
+                if candidate.group_key in seen_group_keys:
+                    continue
+                seen_group_keys.add(candidate.group_key)
+
+                if candidate.item_id in seen_item_ids:
+                    continue
+                seen_item_ids.add(candidate.item_id)
 
             # Hourly cap.
             if hourly_cap > 0 and searches_this_hour >= hourly_cap:

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -13,6 +13,7 @@ import respx
 from cryptography.fernet import Fernet
 
 from houndarr.database import get_db
+from houndarr.engine.candidates import ItemType
 from houndarr.engine.search_loop import run_instance_search
 from houndarr.services.instances import (
     Instance,
@@ -200,6 +201,26 @@ async def _insert_search_log_row(
             (instance_id, item_id, item_type, search_kind, action, reason),
         )
         await conn.commit()
+
+
+async def _seed_release_timing_retry(
+    *,
+    instance_id: int,
+    item_id: int,
+    item_type: ItemType,
+    reason: str = "not yet released",
+) -> None:
+    from houndarr.services.cooldown import record_search
+
+    await record_search(instance_id, item_id, item_type)
+    await _insert_search_log_row(
+        instance_id=instance_id,
+        item_id=item_id,
+        item_type=item_type,
+        search_kind="missing",
+        action="skipped",
+        reason=reason,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -699,17 +720,7 @@ async def test_missing_release_timing_skip_allows_one_retry_while_on_cooldown(
     seeded_instances: None,
 ) -> None:
     """Missing pass may override cooldown after the latest release-timing skip."""
-    from houndarr.services.cooldown import record_search
-
-    await record_search(1, 101, "episode")
-    await _insert_search_log_row(
-        instance_id=1,
-        item_id=101,
-        item_type="episode",
-        search_kind="missing",
-        action="skipped",
-        reason="not yet released",
-    )
+    await _seed_release_timing_retry(instance_id=1, item_id=101, item_type="episode")
 
     respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
         return_value=httpx.Response(200, json=_MISSING_SONARR)
@@ -802,6 +813,295 @@ async def test_missing_release_timing_override_does_not_bypass_current_grace(
     rows = await _get_log_rows()
     assert rows[-1]["action"] == "skipped"
     assert rows[-1]["reason"] == "post-release grace (6h)"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_release_timing_skip_allows_one_retry_while_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Radarr missing pass may override cooldown after a release-timing skip."""
+    await _seed_release_timing_retry(instance_id=2, item_id=201, item_type="movie")
+
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_RADARR)
+    )
+    search_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 2})
+    )
+
+    instance = _make_instance(instance_id=2, itype=InstanceType.radarr, url=RADARR_URL)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+    rows = await _get_log_rows()
+    assert rows[-1]["action"] == "searched"
+    assert rows[-1]["item_type"] == "movie"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_season_context_release_timing_skip_allows_one_retry_while_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Season-context mode may override season cooldown after a release-timing skip."""
+    from houndarr.engine.adapters.sonarr import _season_item_id
+
+    await _seed_release_timing_retry(
+        instance_id=1,
+        item_id=_season_item_id(55, 1),
+        item_type="episode",
+    )
+
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(sonarr_search_mode=SonarrSearchMode.season_context)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+
+    import json as json_mod
+
+    payload = json_mod.loads(search_route.calls[0].request.content)
+    assert payload == {"name": "SeasonSearch", "seriesId": 55, "seasonNumber": 1}
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_season_context_skips_unreleased_record_and_searches_later_eligible_one(
+    seeded_instances: None,
+) -> None:
+    """Season-context mode should not let an unreleased record block a peer."""
+    mixed_records = {
+        "records": [
+            {**_EPISODE_RECORD, "id": 101, "airDateUtc": _FUTURE_AIR_DATE},
+            {
+                **_EPISODE_RECORD,
+                "id": 102,
+                "episodeNumber": 2,
+                "airDateUtc": "2023-09-01T00:00:00Z",
+            },
+        ]
+    }
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=mixed_records),
+            httpx.Response(200, json={"records": []}),
+        ]
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(sonarr_search_mode=SonarrSearchMode.season_context)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+    rows = await _get_log_rows()
+    assert rows[0]["action"] == "skipped"
+    assert rows[0]["reason"] == "not yet released"
+    assert rows[-1]["action"] == "searched"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_lidarr_release_timing_skip_allows_one_retry_while_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Lidarr missing pass may override cooldown after a release-timing skip."""
+    await _seed_release_timing_retry(instance_id=3, item_id=301, item_type="album")
+
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_LIDARR)
+    )
+    search_route = respx.post(f"{LIDARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json={"id": 3})
+    )
+
+    instance = _make_instance(instance_id=3, itype=InstanceType.lidarr, url=LIDARR_URL)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+    rows = await _get_log_rows()
+    assert rows[-1]["action"] == "searched"
+    assert rows[-1]["item_type"] == "album"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_lidarr_artist_context_release_timing_skip_allows_one_retry_while_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Artist-context mode may override artist cooldown after a release-timing skip."""
+    from houndarr.engine.adapters.lidarr import _artist_item_id
+
+    await _seed_release_timing_retry(
+        instance_id=3,
+        item_id=_artist_item_id(50),
+        item_type="album",
+    )
+
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_LIDARR)
+    )
+    search_route = respx.post(f"{LIDARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json={"id": 3})
+    )
+
+    instance = _make_instance(
+        instance_id=3,
+        itype=InstanceType.lidarr,
+        url=LIDARR_URL,
+        lidarr_search_mode=LidarrSearchMode.artist_context,
+    )
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+
+    import json as json_mod
+
+    payload = json_mod.loads(search_route.calls[0].request.content)
+    assert payload == {"name": "ArtistSearch", "artistId": 50}
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_readarr_release_timing_skip_allows_one_retry_while_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Readarr missing pass may override cooldown after a release-timing skip."""
+    await _seed_release_timing_retry(instance_id=4, item_id=401, item_type="book")
+
+    respx.get(f"{READARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_READARR)
+    )
+    search_route = respx.post(f"{READARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json={"id": 4})
+    )
+
+    instance = _make_instance(instance_id=4, itype=InstanceType.readarr, url=READARR_URL)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+    rows = await _get_log_rows()
+    assert rows[-1]["action"] == "searched"
+    assert rows[-1]["item_type"] == "book"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_readarr_author_context_release_timing_skip_allows_one_retry_while_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Author-context mode may override author cooldown after a release-timing skip."""
+    from houndarr.engine.adapters.readarr import _author_item_id
+
+    await _seed_release_timing_retry(
+        instance_id=4,
+        item_id=_author_item_id(60),
+        item_type="book",
+    )
+
+    respx.get(f"{READARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_READARR)
+    )
+    search_route = respx.post(f"{READARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json={"id": 4})
+    )
+
+    instance = _make_instance(
+        instance_id=4,
+        itype=InstanceType.readarr,
+        url=READARR_URL,
+        readarr_search_mode=ReadarrSearchMode.author_context,
+    )
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+
+    import json as json_mod
+
+    payload = json_mod.loads(search_route.calls[0].request.content)
+    assert payload == {"name": "AuthorSearch", "authorId": 60}
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_whisparr_release_timing_skip_allows_one_retry_while_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Whisparr missing pass may override cooldown after a release-timing skip."""
+    await _seed_release_timing_retry(
+        instance_id=5,
+        item_id=501,
+        item_type="whisparr_episode",
+    )
+
+    respx.get(f"{WHISPARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_WHISPARR)
+    )
+    search_route = respx.post(f"{WHISPARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 5})
+    )
+
+    instance = _make_instance(instance_id=5, itype=InstanceType.whisparr, url=WHISPARR_URL)
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+    rows = await _get_log_rows()
+    assert rows[-1]["action"] == "searched"
+    assert rows[-1]["item_type"] == "whisparr_episode"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_whisparr_season_context_release_timing_skip_allows_one_retry_while_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Whisparr season-context mode may override season cooldown after a release-timing skip."""
+    from houndarr.engine.adapters.whisparr import _season_item_id
+
+    await _seed_release_timing_retry(
+        instance_id=5,
+        item_id=_season_item_id(70, 1),
+        item_type="whisparr_episode",
+    )
+
+    respx.get(f"{WHISPARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_WHISPARR)
+    )
+    search_route = respx.post(f"{WHISPARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 5})
+    )
+
+    instance = _make_instance(
+        instance_id=5,
+        itype=InstanceType.whisparr,
+        url=WHISPARR_URL,
+        whisparr_search_mode=WhisparrSearchMode.season_context,
+    )
+    count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert search_route.called
+
+    import json as json_mod
+
+    payload = json_mod.loads(search_route.calls[0].request.content)
+    assert payload == {"name": "SeasonSearch", "seriesId": 70, "seasonNumber": 1}
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/concepts/faq.md
+++ b/website/docs/concepts/faq.md
@@ -14,7 +14,7 @@ See [How Houndarr Works](/docs/concepts/how-houndarr-works#why-only-a-few-items-
 
 ## "Why is Houndarr skipping so much?"
 
-Each skip has a reason logged alongside it — cooldown, post-release grace, hourly cap, or queue backpressure. A high skip count with zero errors means Houndarr is pacing itself correctly. See [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) for what each reason means.
+Each skip has a reason logged alongside it — `on cooldown (Nd)`, `post-release grace (Nh)`, hourly cap, or queue backpressure. A high skip count with zero errors means Houndarr is pacing itself correctly. See [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) for what each reason means.
 
 ## "Does Houndarr decide whether my file meets cutoff?"
 
@@ -23,6 +23,8 @@ No. Your *arr instance maintains the "Wanted > Cutoff Unmet" list based on your 
 ## "Why are future or recently-released titles being skipped?"
 
 Items with no release date or a release date in the future are always skipped (`not yet released`). Items that have been released but are still within the **post-release grace** window (default: 6 hours) are also skipped until the window clears. This avoids hammering indexers for content that may not be available yet.
+
+When that release-timing block clears, the missing pass can retry the item once right away instead of waiting for the full missing cooldown. Cutoff searches do not use that early retry.
 
 For Radarr, release timing uses a priority chain: `digitalRelease` → `physicalRelease` → `releaseDate` → `inCinemas`. If none of those dates are set, or the title is marked as unavailable, it will be skipped.
 

--- a/website/docs/concepts/how-houndarr-works.md
+++ b/website/docs/concepts/how-houndarr-works.md
@@ -75,7 +75,7 @@ Your monitored library
   Actually searched (often just 1–3 items)
 ```
 
-For example, if you have 500 monitored movies in Radarr but only 50 are cutoff-unmet, and 35 of those are on cooldown, 8 are still in their post-release grace window, and your batch is 1 — Houndarr searches 1 movie that cycle. The rest wait for cooldowns to expire or grace windows to pass, and Houndarr works through them over days and weeks.
+For example, if you have 500 monitored movies in Radarr but only 50 are cutoff-unmet, and 35 of those are on cooldown, 8 are still in their post-release grace window, and your batch is 1 — Houndarr searches 1 movie that cycle. The rest wait for cooldowns to expire or grace windows to pass, and Houndarr works through them over days and weeks. Missing items that were blocked only by release timing can get one early retry once they become eligible.
 
 ## The two search passes
 
@@ -88,16 +88,23 @@ Each enabled instance runs two independent passes:
 
 Cutoff search is **off by default**. Enable it only after missing items are under control so the two passes don't compete for the same indexer budget.
 
+If a missing item was skipped because it was `not yet released` or still inside
+`post-release grace (Nh)`, Houndarr allows one retry as soon as that release-timing
+gate clears instead of waiting for the full missing cooldown. Cutoff keeps its
+normal cooldown behavior.
+
 ## What "skipped" means in the logs
 
 Every item Houndarr considers but does not search is logged as `skipped` with a reason:
 
 | Reason in logs | What it means |
 |----------------|---------------|
-| `cooldown (N days remaining)` | Item was searched recently; waiting to retry |
+| `on cooldown (Nd)` | Item was searched recently; waiting to retry |
+| `on cutoff cooldown (Nd)` | Cutoff item was searched recently; waiting to retry |
 | `not yet released` | Item has no release date or release date is in the future |
 | `post-release grace (Nh)` | Release date has passed but the grace window hasn't elapsed yet |
-| `hourly cap reached` | This instance has hit its per-hour search limit |
+| `hourly cap reached (N)` | This instance has hit its missing-pass hourly search limit of `N` |
+| `cutoff hourly cap reached (N)` | This instance has hit its cutoff hourly search limit of `N` |
 | `queue backpressure (N/M)` | Download queue has N items, at or above the configured limit of M (cycle-level skip) |
 
 A high skip count with zero errors means Houndarr is pacing itself correctly — examining candidates, finding most ineligible under your rules, and waiting patiently.

--- a/website/docs/concepts/troubleshooting.md
+++ b/website/docs/concepts/troubleshooting.md
@@ -54,13 +54,19 @@ In your instance's cutoff-unmet view, each item shows when it was last searched.
 
 If most of your log entries say `skipped`, check the reasons:
 
-- **`cooldown (N days remaining)`** — the item was searched recently; Houndarr is waiting before trying again. This is intentional.
+- **`on cooldown (Nd)`** — the item was searched recently; Houndarr is waiting before trying again. This is intentional.
+- **`on cutoff cooldown (Nd)`** — a cutoff item was searched recently; cutoff keeps its own separate cooldown.
 - **`not yet released`** — the item has no release date or the release date is in the future.
 - **`post-release grace (Nh)`** — the release date has passed but the grace window hasn't elapsed yet. Houndarr will search once it clears.
-- **`hourly cap reached`** — your per-hour search limit has been hit for this cycle.
+- **`hourly cap reached (N)`** — your missing-pass hourly search limit of `N` has been hit for this cycle.
+- **`cutoff hourly cap reached (N)`** — your cutoff hourly search limit of `N` has been hit for this cycle.
 - **`queue backpressure (N/M)`** — the download queue has N items, at or above your configured limit of M. The entire cycle was skipped.
 
 These are all normal scheduling behavior.
+
+For missing items only, a prior `not yet released` or `post-release grace (Nh)`
+skip can be followed by one immediate retry on a later cycle once the item
+becomes eligible, even if the normal missing cooldown has not fully elapsed.
 
 ### Step 5 — Check the error count
 

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -59,6 +59,10 @@ Minimum days before retrying the same missing item.
 
 - **Default:** `14`
 - Larger values reduce repeat search noise.
+- Missing only: if the latest missing-pass skip for an item was `not yet released`
+  or `post-release grace (Nh)`, Houndarr allows one retry as soon as the item
+  becomes eligible, even if the normal missing cooldown has not fully elapsed.
+- After that retry, normal missing cooldown resumes.
 
 ### Post-Release Grace (hours)
 
@@ -67,6 +71,9 @@ Hours to wait after an item's release date before searching.
 - **Default:** `6`
 - Items still within this window are logged as `post-release grace (Nh)` and skipped.
 - Items that have not been released yet (no release date, or date in the future) are always skipped with reason `not yet released`, regardless of this setting.
+- Once a missing item clears `not yet released` or `post-release grace (Nh)`,
+  Houndarr may retry it on the next missing pass without waiting for the full
+  missing cooldown.
 
 Release date evaluation varies by app type:
 
@@ -148,6 +155,8 @@ Maximum successful cutoff searches per hour.
 
 Cutoff searches use separate cap/cooldown settings from missing searches so they
 do not consume the same budget.
+
+The release-aware retry above does not apply to cutoff searches.
 
 ## Queue backpressure
 


### PR DESCRIPTION
## Summary

Closes #226

## Changes

- Allow the missing pass to ignore an active cooldown once when the latest missing-pass log for that item shows a release-timing block and the item is now eligible.
- Fix context-mode dedup so an unreleased season, artist, or author record does not block a later eligible record from driving the grouped search.
- Expand regression coverage across Radarr, Sonarr, Lidarr, Readarr, Whisparr, and the season/artist/author context modes.
- Update website docs to describe the missing-only early retry and align logged skip reason strings with current behavior.

## Testing <!-- If applicable -->

All checks pass.

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way