### PR TITLE
fix(ui): scroll lock, mobile modal animation, and dashboard card entrance

### DIFF
--- a/src/houndarr/templates/partials/pages/dashboard_content.html
+++ b/src/houndarr/templates/partials/pages/dashboard_content.html
@@ -1,19 +1,12 @@
 <div class="sr-only" data-page-key="dashboard" data-page-title="Dashboard | Houndarr" aria-hidden="true"></div>
 
 <style>
-  .instance-card {
-    opacity: 1;
-    transform: none;
+  #instance-grid.is-entering {
+    animation: instance-grid-enter var(--dur-base, 180ms) var(--ease-station, cubic-bezier(0.16,1,0.3,1));
   }
 
-  .instance-card.is-entering {
-    opacity: 0;
-    transform: translateY(8px);
-    animation: instance-card-in 220ms var(--ease-station, cubic-bezier(0.16,1,0.3,1)) forwards;
-  }
-
-  @keyframes instance-card-in {
-    from { opacity: 0; transform: translateY(8px); }
+  @keyframes instance-grid-enter {
+    from { opacity: 0.65; transform: translateY(4px); }
     to   { opacity: 1; transform: translateY(0); }
   }
 
@@ -68,8 +61,7 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .instance-card,
-    .instance-card.is-entering,
+    #instance-grid.is-entering,
     .metric-changed {
       transition: none;
       animation: none;
@@ -115,6 +107,7 @@
     const RUN_NOW_SUCCESS_HOLD_MS = 900;
     const RUN_NOW_ERROR_HOLD_MS   = 1100;
     const previousMetrics = new Map();
+    let gridInitialHydration = false;
 
     function toNumber(value) {
       const parsed = Number(value);
@@ -207,6 +200,7 @@
         }
 
         const isInitialHydration = evt.detail.target.dataset.hydrated !== 'true';
+        gridInitialHydration = isInitialHydration;
 
         // ── Summary strip totals ───────────────────────────────────────
         const totals24h = data.reduce(
@@ -290,8 +284,6 @@
               })
               .join('');
 
-            const animationDelay = Math.min(index * 40, 220);
-
             previousMetrics.set(inst.id, {
               searches_last_hour: inst.searches_last_hour,
               searches_today:     inst.searches_today,
@@ -301,11 +293,9 @@
               errors_24h:   toNumber(inst.errors_24h),
             });
 
-            const entryClass = isInitialHydration ? ' is-entering' : '';
-
             return `
-<div class="instance-card${entryClass} bg-[#0e1117] border border-[#1e2638] rounded-xl p-5 flex flex-col gap-4"
-     style="animation-delay:${animationDelay}ms; border-left:3px solid ${typeColor}; box-shadow:var(--shadow-2);">
+<div class="instance-card bg-[#0e1117] border border-[#1e2638] rounded-xl p-5 flex flex-col gap-4"
+     style="border-left:3px solid ${typeColor}; box-shadow:var(--shadow-2);">
 
   <!-- Header: name + type, status badge, run-now -->
   <div class="flex items-start justify-between gap-3">
@@ -405,6 +395,19 @@
           hour12: false, timeZoneName: 'short',
         }).format(parsed);
       };
+
+    document.body.addEventListener(
+      'htmx:afterSwap',
+      function (evt) {
+        if (evt.detail.target.id !== 'instance-grid') return;
+        if (!gridInitialHydration) return;
+        gridInitialHydration = false;
+        const grid = evt.detail.target;
+        grid.classList.add('is-entering');
+        window.setTimeout(function () { grid.classList.remove('is-entering'); }, 200);
+      },
+      { signal },
+    );
 
     document.body.addEventListener(
       'htmx:beforeRequest',

--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -563,6 +563,7 @@
     const accountAnimationMs = 180;
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     let isClosingAddInstanceModal = false;
+    let pendingModalShow = false;
     let isAccountAnimating = false;
     let connectionStatusTimer = null;
 
@@ -832,11 +833,8 @@
     window.houndarrOpenAddInstanceModal = function () {
       addInstanceModal.classList.remove('is-closing');
       isClosingAddInstanceModal = false;
+      pendingModalShow = !addInstanceModal.open;
       setAddInstanceModalChrome('add');
-      if (!addInstanceModal.open) {
-        addInstanceModal.showModal();
-        document.body.style.overflow = 'hidden';
-      }
     };
 
     window.houndarrCloseAddInstanceModal = function () {
@@ -851,6 +849,7 @@
         }
         addInstanceModalContent.innerHTML = '';
         isClosingAddInstanceModal = false;
+        pendingModalShow = false;
         setAddInstanceModalChrome('add');
         document.body.style.overflow = '';
         addInstanceBtn.focus();
@@ -986,6 +985,10 @@
     document.body.addEventListener(
       'htmx:afterSwap',
       function (evt) {
+        if (evt.detail.target.id === 'app-content') {
+          document.body.style.overflow = '';
+        }
+
         if (evt.detail.target.id === 'instance-tbody') {
           window.houndarrCloseAddInstanceModal();
         }
@@ -995,6 +998,12 @@
         }
 
         if (evt.detail.target.id === 'add-instance-modal-content') {
+          if (pendingModalShow) {
+            pendingModalShow = false;
+            addInstanceModal.showModal();
+            document.body.style.overflow = 'hidden';
+          }
+
           const modalForm = addInstanceModalContent.querySelector('form[data-form-mode]');
           if (modalForm) {
             setAddInstanceModalChrome(modalForm.dataset.formMode, modalForm.dataset.instanceName);
@@ -1012,6 +1021,22 @@
             setConnectionTestButtonState('neutral');
           }
         }
+      },
+      { signal },
+    );
+
+    document.body.addEventListener(
+      'htmx:responseError',
+      function () {
+        pendingModalShow = false;
+      },
+      { signal },
+    );
+
+    document.body.addEventListener(
+      'htmx:sendError',
+      function () {
+        pendingModalShow = false;
       },
       { signal },
     );


### PR DESCRIPTION
Closes #267

## What changed

Three UI fixes in the settings modal and dashboard.

**Scroll lock after modal navigation:** The `htmx:afterSwap` handler in the settings page controller now resets `document.body.style.overflow` when `#app-content` is swapped. Previously, navigating to `/settings/help` via the modal's help link left the body overflow locked because the settings page controller's listener never handled `app-content` swaps.

**Mobile modal compact-then-expand:** `showModal()` is now deferred until the HTMX form response lands in `#add-instance-modal-content`. A `pendingModalShow` flag is set on click and consumed in `htmx:afterSwap`, so the dialog animates in fully populated. Error and send-error handlers reset the flag on network failure. Previously, `showModal()` was called immediately on click, so the modal opened near-empty and then grew as the form loaded.

**Dashboard card entrance:** Per-card `opacity: 0` animations are replaced by a single container-level animation on `#instance-grid` that fires only on initial hydration. The new `instance-grid-enter` keyframe matches `shell-content-enter` exactly: `opacity: 0.65 → 1`, `translateY(4px) → 0`, 180ms with station easing. Subsequent 15s poll swaps skip the animation entirely.

## Checklist

- [x] All quality gates pass
- [x] No new dependencies
- [x] Template-only changes; no schema, route, or config changes
- N/A Tests: no behaviour changes to Python logic