### PR TITLE
feat(engine): add inter-search delay between cycle dispatches

### DIFF
--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -8,6 +8,7 @@ triggers the *arr search command for each eligible item, and writes a row to
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
@@ -39,6 +40,13 @@ _CUTOFF_PAGE_SIZE_MIN = 5
 _CUTOFF_PAGE_SIZE_MAX = 25
 _CUTOFF_SCAN_BUDGET_MIN = 12
 _CUTOFF_SCAN_BUDGET_MAX = 60
+
+# Delay inserted between consecutive real searches within one cycle to spread
+# downstream indexer fan-out.  Each *arr search command causes the arr app to
+# query every configured indexer simultaneously; back-to-back searches compound
+# that burst.  A short pause keeps Houndarr polite without changing its
+# sequential architecture.  Zero this in tests via patch.object.
+_INTER_SEARCH_DELAY_SECONDS: float = 3.0
 
 # Upgrade pass hard caps (very conservative, items already have files)
 _UPGRADE_SCAN_BUDGET_MIN = 8
@@ -385,6 +393,7 @@ async def _run_search_pass(  # noqa: C901
                             candidate.item_type,
                             candidate.item_id,
                         )
+                        await asyncio.sleep(_INTER_SEARCH_DELAY_SECONDS)
                         continue
 
                 reason = (
@@ -455,6 +464,7 @@ async def _run_search_pass(  # noqa: C901
                 candidate.item_type,
                 candidate.item_id,
             )
+            await asyncio.sleep(_INTER_SEARCH_DELAY_SECONDS)
 
         if stop_pass:
             break
@@ -671,6 +681,7 @@ async def _run_upgrade_pass(
             candidate.item_type,
             candidate.item_id,
         )
+        await asyncio.sleep(_INTER_SEARCH_DELAY_SECONDS)
 
     # Persist new offset
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,23 @@ from houndarr.auth import CSRF_COOKIE_NAME
 from houndarr.config import AppSettings
 from houndarr.database import init_db, set_db_path
 
+# ---------------------------------------------------------------------------
+# Global speed fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _zero_inter_search_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero the inter-search delay constant so tests run at full speed.
+
+    The real delay exists to spread downstream indexer fan-out; tests do not
+    hit live indexers, so 3-second waits between dispatched items would make
+    the suite unusably slow.
+    """
+    import houndarr.engine.search_loop as _sl
+
+    monkeypatch.setattr(_sl, "_INTER_SEARCH_DELAY_SECONDS", 0.0)
+
 
 @pytest.fixture()
 def tmp_data_dir() -> Generator[str, None, None]:

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -1865,6 +1865,100 @@ async def test_queue_backpressure_skips_at_exact_limit(
 
 
 # ---------------------------------------------------------------------------
+# Tests — inter-search delay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_inter_search_delay_fires_after_searched_dispatch(
+    seeded_instances: None,
+) -> None:
+    """asyncio.sleep is called once per successful missing-pass search."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    sleep_mock = AsyncMock()
+    instance = _make_instance()
+    with patch("houndarr.engine.search_loop.asyncio.sleep", sleep_mock):
+        count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert sleep_mock.call_count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_inter_search_delay_not_fired_when_item_skipped(
+    seeded_instances: None,
+) -> None:
+    """asyncio.sleep is not called when every item is skipped due to cooldown."""
+    from houndarr.services.cooldown import record_search
+
+    await record_search(1, 101, "episode")
+
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR)
+    )
+
+    sleep_mock = AsyncMock()
+    instance = _make_instance()
+    with patch("houndarr.engine.search_loop.asyncio.sleep", sleep_mock):
+        count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 0
+    sleep_mock.assert_not_called()
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_inter_search_delay_fires_in_upgrade_pass(
+    seeded_instances: None,
+) -> None:
+    """asyncio.sleep is called once for a successful upgrade-pass search."""
+    from dataclasses import replace
+
+    library_movie = {
+        "id": 201,
+        "title": "My Movie",
+        "year": 2023,
+        "monitored": True,
+        "hasFile": True,
+        "movieFile": {"qualityCutoffNotMet": False},
+    }
+    # Missing pass returns nothing so only the upgrade pass fires.
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200, json={"page": 1, "pageSize": 10, "totalRecords": 0, "records": []}
+        )
+    )
+    respx.get(f"{RADARR_URL}/api/v3/movie").mock(
+        return_value=httpx.Response(200, json=[library_movie])
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json={"id": 1, "name": "MoviesSearch"})
+    )
+
+    sleep_mock = AsyncMock()
+    instance = replace(
+        _make_instance(itype=InstanceType.radarr, url=RADARR_URL, instance_id=2, batch_size=0),
+        upgrade_enabled=True,
+        upgrade_batch_size=1,
+        upgrade_cooldown_days=7,
+        upgrade_hourly_cap=5,
+    )
+    with patch("houndarr.engine.search_loop.asyncio.sleep", sleep_mock):
+        count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    assert sleep_mock.call_count == 1
+
+
+# ---------------------------------------------------------------------------
 # Tests — supervisor
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #271

## What changed

Inserts a 3-second pause (`_INTER_SEARCH_DELAY_SECONDS`) between consecutive real searches within a single cycle in `_run_search_pass` (both the regular path and the release-timing retry path) and `_run_upgrade_pass`.

**Why:** Each `*arr` search command fans out to all configured indexers simultaneously. Same-cycle multi-kind searches — e.g. cutoff searched at T+0, upgrade searched at T+1s — can produce a burst of near-simultaneous indexer requests. With 11 indexers configured, two back-to-back searches produce roughly 22 indexer queries in one second. The delay spreads that fan-out without changing Houndarr's sequential dispatch architecture.

The delay applies only to `action="searched"` dispatches. Skipped and errored items do not incur the delay.

The constant is internal and not user-configurable. Tests zero it via an autouse `monkeypatch` fixture added to `conftest.py`.

## Checklist

- [x] All quality gates pass (ruff, mypy, bandit, pytest — 647 tests)
- [x] No new dependencies
- [x] No schema, route, or config changes
- [x] Three new tests: delay fires on `searched`, skipped on cooldown does not trigger delay, upgrade pass delay fires