### PR TITLE
fix(ui): resolve iOS modal collapse caused by flex-1 on max-h dialog

### DIFF
--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -499,10 +499,10 @@
 
   <dialog
     id="add-instance-modal"
-    class="m-auto p-0 w-[min(94vw,52rem)] max-h-[min(calc(100dvh-2rem),56rem)] flex flex-col rounded-2xl border border-[#1e2638] bg-[#0e1117] text-slate-100"
+    class="m-auto p-0 w-[min(94vw,52rem)] rounded-2xl border border-[#1e2638] bg-[#0e1117] text-slate-100"
     style="box-shadow:0 30px 80px rgba(0,0,0,0.7), 0 0 0 1px rgba(30,38,56,0.8);"
   >
-    <div class="flex flex-shrink-0 items-start justify-between border-b border-[#1e2638] px-6 py-5">
+    <div class="flex items-start justify-between border-b border-[#1e2638] px-6 py-5">
       <div>
         <h3 id="add-instance-modal-title" class="text-xl font-semibold tracking-tight text-white">
           Add Instance
@@ -537,7 +537,7 @@
       role="dialog"
       aria-modal="true"
       aria-labelledby="add-instance-modal-title"
-      class="flex-1 min-h-0 overflow-y-auto px-6 py-5"
+      class="max-h-[min(calc(100dvh-12rem),44rem)] overflow-y-auto px-6 py-5"
     ></div>
   </dialog>
 </section>


### PR DESCRIPTION
Closes #241

## What changed

The Add/Edit Instance modal was collapsing to a near-zero-height content area on iOS Safari and Chrome for iOS — a tiny scrollable sliver instead of the full form.

`flex-1` on the content div requires the parent to have a definite height. `max-height` is not a definite height per the CSS spec, and iOS WebKit enforces this strictly, so the content div had nothing to grow into.

- Removed `flex flex-col` and `max-h-[min(calc(100dvh-2rem),56rem)]` from the `<dialog>` element
- Removed `flex-shrink-0` from the header div (no longer needed)
- Replaced `flex-1 min-h-0 overflow-y-auto` on the content div with `max-h-[min(calc(100dvh-12rem),44rem)] overflow-y-auto` — a direct constraint using `dvh` units to handle iOS URL-bar resize
- Body scroll-lock JS from #236 is unchanged

## Checklist

- [x] Linked issue has `type:*` and `priority:*` labels
- [x] No unrelated changes
- [ ] Tests added/updated (N/A — template-only change, no logic)
- [x] All quality gates pass locally