### PR TITLE
feat(engine): add opt-in upgrade search pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ website/.docusaurus/
 
 # uv lock file (project uses requirements.txt — uv is a local dev runner)
 uv.lock
+
+# Git worktrees (local development only)
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Houndarr
+# AGENTS.md: Houndarr
 
 Coding-agent reference for the Houndarr repository.
 This file is the primary source of truth for autonomous agents operating here.
@@ -6,15 +6,16 @@ This file is the primary source of truth for autonomous agents operating here.
 ## Project Overview
 
 Houndarr is a self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and
-Whisparr that automatically searches for missing and cutoff-unmet media in
-small, rate-limited batches. It runs as a single Docker container alongside
+Whisparr that automatically searches for missing, cutoff-unmet, and
+upgrade-eligible media in small, rate-limited batches. It runs as a single Docker container alongside
 an existing *arr stack.
 
 **Tech stack:** Python 3.12 / FastAPI / aiosqlite (SQLite) / Jinja2 / HTMX /
 Tailwind CSS CDN. Published to GHCR at `ghcr.io/av1155/houndarr`.
 
 **Scope guard:** Houndarr is a single-purpose tool. Every change must help
-search for missing or cutoff-unmet media in a controlled, polite way.
+search for missing, cutoff-unmet, or upgrade-eligible media in a controlled,
+polite way.
 Do not add download-client integration, indexer management, request workflows,
 multi-user support, or media file manipulation.
 
@@ -29,7 +30,7 @@ python3 -m venv .venv
 .venv/bin/pip install -r requirements-dev.txt
 .venv/bin/pip install -e .
 
-# Run locally (dev mode — auto-reload, API docs at /docs)
+# Run locally (dev mode; auto-reload, API docs at /docs)
 .venv/bin/python -m houndarr --data-dir ./data-dev --dev
 ```
 
@@ -54,7 +55,7 @@ Run **all five** before every commit. CI enforces the same checks.
 ## Running Tests
 
 ```bash
-# Full suite (600 tests, async — count includes parametrised expansions)
+# Full suite (600 tests, async; count includes parametrised expansions)
 .venv/bin/pytest
 
 # Single file
@@ -75,15 +76,15 @@ Run **all five** before every commit. CI enforces the same checks.
 
 **Pytest config** (from `pyproject.toml`):
 
-- `asyncio_mode = "auto"` — async tests run without manual event-loop setup
-- `asyncio_default_fixture_loop_scope = "function"` — each test gets its own loop
-- `addopts = "-q --tb=short"` — default quiet output with short tracebacks
+- `asyncio_mode = "auto"`: async tests run without manual event-loop setup
+- `asyncio_default_fixture_loop_scope = "function"`: each test gets its own loop
+- `addopts = "-q --tb=short"`: default quiet output with short tracebacks
 
 ---
 
 ## CI Checks
 
-### Required checks (10 — branch protection enforced)
+### Required checks (10; branch protection enforced)
 
 | Check name | Workflow file | What it runs |
 |------------|---------------|--------------|
@@ -93,10 +94,10 @@ Run **all five** before every commit. CI enforces the same checks.
 | Test (Python 3.12) | `tests.yml` | `pytest -q --tb=short` + compile check + `--help` |
 | Dependency audit (pip-audit) | `security.yml` | `pip-audit -r requirements.txt -r requirements-dev.txt` |
 | SAST (bandit) | `security.yml` | `bandit -r src/ -c pyproject.toml` |
-| Trivy filesystem scan | `security.yml` | `trivy fs .` — CRITICAL/HIGH with known fix |
+| Trivy filesystem scan | `security.yml` | `trivy fs .` (CRITICAL/HIGH with known fix) |
 | Dependency review | `dependency-review.yml` | PR dependency diff vs GitHub Advisory Database |
 | Build (no push) | `docker.yml` | Multi-arch Docker build (amd64/arm64), no push |
-| Trivy image scan | `docker.yml` | Trivy scan of built Docker image — CRITICAL/HIGH with known fix |
+| Trivy image scan | `docker.yml` | Trivy scan of built Docker image (CRITICAL/HIGH with known fix) |
 
 The five main workflows (`quality`, `tests`, `security`, `dependency-review`,
 `docker`) use `paths-ignore: ["docs/**", "*.md", "website/**"]`. When a PR
@@ -119,7 +120,7 @@ identical check names so branch protection is satisfied.
 
 ### Branch protection on `main`
 
-- 10 required status checks (strict — branch must be up to date)
+- 10 required status checks (strict; branch must be up to date)
 - Required PR reviews enabled (dismiss stale reviews, required conversation resolution)
 - Linear history enforced (no merge commits)
 - No force pushes, no branch deletions
@@ -135,7 +136,13 @@ identical check names so branch protection is satisfied.
 - **Line length:** 100 characters
 - **Indentation:** 4 spaces (2 for YAML/JSON/TOML)
 - **Target Python:** 3.12+ (`target-version = "py312"` in `pyproject.toml`)
-- **Linter/formatter:** Ruff — selected rule sets: `E W F I B C4 UP SIM ANN S N`
+- **Linter/formatter:** Ruff; selected rule sets: `E W F I B C4 UP SIM ANN S N`
+
+### Punctuation
+
+Never use em dashes (`—`) anywhere in source code, comments, HTML templates,
+or documentation. Replace with a colon, semicolon, comma, period, or
+parentheses depending on the context.
 
 ### Imports
 
@@ -162,11 +169,11 @@ from houndarr.database import get_db
 
 ### Type Annotations
 
-- **mypy strict mode** — all public functions need full signatures
+- **mypy strict mode**: all public functions need full signatures
 - Modern union syntax: `str | None`, not `Optional[str]`
 - Builtin generics: `list[str]`, `dict[str, Any]`, not `List`/`Dict`
 - `collections.abc.AsyncGenerator`, not `typing.AsyncGenerator`
-- Specific error codes: `# type: ignore[assignment]` — never bare `# type: ignore`
+- Specific error codes: `# type: ignore[assignment]`; never bare `# type: ignore`
 - Tests are exempt from `ANN` rules (per-file-ignores in `pyproject.toml`)
 
 ### Naming Conventions
@@ -196,7 +203,7 @@ No alternative logging libraries (structlog, loguru) are used.
 ### Error Handling
 
 - **Background tasks:** `except asyncio.CancelledError: raise` first, then
-  broad `except Exception` with `# noqa: BLE001` — log + continue/retry
+  broad `except Exception` with `# noqa: BLE001`; log + continue/retry
 - **HTTP clients:** `response.raise_for_status()` in `_get()`/`_post()`;
   callers catch `httpx.HTTPError` or `httpx.TransportError`
 - **Auth helpers:** catch-all returns `False` (never leaks info)
@@ -214,8 +221,8 @@ No alternative logging libraries (structlog, loguru) are used.
 | `BLE001` | Broad exception in background loops (always with logging) |
 | `A002` | Parameter names `type`/`id` shadowing builtins (FastAPI form/function signature convention) |
 | `SLF001` | Test fixtures and `__main__.py` accessing private module state |
-| `PLW0603` | Module-level global reassignment (singletons) — note: the `PLW` rule family is not currently selected in ruff config, so these comments are defensive/inert |
-| `S101` | Defensive assert in adapters and instance validation — also globally ignored in ruff config; per-file comments are defensive |
+| `PLW0603` | Module-level global reassignment (singletons); the `PLW` rule family is not currently selected in ruff config, so these comments are defensive/inert |
+| `S101` | Defensive assert in adapters and instance validation; also globally ignored in ruff config. Per-file comments are defensive. |
 
 ---
 
@@ -240,8 +247,8 @@ src/houndarr/
     whisparr.py        # WhisparrClient (episode/season search, v3 API)
   engine/
     candidates.py      # SearchCandidate dataclass, ItemType, date helpers
-    search_loop.py     # run_instance_search() — unified search pipeline (queue-backpressure gate)
-    supervisor.py      # Supervisor — one asyncio.Task per enabled instance
+    search_loop.py     # run_instance_search(): unified search pipeline (missing/cutoff/upgrade passes, queue-backpressure gate)
+    supervisor.py      # Supervisor: one asyncio.Task per enabled instance
     adapters/
       __init__.py      # AppAdapter dataclass, ADAPTERS registry, get_adapter()
       sonarr.py        # Sonarr adapter: candidate conversion + dispatch
@@ -264,15 +271,15 @@ src/houndarr/
 
 ### Key patterns
 
-- **Database:** SQLite via aiosqlite; schema version 7; `get_db()` async
+- **Database:** SQLite via aiosqlite; schema version 8; `get_db()` async
   context manager opens a fresh connection per call (WAL mode, FKs enabled)
 - **Config:** `AppSettings` is a plain dataclass (not Pydantic); `get_settings()`
   is a lazy singleton
 - **Encryption:** Master key in `request.app.state.master_key`; passed
-  explicitly to service functions as `master_key=` kwarg — never imported globally
+  explicitly to service functions as `master_key=` kwarg; never imported globally
 - **Auth:** Global `AuthMiddleware` (Starlette `BaseHTTPMiddleware`) handles
   session validation and CSRF enforcement; no per-route auth decorators
-- **HTMX:** SPA-like shell navigation — nav links use `hx-target="#app-content"`
+- **HTMX:** SPA-like shell navigation; nav links use `hx-target="#app-content"`
   with `hx-swap="innerHTML"` and `hx-push-url="true"`. Routes check
   `_is_hx_request(request)` and return either partial or full template.
   Templates are lazily initialised via a module-level singleton
@@ -280,28 +287,28 @@ src/houndarr/
 - **search_log:** Every search attempt writes a row with action
   `searched`/`skipped`/`error`/`info`
 
-### Database schema (SQLite, schema version 7)
+### Database schema (SQLite, schema version 8)
 
 | Table | Purpose | Key constraints |
 |-------|---------|-----------------|
 | `settings` | Key-value config store | `key TEXT PK` |
-| `instances` | *arr instance configs | `type CHECK IN ('radarr','sonarr','lidarr','readarr','whisparr')`; per-type `*_search_mode` columns with CHECK constraints; `post_release_grace_hrs` (default 6); `queue_limit` (default 0) |
+| `instances` | *arr instance configs | `type CHECK IN ('radarr','sonarr','lidarr','readarr','whisparr')`; per-type `*_search_mode` columns with CHECK constraints; `post_release_grace_hrs` (default 6); `queue_limit` (default 0); `upgrade_enabled` (default 0) with per-type `upgrade_*_search_mode`, `upgrade_batch_size`, `upgrade_cooldown_days`, `upgrade_hourly_cap`, `upgrade_item_offset`, `upgrade_series_offset` columns |
 | `cooldowns` | Per-item search cooldown tracking | `instance_id FK→instances ON DELETE CASCADE`; `UNIQUE(instance_id, item_id, item_type)` |
 | `search_log` | Audit trail for every search cycle | `instance_id FK→instances ON DELETE SET NULL`; `action CHECK IN ('searched','skipped','error','info')` |
 
 Full DDL, column definitions, indexes, and migrations (`_migrate_to_v2`
-through `_migrate_to_v7`) are in `src/houndarr/database.py`. Bump
+through `_migrate_to_v8`) are in `src/houndarr/database.py`. Bump
 `SCHEMA_VERSION` when adding new migrations.
 
 ### *arr API reference (local)
 
 Full upstream OpenAPI specs are vendored locally and kept current:
 
-- `docs/api/sonarr_openapi.json` — Sonarr v3 API (OpenAPI 3.0.1)
-- `docs/api/radarr_openapi.json` — Radarr v3 API (OpenAPI 3.0.4)
-- `docs/api/whisparr_openapi.json` — Whisparr v3 API (OpenAPI 3.0.1)
-- `docs/api/lidarr_openapi.json` — Lidarr v1 API (OpenAPI 3.0.4)
-- `docs/api/readarr_openapi.json` — Readarr v1 API (OpenAPI 3.0.1)
+- `docs/api/sonarr_openapi.json`: Sonarr v3 API (OpenAPI 3.0.1)
+- `docs/api/radarr_openapi.json`: Radarr v3 API (OpenAPI 3.0.4)
+- `docs/api/whisparr_openapi.json`: Whisparr v3 API (OpenAPI 3.0.1)
+- `docs/api/lidarr_openapi.json`: Lidarr v1 API (OpenAPI 3.0.4)
+- `docs/api/readarr_openapi.json`: Readarr v1 API (OpenAPI 3.0.1)
 
 **Use these as the source of truth** when modifying or creating *arr client
 code. They document every endpoint, parameter, request body, and response
@@ -310,7 +317,7 @@ schema. See `docs/api/README.md` for usage guidelines.
 All five specs are actively used by their respective clients in `clients/`.
 
 **Freshness:** `api-snapshot-refresh.yml` auto-fetches all five upstream
-specs weekly (Monday 10:00 UTC) and opens a PR if changed — local specs
+specs weekly (Monday 10:00 UTC) and opens a PR if changed; local specs
 are never more than one week stale.
 
 ---
@@ -319,7 +326,7 @@ are never more than one week stale.
 
 - **Framework:** pytest + pytest-asyncio (`asyncio_mode = "auto"`)
 - **Async tests:** use `@pytest.mark.asyncio()` (with parens), return `-> None`
-- **HTTP mocking:** `respx` for httpx calls — use `@respx.mock` decorator
+- **HTTP mocking:** `respx` for httpx calls; use `@respx.mock` decorator
 - **App testing:** `TestClient` (sync) or `AsyncClient` via `ASGITransport`
 
 ### Fixture dependency graph
@@ -332,7 +339,7 @@ tmp_data_dir          (temp directory, no deps)
         └── async_client (AsyncClient, depends on test_settings)
 ```
 
-`db` and `test_settings` are **siblings** — both depend on `tmp_data_dir`
+`db` and `test_settings` are **siblings**; both depend on `tmp_data_dir`
 independently. Tests that need a database AND the app must request both
 `db` and `app` (or use fixtures that depend on `db`).
 
@@ -406,7 +413,7 @@ Examples:
 - `feat: add persistent shell navigation`
 - `chore: bump version to 1.0.4`
 
-**Issue label policy — every issue must have:**
+**Issue label policy; every issue must have:**
 - Exactly one `type:*` label (`type: bug`, `type: feature`, `type: docs`,
   `type: chore`, `type: test`, `type: ci`, `type: security`)
 - Exactly one `priority:*` label (`priority: high`, `priority: medium`,
@@ -463,8 +470,8 @@ Subject line max 50 characters (including the `type(scope): ` prefix); body line
 `VERSION` and `CHANGELOG.md` are the single source of truth. Everything else
 (GitHub Releases, Docker tags, GHCR `latest`) is derived automatically.
 
-- `VERSION` — one line, plain `X.Y.Z` (no `v` prefix)
-- `CHANGELOG.md` — Keep a Changelog format
+- `VERSION`: one line, plain `X.Y.Z` (no `v` prefix)
+- `CHANGELOG.md`: Keep a Changelog format
 
 ### Release workflow
 
@@ -511,7 +518,7 @@ Level-4 `####` subheadings may group items within `###` sections for major
 releases.
 
 **Bullet rules:**
-- One sentence per bullet — no multi-line prose
+- One sentence per bullet; no multi-line prose
 - Lead with user-facing impact, not implementation details
 - End with `(#N)` issue/PR reference
 - Use backticks for identifiers, file names, env vars, UI elements
@@ -540,19 +547,19 @@ and after). Do not use `## [Unreleased]`.
 2. Create a GitHub issue first with clear acceptance criteria.
 3. Apply mandatory labels on the issue before starting work.
 4. Create a scoped branch (`type/short-slug`) from `main`.
-5. Implement only issue-scoped changes — avoid mixed concerns.
+5. Implement only issue-scoped changes; avoid mixed concerns.
 6. Run all five quality gates before committing.
 7. Open a scoped PR linking the issue (`Closes #N`).
 8. Merge only after all required checks pass.
 
 ### What not to change casually
 
-- `VERSION` and `CHANGELOG.md` — only in dedicated version bump PRs
+- `VERSION` and `CHANGELOG.md`: only in dedicated version bump PRs
 - `pyproject.toml` tool config (ruff rules, mypy strictness, pytest settings)
-- `.github/workflows/` — changes trigger workflow-lint and may affect required checks
-- `src/houndarr/database.py` schema migrations — requires `SCHEMA_VERSION` bump
-- `tests/conftest.py` shared fixtures — changes affect all test files
-- `requirements.txt` / `requirements-dev.txt` — dependency changes require
+- `.github/workflows/`: changes trigger workflow-lint and may affect required checks
+- `src/houndarr/database.py` schema migrations: requires `SCHEMA_VERSION` bump
+- `tests/conftest.py` shared fixtures: changes affect all test files
+- `requirements.txt` / `requirements-dev.txt`: dependency changes require
   `pip-audit` to pass
 
 ### When to add or update tests
@@ -572,9 +579,9 @@ and after). Do not use `## [Unreleased]`.
 
 ### Avoiding CI/release breakage
 
-- Do not modify the 10 required check job names — branch protection depends
+- Do not modify the 10 required check job names; branch protection depends
   on exact name matches
-- Do not add `## [Unreleased]` to CHANGELOG.md — the release workflow
+- Do not add `## [Unreleased]` to CHANGELOG.md; the release workflow
   extracts content between `## [X.Y.Z]` headings
 - Do not change `ci-skip.yml` job names without updating branch protection
 - If mypy CI fails with "merge ref not found": push an empty commit to retrigger
@@ -597,7 +604,7 @@ Currently known minor discrepancies:
 ## Public-Facing Voice
 
 All text posted to GitHub under the maintainer's account must read as if a
-human wrote it. Agents ghostwrite — they do not narrate, report, or
+human wrote it. Agents ghostwrite; they do not narrate, report, or
 self-identify.
 
 ### Prohibited in all GitHub-visible text
@@ -623,7 +630,7 @@ Never include:
   something was NOT found)
 - Quality-gate recitation with exact tool names and test counts
   (`"All 5 quality gates pass: ruff check, ruff format, mypy strict,
-  bandit SAST, pytest (312 tests)"` — just say `"all checks pass"`)
+  bandit SAST, pytest (312 tests)"`: just say `"all checks pass"`)
 - grep/search verification as proof (`"grep -ri returns zero matches"`)
 - Post-merge instruction lists in PR bodies
 - `"Follow-up recommendations (not in this PR)"` sections
@@ -641,7 +648,7 @@ Never include:
 - PR template checklist: only check items that actually apply. Leave
   inapplicable items unchecked or mark `N/A`.
 - Comments: short and human (`"Done"`, `"Fixed in abc1234"`, `"Merged"`).
-- Commit messages: follow Conventional Commits. Body optional — if present,
+- Commit messages: follow Conventional Commits. Body optional; if present,
   explain why, not what the agent did.
 - CHANGELOG: follow existing bullet rules (already defined above).
 
@@ -659,7 +666,7 @@ They must never appear in any GitHub-visible artifact.
 ### Documentation voice
 
 All user-facing documentation (website pages, README, CONTRIBUTING, SECURITY,
-in-app help text) must read as if a single human maintainer wrote it — direct,
+in-app help text) must read as if a single human maintainer wrote it: direct,
 concise, and conversational. Documentation should feel authored, not assembled.
 
 **Prohibited in documentation:**
