### PR TITLE
docs: add reverse proxy env var hints to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,6 @@ services:
       - TZ=America/New_York
       - PUID=1000
       - PGID=1000
+      # Reverse proxy (Nginx, Caddy, Traefik, etc.) — see docs/reverse-proxy for details:
+      # - HOUNDARR_SECURE_COOKIES=true         # set Secure flag on cookies when behind HTTPS
+      # - HOUNDARR_TRUSTED_PROXIES=127.0.0.1   # trust X-Forwarded-For from this proxy IP


### PR DESCRIPTION
Adds commented-out `HOUNDARR_SECURE_COOKIES` and `HOUNDARR_TRUSTED_PROXIES` entries to the standalone compose template. Users who clone the repo and copy `docker-compose.yml` directly will now see the two vars needed for HTTPS reverse proxy deployments, without having to find the Reverse Proxy docs page separately.

Closes #239

---

**Checklist**
- [x] Linked issue exists and has required labels
- [x] All quality gates pass (ruff lint, ruff format, mypy, bandit, pytest)
- [x] No behaviour change — docs/config only
- [x] `VERSION` and `CHANGELOG.md` not modified (no release needed)