### PR TITLE
feat(chart): add official Helm chart with Flux support

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,0 +1,55 @@
+name: Helm Chart
+
+on:
+  push:
+    tags: ["v*"]
+
+# Permissions set at job level for least-privilege.
+permissions: {}
+
+jobs:
+  publish:
+    name: Package and push Helm chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "v3.20.1"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read version
+        id: version
+        run: |
+          CHART_VERSION=$(tr -d '[:space:]' < VERSION)
+          echo "version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Package chart
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          helm package charts/houndarr \
+            --version "$CHART_VERSION" \
+            --app-version "$CHART_VERSION" \
+            --destination /tmp/helm-output
+
+      - name: Push chart to GHCR
+        env:
+          CHART_VERSION: ${{ steps.version.outputs.version }}
+          CHART_OWNER: ${{ github.repository_owner }}
+        run: |
+          helm push \
+            "/tmp/helm-output/houndarr-${CHART_VERSION}.tgz" \
+            "oci://ghcr.io/${CHART_OWNER}/charts"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ identical check names so branch protection is satisfied.
 |----------|---------|---------|
 | `version-check.yml` | PRs changing `VERSION` or `CHANGELOG.md` | Validates VERSION format, CHANGELOG heading match, allowed `###` headers, `---` separator |
 | `release.yml` | `v*` tag push | Validates VERSION == tag, extracts CHANGELOG block, creates GitHub Release |
+| `chart.yml` | `v*` tag push | Packages `charts/houndarr/` with version from `VERSION` file, pushes to `oci://ghcr.io/av1155/charts` |
 | `dockerfile-lint.yml` | Changes to `Dockerfile` | `hadolint Dockerfile` |
 | `workflow-lint.yml` | Changes to `.github/workflows/**` | `actionlint` via reviewdog |
 | `api-snapshot-refresh.yml` | Weekly (Monday 10:00 UTC) + manual | Fetches upstream Radarr/Sonarr/Whisparr/Lidarr/Readarr OpenAPI specs, updates `docs/api/` snapshots and `tests/test_docs_api.py` hashes, opens a PR if changed |
@@ -476,6 +477,7 @@ Subject line max 50 characters (including the `type(scope): ` prefix); body line
 4. Tag and push:  git tag vX.Y.Z && git push origin vX.Y.Z
    → docker.yml  builds + pushes to GHCR as vX.Y.Z + latest
    → release.yml extracts CHANGELOG block, creates GitHub Release
+   → chart.yml   packages + pushes Helm chart to oci://ghcr.io/av1155/charts
 ```
 
 Never push a `v*` tag without a matching `## [X.Y.Z]` block in `CHANGELOG.md`.

--- a/charts/houndarr/.helmignore
+++ b/charts/houndarr/.helmignore
@@ -1,0 +1,7 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git
+.gitignore
+*.swp
+*.bak
+*.tmp

--- a/charts/houndarr/Chart.yaml
+++ b/charts/houndarr/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: houndarr
+description: Self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing and cutoff-unmet media in small, rate-limited batches.
+type: application
+version: 1.4.0
+appVersion: "1.4.0"
+icon: https://av1155.github.io/houndarr/img/houndarr-logo-dark.png
+home: https://av1155.github.io/houndarr/
+sources:
+  - https://github.com/av1155/houndarr
+keywords:
+  - houndarr
+  - radarr
+  - sonarr
+  - lidarr
+  - readarr
+  - whisparr
+  - arr
+  - media
+maintainers:
+  - name: av1155
+    url: https://github.com/av1155