@@ -673,7 +680,7 @@ concise, and conversational. Documentation should feel authored, not assembled.
 - Worked examples that read like textbook exercises (step-by-step arithmetic
   with bold emphasis on each subtraction)
 - Exhaustive enumeration of things that are absent (listing many specific
-  analytics services that are not used — just say "no analytics or error
+  analytics services that are not used; just say "no analytics or error
   tracking")
 - FAQ questions that feel reverse-engineered from a prompt rather than
   sourced from real user confusion
@@ -705,7 +712,7 @@ clearly, and trust the reader.
 
 - Write as a maintainer explaining their own tool to a peer.
 - Be concise. Prefer short paragraphs and direct statements.
-- Vary phrasing across pages — do not use the same sentence structure
+- Vary phrasing across pages; do not use the same sentence structure
   to explain similar concepts.
 - Use callouts and admonitions sparingly.
 - Headings should be descriptive or action-oriented, not reassuring

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="src/houndarr/static/img/houndarr-logo-dark.png" alt="Houndarr logo" width="220" />
 </p>
 
-> A focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches.
+> A focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing and upgrade-eligible media in polite, controlled batches.
 >
 > **[Documentation](https://av1155.github.io/houndarr/)** | **[Quick Start](https://av1155.github.io/houndarr/docs/getting-started/quick-start)**
 
@@ -27,6 +27,7 @@ It runs as a single Docker container alongside your existing *arr stack.
 - Connects to one or more Radarr, Sonarr, Lidarr, Readarr, and Whisparr instances
 - Searches for **missing** episodes, movies, albums, and books in small, configurable batches
 - Searches for **cutoff-unmet** items (below your quality profile) separately
+- Optional **library upgrade** pass re-searches items that already meet cutoff, letting your *arr instance find better releases based on quality profiles and custom formats
 - Radarr: movie-level search
 - Sonarr: episode-level search by default, with optional season-context mode
 - Lidarr: album-level search by default, with optional artist-context mode
@@ -42,11 +43,11 @@ It runs as a single Docker container alongside your existing *arr stack.
 
 ## What Houndarr Does Not Do
 
-- **No download-client integration** — it triggers searches in your *arr instances, which handle downloads
-- **No Prowlarr/indexer management** — your *arr instances manage their own indexers
-- **No request workflows** — no Overseerr/Ombi-style request handling
-- **No multi-user support** — single admin username and password
-- **No media file manipulation** — it never touches your library files
+- **No download-client integration**: it triggers searches in your *arr instances, which handle downloads
+- **No Prowlarr/indexer management**: your *arr instances manage their own indexers
+- **No request workflows**: no Overseerr/Ombi-style request handling
+- **No multi-user support**: single admin username and password
+- **No media file manipulation**: it never touches your library files
 
 ---
 
@@ -124,7 +125,7 @@ should store its database and master key.
 | `PGID` | `1000` | Group ID for file ownership inside the container |
 | `TZ` | `UTC` | Container timezone (e.g. `America/New_York`) |
 
-> **Note — LXC / Proxmox / root-based hosts:** If your Docker host runs containers
+> **Note (LXC / Proxmox / root-based hosts):** If your Docker host runs containers
 > as root (a common setup in Proxmox LXC containers), set `PUID=0` and `PGID=0`.
 > Houndarr will skip the privilege-drop and run directly as root, matching the
 > security posture of the rest of your stack. A warning will be printed to stdout
@@ -153,7 +154,7 @@ for setup examples and security requirements.
 2. Create an admin username and password on the setup screen.
 3. Log in with your new credentials.
 4. Go to **Settings** and add your *arr instances (URL + API key).
-5. Enable each instance — Houndarr will begin searching on the configured schedule.
+5. Enable each instance. Houndarr will begin searching on the configured schedule.
 
 For detailed per-instance configuration options, see the
 [Instance Settings Guide](https://av1155.github.io/houndarr/docs/configuration/instance-settings).
@@ -206,4 +207,4 @@ To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/src/houndarr/__init__.py
+++ b/src/houndarr/__init__.py
@@ -1,4 +1,4 @@
-"""Houndarr — focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr."""
+"""Houndarr: focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr."""
 
 from pathlib import Path
 

--- a/src/houndarr/__main__.py
+++ b/src/houndarr/__main__.py
@@ -102,7 +102,7 @@ def cli(
     auth_mode: str,
     auth_proxy_header: str,
 ) -> None:
-    """Houndarr — search for missing media in your *arr stack, politely.
+    """Houndarr: search for missing media in your *arr stack, politely.
 
     A focused self-hosted companion that automatically triggers searches for
     missing and cutoff-unmet media in controlled batches, keeping your

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -78,7 +78,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Warn if no instances are configured yet
     instances = await list_instances(master_key=app.state.master_key)
     if not instances:
-        logger.warning("No instances configured — visit the Settings page to add an instance")
+        logger.warning("No instances configured. Visit the Settings page to add an instance.")
 
     # Start the background search supervisor
     supervisor = Supervisor(master_key=app.state.master_key)

--- a/src/houndarr/auth.py
+++ b/src/houndarr/auth.py
@@ -565,7 +565,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 status_code=401,
             )
 
-        # Authenticated — store username on request state for downstream use
+        # Authenticated: store username on request state for downstream use
         request.state.proxy_auth_user = username
 
         # CSRF check on state-changing methods

--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -103,7 +103,7 @@ class ArrClient(ABC):
     async def get_queue_status(self) -> dict[str, Any]:
         """Fetch the download queue status from the *arr instance.
 
-        Returns a dict with at least ``totalCount`` (int) — the total number
+        Returns a dict with at least ``totalCount`` (int), the total number
         of items currently in the download queue.  All five *arr apps expose
         an identical ``QueueStatusResource`` schema on this endpoint.
 

--- a/src/houndarr/clients/lidarr.py
+++ b/src/houndarr/clients/lidarr.py
@@ -1,4 +1,4 @@
-"""Lidarr v1 API client — missing albums and automatic search."""
+"""Lidarr v1 API client: missing albums and automatic search."""
 
 from __future__ import annotations
 
@@ -9,7 +9,20 @@ import httpx
 
 from houndarr.clients.base import ArrClient
 
-__all__ = ["LidarrClient", "MissingAlbum"]
+__all__ = ["LidarrClient", "LibraryAlbum", "MissingAlbum"]
+
+
+@dataclass(frozen=True)
+class LibraryAlbum:
+    """An album from Lidarr's full library endpoint."""
+
+    album_id: int
+    artist_id: int
+    artist_name: str
+    title: str
+    monitored: bool
+    has_file: bool
+    release_date: str | None
 
 
 @dataclass(frozen=True)
@@ -112,10 +125,39 @@ class LidarrClient(ArrClient):
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_album(r) for r in records]
 
+    async def get_albums(self) -> list[LibraryAlbum]:
+        """Return the full album library.
+
+        Calls ``GET /api/v1/album`` with ``includeArtist=true``.
+
+        Returns:
+            List of :class:`LibraryAlbum` dataclasses.
+        """
+        records: list[dict[str, Any]] = await self._get(
+            "/api/v1/album",
+            includeArtist="true",
+        )
+        return [_parse_library_album(r) for r in records]
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
 # ---------------------------------------------------------------------------
+
+
+def _parse_library_album(record: dict[str, Any]) -> LibraryAlbum:
+    artist: dict[str, Any] = record.get("artist") or {}
+    stats: dict[str, Any] = record.get("statistics") or {}
+    track_file_count = stats.get("trackFileCount", 0)
+    return LibraryAlbum(
+        album_id=record["id"],
+        artist_id=record.get("artistId") or artist.get("id") or 0,
+        artist_name=artist.get("artistName") or "",
+        title=record.get("title") or "",
+        monitored=bool(record.get("monitored", False)),
+        has_file=track_file_count > 0,
+        release_date=record.get("releaseDate"),
+    )
 
 
 def _parse_album(record: dict[str, Any]) -> MissingAlbum:

--- a/src/houndarr/clients/radarr.py
+++ b/src/houndarr/clients/radarr.py
@@ -1,4 +1,4 @@
-"""Radarr v3 API client — missing movies and automatic search."""
+"""Radarr v3 API client: missing movies and automatic search."""
 
 from __future__ import annotations
 
@@ -9,7 +9,22 @@ import httpx
 
 from houndarr.clients.base import ArrClient
 
-__all__ = ["MissingMovie", "RadarrClient"]
+__all__ = ["LibraryMovie", "MissingMovie", "RadarrClient"]
+
+
+@dataclass(frozen=True)
+class LibraryMovie:
+    """A movie from Radarr's full library endpoint."""
+
+    movie_id: int
+    title: str
+    year: int
+    monitored: bool
+    has_file: bool
+    cutoff_met: bool
+    in_cinemas: str | None
+    physical_release: str | None
+    digital_release: str | None
 
 
 @dataclass(frozen=True)
@@ -101,6 +116,18 @@ class RadarrClient(ArrClient):
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_movie(r) for r in records]
 
+    async def get_library(self) -> list[LibraryMovie]:
+        """Return the full movie library.
+
+        Calls ``GET /api/v3/movie`` and returns all movies with metadata
+        needed for upgrade-pass eligibility filtering.
+
+        Returns:
+            List of :class:`LibraryMovie` dataclasses.
+        """
+        records: list[dict[str, Any]] = await self._get("/api/v3/movie")
+        return [_parse_library_movie(r) for r in records]
+
     async def search_movie(self, movie_id: int) -> None:
         """Alias for :meth:`search` with a more descriptive name."""
         await self.search(movie_id)
@@ -109,6 +136,23 @@ class RadarrClient(ArrClient):
 # ---------------------------------------------------------------------------
 # Parsing helpers
 # ---------------------------------------------------------------------------
+
+
+def _parse_library_movie(record: dict[str, Any]) -> LibraryMovie:
+    has_file = bool(record.get("hasFile", False))
+    movie_file: dict[str, Any] = record.get("movieFile") or {}
+    cutoff_not_met = movie_file.get("qualityCutoffNotMet", True)
+    return LibraryMovie(
+        movie_id=record["id"],
+        title=record.get("title") or "",
+        year=record.get("year", 0),
+        monitored=bool(record.get("monitored", False)),
+        has_file=has_file,
+        cutoff_met=not cutoff_not_met if has_file else False,
+        in_cinemas=record.get("inCinemas"),
+        physical_release=record.get("physicalRelease"),
+        digital_release=record.get("digitalRelease"),
+    )
 
 
 def _parse_movie(record: dict[str, Any]) -> MissingMovie:

--- a/src/houndarr/clients/readarr.py
+++ b/src/houndarr/clients/readarr.py
@@ -1,4 +1,4 @@
-"""Readarr v1 API client — missing books and automatic search."""
+"""Readarr v1 API client: missing books and automatic search."""
 
 from __future__ import annotations
 
@@ -9,7 +9,20 @@ import httpx
 
 from houndarr.clients.base import ArrClient
 
-__all__ = ["MissingBook", "ReadarrClient"]
+__all__ = ["LibraryBook", "MissingBook", "ReadarrClient"]
+
+
+@dataclass(frozen=True)
+class LibraryBook:
+    """A book from Readarr's full library endpoint."""
+
+    book_id: int
+    author_id: int
+    author_name: str
+    title: str
+    monitored: bool
+    has_file: bool
+    release_date: str | None
 
 
 @dataclass(frozen=True)
@@ -112,10 +125,39 @@ class ReadarrClient(ArrClient):
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_book(r) for r in records]
 
+    async def get_books(self) -> list[LibraryBook]:
+        """Return the full book library.
+
+        Calls ``GET /api/v1/book`` with ``includeAuthor=true``.
+
+        Returns:
+            List of :class:`LibraryBook` dataclasses.
+        """
+        records: list[dict[str, Any]] = await self._get(
+            "/api/v1/book",
+            includeAuthor="true",
+        )
+        return [_parse_library_book(r) for r in records]
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
 # ---------------------------------------------------------------------------
+
+
+def _parse_library_book(record: dict[str, Any]) -> LibraryBook:
+    author: dict[str, Any] = record.get("author") or {}
+    stats: dict[str, Any] = record.get("statistics") or {}
+    book_file_count = stats.get("bookFileCount", 0)
+    return LibraryBook(
+        book_id=record["id"],
+        author_id=record.get("authorId") or author.get("id") or 0,
+        author_name=author.get("authorName") or "",
+        title=record.get("title") or "",
+        monitored=bool(record.get("monitored", False)),
+        has_file=book_file_count > 0,
+        release_date=record.get("releaseDate"),
+    )
 
 
 def _parse_book(record: dict[str, Any]) -> MissingBook:

--- a/src/houndarr/clients/sonarr.py
+++ b/src/houndarr/clients/sonarr.py
@@ -1,4 +1,4 @@
-"""Sonarr v3 API client — missing episodes and automatic search."""
+"""Sonarr v3 API client: missing episodes and automatic search."""
 
 from __future__ import annotations
 
@@ -9,7 +9,22 @@ import httpx
 
 from houndarr.clients.base import ArrClient
 
-__all__ = ["MissingEpisode", "SonarrClient"]
+__all__ = ["LibraryEpisode", "MissingEpisode", "SonarrClient"]
+
+
+@dataclass(frozen=True)
+class LibraryEpisode:
+    """An episode from Sonarr's full library with file and cutoff metadata."""
+
+    episode_id: int
+    series_id: int
+    series_title: str
+    episode_title: str
+    season: int
+    episode: int
+    monitored: bool
+    has_file: bool
+    cutoff_met: bool
 
 
 @dataclass(frozen=True)
@@ -113,6 +128,38 @@ class SonarrClient(ArrClient):
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_episode(r) for r in records]
 
+    async def get_series(self) -> list[dict[str, Any]]:
+        """Return the full series list.
+
+        Calls ``GET /api/v3/series``.  Returns raw dicts; only ``id`` and
+        ``monitored`` are needed by the upgrade-pass adapter.
+
+        Returns:
+            List of series dicts from Sonarr.
+        """
+        result: list[dict[str, Any]] = await self._get("/api/v3/series")
+        return result
+
+    async def get_episodes(self, series_id: int) -> list[LibraryEpisode]:
+        """Return all episodes for a series with file and cutoff metadata.
+
+        Calls ``GET /api/v3/episode`` with ``seriesId``,
+        ``includeEpisodeFile=true``, and ``includeSeries=true``.
+
+        Args:
+            series_id: Sonarr series ID.
+
+        Returns:
+            List of :class:`LibraryEpisode` dataclasses.
+        """
+        records: list[dict[str, Any]] = await self._get(
+            "/api/v3/episode",
+            seriesId=series_id,
+            includeEpisodeFile="true",
+            includeSeries="true",
+        )
+        return [_parse_library_episode(r) for r in records]
+
     async def search_episode(self, episode_id: int) -> None:
         """Alias for :meth:`search` with a more descriptive name."""
         await self.search(episode_id)
@@ -121,6 +168,24 @@ class SonarrClient(ArrClient):
 # ---------------------------------------------------------------------------
 # Parsing helpers
 # ---------------------------------------------------------------------------
+
+
+def _parse_library_episode(record: dict[str, Any]) -> LibraryEpisode:
+    series: dict[str, Any] = record.get("series") or {}
+    has_file = bool(record.get("hasFile", False))
+    ep_file: dict[str, Any] = record.get("episodeFile") or {}
+    cutoff_not_met = ep_file.get("qualityCutoffNotMet", True)
+    return LibraryEpisode(
+        episode_id=record["id"],
+        series_id=record.get("seriesId") or series.get("id") or 0,
+        series_title=series.get("title") or "",
+        episode_title=record.get("title") or "",
+        season=record.get("seasonNumber", 0),
+        episode=record.get("episodeNumber", 0),
+        monitored=bool(record.get("monitored", False)),
+        has_file=has_file,
+        cutoff_met=not cutoff_not_met if has_file else False,
+    )
 
 
 def _parse_episode(record: dict[str, Any]) -> MissingEpisode:

--- a/src/houndarr/clients/whisparr.py
+++ b/src/houndarr/clients/whisparr.py
@@ -1,4 +1,4 @@
-"""Whisparr v3 API client — missing episodes and automatic search.
+"""Whisparr v3 API client: missing episodes and automatic search.
 
 Whisparr is a Sonarr fork with the same v3 API structure.  Key differences:
 episodes use a ``DateOnly`` release date object instead of an ISO-8601
@@ -15,7 +15,22 @@ import httpx
 
 from houndarr.clients.base import ArrClient
 
-__all__ = ["MissingWhisparrEpisode", "WhisparrClient"]
+__all__ = ["LibraryWhisparrEpisode", "MissingWhisparrEpisode", "WhisparrClient"]
+
+
+@dataclass(frozen=True)
+class LibraryWhisparrEpisode:
+    """An episode from Whisparr's full library with file and cutoff metadata."""
+
+    episode_id: int
+    series_id: int
+    series_title: str
+    episode_title: str
+    season_number: int
+    absolute_episode_number: int | None
+    monitored: bool
+    has_file: bool
+    cutoff_met: bool
 
 
 @dataclass(frozen=True)
@@ -118,10 +133,60 @@ class WhisparrClient(ArrClient):
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_episode(r) for r in records]
 
+    async def get_series(self) -> list[dict[str, Any]]:
+        """Return the full series list.
+
+        Calls ``GET /api/v3/series``.  Returns raw dicts; only ``id`` and
+        ``monitored`` are needed by the upgrade-pass adapter.
+
+        Returns:
+            List of series dicts from Whisparr.
+        """
+        result: list[dict[str, Any]] = await self._get("/api/v3/series")
+        return result
+
+    async def get_episodes(self, series_id: int) -> list[LibraryWhisparrEpisode]:
+        """Return all episodes for a series with file and cutoff metadata.
+
+        Calls ``GET /api/v3/episode`` with ``seriesId``,
+        ``includeEpisodeFile=true``, and ``includeSeries=true``.
+
+        Args:
+            series_id: Whisparr series ID.
+
+        Returns:
+            List of :class:`LibraryWhisparrEpisode` dataclasses.
+        """
+        records: list[dict[str, Any]] = await self._get(
+            "/api/v3/episode",
+            seriesId=series_id,
+            includeEpisodeFile="true",
+            includeSeries="true",
+        )
+        return [_parse_library_episode(r) for r in records]
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
 # ---------------------------------------------------------------------------
+
+
+def _parse_library_episode(record: dict[str, Any]) -> LibraryWhisparrEpisode:
+    series: dict[str, Any] = record.get("series") or {}
+    has_file = bool(record.get("hasFile", False))
+    ep_file: dict[str, Any] = record.get("episodeFile") or {}
+    cutoff_not_met = ep_file.get("qualityCutoffNotMet", True)
+    return LibraryWhisparrEpisode(
+        episode_id=record["id"],
+        series_id=record.get("seriesId") or series.get("id") or 0,
+        series_title=series.get("title") or "",
+        episode_title=record.get("title") or "",
+        season_number=record.get("seasonNumber", 0),
+        absolute_episode_number=record.get("absoluteEpisodeNumber"),
+        monitored=bool(record.get("monitored", False)),
+        has_file=has_file,
+        cutoff_met=not cutoff_not_met if has_file else False,
+    )
 
 
 def _parse_date_only(obj: dict[str, Any] | None) -> datetime | None:

--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -87,7 +87,7 @@ def _parse_trusted_proxies(raw: str) -> TrustedProxies:
 
 
 # ---------------------------------------------------------------------------
-# Runtime settings — set by CLI before the app factory is called
+# Runtime settings: set by CLI before the app factory is called
 # ---------------------------------------------------------------------------
 
 _runtime_settings: AppSettings | None = None
@@ -138,7 +138,7 @@ class AppSettings:
             ``X-Forwarded-For`` is honoured for client-IP detection (rate
             limiting).  When empty, only the direct connection IP is used.
             Corresponds to ``HOUNDARR_TRUSTED_PROXIES`` env var.
-        auth_mode: Authentication mode — ``builtin`` (default) uses local
+        auth_mode: Authentication mode. ``builtin`` (default) uses local
             session-based auth; ``proxy`` delegates authentication to a
             reverse proxy via a trusted header.
             Corresponds to ``HOUNDARR_AUTH_MODE`` env var.
@@ -225,3 +225,12 @@ DEFAULT_READARR_SEARCH_MODE: str = "book"
 DEFAULT_WHISPARR_SEARCH_MODE: str = "episode"
 DEFAULT_QUEUE_LIMIT: int = 0
 DEFAULT_LOG_RETENTION_DAYS: int = 30
+
+# Upgrade search defaults (third, opt-in pass; very conservative)
+DEFAULT_UPGRADE_BATCH_SIZE: int = 1
+DEFAULT_UPGRADE_COOLDOWN_DAYS: int = 90
+DEFAULT_UPGRADE_HOURLY_CAP: int = 1
+DEFAULT_UPGRADE_SONARR_SEARCH_MODE: str = "episode"
+DEFAULT_UPGRADE_LIDARR_SEARCH_MODE: str = "album"
+DEFAULT_UPGRADE_READARR_SEARCH_MODE: str = "book"
+DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE: str = "episode"

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -11,9 +11,9 @@ import aiosqlite
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Schema version — bump when adding new migrations
+# Schema version: bump when adding new migrations
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 8
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -51,6 +51,21 @@ CREATE TABLE IF NOT EXISTS instances (
                                 CHECK(readarr_search_mode IN ('book', 'author_context')),
     whisparr_search_mode TEXT    NOT NULL DEFAULT 'episode'
                                 CHECK(whisparr_search_mode IN ('episode', 'season_context')),
+    upgrade_enabled      INTEGER NOT NULL DEFAULT 0,
+    upgrade_batch_size   INTEGER NOT NULL DEFAULT 1,
+    upgrade_cooldown_days INTEGER NOT NULL DEFAULT 90,
+    upgrade_hourly_cap   INTEGER NOT NULL DEFAULT 1,
+    upgrade_sonarr_search_mode  TEXT NOT NULL DEFAULT 'episode'
+                                CHECK(upgrade_sonarr_search_mode IN ('episode', 'season_context')),
+    upgrade_lidarr_search_mode  TEXT NOT NULL DEFAULT 'album'
+                                CHECK(upgrade_lidarr_search_mode IN ('album', 'artist_context')),
+    upgrade_readarr_search_mode TEXT NOT NULL DEFAULT 'book'
+                                CHECK(upgrade_readarr_search_mode IN ('book', 'author_context')),
+    upgrade_whisparr_search_mode TEXT NOT NULL DEFAULT 'episode'
+                                CHECK(upgrade_whisparr_search_mode
+                                      IN ('episode', 'season_context')),
+    upgrade_item_offset  INTEGER NOT NULL DEFAULT 0,
+    upgrade_series_offset INTEGER NOT NULL DEFAULT 0,
     enabled              INTEGER NOT NULL DEFAULT 1,
     created_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
@@ -162,6 +177,8 @@ async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
         await _migrate_to_v6(db)
     if from_version < 7:
         await _migrate_to_v7(db)
+    if from_version < 8:
+        await _migrate_to_v8(db)
 
     logger.info("Migrated database from schema version %d to %d", from_version, SCHEMA_VERSION)
     await db.execute(
@@ -384,7 +401,7 @@ async def _migrate_to_v6(db: aiosqlite.Connection) -> None:
     )
 
     # Drop the old column.  SQLite 3.35+ supports DROP COLUMN directly.
-    # For older SQLite (pre-3.35), table recreation is needed — but Python
+    # For older SQLite (pre-3.35), table recreation is needed, but Python
     # 3.12 ships with SQLite ≥3.40, so DROP COLUMN is safe.
     await db.execute("ALTER TABLE instances DROP COLUMN unreleased_delay_hrs")
 
@@ -392,12 +409,70 @@ async def _migrate_to_v6(db: aiosqlite.Connection) -> None:
 async def _migrate_to_v7(db: aiosqlite.Connection) -> None:
     """Add ``queue_limit`` column for download-queue backpressure.
 
-    Default is 0 (disabled — no backpressure check).  When set to a positive
+    Default is 0 (disabled; no backpressure check).  When set to a positive
     value, the search loop skips cycles while the *arr download queue exceeds
     the configured threshold.
     """
     if not await _column_exists(db, "instances", "queue_limit"):
         await db.execute("ALTER TABLE instances ADD COLUMN queue_limit INTEGER NOT NULL DEFAULT 0")
+
+
+async def _migrate_to_v8(db: aiosqlite.Connection) -> None:
+    """Add upgrade search columns for the opt-in third search pass.
+
+    Ten new columns on ``instances``: four rate controls, four per-app search
+    modes (dedicated to the upgrade pass), and two offset-tracking columns.
+    All have NOT NULL DEFAULT so the ALTER TABLE is safe for existing rows.
+    """
+    # Rate controls
+    if not await _column_exists(db, "instances", "upgrade_enabled"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_enabled INTEGER NOT NULL DEFAULT 0"
+        )
+    if not await _column_exists(db, "instances", "upgrade_batch_size"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_batch_size INTEGER NOT NULL DEFAULT 1"
+        )
+    if not await _column_exists(db, "instances", "upgrade_cooldown_days"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_cooldown_days INTEGER NOT NULL DEFAULT 90"
+        )
+    if not await _column_exists(db, "instances", "upgrade_hourly_cap"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_hourly_cap INTEGER NOT NULL DEFAULT 1"
+        )
+
+    # Per-app search modes (dedicated to upgrade pass)
+    if not await _column_exists(db, "instances", "upgrade_sonarr_search_mode"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_sonarr_search_mode"
+            " TEXT NOT NULL DEFAULT 'episode'"
+        )
+    if not await _column_exists(db, "instances", "upgrade_lidarr_search_mode"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_lidarr_search_mode"
+            " TEXT NOT NULL DEFAULT 'album'"
+        )
+    if not await _column_exists(db, "instances", "upgrade_readarr_search_mode"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_readarr_search_mode"
+            " TEXT NOT NULL DEFAULT 'book'"
+        )
+    if not await _column_exists(db, "instances", "upgrade_whisparr_search_mode"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_whisparr_search_mode"
+            " TEXT NOT NULL DEFAULT 'episode'"
+        )
+
+    # Offset tracking (operational state, not user-configurable)
+    if not await _column_exists(db, "instances", "upgrade_item_offset"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_item_offset INTEGER NOT NULL DEFAULT 0"
+        )
+    if not await _column_exists(db, "instances", "upgrade_series_offset"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN upgrade_series_offset INTEGER NOT NULL DEFAULT 0"
+        )
 
 
 async def _ensure_v3_indexes(db: aiosqlite.Connection) -> None:

--- a/src/houndarr/engine/adapters/__init__.py
+++ b/src/houndarr/engine/adapters/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
 
 from houndarr.clients.base import ArrClient
 from houndarr.engine.adapters import lidarr, radarr, readarr, sonarr, whisparr
@@ -25,12 +26,18 @@ class AppAdapter:
     Attributes:
         adapt_missing: Convert a raw missing item into a :class:`SearchCandidate`.
         adapt_cutoff: Convert a raw cutoff-unmet item into a :class:`SearchCandidate`.
+        adapt_upgrade: Convert a library item into a :class:`SearchCandidate`
+            for the upgrade pass.
+        fetch_upgrade_pool: Fetch and filter the library for upgrade-eligible
+            items.  Returns a list of app-specific library dataclasses.
         dispatch_search: Send the search command via the appropriate client method.
         make_client: Construct an (unopened) client for the application.
     """
 
     adapt_missing: Callable[..., SearchCandidate]
     adapt_cutoff: Callable[..., SearchCandidate]
+    adapt_upgrade: Callable[..., SearchCandidate]
+    fetch_upgrade_pool: Callable[..., Awaitable[list[Any]]]
     dispatch_search: Callable[..., Awaitable[None]]
     make_client: Callable[[Instance], ArrClient]
 
@@ -39,30 +46,40 @@ ADAPTERS: dict[InstanceType, AppAdapter] = {
     InstanceType.radarr: AppAdapter(
         adapt_missing=radarr.adapt_missing,
         adapt_cutoff=radarr.adapt_cutoff,
+        adapt_upgrade=radarr.adapt_upgrade,
+        fetch_upgrade_pool=radarr.fetch_upgrade_pool,
         dispatch_search=radarr.dispatch_search,
         make_client=radarr.make_client,
     ),
     InstanceType.sonarr: AppAdapter(
         adapt_missing=sonarr.adapt_missing,
         adapt_cutoff=sonarr.adapt_cutoff,
+        adapt_upgrade=sonarr.adapt_upgrade,
+        fetch_upgrade_pool=sonarr.fetch_upgrade_pool,
         dispatch_search=sonarr.dispatch_search,
         make_client=sonarr.make_client,
     ),
     InstanceType.lidarr: AppAdapter(
         adapt_missing=lidarr.adapt_missing,
         adapt_cutoff=lidarr.adapt_cutoff,
+        adapt_upgrade=lidarr.adapt_upgrade,
+        fetch_upgrade_pool=lidarr.fetch_upgrade_pool,
         dispatch_search=lidarr.dispatch_search,
         make_client=lidarr.make_client,
     ),
     InstanceType.readarr: AppAdapter(
         adapt_missing=readarr.adapt_missing,
         adapt_cutoff=readarr.adapt_cutoff,
+        adapt_upgrade=readarr.adapt_upgrade,
+        fetch_upgrade_pool=readarr.fetch_upgrade_pool,
         dispatch_search=readarr.dispatch_search,
         make_client=readarr.make_client,
     ),
     InstanceType.whisparr: AppAdapter(
         adapt_missing=whisparr.adapt_missing,
         adapt_cutoff=whisparr.adapt_cutoff,
+        adapt_upgrade=whisparr.adapt_upgrade,
+        fetch_upgrade_pool=whisparr.fetch_upgrade_pool,
         dispatch_search=whisparr.dispatch_search,
         make_client=whisparr.make_client,
     ),

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -7,13 +7,19 @@ commands via :class:`~houndarr.clients.lidarr.LidarrClient`.
 
 from __future__ import annotations
 
-from houndarr.clients.lidarr import LidarrClient, MissingAlbum
+import logging
+
+from houndarr.clients.lidarr import LibraryAlbum, LidarrClient, MissingAlbum
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
     _is_within_post_release_grace,
 )
 from houndarr.services.instances import Instance, LidarrSearchMode
+
+logger = logging.getLogger(__name__)
+
+_UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES = 10
 
 # ---------------------------------------------------------------------------
 # Label builders
@@ -129,6 +135,99 @@ def adapt_cutoff(item: MissingAlbum, instance: Instance) -> SearchCandidate:
             "album_id": item.album_id,
         },
     )
+
+
+def _library_album_label(item: LibraryAlbum) -> str:
+    """Build a human-readable log label for library albums."""
+    artist = item.artist_name or "Unknown Artist"
+    title = item.title or "Unknown Album"
+    return f"{artist} - {title}"
+
+
+def _library_artist_context_label(item: LibraryAlbum) -> str:
+    """Build a log label for library album in artist-context mode."""
+    artist = item.artist_name or "Unknown Artist"
+    return f"{artist} (artist-context)"
+
+
+def adapt_upgrade(item: LibraryAlbum, instance: Instance) -> SearchCandidate:
+    """Convert a Lidarr library album into a :class:`SearchCandidate` for upgrade.
+
+    Respects ``instance.upgrade_lidarr_search_mode`` for album vs artist-context.
+    No unreleased checks: upgrade items already have files.
+
+    Args:
+        item: A library album from :meth:`LidarrClient.get_albums`.
+        instance: The configured Lidarr instance.
+
+    Returns:
+        A fully populated :class:`SearchCandidate`.
+    """
+    album_mode = instance.upgrade_lidarr_search_mode == LidarrSearchMode.album
+
+    use_artist_context = not album_mode and item.artist_id > 0
+
+    if use_artist_context:
+        item_id = _artist_item_id(item.artist_id)
+        label = _library_artist_context_label(item)
+        group_key: tuple[int, int] | None = (item.artist_id, 0)
+        search_payload = {
+            "command": "ArtistSearch",
+            "artist_id": item.artist_id,
+        }
+    else:
+        item_id = item.album_id
+        label = _library_album_label(item)
+        group_key = None
+        search_payload = {
+            "command": "AlbumSearch",
+            "album_id": item.album_id,
+        }
+
+    return SearchCandidate(
+        item_id=item_id,
+        item_type="album",
+        label=label,
+        unreleased_reason=None,
+        group_key=group_key,
+        search_payload=search_payload,
+    )
+
+
+async def fetch_upgrade_pool(
+    client: LidarrClient,
+    instance: Instance,
+) -> list[LibraryAlbum]:
+    """Fetch and filter Lidarr library for upgrade-eligible albums.
+
+    Builds a cutoff-unmet exclusion set by paginating ``wanted/cutoff``, then
+    returns monitored albums with files that are NOT in the exclusion set.
+
+    Args:
+        client: An open :class:`LidarrClient` context.
+        instance: The configured Lidarr instance.
+
+    Returns:
+        List of upgrade-eligible :class:`LibraryAlbum` items.
+    """
+    exclusion: set[int] = set()
+    for page in range(1, _UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES + 1):
+        try:
+            cutoff_items = await client.get_cutoff_unmet(page=page, page_size=250)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[%s] failed to fetch cutoff page %d for exclusion set",
+                instance.name,
+                page,
+            )
+            break
+        for item in cutoff_items:
+            exclusion.add(item.album_id)
+        if len(cutoff_items) < 250:
+            break
+
+    library = await client.get_albums()
+    return [a for a in library if a.monitored and a.has_file and a.album_id not in exclusion]
 
 
 async def dispatch_search(client: LidarrClient, candidate: SearchCandidate) -> None:

--- a/src/houndarr/engine/adapters/radarr.py
+++ b/src/houndarr/engine/adapters/radarr.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from houndarr.clients.radarr import MissingMovie, RadarrClient
+from houndarr.clients.radarr import LibraryMovie, MissingMovie, RadarrClient
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -21,7 +21,7 @@ _RADARR_UNRELEASED_STATUSES = {"tba", "announced"}
 
 
 # ---------------------------------------------------------------------------
-# Helpers (copied from search_loop.py — originals removed in Phase 2)
+# Helpers (copied from search_loop.py; originals removed in Phase 2)
 # ---------------------------------------------------------------------------
 
 
@@ -94,7 +94,7 @@ def adapt_missing(item: MissingMovie, instance: Instance) -> SearchCandidate:
 def adapt_cutoff(item: MissingMovie, instance: Instance) -> SearchCandidate:
     """Convert a Radarr cutoff-unmet movie into a :class:`SearchCandidate`.
 
-    The logic is identical to :func:`adapt_missing` — Radarr applies the
+    The logic is identical to :func:`adapt_missing`; Radarr applies the
     same unreleased checks and label format for both search kinds.
 
     Args:
@@ -105,6 +105,58 @@ def adapt_cutoff(item: MissingMovie, instance: Instance) -> SearchCandidate:
         A fully populated :class:`SearchCandidate`.
     """
     return adapt_missing(item, instance)
+
+
+def _library_movie_label(item: LibraryMovie) -> str:
+    """Build a human-readable log label for Radarr library movies."""
+    title = item.title or "Unknown Movie"
+    if item.year > 0:
+        return f"{title} ({item.year})"
+    return title
+
+
+def adapt_upgrade(item: LibraryMovie, instance: Instance) -> SearchCandidate:
+    """Convert a Radarr library movie into a :class:`SearchCandidate` for upgrade.
+
+    No unreleased checks: upgrade items already have files.
+
+    Args:
+        item: A library movie from :meth:`RadarrClient.get_library`.
+        instance: The configured Radarr instance.
+
+    Returns:
+        A fully populated :class:`SearchCandidate`.
+    """
+    return SearchCandidate(
+        item_id=item.movie_id,
+        item_type="movie",
+        label=_library_movie_label(item),
+        unreleased_reason=None,
+        group_key=None,
+        search_payload={
+            "command": "MoviesSearch",
+            "movie_id": item.movie_id,
+        },
+    )
+
+
+async def fetch_upgrade_pool(
+    client: RadarrClient,
+    instance: Instance,
+) -> list[LibraryMovie]:
+    """Fetch and filter Radarr library for upgrade-eligible movies.
+
+    Returns monitored movies that have a file and have met their quality cutoff.
+
+    Args:
+        client: An open :class:`RadarrClient` context.
+        instance: The configured Radarr instance.
+
+    Returns:
+        List of upgrade-eligible :class:`LibraryMovie` items.
+    """
+    library = await client.get_library()
+    return [m for m in library if m.monitored and m.has_file and m.cutoff_met]
 
 
 async def dispatch_search(client: RadarrClient, candidate: SearchCandidate) -> None:

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -7,13 +7,19 @@ commands via :class:`~houndarr.clients.readarr.ReadarrClient`.
 
 from __future__ import annotations
 
-from houndarr.clients.readarr import MissingBook, ReadarrClient
+import logging
+
+from houndarr.clients.readarr import LibraryBook, MissingBook, ReadarrClient
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
     _is_within_post_release_grace,
 )
 from houndarr.services.instances import Instance, ReadarrSearchMode
+
+logger = logging.getLogger(__name__)
+
+_UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES = 10
 
 # ---------------------------------------------------------------------------
 # Label builders
@@ -128,6 +134,99 @@ def adapt_cutoff(item: MissingBook, instance: Instance) -> SearchCandidate:
             "book_id": item.book_id,
         },
     )
+
+
+def _library_book_label(item: LibraryBook) -> str:
+    """Build a human-readable log label for library books."""
+    author = item.author_name or "Unknown Author"
+    title = item.title or "Unknown Book"
+    return f"{author} - {title}"
+
+
+def _library_author_context_label(item: LibraryBook) -> str:
+    """Build a log label for library book in author-context mode."""
+    author = item.author_name or "Unknown Author"
+    return f"{author} (author-context)"
+
+
+def adapt_upgrade(item: LibraryBook, instance: Instance) -> SearchCandidate:
+    """Convert a Readarr library book into a :class:`SearchCandidate` for upgrade.
+
+    Respects ``instance.upgrade_readarr_search_mode`` for book vs author-context.
+    No unreleased checks: upgrade items already have files.
+
+    Args:
+        item: A library book from :meth:`ReadarrClient.get_books`.
+        instance: The configured Readarr instance.
+
+    Returns:
+        A fully populated :class:`SearchCandidate`.
+    """
+    book_mode = instance.upgrade_readarr_search_mode == ReadarrSearchMode.book
+
+    use_author_context = not book_mode and item.author_id > 0
+
+    if use_author_context:
+        item_id = _author_item_id(item.author_id)
+        label = _library_author_context_label(item)
+        group_key: tuple[int, int] | None = (item.author_id, 0)
+        search_payload = {
+            "command": "AuthorSearch",
+            "author_id": item.author_id,
+        }
+    else:
+        item_id = item.book_id
+        label = _library_book_label(item)
+        group_key = None
+        search_payload = {
+            "command": "BookSearch",
+            "book_id": item.book_id,
+        }
+
+    return SearchCandidate(
+        item_id=item_id,
+        item_type="book",
+        label=label,
+        unreleased_reason=None,
+        group_key=group_key,
+        search_payload=search_payload,
+    )
+
+
+async def fetch_upgrade_pool(
+    client: ReadarrClient,
+    instance: Instance,
+) -> list[LibraryBook]:
+    """Fetch and filter Readarr library for upgrade-eligible books.
+
+    Builds a cutoff-unmet exclusion set by paginating ``wanted/cutoff``, then
+    returns monitored books with files that are NOT in the exclusion set.
+
+    Args:
+        client: An open :class:`ReadarrClient` context.
+        instance: The configured Readarr instance.
+
+    Returns:
+        List of upgrade-eligible :class:`LibraryBook` items.
+    """
+    exclusion: set[int] = set()
+    for page in range(1, _UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES + 1):
+        try:
+            cutoff_items = await client.get_cutoff_unmet(page=page, page_size=250)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[%s] failed to fetch cutoff page %d for exclusion set",
+                instance.name,
+                page,
+            )
+            break
+        for item in cutoff_items:
+            exclusion.add(item.book_id)
+        if len(cutoff_items) < 250:
+            break
+
+    library = await client.get_books()
+    return [b for b in library if b.monitored and b.has_file and b.book_id not in exclusion]
 
 
 async def dispatch_search(client: ReadarrClient, candidate: SearchCandidate) -> None:

--- a/src/houndarr/engine/adapters/sonarr.py
+++ b/src/houndarr/engine/adapters/sonarr.py
@@ -7,7 +7,10 @@ commands via :class:`~houndarr.clients.sonarr.SonarrClient`.
 
 from __future__ import annotations
 
-from houndarr.clients.sonarr import MissingEpisode, SonarrClient
+import logging
+from typing import Any
+
+from houndarr.clients.sonarr import LibraryEpisode, MissingEpisode, SonarrClient
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -15,8 +18,12 @@ from houndarr.engine.candidates import (
 )
 from houndarr.services.instances import Instance, SonarrSearchMode
 
+logger = logging.getLogger(__name__)
+
+_UPGRADE_MAX_SERIES_PER_CYCLE = 5
+
 # ---------------------------------------------------------------------------
-# Label builders (copied from search_loop.py — originals removed in Phase 2)
+# Label builders (copied from search_loop.py; originals removed in Phase 2)
 # ---------------------------------------------------------------------------
 
 
@@ -156,6 +163,114 @@ def adapt_cutoff(item: MissingEpisode, instance: Instance) -> SearchCandidate:
             "episode_id": item.episode_id,
         },
     )
+
+
+def _library_episode_label(item: LibraryEpisode) -> str:
+    """Build a human-readable log label for library episodes."""
+    code = f"S{item.season:02d}E{item.episode:02d}"
+    series = item.series_title or "Unknown Series"
+    if item.episode_title:
+        return f"{series} - {code} - {item.episode_title}"
+    return f"{series} - {code}"
+
+
+def _library_season_context_label(item: LibraryEpisode) -> str:
+    """Build a log label for library episode in season-context mode."""
+    series = item.series_title or "Unknown Series"
+    return f"{series} - S{item.season:02d} (season-context)"
+
+
+def adapt_upgrade(item: LibraryEpisode, instance: Instance) -> SearchCandidate:
+    """Convert a Sonarr library episode into a :class:`SearchCandidate` for upgrade.
+
+    Respects ``instance.upgrade_sonarr_search_mode`` for episode vs season-context.
+    No unreleased checks: upgrade items already have files.
+
+    Args:
+        item: A library episode from :meth:`SonarrClient.get_episodes`.
+        instance: The configured Sonarr instance.
+
+    Returns:
+        A fully populated :class:`SearchCandidate`.
+    """
+    episode_mode = instance.upgrade_sonarr_search_mode == SonarrSearchMode.episode
+
+    use_season_context = not episode_mode and item.series_id > 0 and item.season > 0
+
+    if use_season_context:
+        item_id = _season_item_id(item.series_id, item.season)
+        label = _library_season_context_label(item)
+        group_key: tuple[int, int] | None = (item.series_id, item.season)
+        search_payload: dict[str, Any] = {
+            "command": "SeasonSearch",
+            "series_id": item.series_id,
+            "season_number": item.season,
+        }
+    else:
+        item_id = item.episode_id
+        label = _library_episode_label(item)
+        group_key = None
+        search_payload = {
+            "command": "EpisodeSearch",
+            "episode_id": item.episode_id,
+        }
+
+    return SearchCandidate(
+        item_id=item_id,
+        item_type="episode",
+        label=label,
+        unreleased_reason=None,
+        group_key=group_key,
+        search_payload=search_payload,
+    )
+
+
+async def fetch_upgrade_pool(
+    client: SonarrClient,
+    instance: Instance,
+) -> list[LibraryEpisode]:
+    """Fetch and filter Sonarr library for upgrade-eligible episodes.
+
+    Uses series rotation: fetches up to ``_UPGRADE_MAX_SERIES_PER_CYCLE``
+    monitored series per cycle, starting from ``instance.upgrade_series_offset``.
+
+    Args:
+        client: An open :class:`SonarrClient` context.
+        instance: The configured Sonarr instance.
+
+    Returns:
+        List of upgrade-eligible :class:`LibraryEpisode` items.
+    """
+    all_series = await client.get_series()
+    monitored = sorted(
+        [s for s in all_series if s.get("monitored", False)],
+        key=lambda s: s.get("id", 0),
+    )
+
+    if not monitored:
+        return []
+
+    offset = instance.upgrade_series_offset % len(monitored)
+    selected = monitored[offset : offset + _UPGRADE_MAX_SERIES_PER_CYCLE]
+    if len(selected) < _UPGRADE_MAX_SERIES_PER_CYCLE:
+        remaining = _UPGRADE_MAX_SERIES_PER_CYCLE - len(selected)
+        selected += monitored[:remaining]
+
+    episodes: list[LibraryEpisode] = []
+    for s in selected:
+        series_id = s.get("id", 0)
+        try:
+            eps = await client.get_episodes(series_id)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[%s] failed to fetch episodes for series %d, skipping",
+                instance.name,
+                series_id,
+            )
+            continue
+        episodes.extend(e for e in eps if e.monitored and e.has_file and e.cutoff_met)
+
+    return episodes
 
 
 async def dispatch_search(client: SonarrClient, candidate: SearchCandidate) -> None:

--- a/src/houndarr/engine/adapters/whisparr.py
+++ b/src/houndarr/engine/adapters/whisparr.py
@@ -11,11 +11,17 @@ with Sonarr), and episode labels omit ``episodeNumber`` (absent in Whisparr).
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
-from houndarr.clients.whisparr import MissingWhisparrEpisode, WhisparrClient
+from houndarr.clients.whisparr import LibraryWhisparrEpisode, MissingWhisparrEpisode, WhisparrClient
 from houndarr.engine.candidates import SearchCandidate
 from houndarr.services.instances import Instance, WhisparrSearchMode
+
+logger = logging.getLogger(__name__)
+
+_UPGRADE_MAX_SERIES_PER_CYCLE = 5
 
 # ---------------------------------------------------------------------------
 # Label builders
@@ -25,7 +31,7 @@ from houndarr.services.instances import Instance, WhisparrSearchMode
 def _episode_label(item: MissingWhisparrEpisode) -> str:
     """Build a human-readable log label for Whisparr episodes.
 
-    Whisparr has no ``episodeNumber`` — labels use season only.
+    Whisparr has no ``episodeNumber``; labels use season only.
     """
     series = item.series_title or "Unknown Series"
     if item.episode_title:
@@ -147,6 +153,116 @@ def adapt_cutoff(item: MissingWhisparrEpisode, instance: Instance) -> SearchCand
             "episode_id": item.episode_id,
         },
     )
+
+
+def _library_episode_label(item: LibraryWhisparrEpisode) -> str:
+    """Build a human-readable log label for library Whisparr episodes."""
+    series = item.series_title or "Unknown Series"
+    if item.episode_title:
+        return f"{series} - S{item.season_number:02d} - {item.episode_title}"
+    return f"{series} - S{item.season_number:02d}"
+
+
+def _library_season_context_label(item: LibraryWhisparrEpisode) -> str:
+    """Build a log label for library Whisparr episode in season-context mode."""
+    series = item.series_title or "Unknown Series"
+    return f"{series} - S{item.season_number:02d} (season-context)"
+
+
+def adapt_upgrade(
+    item: LibraryWhisparrEpisode,
+    instance: Instance,
+) -> SearchCandidate:
+    """Convert a Whisparr library episode into a :class:`SearchCandidate` for upgrade.
+
+    Respects ``instance.upgrade_whisparr_search_mode`` for episode vs season-context.
+    No unreleased checks: upgrade items already have files.
+
+    Args:
+        item: A library episode from :meth:`WhisparrClient.get_episodes`.
+        instance: The configured Whisparr instance.
+
+    Returns:
+        A fully populated :class:`SearchCandidate`.
+    """
+    episode_mode = instance.upgrade_whisparr_search_mode == WhisparrSearchMode.episode
+
+    use_season_context = not episode_mode and item.series_id > 0 and item.season_number > 0
+
+    if use_season_context:
+        item_id = _season_item_id(item.series_id, item.season_number)
+        label = _library_season_context_label(item)
+        group_key: tuple[int, int] | None = (item.series_id, item.season_number)
+        search_payload: dict[str, Any] = {
+            "command": "SeasonSearch",
+            "series_id": item.series_id,
+            "season_number": item.season_number,
+        }
+    else:
+        item_id = item.episode_id
+        label = _library_episode_label(item)
+        group_key = None
+        search_payload = {
+            "command": "EpisodeSearch",
+            "episode_id": item.episode_id,
+        }
+
+    return SearchCandidate(
+        item_id=item_id,
+        item_type="whisparr_episode",
+        label=label,
+        unreleased_reason=None,
+        group_key=group_key,
+        search_payload=search_payload,
+    )
+
+
+async def fetch_upgrade_pool(
+    client: WhisparrClient,
+    instance: Instance,
+) -> list[LibraryWhisparrEpisode]:
+    """Fetch and filter Whisparr library for upgrade-eligible episodes.
+
+    Uses series rotation: fetches up to ``_UPGRADE_MAX_SERIES_PER_CYCLE``
+    monitored series per cycle, starting from ``instance.upgrade_series_offset``.
+
+    Args:
+        client: An open :class:`WhisparrClient` context.
+        instance: The configured Whisparr instance.
+
+    Returns:
+        List of upgrade-eligible :class:`LibraryWhisparrEpisode` items.
+    """
+    all_series = await client.get_series()
+    monitored = sorted(
+        [s for s in all_series if s.get("monitored", False)],
+        key=lambda s: s.get("id", 0),
+    )
+
+    if not monitored:
+        return []
+
+    offset = instance.upgrade_series_offset % len(monitored)
+    selected = monitored[offset : offset + _UPGRADE_MAX_SERIES_PER_CYCLE]
+    if len(selected) < _UPGRADE_MAX_SERIES_PER_CYCLE:
+        remaining = _UPGRADE_MAX_SERIES_PER_CYCLE - len(selected)
+        selected += monitored[:remaining]
+
+    episodes: list[LibraryWhisparrEpisode] = []
+    for s in selected:
+        series_id = s.get("id", 0)
+        try:
+            eps = await client.get_episodes(series_id)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[%s] failed to fetch episodes for series %d, skipping",
+                instance.name,
+                series_id,
+            )
+            continue
+        episodes.extend(e for e in eps if e.monitored and e.has_file and e.cutoff_met)
+
+    return episodes
 
 
 async def dispatch_search(client: WhisparrClient, candidate: SearchCandidate) -> None:

--- a/src/houndarr/engine/candidates.py
+++ b/src/houndarr/engine/candidates.py
@@ -21,7 +21,7 @@ class SearchCandidate:
     """A normalized item ready for the search pipeline.
 
     Adapter functions convert app-specific models into this common shape.
-    The engine sees only ``SearchCandidate`` — it never inspects the
+    The engine sees only ``SearchCandidate``; it never inspects the
     original app-specific model.
 
     Attributes:

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -23,11 +23,11 @@ from houndarr.services.cooldown import (
     is_on_cooldown,
     record_search,
 )
-from houndarr.services.instances import Instance
+from houndarr.services.instances import Instance, InstanceType, update_instance
 
 logger = logging.getLogger(__name__)
 
-SearchKind = Literal["missing", "cutoff"]
+SearchKind = Literal["missing", "cutoff", "upgrade"]
 CycleTrigger = Literal["scheduled", "run_now", "system"]
 
 _MAX_LIST_PAGES_PER_PASS = 5
@@ -39,6 +39,13 @@ _CUTOFF_PAGE_SIZE_MIN = 5
 _CUTOFF_PAGE_SIZE_MAX = 25
 _CUTOFF_SCAN_BUDGET_MIN = 12
 _CUTOFF_SCAN_BUDGET_MAX = 60
+
+# Upgrade pass hard caps (very conservative, items already have files)
+_UPGRADE_SCAN_BUDGET_MIN = 8
+_UPGRADE_SCAN_BUDGET_MAX = 40
+_UPGRADE_BATCH_HARD_CAP = 5
+_UPGRADE_HOURLY_CAP_HARD_CAP = 5
+_UPGRADE_MIN_COOLDOWN_DAYS = 7
 
 
 # ---------------------------------------------------------------------------
@@ -303,7 +310,7 @@ async def _run_search_pass(  # noqa: C901
                     if is_cutoff
                     else f"hourly cap reached ({hourly_cap})"
                 )
-                logger.info("[%s] %s%s — %s", instance.name, log_prefix, candidate.item_id, reason)
+                logger.info("[%s] %s%s: %s", instance.name, log_prefix, candidate.item_id, reason)
                 await _write_log(
                     instance.id,
                     candidate.item_id,
@@ -385,7 +392,7 @@ async def _run_search_pass(  # noqa: C901
                     if is_cutoff
                     else f"on cooldown ({cooldown_days}d)"
                 )
-                logger.debug("[%s] %s%s — %s", instance.name, log_prefix, candidate.item_id, reason)
+                logger.debug("[%s] %s%s: %s", instance.name, log_prefix, candidate.item_id, reason)
                 await _write_log(
                     instance.id,
                     candidate.item_id,
@@ -458,6 +465,227 @@ async def _run_search_pass(  # noqa: C901
 
 
 # ---------------------------------------------------------------------------
+# Upgrade pass (dedicated, does NOT reuse _run_search_pass)
+# ---------------------------------------------------------------------------
+
+
+async def _run_upgrade_pass(
+    instance: Instance,
+    adapter: AppAdapter,
+    master_key: bytes,
+    *,
+    cycle_id: str,
+    cycle_trigger: CycleTrigger,
+) -> int:
+    """Execute the upgrade search pass for *instance*.
+
+    Fetches the library via the adapter, applies offset-based rotation,
+    cooldown checks, and dispatches searches for upgrade-eligible items.
+
+    Args:
+        instance: Fully-populated (decrypted) instance.
+        adapter: The :class:`AppAdapter` for this instance type.
+        master_key: Fernet key for persisting offset updates.
+        cycle_id: Shared cycle identifier for all log rows.
+        cycle_trigger: How this cycle was initiated.
+
+    Returns:
+        Count of items searched in this upgrade pass.
+    """
+    batch_size = min(max(0, instance.upgrade_batch_size), _UPGRADE_BATCH_HARD_CAP)
+    hourly_cap = min(max(0, instance.upgrade_hourly_cap), _UPGRADE_HOURLY_CAP_HARD_CAP)
+    cooldown_days = max(instance.upgrade_cooldown_days, _UPGRADE_MIN_COOLDOWN_DAYS)
+    scan_budget = _clamp(batch_size * 8, _UPGRADE_SCAN_BUDGET_MIN, _UPGRADE_SCAN_BUDGET_MAX)
+
+    if batch_size == 0:
+        return 0
+
+    # Fetch upgrade-eligible pool via the adapter
+    try:
+        async with adapter.make_client(instance) as client:
+            pool = await adapter.fetch_upgrade_pool(client, instance)
+    except Exception as exc:  # noqa: BLE001
+        msg = str(exc)
+        logger.warning("[%s] upgrade pool fetch failed: %s", instance.name, msg)
+        await _write_log(
+            instance.id,
+            None,
+            None,
+            "error",
+            search_kind="upgrade",
+            cycle_id=cycle_id,
+            cycle_trigger=cycle_trigger,
+            message=f"upgrade pool fetch failed: {msg}",
+        )
+        return 0
+
+    # Advance series offset for series-based apps (Sonarr/Whisparr)
+    if instance.type in (InstanceType.sonarr, InstanceType.whisparr):
+        new_series_offset = instance.upgrade_series_offset + 5
+        try:
+            await update_instance(
+                instance.id,
+                master_key=master_key,
+                upgrade_series_offset=new_series_offset,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("[%s] failed to persist upgrade_series_offset", instance.name)
+
+    if not pool:
+        logger.info("[%s] upgrade pool empty, nothing to upgrade", instance.name)
+        await _write_log(
+            instance.id,
+            None,
+            None,
+            "info",
+            search_kind="upgrade",
+            cycle_id=cycle_id,
+            cycle_trigger=cycle_trigger,
+            message="upgrade pool empty",
+        )
+        return 0
+
+    # Sort by item ID for stable ordering
+    def _item_sort_key(item: object) -> int:
+        return (
+            getattr(item, "movie_id", None)
+            or getattr(item, "episode_id", None)
+            or getattr(item, "album_id", None)
+            or getattr(item, "book_id", None)
+            or 0
+        )
+
+    pool.sort(key=_item_sort_key)
+
+    # Apply offset-based rotation
+    offset = instance.upgrade_item_offset % len(pool) if pool else 0
+    rotated = pool[offset:] + pool[:offset]
+
+    searches_this_hour = await _count_searches_last_hour(instance.id, "upgrade")
+    searched = 0
+    scanned = 0
+    seen_item_ids: set[int] = set()
+    seen_group_keys: set[tuple[int, int]] = set()
+    new_offset = offset
+
+    for item in rotated:
+        if searched >= batch_size or scanned >= scan_budget:
+            break
+
+        candidate = adapter.adapt_upgrade(item, instance)
+
+        # Dedup
+        if candidate.group_key is None:
+            if candidate.item_id in seen_item_ids:
+                continue
+            seen_item_ids.add(candidate.item_id)
+        else:
+            if candidate.group_key in seen_group_keys:
+                continue
+            seen_group_keys.add(candidate.group_key)
+            if candidate.item_id in seen_item_ids:
+                continue
+            seen_item_ids.add(candidate.item_id)
+
+        # Hourly cap
+        if hourly_cap > 0 and searches_this_hour >= hourly_cap:
+            reason = f"upgrade hourly cap reached ({hourly_cap})"
+            logger.info("[%s] upgrade %s: %s", instance.name, candidate.item_id, reason)
+            await _write_log(
+                instance.id,
+                candidate.item_id,
+                candidate.item_type,
+                "skipped",
+                search_kind="upgrade",
+                cycle_id=cycle_id,
+                cycle_trigger=cycle_trigger,
+                item_label=candidate.label,
+                reason=reason,
+            )
+            break
+
+        # Cooldown
+        if await is_on_cooldown(instance.id, candidate.item_id, candidate.item_type, cooldown_days):
+            reason = f"on upgrade cooldown ({cooldown_days}d)"
+            logger.debug("[%s] upgrade %s: %s", instance.name, candidate.item_id, reason)
+            await _write_log(
+                instance.id,
+                candidate.item_id,
+                candidate.item_type,
+                "skipped",
+                search_kind="upgrade",
+                cycle_id=cycle_id,
+                cycle_trigger=cycle_trigger,
+                item_label=candidate.label,
+                reason=reason,
+            )
+            new_offset = (offset + scanned + 1) % len(pool)
+            scanned += 1
+            continue
+
+        scanned += 1
+
+        # Dispatch search
+        try:
+            async with adapter.make_client(instance) as dispatch_client:
+                await adapter.dispatch_search(dispatch_client, candidate)
+        except Exception as exc:  # noqa: BLE001
+            msg = str(exc)
+            logger.warning(
+                "[%s] upgrade search failed for %s: %s",
+                instance.name,
+                candidate.item_id,
+                msg,
+            )
+            await _write_log(
+                instance.id,
+                candidate.item_id,
+                candidate.item_type,
+                "error",
+                search_kind="upgrade",
+                cycle_id=cycle_id,
+                cycle_trigger=cycle_trigger,
+                item_label=candidate.label,
+                message=msg,
+            )
+            new_offset = (offset + scanned) % len(pool)
+            continue
+
+        await record_search(instance.id, candidate.item_id, candidate.item_type)
+        await _write_log(
+            instance.id,
+            candidate.item_id,
+            candidate.item_type,
+            "searched",
+            search_kind="upgrade",
+            cycle_id=cycle_id,
+            cycle_trigger=cycle_trigger,
+            item_label=candidate.label,
+        )
+        searched += 1
+        searches_this_hour += 1
+        new_offset = (offset + scanned) % len(pool)
+        logger.info(
+            "[%s] upgrade searched %s %s",
+            instance.name,
+            candidate.item_type,
+            candidate.item_id,
+        )
+
+    # Persist new offset
+    try:
+        await update_instance(
+            instance.id,
+            master_key=master_key,
+            upgrade_item_offset=new_offset,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("[%s] failed to persist upgrade_item_offset", instance.name)
+
+    return searched
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -504,7 +732,7 @@ async def run_instance_search(
             total_queued = int(queue_status.get("totalCount", 0))
             if total_queued >= instance.queue_limit:
                 reason = f"queue backpressure ({total_queued}/{instance.queue_limit})"
-                logger.info("[%s] skipping cycle — %s", instance.name, reason)
+                logger.info("[%s] skipping cycle: %s", instance.name, reason)
                 await _write_log(
                     instance.id,
                     None,
@@ -526,10 +754,10 @@ async def run_instance_search(
             )
         except (httpx.HTTPError, httpx.InvalidURL, KeyError, ValueError):
             # If the queue check fails, log a warning and continue with the
-            # search cycle — failing open avoids blocking searches when the
+            # search cycle; failing open avoids blocking searches when the
             # queue endpoint is temporarily unavailable.
             logger.warning(
-                "[%s] queue status check failed — proceeding with search",
+                "[%s] queue status check failed; proceeding with search",
                 instance.name,
                 exc_info=True,
             )
@@ -554,7 +782,7 @@ async def run_instance_search(
                 cycle_trigger=cycle_trigger,
             )
 
-    logger.info("[%s] cycle complete — %d searched", instance.name, searched)
+    logger.info("[%s] cycle complete: %d searched", instance.name, searched)
 
     # --- Cutoff-unmet pass ---
     if instance.cutoff_enabled:
@@ -582,7 +810,33 @@ async def run_instance_search(
                     cycle_id=cycle_id_value,
                     cycle_trigger=cycle_trigger,
                 )
-            logger.info("[%s] cutoff pass complete — %d searched", instance.name, cutoff_searched)
+            logger.info("[%s] cutoff pass complete: %d searched", instance.name, cutoff_searched)
             searched += cutoff_searched
+
+    # --- Upgrade pass ---
+    if instance.upgrade_enabled:
+        upgrade_target = min(
+            max(0, instance.upgrade_batch_size),
+            _UPGRADE_BATCH_HARD_CAP,
+        )
+        if upgrade_target > 0:
+            logger.info(
+                "[%s] starting upgrade pass (upgrade_batch_size=%d)",
+                instance.name,
+                upgrade_target,
+            )
+            upgrade_searched = await _run_upgrade_pass(
+                instance,
+                adapter,
+                master_key,
+                cycle_id=cycle_id_value,
+                cycle_trigger=cycle_trigger,
+            )
+            logger.info(
+                "[%s] upgrade pass complete: %d searched",
+                instance.name,
+                upgrade_searched,
+            )
+            searched += upgrade_searched
 
     return searched

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -1,4 +1,4 @@
-"""Background supervisor — manages one asyncio.Task per enabled instance.
+"""Background supervisor: manages one asyncio.Task per enabled instance.
 
 The supervisor is started once during application lifespan and runs until
 shutdown.  Each task loops indefinitely: run a search cycle, sleep for
@@ -62,7 +62,7 @@ class Supervisor:
             )
 
         if not self._tasks:
-            logger.warning("Supervisor: no enabled instances configured — nothing to do")
+            logger.warning("Supervisor: no enabled instances configured. Nothing to do.")
             return
 
         await _write_log(
@@ -98,7 +98,7 @@ class Supervisor:
         # Force-cancel anything that outlived the timeout
         for task in pending:
             task.cancel()
-            logger.warning("Supervisor: task did not finish within timeout — force cancelled")
+            logger.warning("Supervisor: task did not finish within timeout; force cancelled")
 
         for task in done:
             exc = task.exception() if not task.cancelled() else None
@@ -214,14 +214,14 @@ class Supervisor:
                 instance = await get_instance(instance_id, master_key=self._master_key)
                 if instance is None:
                     logger.warning(
-                        "Supervisor: instance id=%d no longer exists — stopping loop",
+                        "Supervisor: instance id=%d no longer exists; stopping loop",
                         instance_id,
                     )
                     return
 
                 if not instance.enabled:
                     logger.info(
-                        "Supervisor: instance %r disabled — stopping loop",
+                        "Supervisor: instance %r disabled; stopping loop",
                         instance.name,
                     )
                     return
@@ -232,7 +232,7 @@ class Supervisor:
 
                 if got_connect_error:
                     if not _in_connect_retry:
-                        # First failure — write one error row and enter retry state.
+                        # First failure: write one error row and enter retry state.
                         await _write_log(
                             instance_id=instance.id,
                             item_id=None,
@@ -245,7 +245,7 @@ class Supervisor:
                     await asyncio.sleep(_CONNECT_RETRY_SECS)
                 else:
                     if _in_connect_retry:
-                        # Recovery — write one info row and leave retry state.
+                        # Recovery: write one info row and leave retry state.
                         logger.info(
                             "Supervisor: %r (%s) is reachable again",
                             instance.name,
@@ -293,7 +293,7 @@ class Supervisor:
                 return False
             except httpx.TransportError:
                 logger.warning(
-                    "Supervisor: could not reach %r (%s) — retrying in %d s",
+                    "Supervisor: could not reach %r (%s); retrying in %d s",
                     instance.name,
                     instance.url,
                     _CONNECT_RETRY_SECS,

--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -1,4 +1,4 @@
-"""Logs API — paginated search_log entries with optional filters.
+"""Logs API: paginated search_log entries with optional filters.
 
 GET /api/logs         → JSON list of log rows (used by tests and external consumers)
 GET /api/logs/partial → server-rendered <tbody> HTMX partial (used by the /logs page)
@@ -24,7 +24,7 @@ _LOG_LIMIT_DEFAULT = 50
 _LOG_LIMIT_MAX = 5000
 _LOG_LIMIT_ALL = 5000
 _LOG_LOAD_MORE_CHUNK_MAX = 100
-_SEARCH_KINDS = {"missing", "cutoff"}
+_SEARCH_KINDS = {"missing", "cutoff", "upgrade"}
 _CYCLE_TRIGGERS = {"scheduled", "run_now", "system"}
 
 
@@ -173,7 +173,7 @@ async def _query_logs(
         search_kind: ``missing`` or ``cutoff`` (None = all).
         cycle_trigger: ``scheduled``, ``run_now``, or ``system`` (None = all).
         hide_system: When True, hide system lifecycle rows from results.
-        before: ISO-8601 timestamp cursor — return rows older than this value.
+        before: ISO-8601 timestamp cursor; returns rows older than this value.
         limit: Maximum number of rows to return.
 
     Returns:
@@ -331,7 +331,7 @@ async def get_logs(
         search_kind: Filter by search pass kind (``missing`` or ``cutoff``).
         cycle_trigger: Filter by cycle trigger (``scheduled``, ``run_now``, ``system``).
         hide_system: When true, hide system lifecycle rows.
-        before: Timestamp cursor — only return rows older than this ISO-8601 value.
+        before: Timestamp cursor; only return rows older than this ISO-8601 value.
         limit: Max rows (1–500, default 50).
 
     Returns:

--- a/src/houndarr/routes/api/status.py
+++ b/src/houndarr/routes/api/status.py
@@ -1,4 +1,4 @@
-"""Status API — per-instance search metrics and run-now trigger.
+"""Status API: per-instance search metrics and run-now trigger.
 
 GET  /api/status             → JSON list of InstanceStatus objects
 POST /api/instances/{id}/run-now → trigger an immediate search cycle (202)

--- a/src/houndarr/routes/health.py
+++ b/src/houndarr/routes/health.py
@@ -1,4 +1,4 @@
-"""Health check endpoint — unauthenticated, used by Docker HEALTHCHECK."""
+"""Health check endpoint: unauthenticated, used by Docker HEALTHCHECK."""
 
 from __future__ import annotations
 

--- a/src/houndarr/routes/pages.py
+++ b/src/houndarr/routes/pages.py
@@ -199,7 +199,7 @@ async def dashboard(request: Request) -> HTMLResponse:
 
 @router.get("/logs", response_class=HTMLResponse)
 async def logs_page(request: Request) -> HTMLResponse:
-    """Search log viewer page — initial render with no filters applied."""
+    """Search log viewer page: initial render with no filters applied."""
     from houndarr.routes.api.logs import _compute_load_more_limit, _query_logs, _summarize_rows
 
     master_key: bytes = request.app.state.master_key

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -1,4 +1,4 @@
-"""Settings page routes — instance management via HTMX."""
+"""Settings page routes: instance management via HTMX."""
 
 from __future__ import annotations
 
@@ -31,6 +31,13 @@ from houndarr.config import (
     DEFAULT_READARR_SEARCH_MODE,
     DEFAULT_SLEEP_INTERVAL_MINUTES,
     DEFAULT_SONARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_BATCH_SIZE,
+    DEFAULT_UPGRADE_COOLDOWN_DAYS,
+    DEFAULT_UPGRADE_HOURLY_CAP,
+    DEFAULT_UPGRADE_LIDARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_READARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_SONARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     DEFAULT_WHISPARR_SEARCH_MODE,
     get_settings,
 )
@@ -179,6 +186,21 @@ def _validate_cutoff_controls(
         return "Cutoff cooldown days must be 0 or greater."
     if cutoff_hourly_cap < 0:
         return "Cutoff hourly cap must be 0 or greater."
+    return None
+
+
+def _validate_upgrade_controls(
+    upgrade_batch_size: int,
+    upgrade_cooldown_days: int,
+    upgrade_hourly_cap: int,
+) -> str | None:
+    """Validate upgrade-specific numeric controls from form submissions."""
+    if upgrade_batch_size < 1:
+        return "Upgrade batch size must be at least 1."
+    if upgrade_cooldown_days < 7:
+        return "Upgrade cooldown days must be at least 7."
+    if upgrade_hourly_cap < 0:
+        return "Upgrade hourly cap must be 0 or greater."
     return None
 
 
@@ -435,6 +457,14 @@ async def instance_create(
     lidarr_search_mode: Annotated[str, Form()] = DEFAULT_LIDARR_SEARCH_MODE,
     readarr_search_mode: Annotated[str, Form()] = DEFAULT_READARR_SEARCH_MODE,
     whisparr_search_mode: Annotated[str, Form()] = DEFAULT_WHISPARR_SEARCH_MODE,
+    upgrade_enabled: Annotated[str, Form()] = "",
+    upgrade_batch_size: Annotated[int, Form()] = DEFAULT_UPGRADE_BATCH_SIZE,
+    upgrade_cooldown_days: Annotated[int, Form()] = DEFAULT_UPGRADE_COOLDOWN_DAYS,
+    upgrade_hourly_cap: Annotated[int, Form()] = DEFAULT_UPGRADE_HOURLY_CAP,
+    upgrade_sonarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_SONARR_SEARCH_MODE,
+    upgrade_lidarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_LIDARR_SEARCH_MODE,
+    upgrade_readarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_READARR_SEARCH_MODE,
+    upgrade_whisparr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     connection_verified: Annotated[str, Form()] = "false",
 ) -> HTMLResponse:
     """Create a new instance and return the updated instance table body."""
@@ -455,6 +485,14 @@ async def instance_create(
     if validation_error is not None:
         return _connection_guard_response(validation_error)
 
+    upgrade_validation_error = _validate_upgrade_controls(
+        upgrade_batch_size,
+        upgrade_cooldown_days,
+        upgrade_hourly_cap,
+    )
+    if upgrade_validation_error is not None:
+        return _connection_guard_response(upgrade_validation_error)
+
     if connection_verified != "true":
         return _connection_guard_response("Test connection successfully before adding.")
 
@@ -470,6 +508,16 @@ async def instance_create(
     )
     if isinstance(search_modes, str):
         return _connection_guard_response(search_modes)
+
+    upgrade_modes = _resolve_search_modes(
+        instance_type,
+        upgrade_sonarr_search_mode,
+        upgrade_lidarr_search_mode,
+        upgrade_readarr_search_mode,
+        upgrade_whisparr_search_mode,
+    )
+    if isinstance(upgrade_modes, str):
+        return _connection_guard_response(upgrade_modes)
 
     instance = await create_instance(
         master_key=_master_key(request),
@@ -492,6 +540,14 @@ async def instance_create(
         lidarr_search_mode=search_modes.lidarr,
         readarr_search_mode=search_modes.readarr,
         whisparr_search_mode=search_modes.whisparr,
+        upgrade_enabled=upgrade_enabled == "on",
+        upgrade_batch_size=upgrade_batch_size,
+        upgrade_cooldown_days=upgrade_cooldown_days,
+        upgrade_hourly_cap=upgrade_hourly_cap,
+        upgrade_sonarr_search_mode=upgrade_modes.sonarr,
+        upgrade_lidarr_search_mode=upgrade_modes.lidarr,
+        upgrade_readarr_search_mode=upgrade_modes.readarr,
+        upgrade_whisparr_search_mode=upgrade_modes.whisparr,
     )
 
     supervisor = getattr(request.app.state, "supervisor", None)
@@ -544,6 +600,14 @@ async def instance_update(
     lidarr_search_mode: Annotated[str, Form()] = DEFAULT_LIDARR_SEARCH_MODE,
     readarr_search_mode: Annotated[str, Form()] = DEFAULT_READARR_SEARCH_MODE,
     whisparr_search_mode: Annotated[str, Form()] = DEFAULT_WHISPARR_SEARCH_MODE,
+    upgrade_enabled: Annotated[str, Form()] = "",
+    upgrade_batch_size: Annotated[int, Form()] = DEFAULT_UPGRADE_BATCH_SIZE,
+    upgrade_cooldown_days: Annotated[int, Form()] = DEFAULT_UPGRADE_COOLDOWN_DAYS,
+    upgrade_hourly_cap: Annotated[int, Form()] = DEFAULT_UPGRADE_HOURLY_CAP,
+    upgrade_sonarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_SONARR_SEARCH_MODE,
+    upgrade_lidarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_LIDARR_SEARCH_MODE,
+    upgrade_readarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_READARR_SEARCH_MODE,
+    upgrade_whisparr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     connection_verified: Annotated[str, Form()] = "false",
 ) -> HTMLResponse:
     """Update an existing instance and return the refreshed row partial.
@@ -570,6 +634,14 @@ async def instance_update(
     if validation_error is not None:
         return _connection_guard_response(validation_error)
 
+    upgrade_validation_error = _validate_upgrade_controls(
+        upgrade_batch_size,
+        upgrade_cooldown_days,
+        upgrade_hourly_cap,
+    )
+    if upgrade_validation_error is not None:
+        return _connection_guard_response(upgrade_validation_error)
+
     # Fetch the current instance early; needed for both key resolution and save
     current = await get_instance(instance_id, master_key=_master_key(request))
     if current is None:
@@ -594,6 +666,32 @@ async def instance_update(
     if isinstance(search_modes, str):
         return _connection_guard_response(search_modes)
 
+    upgrade_modes = _resolve_search_modes(
+        instance_type,
+        upgrade_sonarr_search_mode,
+        upgrade_lidarr_search_mode,
+        upgrade_readarr_search_mode,
+        upgrade_whisparr_search_mode,
+    )
+    if isinstance(upgrade_modes, str):
+        return _connection_guard_response(upgrade_modes)
+
+    # Reset offsets when upgrade is toggled off
+    new_upgrade_enabled = upgrade_enabled == "on"
+    upgrade_fields: dict[str, object] = {
+        "upgrade_enabled": new_upgrade_enabled,
+        "upgrade_batch_size": upgrade_batch_size,
+        "upgrade_cooldown_days": upgrade_cooldown_days,
+        "upgrade_hourly_cap": upgrade_hourly_cap,
+        "upgrade_sonarr_search_mode": upgrade_modes.sonarr,
+        "upgrade_lidarr_search_mode": upgrade_modes.lidarr,
+        "upgrade_readarr_search_mode": upgrade_modes.readarr,
+        "upgrade_whisparr_search_mode": upgrade_modes.whisparr,
+    }
+    if current.upgrade_enabled and not new_upgrade_enabled:
+        upgrade_fields["upgrade_item_offset"] = 0
+        upgrade_fields["upgrade_series_offset"] = 0
+
     updated = await update_instance(
         instance_id,
         master_key=_master_key(request),
@@ -616,6 +714,7 @@ async def instance_update(
         lidarr_search_mode=search_modes.lidarr,
         readarr_search_mode=search_modes.readarr,
         whisparr_search_mode=search_modes.whisparr,
+        **upgrade_fields,
     )
     if updated is None:
         return HTMLResponse(content="Not found", status_code=404)
@@ -637,7 +736,7 @@ async def instance_delete(request: Request, instance_id: int) -> Response:
         await supervisor.stop_instance_task(instance_id)
 
     await delete_instance(instance_id)
-    # Return an empty 200 — HTMX hx-swap="outerHTML" with empty content
+    # Return an empty 200. HTMX hx-swap="outerHTML" with empty content
     # removes the row from the DOM.
     return Response(status_code=200)
 

--- a/src/houndarr/services/cooldown.py
+++ b/src/houndarr/services/cooldown.py
@@ -1,13 +1,13 @@
-"""Cooldown service — per-item search tracking and per-instance hourly cap.
+"""Cooldown service: per-item search tracking and per-instance hourly cap.
 
 The ``cooldowns`` table stores the last time each (instance, item) pair was
 searched.  This module provides the four operations the search engine needs:
 
-* :func:`is_on_cooldown` — should we skip this item?
-* :func:`record_search` — mark an item as just-searched (upsert).
-* :func:`count_searches_last_hour` — how many searches has this instance done
+* :func:`is_on_cooldown` - should we skip this item?
+* :func:`record_search` - mark an item as just-searched (upsert).
+* :func:`count_searches_last_hour` - how many searches has this instance done
   in the past 60 minutes?
-* :func:`clear_cooldowns` — admin reset for a single instance.
+* :func:`clear_cooldowns` - admin reset for a single instance.
 """
 
 from __future__ import annotations

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -1,4 +1,4 @@
-"""Instance CRUD service — create, read, update, and delete *arr instances.
+"""Instance CRUD service: create, read, update, and delete *arr instances.
 
 API keys are never stored in plaintext.  Every write encrypts with the
 caller-supplied Fernet *master_key*; every read decrypts transparently.
@@ -23,6 +23,13 @@ from houndarr.config import (
     DEFAULT_READARR_SEARCH_MODE,
     DEFAULT_SLEEP_INTERVAL_MINUTES,
     DEFAULT_SONARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_BATCH_SIZE,
+    DEFAULT_UPGRADE_COOLDOWN_DAYS,
+    DEFAULT_UPGRADE_HOURLY_CAP,
+    DEFAULT_UPGRADE_LIDARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_READARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_SONARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     DEFAULT_WHISPARR_SEARCH_MODE,
 )
 from houndarr.crypto import decrypt, encrypt
@@ -71,7 +78,7 @@ class WhisparrSearchMode(StrEnum):
 class Instance:
     """In-memory representation of a configured *arr instance.
 
-    ``api_key`` is always the **decrypted** plaintext value — the encrypted
+    ``api_key`` is always the **decrypted** plaintext value; the encrypted
     form is only ever kept in the database column ``encrypted_api_key``.
     """
 
@@ -97,6 +104,16 @@ class Instance:
     lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album
     readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book
     whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode
+    upgrade_enabled: bool = False
+    upgrade_batch_size: int = DEFAULT_UPGRADE_BATCH_SIZE
+    upgrade_cooldown_days: int = DEFAULT_UPGRADE_COOLDOWN_DAYS
+    upgrade_hourly_cap: int = DEFAULT_UPGRADE_HOURLY_CAP
+    upgrade_sonarr_search_mode: SonarrSearchMode = SonarrSearchMode.episode
+    upgrade_lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album
+    upgrade_readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book
+    upgrade_whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode
+    upgrade_item_offset: int = 0
+    upgrade_series_offset: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +146,16 @@ def _row_to_instance(row: Any, master_key: bytes) -> Instance:
         lidarr_search_mode=LidarrSearchMode(row["lidarr_search_mode"]),
         readarr_search_mode=ReadarrSearchMode(row["readarr_search_mode"]),
         whisparr_search_mode=WhisparrSearchMode(row["whisparr_search_mode"]),
+        upgrade_enabled=bool(row["upgrade_enabled"]),
+        upgrade_batch_size=row["upgrade_batch_size"],
+        upgrade_cooldown_days=row["upgrade_cooldown_days"],
+        upgrade_hourly_cap=row["upgrade_hourly_cap"],
+        upgrade_sonarr_search_mode=SonarrSearchMode(row["upgrade_sonarr_search_mode"]),
+        upgrade_lidarr_search_mode=LidarrSearchMode(row["upgrade_lidarr_search_mode"]),
+        upgrade_readarr_search_mode=ReadarrSearchMode(row["upgrade_readarr_search_mode"]),
+        upgrade_whisparr_search_mode=WhisparrSearchMode(row["upgrade_whisparr_search_mode"]),
+        upgrade_item_offset=row["upgrade_item_offset"],
+        upgrade_series_offset=row["upgrade_series_offset"],
     )
 
 
@@ -159,6 +186,22 @@ async def create_instance(
     lidarr_search_mode: LidarrSearchMode = LidarrSearchMode(DEFAULT_LIDARR_SEARCH_MODE),
     readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode(DEFAULT_READARR_SEARCH_MODE),
     whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode(DEFAULT_WHISPARR_SEARCH_MODE),
+    upgrade_enabled: bool = False,
+    upgrade_batch_size: int = DEFAULT_UPGRADE_BATCH_SIZE,
+    upgrade_cooldown_days: int = DEFAULT_UPGRADE_COOLDOWN_DAYS,
+    upgrade_hourly_cap: int = DEFAULT_UPGRADE_HOURLY_CAP,
+    upgrade_sonarr_search_mode: SonarrSearchMode = SonarrSearchMode(
+        DEFAULT_UPGRADE_SONARR_SEARCH_MODE
+    ),
+    upgrade_lidarr_search_mode: LidarrSearchMode = LidarrSearchMode(
+        DEFAULT_UPGRADE_LIDARR_SEARCH_MODE
+    ),
+    upgrade_readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode(
+        DEFAULT_UPGRADE_READARR_SEARCH_MODE
+    ),
+    upgrade_whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode(
+        DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE
+    ),
 ) -> Instance:
     """Insert a new instance row and return the populated :class:`Instance`.
 
@@ -167,7 +210,7 @@ async def create_instance(
         name: Human-readable label for the instance.
         type: One of ``radarr``, ``sonarr``, ``lidarr``, ``readarr``, ``whisparr``.
         url: Base URL of the *arr instance (e.g. ``http://sonarr:8989``).
-        api_key: Plaintext API key — will be encrypted before being written.
+        api_key: Plaintext API key; will be encrypted before being written.
         enabled: Whether the search engine should process this instance.
         batch_size: Number of missing items to search per run.
         sleep_interval_mins: Minutes to sleep between search cycles.
@@ -184,6 +227,14 @@ async def create_instance(
         lidarr_search_mode: Lidarr missing-search strategy mode.
         readarr_search_mode: Readarr missing-search strategy mode.
         whisparr_search_mode: Whisparr missing-search strategy mode.
+        upgrade_enabled: Whether upgrade searching is active.
+        upgrade_batch_size: Number of upgrade items per run.
+        upgrade_cooldown_days: Days to wait before re-searching upgrade items.
+        upgrade_hourly_cap: Maximum upgrade searches allowed per hour.
+        upgrade_sonarr_search_mode: Sonarr upgrade-search strategy mode.
+        upgrade_lidarr_search_mode: Lidarr upgrade-search strategy mode.
+        upgrade_readarr_search_mode: Readarr upgrade-search strategy mode.
+        upgrade_whisparr_search_mode: Whisparr upgrade-search strategy mode.
 
     Returns:
         The newly created :class:`Instance` with its database-assigned *id*.
@@ -198,8 +249,15 @@ async def create_instance(
                 hourly_cap, cooldown_days, post_release_grace_hrs, queue_limit,
                 cutoff_enabled, cutoff_batch_size, cutoff_cooldown_days, cutoff_hourly_cap,
                 sonarr_search_mode, lidarr_search_mode, readarr_search_mode,
-                whisparr_search_mode
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                whisparr_search_mode,
+                upgrade_enabled, upgrade_batch_size, upgrade_cooldown_days,
+                upgrade_hourly_cap,
+                upgrade_sonarr_search_mode, upgrade_lidarr_search_mode,
+                upgrade_readarr_search_mode, upgrade_whisparr_search_mode
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?
+            )
             """,
             (
                 name,
@@ -221,6 +279,14 @@ async def create_instance(
                 lidarr_search_mode.value,
                 readarr_search_mode.value,
                 whisparr_search_mode.value,
+                int(upgrade_enabled),
+                upgrade_batch_size,
+                upgrade_cooldown_days,
+                upgrade_hourly_cap,
+                upgrade_sonarr_search_mode.value,
+                upgrade_lidarr_search_mode.value,
+                upgrade_readarr_search_mode.value,
+                upgrade_whisparr_search_mode.value,
             ),
         )
         await db.commit()
@@ -228,7 +294,7 @@ async def create_instance(
         assert row_id is not None  # noqa: S101
 
     instance = await get_instance(row_id, master_key=master_key)
-    assert instance is not None  # just inserted — cannot be None  # noqa: S101
+    assert instance is not None  # just inserted, cannot be None  # noqa: S101
     return instance
 
 
@@ -287,7 +353,12 @@ async def update_instance(
             ``cutoff_enabled``, ``cutoff_batch_size``,
             ``cutoff_cooldown_days``, ``cutoff_hourly_cap``,
             ``sonarr_search_mode``, ``lidarr_search_mode``,
-            ``readarr_search_mode``, ``whisparr_search_mode``.
+            ``readarr_search_mode``, ``whisparr_search_mode``,
+            ``upgrade_enabled``, ``upgrade_batch_size``,
+            ``upgrade_cooldown_days``, ``upgrade_hourly_cap``,
+            ``upgrade_sonarr_search_mode``, ``upgrade_lidarr_search_mode``,
+            ``upgrade_readarr_search_mode``, ``upgrade_whisparr_search_mode``,
+            ``upgrade_item_offset``, ``upgrade_series_offset``.
 
     Returns:
         Updated :class:`Instance`, or ``None`` if *id* does not exist.
@@ -313,6 +384,16 @@ async def update_instance(
         "lidarr_search_mode": "lidarr_search_mode",
         "readarr_search_mode": "readarr_search_mode",
         "whisparr_search_mode": "whisparr_search_mode",
+        "upgrade_enabled": "upgrade_enabled",
+        "upgrade_batch_size": "upgrade_batch_size",
+        "upgrade_cooldown_days": "upgrade_cooldown_days",
+        "upgrade_hourly_cap": "upgrade_hourly_cap",
+        "upgrade_sonarr_search_mode": "upgrade_sonarr_search_mode",
+        "upgrade_lidarr_search_mode": "upgrade_lidarr_search_mode",
+        "upgrade_readarr_search_mode": "upgrade_readarr_search_mode",
+        "upgrade_whisparr_search_mode": "upgrade_whisparr_search_mode",
+        "upgrade_item_offset": "upgrade_item_offset",
+        "upgrade_series_offset": "upgrade_series_offset",
     }
 
     _search_mode_fields = {
@@ -320,6 +401,10 @@ async def update_instance(
         "lidarr_search_mode",
         "readarr_search_mode",
         "whisparr_search_mode",
+        "upgrade_sonarr_search_mode",
+        "upgrade_lidarr_search_mode",
+        "upgrade_readarr_search_mode",
+        "upgrade_whisparr_search_mode",
     }
 
     assignments: list[str] = []
@@ -336,13 +421,13 @@ async def update_instance(
             field_name in _search_mode_fields and isinstance(value, StrEnum)
         ):
             value = value.value
-        elif field_name in ("enabled", "cutoff_enabled"):
+        elif field_name in ("enabled", "cutoff_enabled", "upgrade_enabled"):
             value = int(bool(value))
         assignments.append(f"{col} = ?")
         values.append(value)
 
     if not assignments:
-        # Nothing to do — return current state
+        # Nothing to do; return current state
         return await get_instance(id, master_key=master_key)
 
     # Always refresh updated_at

--- a/src/houndarr/services/url_validation.py
+++ b/src/houndarr/services/url_validation.py
@@ -1,4 +1,4 @@
-"""Instance URL validation — guards against SSRF and obviously unsafe targets.
+"""Instance URL validation: guards against SSRF and obviously unsafe targets.
 
 Self-hosted context notes
 --------------------------
@@ -29,7 +29,7 @@ _ALLOWED_SCHEMES = frozenset(["http", "https"])
 
 # Loopback ranges blocked by default.  Private ranges (10/8, 172.16/12,
 # 192.168/16) are NOT blocked because Docker / LAN setups legitimately use them.
-# Hostnames that should never be used directly — operators must use container
+# Hostnames that should never be used directly; operators must use container
 # names or FQDNs instead.
 _BLOCKED_HOSTNAMES: frozenset[str] = frozenset(["localhost"])
 

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -58,11 +58,11 @@
   <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js" defer></script>
   <link rel="stylesheet" href="/static/css/app.css" />
 
-  <!-- Client helpers — defined early so page scripts can use them on first load -->
+  <!-- Client helpers: defined early so page scripts can use them on first load -->
   <script>
     (function () {
       function formatLocalTimestamp(isoTimestamp) {
-        if (!isoTimestamp) return '—';
+        if (!isoTimestamp) return 'N/A';
         const parsed = new Date(isoTimestamp);
         if (Number.isNaN(parsed.getTime())) return isoTimestamp;
         const compact = window.matchMedia('(max-width: 767px)').matches;
@@ -153,7 +153,7 @@
   <div id="mobile-nav-backdrop" class="sm:hidden fixed inset-0 z-40 mobile-nav-backdrop" aria-hidden="true"></div>
   {% endif %}
 
-  <!-- Flash messages — Station left-border style -->
+  <!-- Flash messages: Station left-border style -->
   {% if flash_error %}
   <div id="flash-error"
        class="border-l-4 border-red-500 bg-red-950/30 text-red-200 px-5 py-3 text-sm"

--- a/src/houndarr/templates/dashboard.html
+++ b/src/houndarr/templates/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard — Houndarr{% endblock %}
+{% block title %}Dashboard | Houndarr{% endblock %}
 
 {% block content %}
   {% include "partials/pages/dashboard_content.html" %}

--- a/src/houndarr/templates/login.html
+++ b/src/houndarr/templates/login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% set show_nav = false %}
 
-{% block title %}Login — Houndarr{% endblock %}
+{% block title %}Login | Houndarr{% endblock %}
 
 {% block content %}
 <div class="auth-glow-bg flex items-center justify-center min-h-[calc(100vh-8rem)] -mx-4 sm:-mx-6 lg:-mx-8 -my-6 sm:-my-8 px-4">

--- a/src/houndarr/templates/logs.html
+++ b/src/houndarr/templates/logs.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Logs — Houndarr{% endblock %}
+{% block title %}Logs | Houndarr{% endblock %}
 
 {% block content %}
   {% include "partials/pages/logs_content.html" %}

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -10,7 +10,7 @@
 {% set target  = "#instance-row-" ~ instance.id if is_edit else "#instance-tbody" %}
 {% set swap    = "outerHTML" if is_edit else "innerHTML" %}
 
-{# Shared input class — Station style #}
+{# Shared input class: Station style #}
 {% set input_cls = "w-full h-11 bg-[#0e1117] border border-[#2a3448] rounded-lg px-3 text-base text-white placeholder:text-slate-600 font-sans focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors" %}
 {% set mono_input_cls = "w-full h-11 bg-[#0e1117] border border-[#2a3448] rounded-lg px-3 text-base text-white placeholder:text-slate-600 font-mono focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors" %}
 
@@ -82,7 +82,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-api-key">API Key</label>
           <input id="{{ form_id }}-api-key" name="api_key" type="password" required
                  value="{{ '__UNCHANGED__' if is_edit else '' }}"
-                 placeholder="{{ '(stored — enter new value to change)' if is_edit else '••••••••••••••••' }}"
+                 placeholder="{{ '(stored; enter new value to change)' if is_edit else '••••••••••••••••' }}"
                  class="{{ mono_input_cls }}" />
         </div>
       </div>
@@ -213,6 +213,86 @@
                  value="{{ instance.cutoff_hourly_cap }}"
                  class="{{ mono_input_cls }}" />
         </div>
+      </div>
+    </section>
+
+    <!-- Library Upgrades section -->
+    <section class="rounded-xl border border-[#1e2638] bg-[#07080f]/50 p-4 sm:p-5 space-y-4">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h4 class="text-sm font-semibold text-slate-200">Library Upgrades</h4>
+          <p class="text-xs text-slate-500 mt-0.5">Opt-in third pass. Searches items that already meet cutoff for better releases.</p>
+        </div>
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-md border border-[#2a3448] bg-[#0e1117] px-3 py-2">
+          <input type="checkbox" name="upgrade_enabled" value="on"
+                 {% if is_edit and instance.upgrade_enabled %}checked{% endif %}
+                 class="rounded border-[#2a3448] bg-[#0e1117] text-brand-500 focus:ring-brand-500 focus:ring-offset-[#07080f]" />
+          <span class="text-xs font-medium text-slate-300">Enable upgrade search</span>
+        </label>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-ubatch">Upgrade Batch</label>
+          <input id="{{ form_id }}-ubatch" name="upgrade_batch_size" type="number" min="1" max="250"
+                 value="{{ instance.upgrade_batch_size }}"
+                 class="{{ mono_input_cls }}" />
+          <p class="mt-1.5 text-xs text-slate-600">Hard cap: 5 per cycle.</p>
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-ucool">Upgrade Cooldown (days)</label>
+          <input id="{{ form_id }}-ucool" name="upgrade_cooldown_days" type="number" min="7"
+                 value="{{ instance.upgrade_cooldown_days }}"
+                 class="{{ mono_input_cls }}" />
+          <p class="mt-1.5 text-xs text-slate-600">Minimum: 7 days.</p>
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-uhcap">Upgrade Hourly Cap</label>
+          <input id="{{ form_id }}-uhcap" name="upgrade_hourly_cap" type="number" min="0"
+                 value="{{ instance.upgrade_hourly_cap }}"
+                 class="{{ mono_input_cls }}" />
+          <p class="mt-1.5 text-xs text-slate-600">Hard cap: 5. 0 = unlimited.</p>
+        </div>
+      </div>
+      {# Per-app upgrade search mode selectors #}
+      <div data-sonarr-only="true"
+           {% if instance.type.value != 'sonarr' %}style="display:none;"{% endif %}>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-sonarr-mode">
+          Sonarr Upgrade Search Mode
+        </label>
+        <select id="{{ form_id }}-upgrade-sonarr-mode" name="upgrade_sonarr_search_mode" class="{{ input_cls }}">
+          <option value="episode"        {% if instance.upgrade_sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
+          <option value="season_context" {% if instance.upgrade_sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
+        </select>
+      </div>
+      <div data-lidarr-only="true"
+           {% if instance.type.value != 'lidarr' %}style="display:none;"{% endif %}>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-lidarr-mode">
+          Lidarr Upgrade Search Mode
+        </label>
+        <select id="{{ form_id }}-upgrade-lidarr-mode" name="upgrade_lidarr_search_mode" class="{{ input_cls }}">
+          <option value="album"          {% if instance.upgrade_lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
+          <option value="artist_context" {% if instance.upgrade_lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search</option>
+        </select>
+      </div>
+      <div data-readarr-only="true"
+           {% if instance.type.value != 'readarr' %}style="display:none;"{% endif %}>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-readarr-mode">
+          Readarr Upgrade Search Mode
+        </label>
+        <select id="{{ form_id }}-upgrade-readarr-mode" name="upgrade_readarr_search_mode" class="{{ input_cls }}">
+          <option value="book"           {% if instance.upgrade_readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
+          <option value="author_context" {% if instance.upgrade_readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search</option>
+        </select>
+      </div>
+      <div data-whisparr-only="true"
+           {% if instance.type.value != 'whisparr' %}style="display:none;"{% endif %}>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-whisparr-mode">
+          Whisparr Upgrade Search Mode
+        </label>
+        <select id="{{ form_id }}-upgrade-whisparr-mode" name="upgrade_whisparr_search_mode" class="{{ input_cls }}">
+          <option value="episode"        {% if instance.upgrade_whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
+          <option value="season_context" {% if instance.upgrade_whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
+        </select>
       </div>
     </section>
 

--- a/src/houndarr/templates/partials/instance_row.html
+++ b/src/houndarr/templates/partials/instance_row.html
@@ -1,4 +1,4 @@
-{# Single instance row — used by both initial render and HTMX swap after update. #}
+{# Single instance row: used by both initial render and HTMX swap after update. #}
 <tr id="instance-row-{{ instance.id }}"
     class="border-b border-[#1e2638] hover:bg-[#151b27] transition-colors">
   <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.name }}</td>

--- a/src/houndarr/templates/partials/instance_table_body.html
+++ b/src/houndarr/templates/partials/instance_table_body.html
@@ -1,4 +1,4 @@
-{# Refreshed table body — returned by POST /settings/instances after create. #}
+{# Refreshed table body: returned by POST /settings/instances after create. #}
 {% for instance in instances %}
   {% include "partials/instance_row.html" %}
 {% endfor %}

--- a/src/houndarr/templates/partials/log_rows.html
+++ b/src/houndarr/templates/partials/log_rows.html
@@ -1,4 +1,4 @@
-{# Log table rows partial — rendered by GET /api/logs/partial and swapped into #log-tbody #}
+{# Log table rows partial: rendered by GET /api/logs/partial and swapped into #log-tbody #}
 {% if rows %}
   {% set ns = namespace(previous_cycle_id='') %}
   {% for row in rows %}
@@ -31,7 +31,7 @@
       data-cycle-progress="{{ row.cycle_progress or '' }}">
     {# Timestamp #}
     <td class="px-3 py-2.5 text-xs text-slate-400 whitespace-nowrap font-mono" data-log-ts="{{ row.timestamp or '' }}" data-col="timestamp">
-      {{ row.timestamp[:19].replace("T", " ") if row.timestamp else "—" }}
+      {{ row.timestamp[:19].replace("T", " ") if row.timestamp else "-" }}
     </td>
 
     {# Instance #}
@@ -54,7 +54,7 @@
 
     {# Type #}
     <td class="px-3 py-2.5 text-xs text-slate-400 capitalize font-sans" data-col="type">
-      {{ row.item_type or "—" }}
+      {{ row.item_type or "-" }}
     </td>
 
     {# Search kind #}
@@ -63,8 +63,10 @@
         <span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium font-mono bg-sky-950/50 text-sky-300 border border-sky-900/40">missing</span>
       {% elif row.search_kind == "cutoff" %}
         <span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium font-mono bg-amber-950/40 text-amber-300 border border-amber-900/40">cutoff</span>
+      {% elif row.search_kind == "upgrade" %}
+        <span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium font-mono bg-violet-950/50 text-violet-300 border border-violet-900/40">upgrade</span>
       {% else %}
-        <span class="text-slate-600">—</span>
+        <span class="text-slate-600">-</span>
       {% endif %}
     </td>
 
@@ -77,7 +79,7 @@
       {% elif row.cycle_trigger == "system" %}
         <span class="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium font-mono bg-[#1e2638] text-slate-300">system</span>
       {% else %}
-        <span class="text-slate-600">—</span>
+        <span class="text-slate-600">-</span>
       {% endif %}
     </td>
 
@@ -86,7 +88,7 @@
       {% if row.cycle_id %}
         {{ row.cycle_id[:8] }}
       {% else %}
-        <span class="text-slate-600">—</span>
+        <span class="text-slate-600">-</span>
       {% endif %}
     </td>
 
@@ -110,7 +112,7 @@
       {% elif row.item_type and row.item_id is not none %}
         <div class="truncate text-slate-400">{{ row.item_type|capitalize }} {{ row.item_id }}</div>
       {% else %}
-        <div class="truncate text-slate-600">—</div>
+        <div class="truncate text-slate-600">-</div>
       {% endif %}
       {% if row.item_id is not none %}
         <div class="text-[10px] text-slate-600 font-mono">id:{{ row.item_id }}</div>
@@ -121,7 +123,7 @@
     <td class="px-3 py-2.5 text-xs text-slate-400 font-sans"
         data-col="reason"
         title="{{ (row.reason or row.message or '') }}">
-      {{ row.reason or row.message or "—" }}
+      {{ row.reason or row.message or "-" }}
     </td>
   </tr>
   {% if row.cycle_id %}
@@ -131,7 +133,7 @@
   {% endif %}
   {% endfor %}
 
-  {# Pagination: "Load older" link — only show if we got a full page #}
+  {# Pagination: "Load older" link; only show if we got a full page #}
   {% if rows | length >= limit %}
   {% set next_limit = load_more_limit if load_more_limit is defined else limit %}
   <tr id="pagination-row">

--- a/src/houndarr/templates/partials/pages/dashboard_content.html
+++ b/src/houndarr/templates/partials/pages/dashboard_content.html
@@ -1,4 +1,4 @@
-<div class="sr-only" data-page-key="dashboard" data-page-title="Dashboard — Houndarr" aria-hidden="true"></div>
+<div class="sr-only" data-page-key="dashboard" data-page-title="Dashboard | Houndarr" aria-hidden="true"></div>
 
 <style>
   .instance-card {
@@ -94,7 +94,7 @@
   >+ Add Instance</a>
 </div>
 
-<!-- Instance grid — polled every 15 s via HTMX -->
+<!-- Instance grid: polled every 15 s via HTMX -->
 <div
   id="instance-grid"
   data-hydrated="false"
@@ -246,7 +246,7 @@
             const skipped24hChanged  = previous && previous.skipped_24h  !== toNumber(inst.skipped_24h);
             const errors24hChanged   = previous && previous.errors_24h   !== toNumber(inst.errors_24h);
 
-            // Status badge — pulsing dot for active
+            // Status badge: pulsing dot for active
             const badge = inst.enabled
               ? `<span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-950/50 text-emerald-300 border border-emerald-800/40">
                    <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block station-pulse-dot"></span> Active
@@ -265,7 +265,7 @@
             };
             const typeBadge = typeBadgeMap[inst.type] || typeBadgeMap.sonarr;
 
-            // Left border color — signature Station type indicator
+            // Left border color: signature Station type indicator
             const typeColor = TYPE_COLOR_MAP[inst.type] || TYPE_COLOR_MAP.sonarr;
 
             const lastSearch   = inst.last_search_at ? formatLocalTimestamp(inst.last_search_at) : 'Never';

--- a/src/houndarr/templates/partials/pages/logs_content.html
+++ b/src/houndarr/templates/partials/pages/logs_content.html
@@ -1,4 +1,4 @@
-<div class="sr-only" data-page-key="logs" data-page-title="Logs — Houndarr" aria-hidden="true"></div>
+<div class="sr-only" data-page-key="logs" data-page-title="Logs | Houndarr" aria-hidden="true"></div>
 
 <style>
   #logs-table-shell {
@@ -46,11 +46,11 @@
       width: 100%;
     }
 
-    /* Preferred widths for predictable columns — auto layout uses these as
+    /* Preferred widths for predictable columns; auto layout uses these as
        hints and lets content push wider if needed. */
     th[data-col='timestamp'] { width: 150px; }
     th[data-col='instance']  { width: 80px;  }
-    /* action / type / kind have no explicit width — they size to badge content */
+    /* action / type / kind have no explicit width; they size to badge content */
 
     /* Media and reason absorb the remaining space */
     th[data-col='media']  { width: 35%; }
@@ -63,7 +63,7 @@
       text-overflow: ellipsis;
     }
 
-    /* Cycle ID, Cycle Outcome, Trigger — shown in the cycle group header row */
+    /* Cycle ID, Cycle Outcome, Trigger: shown in the cycle group header row */
     th[data-col='cycle'],   td[data-col='cycle'],
     th[data-col='outcome'], td[data-col='outcome'],
     th[data-col='trigger'], td[data-col='trigger'] {
@@ -374,6 +374,7 @@
       <option value="">All kinds</option>
       <option value="missing" {% if selected_search_kind == "missing" %}selected{% endif %}>Missing</option>
       <option value="cutoff" {% if selected_search_kind == "cutoff" %}selected{% endif %}>Cutoff</option>
+      <option value="upgrade" {% if selected_search_kind == "upgrade" %}selected{% endif %}>Upgrade</option>
     </select>
   </div>
 
@@ -496,7 +497,7 @@
       window.houndarrClientHelpers?.formatLocalTimestamp ||
       function (isoTimestamp) {
         if (!isoTimestamp) {
-          return '—';
+          return 'N/A';
         }
 
         const parsed = new Date(isoTimestamp);
@@ -577,9 +578,9 @@
     }
 
     function _mdCell(value) {
-      // Use em-dash for blank cells, as in the original behavior.
+      // Use a hyphen for blank cells.
       const str = String(value);
-      return _escapePipes(str || '—');
+      return _escapePipes(str || '-');
     }
 
     function buildMarkdown(rows) {
@@ -632,7 +633,7 @@
         if (c.cycle) parts.push(`cycle:${c.cycle}`);
         if (c.cycle_outcome) parts.push(`outcome:${c.cycle_outcome}`);
         if (c.media) parts.push(c.media);
-        if (c.reason) parts.push(`— ${c.reason}`);
+        if (c.reason) parts.push(`reason: ${c.reason}`);
         lines.push(parts.join('  '));
       });
       return lines.join('\n');

--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -1,4 +1,4 @@
-<div class="sr-only" data-page-key="settings" data-page-title="Settings — Houndarr" aria-hidden="true"></div>
+<div class="sr-only" data-page-key="settings" data-page-title="Settings | Houndarr" aria-hidden="true"></div>
 
 <style>
   #add-instance-modal {

--- a/src/houndarr/templates/partials/pages/settings_help_content.html
+++ b/src/houndarr/templates/partials/pages/settings_help_content.html
@@ -1,7 +1,7 @@
 <div
   class="sr-only"
   data-page-key="settings-help"
-  data-page-title="Settings Help — Houndarr"
+  data-page-title="Settings Help | Houndarr"
   aria-hidden="true"
 ></div>
 
@@ -198,6 +198,73 @@
   </section>
 
   <section class="help-reveal rounded-xl border border-[#1e2638] bg-[#0e1117] p-5">
+    <h2 class="text-lg font-semibold text-slate-100 mb-1">Library Upgrade Controls</h2>
+    <p class="text-xs text-slate-400 mb-4">
+      Lowest priority. Re-searches items that already meet cutoff for better releases. Keep off unless missing and cutoff backlogs are stable.
+    </p>
+    <div class="space-y-3">
+      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+        <div class="flex items-center justify-between gap-3">
+          <h3 class="text-sm font-semibold text-slate-200">Upgrade search</h3>
+          <span class="text-[11px] px-2 py-0.5 rounded-full bg-[#1e2638] text-slate-400 border border-[#2a3448] font-mono"
+            >Default: Off</span
+          >
+        </div>
+        <p class="mt-1 text-sm text-slate-300">
+          Enables upgrade pass for library items that already have files and meet your quality cutoff.
+        </p>
+      </div>
+      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+        <div class="flex items-center justify-between gap-3">
+          <h3 class="text-sm font-semibold text-slate-200">Upgrade Batch</h3>
+          <span
+            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            >Default: 1</span
+          >
+        </div>
+        <p class="mt-1 text-sm text-slate-300">Maximum upgrade items considered per cycle. Hard cap: 5.</p>
+      </div>
+      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+        <div class="flex items-center justify-between gap-3">
+          <h3 class="text-sm font-semibold text-slate-200">Upgrade Cooldown (days)</h3>
+          <span
+            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            >Default: 90</span
+          >
+        </div>
+        <p class="mt-1 text-sm text-slate-300">Minimum delay before retrying the same upgrade item. Minimum: 7 days.</p>
+      </div>
+      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+        <div class="flex items-center justify-between gap-3">
+          <h3 class="text-sm font-semibold text-slate-200">Upgrade Cap</h3>
+          <span
+            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            >Default: 1</span
+          >
+        </div>
+        <p class="mt-1 text-sm text-slate-300">
+          Maximum successful upgrade searches per hour (<code>0</code> = unlimited). Hard cap: 5.
+        </p>
+      </div>
+      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+        <div class="flex items-center justify-between gap-3">
+          <h3 class="text-sm font-semibold text-slate-200">Upgrade Search Mode</h3>
+          <span class="text-[11px] px-2 py-0.5 rounded-full bg-[#1e2638] text-slate-400 border border-[#2a3448] font-mono"
+            >Per-app setting</span
+          >
+        </div>
+        <p class="mt-1 text-sm text-slate-300">
+          Sonarr, Lidarr, Readarr, and Whisparr each offer an advanced search mode for the upgrade pass,
+          independent of the missing search mode. Radarr always uses movie-level search.
+        </p>
+      </div>
+    </div>
+    <p class="mt-4 text-xs text-slate-400">
+      Upgrade has its own budget, cooldown, and offset rotation so it does not compete with missing or cutoff searches.
+    </p>
+  </section>
+
+  <section class="help-reveal rounded-xl border border-[#1e2638] bg-[#0e1117] p-5">
     <h2 class="text-lg font-semibold text-slate-100 mb-3">Safe Starting Preset</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
       <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
@@ -230,6 +297,18 @@
       <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
         Cutoff Cap: <strong class="text-slate-100">1</strong>
       </div>
+      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+        Upgrade Search: <strong class="text-slate-100">Off</strong>
+      </div>
+      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+        Upgrade Batch: <strong class="text-slate-100">1</strong>
+      </div>
+      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+        Upgrade Cooldown: <strong class="text-slate-100">90 days</strong>
+      </div>
+      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+        Upgrade Cap: <strong class="text-slate-100">1</strong>
+      </div>
     </div>
   </section>
 
@@ -239,7 +318,8 @@
       <li>Increase Batch Size slightly.</li>
       <li>Lower Sleep slightly.</li>
       <li>Increase Hourly Cap only if indexers remain healthy.</li>
-      <li>Enable Cutoff search last.</li>
+      <li>Enable Cutoff search after missing backlog is under control.</li>
+      <li>Enable Upgrade search last, only after both missing and cutoff are stable.</li>
     </ol>
     <p class="mt-3 text-xs text-slate-400">
       Change one control at a time and observe logs for at least 24 hours.

--- a/src/houndarr/templates/settings.html
+++ b/src/houndarr/templates/settings.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Settings — Houndarr{% endblock %}
+{% block title %}Settings | Houndarr{% endblock %}
 
 {% block content %}
   {% include "partials/pages/settings_content.html" %}

--- a/src/houndarr/templates/settings_help.html
+++ b/src/houndarr/templates/settings_help.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Settings Help — Houndarr{% endblock %}
+{% block title %}Settings Help | Houndarr{% endblock %}
 
 {% block content %}
   {% include "partials/pages/settings_help_content.html" %}

--- a/src/houndarr/templates/setup.html
+++ b/src/houndarr/templates/setup.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% set show_nav = false %}
 
-{% block title %}Setup — Houndarr{% endblock %}
+{% block title %}Setup | Houndarr{% endblock %}
 
 {% block content %}
 <div class="auth-glow-bg flex items-center justify-center min-h-[calc(100vh-8rem)] -mx-4 sm:-mx-6 lg:-mx-8 -my-6 sm:-my-8 px-4">

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -337,7 +337,7 @@ def test_full_pages_render_consistent_titles(app: TestClient) -> None:
     """Full HTML pages should render '<Page> - Houndarr' title format."""
     setup_resp = app.get("/setup")
     assert setup_resp.status_code == 200
-    assert b"<title>Setup \xe2\x80\x94 Houndarr</title>" in setup_resp.content
+    assert b"<title>Setup | Houndarr</title>" in setup_resp.content
 
     app.post(
         "/setup",
@@ -346,25 +346,25 @@ def test_full_pages_render_consistent_titles(app: TestClient) -> None:
 
     login_resp = app.get("/login")
     assert login_resp.status_code == 200
-    assert b"<title>Login \xe2\x80\x94 Houndarr</title>" in login_resp.content
+    assert b"<title>Login | Houndarr</title>" in login_resp.content
 
     app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
 
     dashboard_resp = app.get("/")
     assert dashboard_resp.status_code == 200
-    assert b"<title>Dashboard \xe2\x80\x94 Houndarr</title>" in dashboard_resp.content
+    assert b"<title>Dashboard | Houndarr</title>" in dashboard_resp.content
 
     settings_resp = app.get("/settings")
     assert settings_resp.status_code == 200
-    assert b"<title>Settings \xe2\x80\x94 Houndarr</title>" in settings_resp.content
+    assert b"<title>Settings | Houndarr</title>" in settings_resp.content
 
     logs_resp = app.get("/logs")
     assert logs_resp.status_code == 200
-    assert b"<title>Logs \xe2\x80\x94 Houndarr</title>" in logs_resp.content
+    assert b"<title>Logs | Houndarr</title>" in logs_resp.content
 
     help_resp = app.get("/settings/help")
     assert help_resp.status_code == 200
-    assert b"<title>Settings Help \xe2\x80\x94 Houndarr</title>" in help_resp.content
+    assert b"<title>Settings Help | Houndarr</title>" in help_resp.content
 
 
 def test_login_page_includes_browser_identity_metadata(app: TestClient) -> None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,7 +29,7 @@ async def test_schema_created(db: None) -> None:
 async def test_schema_version_set(db: None) -> None:
     """Schema version should be set after init."""
     version = await get_setting("schema_version")
-    assert version == "7"
+    assert version == "8"
 
 
 @pytest.mark.asyncio()
@@ -110,7 +110,7 @@ async def test_init_db_migrates_v1_schema_to_v3(tmp_path: Path) -> None:
         search_log_columns = {row[1] async for row in search_log_cur}
         instance_columns = {row[1] async for row in instances_cur}
 
-    assert await get_setting("schema_version") == "7"
+    assert await get_setting("schema_version") == "8"
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
     assert "cycle_id" in search_log_columns
@@ -179,7 +179,7 @@ async def test_init_db_migrates_v2_schema_to_v4(tmp_path: Path) -> None:
         async with conn.execute("PRAGMA table_info(search_log)") as cur:
             search_log_columns = {row[1] async for row in cur}
 
-    assert await get_setting("schema_version") == "7"
+    assert await get_setting("schema_version") == "8"
     assert "cycle_id" in search_log_columns
     assert "cycle_trigger" in search_log_columns
 
@@ -246,7 +246,7 @@ async def test_init_db_migrates_v3_schema_to_v4(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "7"
+    assert await get_setting("schema_version") == "8"
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
             instance_columns = {row[1] async for row in cur}
@@ -329,7 +329,7 @@ async def test_init_db_migrates_v4_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "7"
+    assert await get_setting("schema_version") == "8"
 
     async with get_db() as conn:
         # Verify new columns exist
@@ -463,7 +463,7 @@ async def test_init_db_migrates_v5_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "7"
+    assert await get_setting("schema_version") == "8"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -560,7 +560,7 @@ async def test_init_db_migrates_v6_schema_to_v7(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "7"
+    assert await get_setting("schema_version") == "8"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:

--- a/website/docs/concepts/faq.md
+++ b/website/docs/concepts/faq.md
@@ -22,7 +22,7 @@ See [How Houndarr Works](/docs/concepts/how-houndarr-works#why-only-a-few-items-
 
 ## "Why is Houndarr skipping so much?"
 
-Each skip has a reason logged alongside it — `on cooldown (Nd)`, `post-release grace (Nh)`, hourly cap, or queue backpressure. A high skip count with zero errors means Houndarr is pacing itself correctly. See [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) for what each reason means.
+Each skip has a reason logged alongside it: `on cooldown (Nd)`, `post-release grace (Nh)`, hourly cap, or queue backpressure. A high skip count with zero errors means Houndarr is pacing itself correctly. See [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) for what each reason means.
 
 ## "Does Houndarr decide whether my file meets cutoff?"
 
@@ -42,11 +42,11 @@ If you set a **Queue Limit** on an instance, Houndarr checks the download queue 
 
 ## "Does Houndarr search my whole library?"
 
-No. It only acts on what your *arr instances report as wanted — items from `wanted/missing` and `wanted/cutoff`. Everything else in your library is invisible to Houndarr.
+It searches items from `wanted/missing` and `wanted/cutoff`. If upgrade search is enabled, it also re-searches library items that already meet cutoff, rotating through your library over time. Everything else is untouched.
 
 ## "Why is Houndarr searching so slowly?"
 
-The defaults are conservative on purpose — batch size 2, hourly cap 4, 14-day cooldown. With a large backlog, clearing it takes weeks. You can increase throughput gradually; see [Increasing throughput](/docs/configuration/instance-settings#increasing-throughput).
+The defaults are conservative on purpose (batch size 2, hourly cap 4, 14-day cooldown). With a large backlog, clearing it takes weeks. You can increase throughput gradually; see [Increasing throughput](/docs/configuration/instance-settings#increasing-throughput).
 
 ## "My *arr instance shows many cutoff-unmet items. Why is Houndarr only searching a few per day?"
 
@@ -57,6 +57,10 @@ The cutoff controls (batch 1, cap 1, cooldown 21 days) are more conservative tha
 Check in order: is the instance enabled (green toggle)? Has at least one sleep interval passed (default: 30 min)? Does your *arr instance actually have items in its wanted lists? Are there `error` entries in the Logs page?
 
 See [Troubleshooting](/docs/concepts/troubleshooting) for a step-by-step guide.
+
+## "What is upgrade search? How is it different from cutoff?"
+
+Cutoff search targets items your *arr instance flags as *below* your quality cutoff (they don't meet your minimum standard). Upgrade search targets items that *already meet* cutoff but might have better releases available based on quality profiles and custom format scoring. Upgrade search reads the full library rather than the `wanted/cutoff` list, and uses much more conservative defaults (batch 1, cooldown 90 days, hourly cap 1, hard caps enforced). Enable it only after missing and cutoff backlogs are stable.
 
 ## "Can Houndarr search for things that aren't in my *arr instance yet?"
 

--- a/website/docs/concepts/how-houndarr-works.md
+++ b/website/docs/concepts/how-houndarr-works.md
@@ -14,9 +14,10 @@ It does not download anything, parse releases, evaluate quality, or replace your
 
 ```
 1. Houndarr asks your *arr instance: "What items are missing or cutoff-unmet?"
+   (and optionally: "What items already meet cutoff but could be upgraded?")
        ↓
 2. The instance responds with its wanted list
-   (only monitored items that are missing or below quality cutoff)
+   (only monitored items that are missing, below quality cutoff, or upgrade-eligible)
        ↓
 3. Houndarr applies its scheduling rules to each candidate
    (cooldown, hourly cap, post-release grace, batch size)
@@ -35,17 +36,17 @@ A **monitored** item in your *arr instance just means the software is tracking i
 | Item state | Will Houndarr search it? |
 |-----------------------------|--------------------------|
 | Monitored + missing | Yes, if eligible under scheduling rules |
-| Monitored + downloaded + cutoff met | **No** — not in any wanted list |
+| Monitored + downloaded + cutoff met | **No** (unless upgrade search is enabled for the instance) |
 | Monitored + downloaded + cutoff unmet | Yes (if cutoff search is enabled), if eligible |
-| Not monitored | **No** — Houndarr only reads monitored wanted lists |
+| Not monitored | **No**. Houndarr only reads monitored wanted lists. |
 
 ## Who decides "cutoff unmet"?
 
-Your *arr instance — not Houndarr. It populates the `wanted/cutoff` API list based on your quality profile settings. Houndarr reads that list and applies its scheduling rules on top.
+Your *arr instance, not Houndarr. It populates the `wanted/cutoff` API list based on your quality profile settings. Houndarr reads that list and applies its scheduling rules on top.
 
 If cutoff searches aren't happening, check whether the item actually appears in your instance's own "Wanted > Cutoff Unmet" view first.
 
-:::tip Quality profiles are managed in your *arr instance — not Houndarr
+:::tip Quality profiles are managed in your *arr instance, not Houndarr
 Houndarr works best when your *arr instances are already configured with
 quality profiles you trust. It does not manage quality profiles or custom formats.
 
@@ -62,7 +63,7 @@ Think of it as a funnel:
 ```
 Your monitored library
         │
-        │  *arr instance filter: only missing or cutoff-unmet items
+        │  *arr instance filter: missing, cutoff-unmet, or upgrade-eligible items
         ▼
   Wanted list (much smaller)
         │
@@ -75,18 +76,21 @@ Your monitored library
   Actually searched (often just 1–3 items)
 ```
 
-For example, if you have 500 monitored movies in Radarr but only 50 are cutoff-unmet, and 35 of those are on cooldown, 8 are still in their post-release grace window, and your batch is 1 — Houndarr searches 1 movie that cycle. The rest wait for cooldowns to expire or grace windows to pass, and Houndarr works through them over days and weeks. Missing items that were blocked only by release timing can get one early retry once they become eligible.
+For example, if you have 500 monitored movies in Radarr but only 50 are cutoff-unmet, and 35 of those are on cooldown, 8 are still in their post-release grace window, and your batch is 1, Houndarr searches 1 movie that cycle. The rest wait for cooldowns to expire or grace windows to pass, and Houndarr works through them over days and weeks. Missing items that were blocked only by release timing can get one early retry once they become eligible.
 
-## The two search passes
+## The three search passes
 
-Each enabled instance runs two independent passes:
+Each enabled instance can run up to three independent passes:
 
 | Pass | What it searches | Key controls |
 |------|-----------------|--------------|
 | **Missing** | Items from the instance's `wanted/missing` list | Batch size, sleep interval, hourly cap, cooldown, post-release grace |
 | **Cutoff** | Items from the instance's `wanted/cutoff` list | Cutoff batch, cutoff cap, cutoff cooldown |
+| **Upgrade** | Library items that already have files and meet cutoff | Upgrade batch (hard cap: 5), upgrade cap (hard cap: 5), upgrade cooldown (min 7 days) |
 
 Cutoff search is **off by default**. Enable it only after missing items are under control so the two passes don't compete for the same indexer budget.
+
+Upgrade search is also **off by default** and much more conservative. It re-searches items that your *arr instance already considers complete, letting the instance find better releases based on quality profiles and custom format scoring. Enable it only after both missing and cutoff backlogs are stable.
 
 If a missing item was skipped because it was `not yet released` or still inside
 `post-release grace (Nh)`, Houndarr allows one retry as soon as that release-timing
@@ -101,17 +105,19 @@ Every item Houndarr considers but does not search is logged as `skipped` with a 
 |----------------|---------------|
 | `on cooldown (Nd)` | Item was searched recently; waiting to retry |
 | `on cutoff cooldown (Nd)` | Cutoff item was searched recently; waiting to retry |
+| `on upgrade cooldown (Nd)` | Upgrade item was searched recently; waiting to retry |
 | `not yet released` | Item has no release date or release date is in the future |
 | `post-release grace (Nh)` | Release date has passed but the grace window hasn't elapsed yet |
 | `hourly cap reached (N)` | This instance has hit its missing-pass hourly search limit of `N` |
 | `cutoff hourly cap reached (N)` | This instance has hit its cutoff hourly search limit of `N` |
+| `upgrade hourly cap reached (N)` | This instance has hit its upgrade hourly search limit of `N` |
 | `queue backpressure (N/M)` | Download queue has N items, at or above the configured limit of M (cycle-level skip) |
 
-A high skip count with zero errors means Houndarr is pacing itself correctly — examining candidates, finding most ineligible under your rules, and waiting patiently.
+A high skip count with zero errors means Houndarr is pacing itself correctly: examining candidates, finding most ineligible under your rules, and waiting patiently.
 
 ![Logs page](../../static/img/screenshots/Logs_Houndarr.jpeg)
 
-On mobile, log entries are presented as stacked cards — each card corresponds to one cycle group or individual row:
+On mobile, log entries are presented as stacked cards; each card corresponds to one cycle group or individual row:
 
 ![Logs page on mobile](../../static/img/screenshots/Logs_Houndarr_Smartphone.jpeg)
 

--- a/website/docs/concepts/troubleshooting.md
+++ b/website/docs/concepts/troubleshooting.md
@@ -10,7 +10,7 @@ description: How to verify Houndarr is working correctly, interpret logs, and di
 
 If you are unsure whether Houndarr is actually doing anything, follow these steps before assuming something is broken.
 
-### Step 1 — Open your *arr instance's own wanted pages
+### Step 1: Open your *arr instance's own wanted pages
 
 In Sonarr/Whisparr: **Wanted → Missing** and **Wanted → Cutoff Unmet**  
 In Radarr: **Wanted → Missing** and **Wanted → Cutoff Unmet**  
@@ -19,13 +19,13 @@ In Readarr: **Wanted → Missing** and **Wanted → Cutoff Unmet**
 
 If those pages are empty, Houndarr has nothing to search.
 
-### Step 2 — Compare items to Houndarr logs
+### Step 2: Compare items to Houndarr logs
 
 Open Houndarr's **Logs** page and look at recent activity. Each row shows:
 
 | Field | What it tells you |
 |-------|-------------------|
-| **Action** | `searched` — a search command was sent; `skipped` — item was ineligible this cycle; `error` — something went wrong |
+| **Action** | `searched` (a search command was sent), `skipped` (item was ineligible this cycle), or `error` (something went wrong) |
 | **Reason** | Why the item was skipped or what kind of search was triggered |
 | **Item label** | The series/movie/album/book title and relevant details |
 | **Timestamp** | When the action occurred |
@@ -38,29 +38,31 @@ If you see `searched` entries for items that also appear in your *arr instance's
 
 Each log row includes context fields that help you group and filter activity:
 
-- **`cycle_id`** — a unique ID shared by all rows from a single search cycle (both missing and cutoff passes). Use this to see everything that happened in one run.
-- **`cycle_trigger`** — one of `scheduled` (normal timer), `run_now` (manual button press), or `system` (supervisor lifecycle events like startup).
-- **`search_kind`** — `missing` or `cutoff` for item-level rows; empty for system rows.
+- **`cycle_id`**: a unique ID shared by all rows from a single search cycle (both missing and cutoff passes). Use this to see everything that happened in one run.
+- **`cycle_trigger`**: one of `scheduled` (normal timer), `run_now` (manual button press), or `system` (supervisor lifecycle events like startup).
+- **`search_kind`**: `missing`, `cutoff`, or `upgrade` for item-level rows; empty for system rows.
 
-The Logs page groups rows by cycle when metadata exists and shows a **Cycle outcome** indicator: `searched` (at least one item was searched), `skips only` (all candidates were ineligible), or `unknown` (no metadata).
+The Logs page groups rows by cycle when metadata exists and shows a **Cycle outcome** indicator: `searched` (at least one item was searched), `skips only` (all candidates were ineligible), or `unknown` (no metadata). Use the **Kind** filter to narrow to `missing`, `cutoff`, or `upgrade` rows.
 
 By default, system rows (supervisor startup messages) are hidden. Use the filter controls to show them if needed.
 
-### Step 3 — Check "Last Searched" timestamps in your *arr instance
+### Step 3: Check "Last Searched" timestamps in your *arr instance
 
 In your instance's cutoff-unmet view, each item shows when it was last searched. If those timestamps match recent Houndarr log entries, you have confirmed end-to-end that the search commands are reaching the instance and being executed.
 
-### Step 4 — Expect skips for cooldown, grace, and queue items
+### Step 4: Expect skips for cooldown, grace, and queue items
 
 If most of your log entries say `skipped`, check the reasons:
 
-- **`on cooldown (Nd)`** — the item was searched recently; Houndarr is waiting before trying again. This is intentional.
-- **`on cutoff cooldown (Nd)`** — a cutoff item was searched recently; cutoff keeps its own separate cooldown.
-- **`not yet released`** — the item has no release date or the release date is in the future.
-- **`post-release grace (Nh)`** — the release date has passed but the grace window hasn't elapsed yet. Houndarr will search once it clears.
-- **`hourly cap reached (N)`** — your missing-pass hourly search limit of `N` has been hit for this cycle.
-- **`cutoff hourly cap reached (N)`** — your cutoff hourly search limit of `N` has been hit for this cycle.
-- **`queue backpressure (N/M)`** — the download queue has N items, at or above your configured limit of M. The entire cycle was skipped.
+- **`on cooldown (Nd)`**: the item was searched recently; Houndarr is waiting before trying again. This is intentional.
+- **`on cutoff cooldown (Nd)`**: a cutoff item was searched recently; cutoff keeps its own separate cooldown.
+- **`on upgrade cooldown (Nd)`**: an upgrade item was searched recently; upgrade keeps its own separate cooldown.
+- **`not yet released`**: the item has no release date or the release date is in the future.
+- **`post-release grace (Nh)`**: the release date has passed but the grace window hasn't elapsed yet. Houndarr will search once it clears.
+- **`hourly cap reached (N)`**: your missing-pass hourly search limit of `N` has been hit for this cycle.
+- **`cutoff hourly cap reached (N)`**: your cutoff hourly search limit of `N` has been hit for this cycle.
+- **`upgrade hourly cap reached (N)`**: your upgrade hourly search limit of `N` has been hit for this cycle.
+- **`queue backpressure (N/M)`**: the download queue has N items, at or above your configured limit of M. The entire cycle was skipped.
 
 These are all normal scheduling behavior.
 
@@ -68,17 +70,17 @@ For missing items only, a prior `not yet released` or `post-release grace (Nh)`
 skip can be followed by one immediate retry on a later cycle once the item
 becomes eligible, even if the normal missing cooldown has not fully elapsed.
 
-### Step 5 — Check the error count
+### Step 5: Check the error count
 
-Look at your logs. If you see many `skipped` entries, some `searched` entries, and zero `error` entries, Houndarr is connected and running correctly. Errors mean something is wrong with the connection or API key — skips do not.
+Look at your logs. If you see many `skipped` entries, some `searched` entries, and zero `error` entries, Houndarr is connected and running correctly. Errors mean something is wrong with the connection or API key; skips do not.
 
-### Step 6 — Conservative defaults are slow by design
+### Step 6: Conservative defaults are slow by design
 
 The default settings are intentionally conservative:
 
-- **Batch size 2** — only 2 items per cycle
-- **Hourly cap 4** — maximum 4 searches per hour
-- **Cooldown 14 days** — no item is searched more than once every two weeks
+- **Batch size 2**: only 2 items per cycle
+- **Hourly cap 4**: maximum 4 searches per hour
+- **Cooldown 14 days**: no item is searched more than once every two weeks
 
 With these defaults, Houndarr might search 4–8 items in a day. If your backlog has hundreds of items, clearing it takes weeks. You can increase throughput by raising the batch size or hourly cap, but do so gradually and monitor your indexer health.
 
@@ -102,7 +104,7 @@ See [Instance Settings](/docs/configuration/instance-settings#increasing-through
 
 **Checks:**
 1. Open your *arr instance's wanted pages. If they are empty, there is nothing for Houndarr to search.
-2. Check the Houndarr Logs page for the instance. Look at the most recent entries — if you see `skipped` with reason `hourly cap reached`, wait until the next hour window.
+2. Check the Houndarr Logs page for the instance. Look at the most recent entries; if you see `skipped` with reason `hourly cap reached`, wait until the next hour window.
 3. Confirm the instance is enabled (green toggle in Settings).
 4. Check that the sleep interval has elapsed since the last cycle. With a 30-minute sleep, Houndarr runs approximately twice per hour.
 
@@ -118,9 +120,9 @@ See [Instance Settings](/docs/configuration/instance-settings#increasing-through
 
 `error` log entries include a message field explaining what went wrong. Common causes:
 
-- **HTTP 401** — API key is wrong or has been rotated in your *arr instance.
-- **HTTP 404** — The item was removed from the instance between the time Houndarr read the wanted list and the time it issued the search.
-- **Connection refused / timeout** — the instance is unreachable (see connection troubleshooting above).
+- **HTTP 401**: API key is wrong or has been rotated in your *arr instance.
+- **HTTP 404**: The item was removed from the instance between the time Houndarr read the wanted list and the time it issued the search.
+- **Connection refused / timeout**: the instance is unreachable (see connection troubleshooting above).
 
 Occasional 404 errors are harmless. A stream of connection errors suggests a network or configuration issue.
 

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -24,9 +24,9 @@ Houndarr is configured primarily through environment variables set in your
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `HOUNDARR_SECURE_COOKIES` | `false` | Set `Secure` flag on cookies (enable when behind HTTPS) |
-| `HOUNDARR_TRUSTED_PROXIES` | _(empty)_ | Comma-separated trusted proxy IPs or CIDR subnets (e.g. `10.0.0.1,172.18.0.0/16`) — used for `X-Forwarded-For` and proxy auth |
+| `HOUNDARR_TRUSTED_PROXIES` | _(empty)_ | Comma-separated trusted proxy IPs or CIDR subnets (e.g. `10.0.0.1,172.18.0.0/16`); used for `X-Forwarded-For` and proxy auth |
 | `HOUNDARR_AUTH_MODE` | `builtin` | Authentication method: `builtin` (default) or `proxy` (delegate to SSO reverse proxy) |
-| `HOUNDARR_AUTH_PROXY_HEADER` | _(empty)_ | Header carrying the authenticated username in proxy mode (e.g. `Remote-User`, `X-authentik-username`) — required when `AUTH_MODE=proxy` |
+| `HOUNDARR_AUTH_PROXY_HEADER` | _(empty)_ | Header carrying the authenticated username in proxy mode (e.g. `Remote-User`, `X-authentik-username`); required when `AUTH_MODE=proxy` |
 
 ## Container settings
 
@@ -47,8 +47,8 @@ stack. A warning will be printed to stdout at startup as a reminder.
 
 ### Explicit non-root mode (`user:` / `runAsUser`)
 
-If you start the container as a non-root user — via `user:` in Docker Compose
-or `securityContext.runAsUser` in Kubernetes — `PUID` and `PGID` are
+If you start the container as a non-root user (via `user:` in Docker Compose
+or `securityContext.runAsUser` in Kubernetes), `PUID` and `PGID` are
 **ignored**. The entrypoint cannot remap file ownership without root, so it
 skips remapping and runs the application directly as the specified UID/GID.
 
@@ -85,6 +85,6 @@ See [Reverse Proxy](reverse-proxy.md) for the full configuration.
 
 `HOUNDARR_AUTH_MODE=proxy` delegates authentication to an SSO reverse proxy
 (Authelia, Authentik, oauth2-proxy, etc.). Requires both
-`HOUNDARR_AUTH_PROXY_HEADER` and `HOUNDARR_TRUSTED_PROXIES` — the app refuses
+`HOUNDARR_AUTH_PROXY_HEADER` and `HOUNDARR_TRUSTED_PROXIES`; the app refuses
 to start without them. See [SSO proxy authentication](reverse-proxy.md#sso-proxy-authentication)
 for setup instructions and examples.

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -7,7 +7,7 @@ description: Detailed guide to all per-instance search settings in Houndarr.
 # Instance Settings
 
 This guide explains each setting available when adding or editing an instance
-in Houndarr. The defaults are conservative — keep settings low to reduce
+in Houndarr. The defaults are conservative; keep settings low to reduce
 indexer/API pressure and avoid bans.
 
 ![Add instance form](../../static/img/screenshots/Settings_Houndarr_Add_Instance_Settings.jpeg)
@@ -29,6 +29,9 @@ indexer/API pressure and avoid bans.
   (`SeasonSearch` with `seriesId` + `seasonNumber`) when enabled per instance.
 - Wanted-list reads are restricted to monitored items (`monitored=true`) for both
   missing and cutoff passes across all app types.
+- **Upgrade pass:** Re-uses the same search commands as above but targets library
+  items that already have files and meet cutoff. The upgrade pass reads the full
+  library endpoint rather than the `wanted/*` APIs.
 
 ## Missing search controls
 
@@ -93,7 +96,7 @@ Season-context mode sends at most one `SeasonSearch` per `(series, season)` per 
 
 :::info
 Cooldown in season-context mode is tracked at the season level using a stable synthetic
-identifier derived from the series ID and season number — not through any individual
+identifier derived from the series ID and season number, not through any individual
 episode. This ensures cooldown history is consistent across cycles regardless of which
 episode happens to appear first on the wanted list.
 :::
@@ -158,6 +161,51 @@ do not consume the same budget.
 
 The release-aware retry above does not apply to cutoff searches.
 
+## Library upgrade controls
+
+### Upgrade search
+
+Enable searching for items that already have files and meet your quality cutoff. This lets your *arr instance find better releases based on quality profiles and custom format scoring.
+
+- **Default:** Off
+- Keep this off unless both missing and cutoff backlogs are stable.
+- Unlike cutoff search (which targets items *below* cutoff), upgrade search targets items that *already meet* cutoff.
+
+### Upgrade Batch
+
+Maximum upgrade items considered per cycle.
+
+- **Default:** `1`
+- **Hard cap:** `5`. The engine enforces this maximum regardless of the configured value.
+
+### Upgrade Cooldown (days)
+
+Minimum days before retrying the same upgrade item.
+
+- **Default:** `90`
+- **Minimum:** `7`. The engine enforces this floor.
+- Much longer than missing or cutoff cooldowns because upgrades are lowest priority.
+
+### Upgrade Cap
+
+Maximum successful upgrade searches per hour.
+
+- **Default:** `1`
+- **Hard cap:** `5`. The engine enforces this maximum.
+- Set `0` to disable upgrade hourly cap.
+
+### Upgrade Search Mode
+
+Per-app strategy for upgrade-pass search commands. Each app type (Sonarr, Lidarr, Readarr, Whisparr) has its own upgrade search mode, independent of the missing search mode. Radarr always searches at the movie level.
+
+- **Sonarr/Whisparr:** Episode (default) or Season-context
+- **Lidarr:** Album (default) or Artist-context
+- **Readarr:** Book (default) or Author-context
+
+### Offset-based rotation
+
+The upgrade pass uses a persistent offset to rotate through your library over time rather than always starting from the beginning. This ensures fair coverage across your entire library. Offsets reset to zero when upgrade search is toggled off.
+
 ## Queue backpressure
 
 When `Queue Limit` is set above zero, Houndarr checks the instance's download
@@ -181,7 +229,7 @@ grace, or caps), but it stays bounded:
 This improves backlog rotation while preserving polite API behavior.
 
 :::tip Why am I seeing mostly skips?
-Skips are normal — see [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) and the [FAQ](/docs/concepts/faq) for details.
+Skips are normal. See [How Houndarr Works](/docs/concepts/how-houndarr-works#what-skipped-means-in-the-logs) and the [FAQ](/docs/concepts/faq) for details.
 :::
 
 ## Recommended starting profile
@@ -198,6 +246,10 @@ Skips are normal — see [How Houndarr Works](/docs/concepts/how-houndarr-works#
 | Cutoff Batch | `1` |
 | Cutoff Cooldown | `21` |
 | Cutoff Cap | `1` |
+| Upgrade search | Off |
+| Upgrade Batch | `1` (hard cap: 5) |
+| Upgrade Cooldown | `90` (min: 7) |
+| Upgrade Cap | `1` (hard cap: 5) |
 
 ## Increasing throughput
 
@@ -208,7 +260,8 @@ Suggested order:
 1. Increase **Batch Size** slightly.
 2. Lower **Sleep (minutes)** slightly.
 3. Increase **Hourly Cap** only if indexers remain healthy.
-4. Enable **Cutoff search** last.
+4. Enable **Cutoff search** after missing backlog is under control.
+5. Enable **Upgrade search** last, only after both missing and cutoff are stable.
 
 ## Status control
 

--- a/website/docs/configuration/reverse-proxy.md
+++ b/website/docs/configuration/reverse-proxy.md
@@ -96,7 +96,7 @@ otherwise occur.
 
 In proxy auth mode, Houndarr does not show a login page. The proxy
 authenticates the user and sets a header with the username before forwarding
-the request. Houndarr reads the username from that header — but only after
+the request. Houndarr reads the username from that header, but only after
 verifying the request originates from a trusted proxy IP. Requests that
 bypass the proxy get `403 Forbidden`.
 
@@ -108,7 +108,7 @@ Three settings must all be set together:
 |----------|-------------|
 | `HOUNDARR_AUTH_MODE=proxy` | Switch from built-in session auth to proxy auth |
 | `HOUNDARR_AUTH_PROXY_HEADER` | Header name your proxy sets with the authenticated username |
-| `HOUNDARR_TRUSTED_PROXIES` | Your proxy's IP or subnet — requests from other IPs are blocked |
+| `HOUNDARR_TRUSTED_PROXIES` | Your proxy's IP or subnet; requests from other IPs are blocked |
 
 Houndarr refuses to start if `AUTH_MODE=proxy` is set without both of the
 other two variables. The auth header name cannot be a reserved HTTP header
@@ -117,7 +117,7 @@ other two variables. The auth header name cannot be a reserved HTTP header
 :::warning
 **Expose only the port your proxy sits in front of.** In proxy mode,
 Houndarr trusts that the proxy has already authenticated the user. Any client
-that reaches port 8877 directly — bypassing the proxy — can forge the auth
+that reaches port 8877 directly (bypassing the proxy) can forge the auth
 header. Do not expose port 8877 to the internet without the proxy in front.
 :::
 
@@ -185,7 +185,7 @@ services:
 
 | Area | Behavior |
 |------|---------|
-| Login / setup | Redirected to `/` — no local credentials needed |
+| Login / setup | Redirected to `/`; no local credentials needed |
 | Logout | Clears the CSRF cookie, redirects to `/` |
 | Account settings | Password change section hidden |
 | `/api/health` | Still public, no auth required |

--- a/website/docs/getting-started/first-run-setup.md
+++ b/website/docs/getting-started/first-run-setup.md
@@ -14,7 +14,7 @@ Navigate to `http://<your-host>:8877`. You will see the setup screen prompting y
 to create an admin username and password.
 
 - Choose a strong password (Houndarr enforces minimum complexity requirements).
-- This is the only account — Houndarr uses a single-admin authentication model.
+- This is the only account. Houndarr uses a single-admin authentication model.
 
 ## 2. Log in
 
@@ -28,10 +28,10 @@ Go to **Settings** and click **Add Instance** to connect your *arr instances.
 
 For each instance you need:
 
-- **Name** — a friendly label (e.g., "Radarr Movies", "Sonarr 4K", "Lidarr Music")
-- **Type** — Radarr, Sonarr, Lidarr, Readarr, or Whisparr
-- **URL** — the base URL of the instance (e.g., `http://sonarr:8989`)
-- **API Key** — found in your *arr instance under Settings > General
+- **Name**: a friendly label (e.g., "Radarr Movies", "Sonarr 4K", "Lidarr Music")
+- **Type**: Radarr, Sonarr, Lidarr, Readarr, or Whisparr
+- **URL**: the base URL of the instance (e.g., `http://sonarr:8989`)
+- **API Key**: found in your *arr instance under Settings > General
 
 :::tip
 API keys are encrypted at rest using Fernet symmetric encryption and are never

--- a/website/docs/getting-started/helm.md
+++ b/website/docs/getting-started/helm.md
@@ -9,7 +9,7 @@ description: Install Houndarr with Helm or manage it via Flux using the official
 The official Houndarr Helm chart is published to GHCR as an OCI artifact and works with both plain `helm` and Flux.
 
 :::warning
-Houndarr uses SQLite. Only one replica is supported — do not scale beyond 1.
+Houndarr uses SQLite. Only one replica is supported; do not scale beyond 1.
 :::
 
 ## Prerequisites
@@ -70,7 +70,7 @@ Back up the `/data` PVC before upgrading. It contains the Fernet encryption mast
 
 ## Flux HelmRelease (OCI)
 
-Use `OCIRepository` (not `HelmRepository` with `type: oci` — that API is in maintenance mode per the Flux docs) to consume the chart in Flux.
+Use `OCIRepository` (not `HelmRepository` with `type: oci`; that API is in maintenance mode per the Flux docs) to consume the chart in Flux.
 
 ```yaml
 apiVersion: source.toolkit.fluxcd.io/v1

--- a/website/docs/getting-started/kubernetes.md
+++ b/website/docs/getting-started/kubernetes.md
@@ -9,7 +9,7 @@ description: How to deploy Houndarr on Kubernetes using a StatefulSet.
 Houndarr can run on Kubernetes using a StatefulSet with persistent storage.
 
 :::warning
-Houndarr uses SQLite. Only one replica is supported — do not scale beyond 1.
+Houndarr uses SQLite. Only one replica is supported; do not scale beyond 1.
 :::
 
 Prefer Helm or Flux? See the [Helm guide](./helm) for chart-based installation.
@@ -40,7 +40,7 @@ metadata:
   namespace: houndarr
 spec:
   serviceName: "houndarr"
-  replicas: 1 # SQLite — do not increase
+  replicas: 1 # SQLite; do not increase
   selector:
     matchLabels:
       app: houndarr
@@ -100,7 +100,7 @@ spec:
 ```
 
 The `volumeClaimTemplates` block creates a PVC automatically. The StatefulSet
-manages its lifecycle — the PVC persists even if the pod is deleted or
+manages its lifecycle; the PVC persists even if the pod is deleted or
 rescheduled.
 
 :::danger
@@ -112,7 +112,7 @@ If the master key is lost, all stored API keys become unrecoverable.
 
 If your cluster enforces Pod Security Standards or you need `runAsNonRoot:
 true`, replace the PUID/PGID env vars with a `securityContext` block. Do not
-combine both approaches — use one or the other.
+combine both approaches; use one or the other.
 
 ```yaml
 apiVersion: apps/v1
@@ -122,7 +122,7 @@ metadata:
   namespace: houndarr
 spec:
   serviceName: "houndarr"
-  replicas: 1 # SQLite — do not increase
+  replicas: 1 # SQLite; do not increase
   selector:
     matchLabels:
       app: houndarr
@@ -149,7 +149,7 @@ spec:
           env:
             - name: TZ
               value: "America/New_York"
-            # No PUID/PGID — securityContext handles user identity
+            # No PUID/PGID; securityContext handles user identity
             # Uncomment when using an Ingress with TLS:
             # - name: HOUNDARR_SECURE_COOKIES
             #   value: "true"
@@ -273,8 +273,8 @@ spec:
 
 When using TLS, uncomment the security env vars in the StatefulSet:
 
-- `HOUNDARR_SECURE_COOKIES=true` — marks session cookies as HTTPS-only
-- `HOUNDARR_TRUSTED_PROXIES` — set to your ingress controller's pod CIDR so
+- `HOUNDARR_SECURE_COOKIES=true`: marks session cookies as HTTPS-only
+- `HOUNDARR_TRUSTED_PROXIES`: set to your ingress controller's pod CIDR so
   the rate limiter sees real client IPs
 
 See [Environment Variables](/docs/configuration/environment-variables) and

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -47,12 +47,12 @@ prompted to create an admin username and password.
 1. Create your admin account on the setup screen.
 2. Log in and go to **Settings**.
 3. Add your *arr instances (URL + API key).
-4. Enable each instance — Houndarr begins searching on the configured schedule.
+4. Enable each instance. Houndarr begins searching on the configured schedule.
 
 For more details, see [First-Run Setup](first-run-setup.md).
 
 :::tip Good to know
-Houndarr does not search your entire library — only items that your *arr instances report as missing or below your quality cutoff, in small batches. See [How Houndarr Works](/docs/concepts/how-houndarr-works) for details.
+Houndarr does not search your entire library at once. It works through missing and cutoff-unmet items in small batches. An optional upgrade pass can also re-search items that already meet cutoff. See [How Houndarr Works](/docs/concepts/how-houndarr-works) for details.
 :::
 
 ## Using `docker run`
@@ -107,7 +107,7 @@ In this mode, `PUID` and `PGID` are ignored. The entrypoint validates that
 `/data` is writable at startup and exits with clear instructions if it is not.
 
 :::tip When to use which mode
-Most users — especially on Docker Compose, Unraid, or Proxmox — should use
+Most users (especially on Docker Compose, Unraid, or Proxmox) should use
 the default mode with `PUID`/`PGID`. The non-root mode is primarily useful
 for Kubernetes with `runAsNonRoot: true` or hardened environments that
 disallow root-starting containers. See

--- a/website/docs/security/trust-and-security.md
+++ b/website/docs/security/trust-and-security.md
@@ -66,8 +66,8 @@ The database column is named `encrypted_api_key`. Plaintext API keys are never
 stored on disk.
 
 Relevant source files:
-- `src/houndarr/crypto.py` — `encrypt()` and `decrypt()` functions
-- `src/houndarr/services/instances.py` — instance CRUD with encryption on
+- `src/houndarr/crypto.py`: `encrypt()` and `decrypt()` functions
+- `src/houndarr/services/instances.py`: instance CRUD with encryption on
   write and decryption on read
 
 ### The master key
@@ -115,10 +115,10 @@ output, or JSON API payload. Specifically:
 - The `/api/health` endpoint returns only `{"status": "ok"}`.
 
 Relevant source files:
-- `src/houndarr/routes/settings.py` — sentinel constant and resolution logic
-- `src/houndarr/templates/partials/instance_form.html` — form pre-fills
+- `src/houndarr/routes/settings.py`: sentinel constant and resolution logic
+- `src/houndarr/templates/partials/instance_form.html`: form pre-fills
   sentinel, not the key
-- `src/houndarr/routes/api/status.py` — field-level selection omitting
+- `src/houndarr/routes/api/status.py`: field-level selection omitting
   `api_key`
 
 ## Authentication and session security
@@ -136,7 +136,7 @@ are never stored.
 **Sessions:** Sessions use signed tokens via `itsdangerous.URLSafeTimedSerializer`
 with an HMAC signature. The signing secret is a 64-character hex string generated
 from `os.urandom(32)` on first setup, stored in the database. The token payload
-contains only a creation timestamp and a CSRF nonce — no username, password, or
+contains only a creation timestamp and a CSRF nonce; no username, password, or
 API keys. Session tokens expire after **24 hours**, enforced server-side.
 
 **Login rate limiting:** A brute-force limiter allows **5 failed login attempts
@@ -157,7 +157,7 @@ read after verifying the request originates from a trusted proxy IP;
 untrusted IPs receive `403 Forbidden` with no fallback to a login form.
 
 The `HOUNDARR_AUTH_PROXY_HEADER` and `HOUNDARR_TRUSTED_PROXIES` settings must
-both be provided — the app refuses to start without them. See
+both be provided; the app refuses to start without them. See
 [SSO proxy authentication](/docs/configuration/reverse-proxy#sso-proxy-authentication)
 for setup instructions.
 
@@ -225,8 +225,8 @@ Linuxserver.io and similar self-hosted container images.
 
 ### Explicit non-root mode
 
-If your container runtime starts the process as a non-root user — via `user:`
-in Docker Compose or `securityContext.runAsUser` in Kubernetes — the
+If your container runtime starts the process as a non-root user (via `user:`
+in Docker Compose or `securityContext.runAsUser` in Kubernetes), the
 entrypoint detects this and skips all PUID/PGID remapping. The application
 runs directly as the specified UID/GID.
 
@@ -327,9 +327,9 @@ The persistent data directory (default `/data` in Docker) contains:
 **If using proxy auth mode (`HOUNDARR_AUTH_MODE=proxy`):**
 
 - [ ] Set `HOUNDARR_TRUSTED_PROXIES` to only your proxy's specific IP or subnet
-      — avoid broad ranges like `0.0.0.0/0`
+      (avoid broad ranges like `0.0.0.0/0`)
 - [ ] Ensure port 8877 is not reachable without going through the authenticating
-      proxy — direct access bypasses SSO
+      proxy (direct access bypasses SSO)
 - [ ] Verify your proxy strips/overwrites the auth header from client requests
       before forwarding (all major SSO proxies do this by default)
 

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -22,12 +22,13 @@ const FeatureList: FeatureItem[] = [
     ),
   },
   {
-    title: 'Missing & Cutoff',
+    title: 'Missing, Cutoff & Upgrade',
     icon: '🔍',
     description: (
       <>
         Automatically searches for missing episodes, movies, albums, and
-        books, plus items below your quality cutoff. Each search type has
+        books, plus items below your quality cutoff. An optional upgrade pass
+        re-searches completed items for better releases. Each search type has
         independent controls and budgets.
       </>
     ),

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -16,34 +16,34 @@ type ScreenshotItem = {
 
 const DASHBOARD_SCREENSHOT: ScreenshotItem = {
   src: require('@site/static/img/screenshots/Dashboard_Houndarr.jpeg').default,
-  alt: 'Houndarr Dashboard — instance cards with search metrics and activity',
-  caption: 'Dashboard — live search metrics, instance status, and on-demand triggers',
+  alt: 'Houndarr Dashboard: instance cards with search metrics and activity',
+  caption: 'Dashboard: live search metrics, instance status, and on-demand triggers',
 };
 
 const SUPPORTING_SCREENSHOTS: ScreenshotItem[] = [
   {
     src: require('@site/static/img/screenshots/Logs_Houndarr.jpeg').default,
-    alt: 'Houndarr Logs — filterable search activity log',
+    alt: 'Houndarr Logs: filterable search activity log',
     caption: 'Logs',
   },
   {
     src: require('@site/static/img/screenshots/Settings_Houndarr.jpeg').default,
-    alt: 'Houndarr Settings — instance list with enable toggles',
+    alt: 'Houndarr Settings: instance list with enable toggles',
     caption: 'Settings',
   },
   {
     src: require('@site/static/img/screenshots/Settings_Houndarr_Add_Instance_Settings.jpeg').default,
-    alt: 'Houndarr Add Instance — search and cutoff configuration',
+    alt: 'Houndarr Add Instance: search, cutoff, and upgrade configuration',
     caption: 'Instance config',
   },
   {
     src: require('@site/static/img/screenshots/Settings_Account_Houndarr.jpeg').default,
-    alt: 'Houndarr Account settings — password and session management',
+    alt: 'Houndarr Account settings: password and session management',
     caption: 'Account',
   },
   {
     src: require('@site/static/img/screenshots/Settings_Help_Houndarr.jpeg').default,
-    alt: 'Houndarr Help — in-app settings reference',
+    alt: 'Houndarr Help: in-app settings reference',
     caption: 'Help',
   },
 ];
@@ -111,7 +111,7 @@ function HomepageHeader() {
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className={clsx('container', styles.heroInner)}>
 
-        {/* Left column — text content */}
+        {/* Left column: text content */}
         <div className={styles.heroLeft}>
           <img
             src={require('@site/static/img/houndarr-logo-dark.png').default}
@@ -137,7 +137,7 @@ function HomepageHeader() {
           </div>
         </div>
 
-        {/* Right column — dashboard preview */}
+        {/* Right column: dashboard preview */}
         <div className={styles.heroRight}>
           <img
             src={DASHBOARD_SCREENSHOT.src}
@@ -159,15 +159,15 @@ function Screenshots() {
           See It in Action
         </Heading>
 
-        {/* Hero — Dashboard takes full width */}
+        {/* Hero: Dashboard takes full width */}
         <div className={styles.screenshotHero}>
           <img src={DASHBOARD_SCREENSHOT.src} alt={DASHBOARD_SCREENSHOT.alt} />
           <p className={styles.screenshotCaption}>
-            <strong>Dashboard</strong> — live search metrics, instance status, and on-demand triggers
+            <strong>Dashboard</strong>: live search metrics, instance status, and on-demand triggers
           </p>
         </div>
 
-        {/* Supporting grid — remaining screens */}
+        {/* Supporting grid: remaining screens */}
         <div className={styles.screenshotGallery}>
           {SUPPORTING_SCREENSHOTS.map((item) => (
             <div key={item.caption}>
@@ -224,7 +224,7 @@ function WhatItDoesNot() {
             <ul>
               {SCOPE_EXCLUSIONS.map((item) => (
                 <li key={item.title}>
-                  <strong>{item.title}</strong> — {item.detail}
+                  <strong>{item.title}</strong>: {item.detail}
                 </li>
               ))}
             </ul>
@@ -239,7 +239,7 @@ export default function Home(): ReactNode {
   return (
     <Layout
       title="Polite media searching for your *arr stack"
-      description="A self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing media in polite, controlled batches.">
+      description="A self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing and upgrade-eligible media in polite, controlled batches.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
## Summary

Adds an opt-in third search pass that periodically re-searches library items which already have files and meet your quality cutoff, giving your \*arr instances a chance to find better releases based on quality profiles and custom format scoring.

Closes #264

## How the three passes work

All three passes only touch **monitored** items.

| Pass | Source | Has file? | Meets cutoff? | Goal |
|------|--------|-----------|---------------|------|
| **Missing** | `wanted/missing` | No | — | Acquire something |
| **Cutoff** | `wanted/cutoff` | Yes | No | Acquire something better than what's there |
| **Upgrade** | Full library | Yes | Yes | Let \*arr find an even better release based on quality profile/custom format scoring |

Missing and cutoff read the `wanted/*` APIs, so \*arr drives what appears there. Upgrade reads the full library directly and rotates through it using a persistent offset, so every monitored item with a file gets coverage over time. Each pass has its own cap, cooldown, and batch controls and they never share budget.

## Changes

- New upgrade search pass in the engine, reading the full library rather than `wanted/*` APIs
- Offset-based rotation so coverage spreads evenly across the library over time
- Independent controls: batch size (default 1, hard cap 5), cooldown (default 90 days, min 7), hourly cap (default 1, hard cap 5)
- Per-app upgrade search mode (episode/season-context for Sonarr/Whisparr, album/artist for Lidarr, book/author for Readarr; Radarr always movie-level)
- Schema migration to v8 with 10 new columns on `instances`
- UI: instance form section, in-app help page, log badge, filter dropdown
- Documentation updated across website and in-app help
- Punctuation cleanup across 59 source, template, and doc files (em dashes replaced with standard punctuation throughout; bundled here since it touched many of the same files)

## Testing

All checks pass (644 tests). Tested locally against a live Sonarr instance — upgrade pool rotation, cap enforcement, and cooldown tracking all behave as expected.

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way