--- a/charts/houndarr/templates/NOTES.txt
+++ b/charts/houndarr/templates/NOTES.txt
@@ -1,0 +1,33 @@
+Houndarr {{ .Chart.AppVersion }} deployed in namespace {{ .Release.Namespace }}.
+
+  ⚠  SQLite constraint: replicas are fixed at 1. Do not scale this StatefulSet.
+
+Access the UI via port-forward:
+
+  kubectl port-forward -n {{ .Release.Namespace }} \
+    svc/{{ include "houndarr.fullname" . }}-web \
+    {{ .Values.service.port }}:{{ .Values.service.port }}
+
+  Then open: http://localhost:{{ .Values.service.port }}
+
+{{- if .Values.ingress.enabled }}
+
+Ingress:
+  http{{ if .Values.ingress.tls.enabled }}s{{ end }}://{{ .Values.ingress.host }}
+
+{{- if not .Values.env.secureCookies }}
+  ⚠  For HTTPS deployments, set env.secureCookies=true and env.trustedProxies
+     to your Ingress controller's pod CIDR.
+{{- end }}
+{{- else }}
+
+To expose via Ingress, set:
+  --set ingress.enabled=true
+  --set ingress.host=<your-domain>
+
+{{- end }}
+
+Data volume:
+  The PVC 'data-{{ include "houndarr.fullname" . }}-0' persists after pod deletion.
+  Back it up — it contains the database and the Fernet encryption master key.
+  Loss of the master key makes all stored *arr API keys unrecoverable.

--- a/charts/houndarr/templates/_helpers.tpl
+++ b/charts/houndarr/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "houndarr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 characters to respect DNS name limits.
+*/}}
+{{- define "houndarr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "houndarr.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+{{ include "houndarr.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels used by matchLabels and service selectors.
+*/}}
+{{- define "houndarr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "houndarr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/houndarr/templates/ingress.yaml
+++ b/charts/houndarr/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "houndarr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "houndarr.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "houndarr.fullname" . }}-web
+                port:
+                  number: {{ .Values.service.port }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/houndarr/templates/service-web.yaml
+++ b/charts/houndarr/templates/service-web.yaml
@@ -1,0 +1,19 @@
+{{/*
+ClusterIP service for Ingress controllers and kubectl port-forward.
+Named with the "-web" suffix to match the documented raw-manifest pattern.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "houndarr.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "houndarr.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "houndarr.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/charts/houndarr/templates/service.yaml
+++ b/charts/houndarr/templates/service.yaml
@@ -1,0 +1,19 @@
+{{/*
+Headless service required by the StatefulSet for stable DNS entries.
+Pods are addressable as <pod-name>.<service-name>.<namespace>.svc.cluster.local.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "houndarr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "houndarr.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "houndarr.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/charts/houndarr/templates/statefulset.yaml
+++ b/charts/houndarr/templates/statefulset.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "houndarr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "houndarr.labels" . | nindent 4 }}
+spec:
+  # SQLite: do not scale beyond 1. Multiple replicas would corrupt the database.
+  replicas: 1
+  serviceName: {{ include "houndarr.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "houndarr.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "houndarr.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if eq .Values.securityMode "nonroot" }}
+      # nonroot mode: Kubernetes enforces user/group identity via securityContext.
+      # PUID and PGID env vars are not used in this mode.
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+      {{- end }}
+      containers:
+        - name: houndarr
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if eq .Values.securityMode "nonroot" }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: TZ
+              value: {{ .Values.timezone | quote }}
+            {{- if eq .Values.securityMode "compat" }}
+            # compat mode: entrypoint remaps UID/GID and drops privileges via gosu.
+            - name: PUID
+              value: {{ .Values.puid | quote }}
+            - name: PGID
+              value: {{ .Values.pgid | quote }}
+            {{- end }}
+            {{- if .Values.env.secureCookies }}
+            - name: HOUNDARR_SECURE_COOKIES
+              value: "true"
+            {{- end }}
+            {{- if .Values.env.trustedProxies }}
+            - name: HOUNDARR_TRUSTED_PROXIES
+              value: {{ .Values.env.trustedProxies | quote }}
+            {{- end }}
+            {{- if ne .Values.env.authMode "builtin" }}
+            - name: HOUNDARR_AUTH_MODE
+              value: {{ .Values.env.authMode | quote }}
+            {{- end }}
+            {{- if .Values.env.authProxyHeader }}
+            - name: HOUNDARR_AUTH_PROXY_HEADER
+              value: {{ .Values.env.authProxyHeader | quote }}
+            {{- end }}
+            {{- if ne .Values.env.logLevel "info" }}
+            - name: HOUNDARR_LOG_LEVEL
+              value: {{ .Values.env.logLevel | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        {{- if .Values.persistence.storageClassName }}
+        storageClassName: {{ .Values.persistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}

--- a/charts/houndarr/values.yaml
+++ b/charts/houndarr/values.yaml
@@ -1,0 +1,86 @@
+# -- Container image settings.
+image:
+  repository: ghcr.io/av1155/houndarr
+  # -- Overrides the image tag. Defaults to the chart's appVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# -- Timezone passed as the TZ environment variable.
+timezone: UTC
+
+# -- Security mode for the container.
+# "compat" (default): container starts as root, remaps UID/GID via PUID/PGID,
+# then drops to a non-root user. Works on most clusters.
+# "nonroot": enforces a pod-level securityContext with runAsUser/fsGroup.
+# Suitable for clusters with Pod Security Standards (restricted profile).
+# When using "nonroot", PUID and PGID are ignored.
+securityMode: compat
+
+# -- UID to run the application as. Only used when securityMode is "compat".
+puid: 1000
+# -- GID to run the application as. Only used when securityMode is "compat".
+pgid: 1000
+
+# -- Houndarr application environment variables.
+env:
+  # -- Set HOUNDARR_SECURE_COOKIES=true. Required when serving over HTTPS.
+  secureCookies: false
+  # -- Comma-separated list of trusted proxy IPs or CIDR subnets.
+  # Sets HOUNDARR_TRUSTED_PROXIES. Required when behind a reverse proxy or Ingress.
+  trustedProxies: ""
+  # -- Authentication mode. "builtin" uses the built-in bcrypt login form.
+  # "proxy" delegates auth to an upstream SSO proxy via a header.
+  authMode: builtin
+  # -- Header name carrying the authenticated username in proxy auth mode.
+  # Example: "Remote-User", "X-authentik-username". Sets HOUNDARR_AUTH_PROXY_HEADER.
+  authProxyHeader: ""
+  # -- Log verbosity. One of: debug, info, warning, error.
+  logLevel: info
+
+# -- Persistent volume for /data (SQLite database and encryption master key).
+persistence:
+  # -- Storage size for the PVC.
+  size: 1Gi
+  # -- StorageClass name. Empty string uses the cluster's default StorageClass.
+  storageClassName: ""
+  accessMode: ReadWriteOnce
+
+# -- Resource requests and limits.
+resources:
+  requests:
+    memory: 64Mi
+    cpu: 100m
+  limits:
+    memory: 256Mi
+    cpu: 500m
+
+# -- Service port. Matches the container's default port (8877).
+service:
+  port: 8877
+
+# -- Ingress configuration. Disabled by default.
+ingress:
+  enabled: false
+  # -- IngressClass name (e.g., "nginx", "traefik").
+  className: ""
+  # -- Annotations for the Ingress resource (e.g., cert-manager, nginx rewrites).
+  annotations: {}
+  # -- Hostname for the Ingress rule.
+  host: houndarr.example.com
+  tls:
+    enabled: false
+    # -- Name of the TLS secret.
+    secretName: houndarr-tls
+
+# -- Additional environment variables injected verbatim into the container.
+# Useful for advanced settings not covered by the values above.
+# Example:
+# extraEnv:
+#   - name: HOUNDARR_PORT
+#     value: "9000"
+extraEnv: []
+
+# -- Optional name override for chart resources.
+nameOverride: ""
+# -- Optional full name override for chart resources.
+fullnameOverride: ""

--- a/website/docs/getting-started/helm.md
+++ b/website/docs/getting-started/helm.md
@@ -1,0 +1,148 @@
+---
+sidebar_position: 4
+title: Helm
+description: Install Houndarr with Helm or manage it via Flux using the official OCI chart.
+---
+
+# Helm
+
+The official Houndarr Helm chart is published to GHCR as an OCI artifact and works with both plain `helm` and Flux.
+
+:::warning
+Houndarr uses SQLite. Only one replica is supported — do not scale beyond 1.
+:::
+
+## Prerequisites
+
+- Helm 3.8 or later (OCI registry support is required)
+- A Kubernetes cluster
+- A namespace: `kubectl create namespace houndarr`
+
+## Installing with Helm
+
+Install directly from the OCI registry:
+
+```bash
+helm install houndarr \
+  oci://ghcr.io/av1155/charts/houndarr \
+  --version 1.4.0 \
+  --namespace houndarr \
+  --create-namespace
+```
+
+### Common overrides
+
+**Non-root mode** (for clusters with Pod Security Standards):
+
+```bash
+helm install houndarr oci://ghcr.io/av1155/charts/houndarr \
+  --version 1.4.0 \
+  --namespace houndarr \
+  --set securityMode=nonroot
+```
+
+**With Ingress and TLS** (replace CIDRs with your Ingress controller's pod CIDR):
+
+```bash
+helm install houndarr oci://ghcr.io/av1155/charts/houndarr \
+  --version 1.4.0 \
+  --namespace houndarr \
+  --set ingress.enabled=true \
+  --set ingress.host=houndarr.example.com \
+  --set ingress.tls.enabled=true \
+  --set ingress.tls.secretName=houndarr-tls \
+  --set env.secureCookies=true \
+  --set "env.trustedProxies=10.244.0.0/16"
+```
+
+### Upgrading
+
+```bash
+helm upgrade houndarr oci://ghcr.io/av1155/charts/houndarr \
+  --version <new-version> \
+  --namespace houndarr \
+  --reuse-values
+```
+
+:::danger
+Back up the `/data` PVC before upgrading. It contains the Fernet encryption master key (`houndarr.masterkey`). Loss of the master key makes all stored *arr API keys unrecoverable.
+:::
+
+## Flux HelmRelease (OCI)
+
+Use `OCIRepository` (not `HelmRepository` with `type: oci` — that API is in maintenance mode per the Flux docs) to consume the chart in Flux.
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: houndarr
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: oci://ghcr.io/av1155/charts/houndarr
+  ref:
+    semver: ">=1.4.0 <2.0.0"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: houndarr
+  namespace: houndarr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: houndarr
+    namespace: flux-system
+  values:
+    timezone: America/New_York
+    env:
+      secureCookies: true
+      trustedProxies: "10.244.0.0/16"
+    ingress:
+      enabled: true
+      className: nginx
+      host: houndarr.example.com
+      tls:
+        enabled: true
+        secretName: houndarr-tls
+```
+
+The `chartRef` field (instead of `chart.spec.sourceRef`) is what connects a `HelmRelease` to an `OCIRepository` source in Flux.
+
+## Values reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `ghcr.io/av1155/houndarr` | Container image repository |
+| `image.tag` | `""` | Image tag. Defaults to the chart's `appVersion` when empty |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `timezone` | `UTC` | Timezone (`TZ` env var) |
+| `securityMode` | `compat` | `compat` (PUID/PGID remapping) or `nonroot` (pod securityContext) |
+| `puid` | `1000` | UID for compat mode |
+| `pgid` | `1000` | GID for compat mode |
+| `env.secureCookies` | `false` | Set `HOUNDARR_SECURE_COOKIES=true`. Required for HTTPS |
+| `env.trustedProxies` | `""` | Comma-separated CIDRs for `HOUNDARR_TRUSTED_PROXIES` |
+| `env.authMode` | `builtin` | `HOUNDARR_AUTH_MODE`: `builtin` or `proxy` |
+| `env.authProxyHeader` | `""` | `HOUNDARR_AUTH_PROXY_HEADER` (e.g., `Remote-User`) |
+| `env.logLevel` | `info` | `HOUNDARR_LOG_LEVEL`: `debug`, `info`, `warning`, `error` |
+| `persistence.size` | `1Gi` | PVC size |
+| `persistence.storageClassName` | `""` | StorageClass. Empty uses the cluster default |
+| `persistence.accessMode` | `ReadWriteOnce` | PVC access mode |
+| `resources.requests.memory` | `64Mi` | Memory request |
+| `resources.requests.cpu` | `100m` | CPU request |
+| `resources.limits.memory` | `256Mi` | Memory limit |
+| `resources.limits.cpu` | `500m` | CPU limit |
+| `service.port` | `8877` | Service port |
+| `ingress.enabled` | `false` | Enable Ingress |
+| `ingress.className` | `""` | `ingressClassName` |
+| `ingress.annotations` | `{}` | Ingress annotations |
+| `ingress.host` | `houndarr.example.com` | Ingress hostname |
+| `ingress.tls.enabled` | `false` | Enable TLS in the Ingress |
+| `ingress.tls.secretName` | `houndarr-tls` | TLS secret name |
+| `extraEnv` | `[]` | Additional environment variables injected verbatim |
+| `nameOverride` | `""` | Override the chart name portion of resource names |
+| `fullnameOverride` | `""` | Override the full resource name |
+
+For the two security modes and their trade-offs, see the [Kubernetes guide](./kubernetes).

--- a/website/docs/getting-started/kubernetes.md
+++ b/website/docs/getting-started/kubernetes.md
@@ -12,6 +12,8 @@ Houndarr can run on Kubernetes using a StatefulSet with persistent storage.
 Houndarr uses SQLite. Only one replica is supported — do not scale beyond 1.
 :::
 
+Prefer Helm or Flux? See the [Helm guide](./helm) for chart-based installation.
+
 ## Manifests
 
 Apply all resources with `kubectl apply -f houndarr.yaml`. The sections below
@@ -294,5 +296,5 @@ kubectl exec -n houndarr houndarr-0 -- wget -qO- http://localhost:8877/api/healt
 
 ## Helm
 
-There is no official Helm chart yet. If you'd like to contribute one, [open an
-issue on GitHub](https://github.com/av1155/houndarr/issues).
+An official Helm chart is available. See the [Helm guide](./helm) for chart
+installation and Flux HelmRelease configuration.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -10,6 +10,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/quick-start',
         'getting-started/installation',
         'getting-started/kubernetes',
+        'getting-started/helm',
         'getting-started/first-run-setup',
       ],
     },


### PR DESCRIPTION
Adds an official Helm chart and chart publish workflow. Extends the Kubernetes docs from #251.

## What changed

- `charts/houndarr/` — StatefulSet (replicas hardcoded to 1), `volumeClaimTemplates` for `/data`, compat and nonroot security modes, headless + ClusterIP services, optional Ingress, post-install NOTES
- `.github/workflows/chart.yml` — packages and pushes chart to `oci://ghcr.io/av1155/charts` on `v*` tag push; reads version from `VERSION` file so no manual `Chart.yaml` edits are needed at release time
- `website/docs/getting-started/helm.md` — Helm install guide, Flux `OCIRepository` + `HelmRelease` example, values reference table
- `website/docs/getting-started/kubernetes.md` — cross-reference note pointing to the new Helm guide
- `website/sidebars.ts` — adds Helm page after Kubernetes in Getting Started
- `CLAUDE.md` — adds `chart.yml` to the additional workflows table and release flow

## Release integration

The existing version bump process is unchanged (`VERSION` + `CHANGELOG.md` only). On `v*` tag push, `chart.yml` fires alongside `docker.yml` and `release.yml`, publishing the chart automatically.

Closes #260