### PR TITLE
test: extend functionality test suite and add docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ security and container checks.
 ## Running Tests
 
 ```bash
-# Full suite (710 tests, async; count includes parametrised expansions)
+# Full suite (949 tests, async; count includes parametrised expansions)
 .venv/bin/pytest
 
 # Single file

--- a/tests/test_clients/test_client_edge_cases.py
+++ b/tests/test_clients/test_client_edge_cases.py
@@ -1,0 +1,300 @@
+"""Tests for client edge cases: queue status, cutoff_unmet, search, error propagation."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from houndarr.clients.lidarr import LidarrClient
+from houndarr.clients.radarr import RadarrClient
+from houndarr.clients.readarr import ReadarrClient
+from houndarr.clients.sonarr import SonarrClient
+from houndarr.clients.whisparr import WhisparrClient
+
+# ---------------------------------------------------------------------------
+# Queue status: per-app path verification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_queue_status_success() -> None:
+    """SonarrClient.get_queue_status returns the parsed JSON dict."""
+    payload = {"totalCount": 5, "unknownCount": 0}
+    respx.get("http://sonarr:8989/api/v3/queue/status").mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+    async with SonarrClient(url="http://sonarr:8989", api_key="test") as client:
+        result = await client.get_queue_status()
+    assert result["totalCount"] == 5
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_queue_status_path() -> None:
+    """SonarrClient requests /api/v3/queue/status."""
+    route = respx.get("http://sonarr:8989/api/v3/queue/status").mock(
+        return_value=httpx.Response(200, json={"totalCount": 0}),
+    )
+    async with SonarrClient(url="http://sonarr:8989", api_key="test") as client:
+        await client.get_queue_status()
+    assert route.called
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_queue_status_success() -> None:
+    """RadarrClient.get_queue_status returns the parsed JSON dict."""
+    payload = {"totalCount": 3}
+    respx.get("http://radarr:7878/api/v3/queue/status").mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+    async with RadarrClient(url="http://radarr:7878", api_key="test") as client:
+        result = await client.get_queue_status()
+    assert result["totalCount"] == 3
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_lidarr_queue_status_uses_v1_path() -> None:
+    """LidarrClient uses /api/v1/queue/status (not v3)."""
+    route = respx.get("http://lidarr:8686/api/v1/queue/status").mock(
+        return_value=httpx.Response(200, json={"totalCount": 2}),
+    )
+    async with LidarrClient(url="http://lidarr:8686", api_key="test") as client:
+        result = await client.get_queue_status()
+    assert route.called
+    assert result["totalCount"] == 2
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_readarr_queue_status_uses_v1_path() -> None:
+    """ReadarrClient uses /api/v1/queue/status (not v3)."""
+    route = respx.get("http://readarr:8787/api/v1/queue/status").mock(
+        return_value=httpx.Response(200, json={"totalCount": 1}),
+    )
+    async with ReadarrClient(url="http://readarr:8787", api_key="test") as client:
+        result = await client.get_queue_status()
+    assert route.called
+    assert result["totalCount"] == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_whisparr_queue_status_uses_v3_path() -> None:
+    """WhisparrClient uses /api/v3/queue/status."""
+    route = respx.get("http://whisparr:6969/api/v3/queue/status").mock(
+        return_value=httpx.Response(200, json={"totalCount": 0}),
+    )
+    async with WhisparrClient(url="http://whisparr:6969", api_key="test") as client:
+        result = await client.get_queue_status()
+    assert route.called
+    assert result["totalCount"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_status_http_500_raises() -> None:
+    """HTTP 500 on queue/status raises HTTPStatusError."""
+    respx.get("http://sonarr:8989/api/v3/queue/status").mock(
+        return_value=httpx.Response(500),
+    )
+    async with SonarrClient(url="http://sonarr:8989", api_key="test") as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_queue_status()
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_status_transport_error_propagates() -> None:
+    """A ConnectError on queue/status propagates as-is."""
+    respx.get("http://sonarr:8989/api/v3/queue/status").mock(
+        side_effect=httpx.ConnectError("connection refused"),
+    )
+    async with SonarrClient(url="http://sonarr:8989", api_key="test") as client:
+        with pytest.raises(httpx.ConnectError):
+            await client.get_queue_status()
+
+
+# ---------------------------------------------------------------------------
+# get_cutoff_unmet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_get_cutoff_unmet_returns_episodes() -> None:
+    """SonarrClient.get_cutoff_unmet parses the paginated response."""
+    payload = {
+        "page": 1,
+        "pageSize": 10,
+        "totalRecords": 1,
+        "records": [
+            {
+                "id": 101,
+                "seriesId": 55,
+                "title": "Pilot",
+                "seasonNumber": 1,
+                "episodeNumber": 1,
+                "airDateUtc": "2023-09-01T00:00:00Z",
+                "series": {"title": "My Show"},
+            },
+        ],
+    }
+    respx.get("http://sonarr:8989/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+    async with SonarrClient(url="http://sonarr:8989", api_key="test") as client:
+        episodes = await client.get_cutoff_unmet(page=1, page_size=10)
+    assert len(episodes) == 1
+    assert episodes[0].episode_id == 101
+    assert episodes[0].series_title == "My Show"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_get_cutoff_unmet_returns_movies() -> None:
+    """RadarrClient.get_cutoff_unmet parses the paginated response."""
+    payload = {
+        "page": 1,
+        "pageSize": 10,
+        "totalRecords": 1,
+        "records": [
+            {
+                "id": 201,
+                "title": "My Movie",
+                "year": 2023,
+                "status": "released",
+                "minimumAvailability": "released",
+                "isAvailable": True,
+                "inCinemas": "2023-01-01T00:00:00Z",
+                "physicalRelease": "2023-02-01T00:00:00Z",
+                "releaseDate": "2023-02-01T00:00:00Z",
+                "digitalRelease": None,
+            },
+        ],
+    }
+    respx.get("http://radarr:7878/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+    async with RadarrClient(url="http://radarr:7878", api_key="test") as client:
+        movies = await client.get_cutoff_unmet(page=1, page_size=10)
+    assert len(movies) == 1
+    assert movies[0].movie_id == 201
+    assert movies[0].title == "My Movie"
+
+
+# ---------------------------------------------------------------------------
+# search: verify POST body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_search_posts_episode_search() -> None:
+    """SonarrClient.search POSTs EpisodeSearch with the correct episode ID."""
+    route = respx.post("http://sonarr:8989/api/v3/command").mock(
+        return_value=httpx.Response(200, json={"id": 1, "name": "EpisodeSearch"}),
+    )
+    async with SonarrClient(url="http://sonarr:8989", api_key="test") as client:
+        await client.search(101)
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["name"] == "EpisodeSearch"
+    assert body["episodeIds"] == [101]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_search_posts_movies_search() -> None:
+    """RadarrClient.search POSTs MoviesSearch with the correct movie ID."""
+    route = respx.post("http://radarr:7878/api/v3/command").mock(
+        return_value=httpx.Response(200, json={"id": 1, "name": "MoviesSearch"}),
+    )
+    async with RadarrClient(url="http://radarr:7878", api_key="test") as client:
+        await client.search(201)
+
+    body = json.loads(route.calls[0].request.content)
+    assert body["name"] == "MoviesSearch"
+    assert body["movieIds"] == [201]
+
+
+# ---------------------------------------------------------------------------
+# get_library
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_get_library_returns_movies() -> None:
+    """RadarrClient.get_library parses the flat array response."""
+    payload = [
+        {
+            "id": 201,
+            "title": "My Movie",
+            "year": 2023,
+            "monitored": True,
+            "hasFile": True,
+            "movieFile": {"qualityCutoffNotMet": False},
+            "inCinemas": "2023-01-01T00:00:00Z",
+            "physicalRelease": None,
+            "digitalRelease": None,
+        },
+    ]
+    respx.get("http://radarr:7878/api/v3/movie").mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+    async with RadarrClient(url="http://radarr:7878", api_key="test") as client:
+        movies = await client.get_library()
+    assert len(movies) == 1
+    assert movies[0].movie_id == 201
+    assert movies[0].monitored is True
+    assert movies[0].has_file is True
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_library_cutoff_met_parsing() -> None:
+    """qualityCutoffNotMet=False means cutoff_met=True on LibraryMovie."""
+    payload = [
+        {
+            "id": 202,
+            "title": "Quality Movie",
+            "year": 2022,
+            "monitored": True,
+            "hasFile": True,
+            "movieFile": {"qualityCutoffNotMet": False},
+            "inCinemas": None,
+            "physicalRelease": None,
+            "digitalRelease": None,
+        },
+    ]
+    respx.get("http://radarr:7878/api/v3/movie").mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+    async with RadarrClient(url="http://radarr:7878", api_key="test") as client:
+        movies = await client.get_library()
+    assert movies[0].cutoff_met is True
+
+
+# ---------------------------------------------------------------------------
+# aclose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_client_aclose_callable() -> None:
+    """aclose() can be called without error, closing the underlying client."""
+    client = SonarrClient(url="http://sonarr:8989", api_key="test")
+    await client.aclose()
+    assert client._client.is_closed  # noqa: SLF001

--- a/tests/test_database_edge_cases.py
+++ b/tests/test_database_edge_cases.py
@@ -1,0 +1,173 @@
+"""Tests for database edge cases: purge_old_logs, get_setting, set_setting, concurrent access."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from houndarr.database import get_db, get_setting, purge_old_logs, set_setting
+
+# ---------------------------------------------------------------------------
+# purge_old_logs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_purge_old_logs_zero_days_noop(db: None) -> None:
+    """retention_days=0 disables purging and returns 0."""
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO search_log (action, timestamp)"
+            " VALUES ('info', datetime('now', '-100 days'))",
+        )
+        await conn.commit()
+
+    deleted = await purge_old_logs(0)
+    assert deleted == 0
+
+
+@pytest.mark.asyncio()
+async def test_purge_old_logs_negative_days_noop(db: None) -> None:
+    """Negative retention_days disables purging and returns 0."""
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO search_log (action, timestamp)"
+            " VALUES ('info', datetime('now', '-100 days'))",
+        )
+        await conn.commit()
+
+    deleted = await purge_old_logs(-7)
+    assert deleted == 0
+
+
+@pytest.mark.asyncio()
+async def test_purge_old_logs_deletes_old_rows(db: None) -> None:
+    """Rows older than retention_days are deleted."""
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO search_log (action, timestamp)"
+            " VALUES ('info', datetime('now', '-60 days'))",
+        )
+        await conn.commit()
+
+    deleted = await purge_old_logs(30)
+    assert deleted == 1
+
+
+@pytest.mark.asyncio()
+async def test_purge_old_logs_preserves_recent_rows(db: None) -> None:
+    """Rows newer than retention_days are preserved."""
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO search_log (action, timestamp)"
+            " VALUES ('info', datetime('now', '-5 days'))",
+        )
+        await conn.commit()
+
+    deleted = await purge_old_logs(30)
+    assert deleted == 0
+
+    async with get_db() as conn:
+        async with conn.execute("SELECT COUNT(*) FROM search_log") as cur:
+            row = await cur.fetchone()
+    assert row is not None
+    assert int(row[0]) == 1
+
+
+@pytest.mark.asyncio()
+async def test_purge_old_logs_returns_count(db: None) -> None:
+    """purge_old_logs returns the exact number of rows deleted."""
+    async with get_db() as conn:
+        for i in range(5):
+            await conn.execute(
+                "INSERT INTO search_log (action, timestamp)"
+                " VALUES ('info', datetime('now', ? || ' days'))",
+                (f"-{40 + i}",),
+            )
+        # Also insert a recent row that should survive
+        await conn.execute(
+            "INSERT INTO search_log (action, timestamp)"
+            " VALUES ('info', datetime('now', '-2 days'))",
+        )
+        await conn.commit()
+
+    deleted = await purge_old_logs(30)
+    assert deleted == 5
+
+
+# ---------------------------------------------------------------------------
+# get_setting / set_setting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_get_setting_missing_key_returns_default(db: None) -> None:
+    """A missing key returns the provided default."""
+    result = await get_setting("nonexistent", default="fallback")
+    assert result == "fallback"
+
+
+@pytest.mark.asyncio()
+async def test_get_setting_missing_key_no_default_returns_none(db: None) -> None:
+    """A missing key with no default returns None."""
+    result = await get_setting("nonexistent")
+    assert result is None
+
+
+@pytest.mark.asyncio()
+async def test_get_setting_existing_key(db: None) -> None:
+    """An existing key returns its stored value."""
+    # schema_version is set during init_db
+    result = await get_setting("schema_version")
+    assert result is not None
+    assert int(result) > 0
+
+
+@pytest.mark.asyncio()
+async def test_set_setting_inserts_new(db: None) -> None:
+    """set_setting inserts a new key-value pair."""
+    await set_setting("test_key", "test_value")
+    result = await get_setting("test_key")
+    assert result == "test_value"
+
+
+@pytest.mark.asyncio()
+async def test_set_setting_overwrites_existing(db: None) -> None:
+    """set_setting overwrites the value of an existing key."""
+    await set_setting("overwrite_key", "first")
+    await set_setting("overwrite_key", "second")
+    result = await get_setting("overwrite_key")
+    assert result == "second"
+
+
+@pytest.mark.asyncio()
+async def test_set_setting_then_get_roundtrip(db: None) -> None:
+    """A set followed by a get returns the exact same value."""
+    value = "complex value with spaces & symbols!"
+    await set_setting("roundtrip", value)
+    result = await get_setting("roundtrip")
+    assert result == value
+
+
+# ---------------------------------------------------------------------------
+# Concurrent get_db calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_concurrent_get_db_calls_succeed(db: None) -> None:
+    """Multiple concurrent get_db contexts do not deadlock or fail."""
+
+    async def _write_setting(key: str, value: str) -> None:
+        await set_setting(key, value)
+
+    await asyncio.gather(
+        _write_setting("concurrent_a", "val_a"),
+        _write_setting("concurrent_b", "val_b"),
+        _write_setting("concurrent_c", "val_c"),
+    )
+
+    assert await get_setting("concurrent_a") == "val_a"
+    assert await get_setting("concurrent_b") == "val_b"
+    assert await get_setting("concurrent_c") == "val_c"

--- a/tests/test_engine/conftest.py
+++ b/tests/test_engine/conftest.py
@@ -1,0 +1,280 @@
+"""Shared fixtures and helpers for engine test files."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest_asyncio
+from cryptography.fernet import Fernet
+
+from houndarr.database import get_db
+from houndarr.engine.candidates import ItemType
+from houndarr.services.instances import (
+    Instance,
+    InstanceType,
+    LidarrSearchMode,
+    ReadarrSearchMode,
+    SonarrSearchMode,
+    WhisparrSearchMode,
+)
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+SONARR_URL = "http://sonarr:8989"
+RADARR_URL = "http://radarr:7878"
+LIDARR_URL = "http://lidarr:8686"
+READARR_URL = "http://readarr:8787"
+WHISPARR_URL = "http://whisparr:6969"
+MASTER_KEY: bytes = Fernet.generate_key()
+
+_EPISODE_RECORD: dict[str, Any] = {
+    "id": 101,
+    "seriesId": 55,
+    "title": "Pilot",
+    "seasonNumber": 1,
+    "episodeNumber": 1,
+    "airDateUtc": "2023-09-01T00:00:00Z",
+    "series": {"title": "My Show"},
+}
+
+_MOVIE_RECORD: dict[str, Any] = {
+    "id": 201,
+    "title": "My Movie",
+    "year": 2023,
+    "status": "released",
+    "minimumAvailability": "released",
+    "isAvailable": True,
+    "inCinemas": "2023-01-01T00:00:00Z",
+    "physicalRelease": "2023-02-01T00:00:00Z",
+    "releaseDate": "2023-02-01T00:00:00Z",
+    "digitalRelease": None,
+}
+
+_ALBUM_RECORD: dict[str, Any] = {
+    "id": 301,
+    "artistId": 50,
+    "title": "Greatest Hits",
+    "releaseDate": "2023-03-15T00:00:00Z",
+    "artist": {"id": 50, "artistName": "Test Artist"},
+}
+
+_BOOK_RECORD: dict[str, Any] = {
+    "id": 401,
+    "authorId": 60,
+    "title": "Test Book",
+    "releaseDate": "2023-06-01T00:00:00Z",
+    "author": {"id": 60, "authorName": "Test Author"},
+}
+
+_WHISPARR_EPISODE_RECORD: dict[str, Any] = {
+    "id": 501,
+    "seriesId": 70,
+    "title": "Scene Title",
+    "seasonNumber": 1,
+    "absoluteEpisodeNumber": 5,
+    "releaseDate": {"year": 2023, "month": 9, "day": 1},
+    "series": {"id": 70, "title": "My Whisparr Show"},
+}
+
+_MISSING_SONARR: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_EPISODE_RECORD],
+}
+_MISSING_RADARR: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_MOVIE_RECORD],
+}
+_MISSING_LIDARR: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_ALBUM_RECORD],
+}
+_MISSING_READARR: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_BOOK_RECORD],
+}
+_MISSING_WHISPARR: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_WHISPARR_EPISODE_RECORD],
+}
+_COMMAND_RESP: dict[str, Any] = {"id": 1, "name": "EpisodeSearch"}
+_FUTURE_AIR_DATE = "2999-01-01T00:00:00Z"
+
+# URL map for easy per-type lookups
+URL_FOR_TYPE: dict[InstanceType, str] = {
+    InstanceType.sonarr: SONARR_URL,
+    InstanceType.radarr: RADARR_URL,
+    InstanceType.lidarr: LIDARR_URL,
+    InstanceType.readarr: READARR_URL,
+    InstanceType.whisparr: WHISPARR_URL,
+}
+
+
+# ---------------------------------------------------------------------------
+# Instance factory
+# ---------------------------------------------------------------------------
+
+
+def make_instance(
+    *,
+    instance_id: int = 1,
+    itype: InstanceType = InstanceType.sonarr,
+    url: str | None = None,
+    batch_size: int = 10,
+    hourly_cap: int = 20,
+    cooldown_days: int = 7,
+    post_release_grace_hrs: int = 24,
+    queue_limit: int = 0,
+    enabled: bool = True,
+    cutoff_enabled: bool = False,
+    cutoff_batch_size: int = 5,
+    cutoff_cooldown_days: int = 21,
+    cutoff_hourly_cap: int = 1,
+    sonarr_search_mode: SonarrSearchMode = SonarrSearchMode.episode,
+    lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album,
+    readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book,
+    whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode,
+    upgrade_enabled: bool = False,
+    upgrade_batch_size: int = 1,
+    upgrade_cooldown_days: int = 90,
+    upgrade_hourly_cap: int = 1,
+    upgrade_sonarr_search_mode: SonarrSearchMode = SonarrSearchMode.episode,
+    upgrade_lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album,
+    upgrade_readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book,
+    upgrade_whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode,
+    upgrade_item_offset: int = 0,
+    upgrade_series_offset: int = 0,
+) -> Instance:
+    """Build an Instance with sensible defaults for testing."""
+    resolved_url = url or URL_FOR_TYPE.get(itype, SONARR_URL)
+    return Instance(
+        id=instance_id,
+        name="Test Instance",
+        type=itype,
+        url=resolved_url,
+        api_key="test-api-key",
+        enabled=enabled,
+        batch_size=batch_size,
+        sleep_interval_mins=15,
+        hourly_cap=hourly_cap,
+        cooldown_days=cooldown_days,
+        post_release_grace_hrs=post_release_grace_hrs,
+        queue_limit=queue_limit,
+        cutoff_enabled=cutoff_enabled,
+        cutoff_batch_size=cutoff_batch_size,
+        cutoff_cooldown_days=cutoff_cooldown_days,
+        cutoff_hourly_cap=cutoff_hourly_cap,
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        sonarr_search_mode=sonarr_search_mode,
+        lidarr_search_mode=lidarr_search_mode,
+        readarr_search_mode=readarr_search_mode,
+        whisparr_search_mode=whisparr_search_mode,
+        upgrade_enabled=upgrade_enabled,
+        upgrade_batch_size=upgrade_batch_size,
+        upgrade_cooldown_days=upgrade_cooldown_days,
+        upgrade_hourly_cap=upgrade_hourly_cap,
+        upgrade_sonarr_search_mode=upgrade_sonarr_search_mode,
+        upgrade_lidarr_search_mode=upgrade_lidarr_search_mode,
+        upgrade_readarr_search_mode=upgrade_readarr_search_mode,
+        upgrade_whisparr_search_mode=upgrade_whisparr_search_mode,
+        upgrade_item_offset=upgrade_item_offset,
+        upgrade_series_offset=upgrade_series_offset,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def seeded_instances(db: None) -> AsyncGenerator[None, None]:
+    """Seed FK-required rows into instances so search_log/cooldowns can reference them."""
+    from houndarr.crypto import encrypt
+
+    encrypted = encrypt("test-api-key", MASTER_KEY)
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
+            [
+                (1, "Sonarr Test", "sonarr", SONARR_URL, encrypted),
+                (2, "Radarr Test", "radarr", RADARR_URL, encrypted),
+                (3, "Lidarr Test", "lidarr", LIDARR_URL, encrypted),
+                (4, "Readarr Test", "readarr", READARR_URL, encrypted),
+                (5, "Whisparr Test", "whisparr", WHISPARR_URL, encrypted),
+            ],
+        )
+        await conn.commit()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def get_log_rows() -> list[dict[str, Any]]:
+    """Fetch all search_log rows ordered by id."""
+    async with get_db() as conn:
+        async with conn.execute("SELECT * FROM search_log ORDER BY id ASC") as cur:
+            rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def insert_search_log_row(
+    *,
+    instance_id: int,
+    item_id: int,
+    item_type: str,
+    search_kind: str,
+    action: str,
+    reason: str | None = None,
+    cycle_id: str | None = None,
+    cycle_trigger: str | None = None,
+) -> None:
+    """Insert a raw search_log row for test setup."""
+    async with get_db() as conn:
+        await conn.execute(
+            """
+            INSERT INTO search_log
+                (instance_id, item_id, item_type, search_kind, action, reason,
+                 cycle_id, cycle_trigger)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (instance_id, item_id, item_type, search_kind, action, reason, cycle_id, cycle_trigger),
+        )
+        await conn.commit()
+
+
+async def seed_release_timing_retry(
+    *,
+    instance_id: int,
+    item_id: int,
+    item_type: ItemType,
+    reason: str = "not yet released",
+) -> None:
+    """Set up an item on cooldown with a release-timing skip reason."""
+    from houndarr.services.cooldown import record_search
+
+    await record_search(instance_id, item_id, item_type)
+    await insert_search_log_row(
+        instance_id=instance_id,
+        item_id=item_id,
+        item_type=item_type,
+        search_kind="missing",
+        action="skipped",
+        reason=reason,
+    )

--- a/tests/test_engine/test_adapter_edge_cases.py
+++ b/tests/test_engine/test_adapter_edge_cases.py
@@ -1,0 +1,566 @@
+"""Tests for adapter edge cases: adapt_missing, adapt_cutoff, adapt_upgrade per app."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from houndarr.clients.lidarr import LibraryAlbum, MissingAlbum
+from houndarr.clients.radarr import LibraryMovie, MissingMovie
+from houndarr.clients.readarr import LibraryBook, MissingBook
+from houndarr.clients.sonarr import LibraryEpisode, MissingEpisode
+from houndarr.clients.whisparr import LibraryWhisparrEpisode, MissingWhisparrEpisode
+from houndarr.engine.adapters import lidarr as lidarr_adapter
+from houndarr.engine.adapters import radarr as radarr_adapter
+from houndarr.engine.adapters import readarr as readarr_adapter
+from houndarr.engine.adapters import sonarr as sonarr_adapter
+from houndarr.engine.adapters import whisparr as whisparr_adapter
+from houndarr.engine.adapters.lidarr import _artist_item_id
+from houndarr.engine.adapters.readarr import _author_item_id
+from houndarr.engine.adapters.sonarr import _season_item_id
+from houndarr.services.instances import (
+    InstanceType,
+    LidarrSearchMode,
+    ReadarrSearchMode,
+    SonarrSearchMode,
+    WhisparrSearchMode,
+)
+from tests.test_engine.conftest import make_instance
+
+# ---------------------------------------------------------------------------
+# Shared test data builders
+# ---------------------------------------------------------------------------
+
+_PAST_DATE = "2020-01-01T00:00:00Z"
+
+
+def _missing_episode(
+    *,
+    episode_id: int = 101,
+    series_id: int | None = 55,
+    season: int = 1,
+    episode: int = 1,
+    air_date_utc: str | None = _PAST_DATE,
+) -> MissingEpisode:
+    return MissingEpisode(
+        episode_id=episode_id,
+        series_id=series_id,
+        series_title="My Show",
+        episode_title="Pilot",
+        season=season,
+        episode=episode,
+        air_date_utc=air_date_utc,
+    )
+
+
+def _library_episode(
+    *,
+    episode_id: int = 101,
+    series_id: int = 55,
+    season: int = 1,
+    episode: int = 1,
+) -> LibraryEpisode:
+    return LibraryEpisode(
+        episode_id=episode_id,
+        series_id=series_id,
+        series_title="My Show",
+        episode_title="Pilot",
+        season=season,
+        episode=episode,
+        monitored=True,
+        has_file=True,
+        cutoff_met=True,
+    )
+
+
+def _missing_movie(*, movie_id: int = 201) -> MissingMovie:
+    return MissingMovie(
+        movie_id=movie_id,
+        title="My Movie",
+        year=2023,
+        status="released",
+        minimum_availability="released",
+        is_available=True,
+        in_cinemas="2023-01-01T00:00:00Z",
+        physical_release="2023-02-01T00:00:00Z",
+        release_date="2023-02-01T00:00:00Z",
+        digital_release=None,
+    )
+
+
+def _library_movie(*, movie_id: int = 201) -> LibraryMovie:
+    return LibraryMovie(
+        movie_id=movie_id,
+        title="My Movie",
+        year=2023,
+        monitored=True,
+        has_file=True,
+        cutoff_met=True,
+        in_cinemas="2023-01-01T00:00:00Z",
+        physical_release=None,
+        digital_release=None,
+    )
+
+
+def _missing_album(
+    *,
+    album_id: int = 301,
+    artist_id: int = 50,
+) -> MissingAlbum:
+    return MissingAlbum(
+        album_id=album_id,
+        artist_id=artist_id,
+        artist_name="Test Artist",
+        title="Greatest Hits",
+        release_date=_PAST_DATE,
+    )
+
+
+def _library_album(
+    *,
+    album_id: int = 301,
+    artist_id: int = 50,
+) -> LibraryAlbum:
+    return LibraryAlbum(
+        album_id=album_id,
+        artist_id=artist_id,
+        artist_name="Test Artist",
+        title="Greatest Hits",
+        monitored=True,
+        has_file=True,
+        release_date=_PAST_DATE,
+    )
+
+
+def _missing_book(
+    *,
+    book_id: int = 401,
+    author_id: int = 60,
+) -> MissingBook:
+    return MissingBook(
+        book_id=book_id,
+        author_id=author_id,
+        author_name="Test Author",
+        title="Test Book",
+        release_date=_PAST_DATE,
+    )
+
+
+def _library_book(
+    *,
+    book_id: int = 401,
+    author_id: int = 60,
+) -> LibraryBook:
+    return LibraryBook(
+        book_id=book_id,
+        author_id=author_id,
+        author_name="Test Author",
+        title="Test Book",
+        monitored=True,
+        has_file=True,
+        release_date=_PAST_DATE,
+    )
+
+
+def _missing_whisparr_episode(
+    *,
+    episode_id: int = 501,
+    series_id: int | None = 70,
+    season_number: int = 1,
+    release_date: datetime | None = None,
+) -> MissingWhisparrEpisode:
+    return MissingWhisparrEpisode(
+        episode_id=episode_id,
+        series_id=series_id,
+        series_title="My Whisparr Show",
+        episode_title="Scene Title",
+        season_number=season_number,
+        absolute_episode_number=5,
+        release_date=release_date,
+    )
+
+
+def _library_whisparr_episode(
+    *,
+    episode_id: int = 501,
+    series_id: int = 70,
+    season_number: int = 1,
+) -> LibraryWhisparrEpisode:
+    return LibraryWhisparrEpisode(
+        episode_id=episode_id,
+        series_id=series_id,
+        series_title="My Whisparr Show",
+        episode_title="Scene Title",
+        season_number=season_number,
+        absolute_episode_number=5,
+        monitored=True,
+        has_file=True,
+        cutoff_met=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sonarr adapter
+# ---------------------------------------------------------------------------
+
+
+def test_sonarr_adapt_missing_episode_mode() -> None:
+    """Episode mode: item_id=episode_id, group_key=None."""
+    inst = make_instance(itype=InstanceType.sonarr, sonarr_search_mode=SonarrSearchMode.episode)
+    item = _missing_episode()
+    cand = sonarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 101
+    assert cand.item_type == "episode"
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "EpisodeSearch"
+    assert cand.search_payload["episode_id"] == 101
+
+
+def test_sonarr_adapt_missing_season_context() -> None:
+    """Season-context mode: synthetic item_id, group_key=(series_id, season)."""
+    inst = make_instance(
+        itype=InstanceType.sonarr,
+        sonarr_search_mode=SonarrSearchMode.season_context,
+    )
+    item = _missing_episode(series_id=55, season=2)
+    cand = sonarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == _season_item_id(55, 2)
+    assert cand.group_key == (55, 2)
+    assert cand.search_payload["command"] == "SeasonSearch"
+
+
+def test_sonarr_adapt_missing_season_zero_falls_back_to_episode() -> None:
+    """Season 0 (specials) in season_context mode falls back to episode mode."""
+    inst = make_instance(
+        itype=InstanceType.sonarr,
+        sonarr_search_mode=SonarrSearchMode.season_context,
+    )
+    item = _missing_episode(series_id=55, season=0)
+    cand = sonarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 101
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "EpisodeSearch"
+
+
+def test_sonarr_adapt_missing_series_id_none_falls_back() -> None:
+    """series_id=None in season_context mode falls back to episode mode."""
+    inst = make_instance(
+        itype=InstanceType.sonarr,
+        sonarr_search_mode=SonarrSearchMode.season_context,
+    )
+    item = _missing_episode(series_id=None, season=1)
+    cand = sonarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 101
+    assert cand.group_key is None
+
+
+def test_sonarr_adapt_cutoff_always_episode_mode() -> None:
+    """Cutoff pass always uses episode mode, regardless of sonarr_search_mode."""
+    inst = make_instance(
+        itype=InstanceType.sonarr,
+        sonarr_search_mode=SonarrSearchMode.episode,
+    )
+    item = _missing_episode()
+    cand = sonarr_adapter.adapt_cutoff(item, inst)
+
+    assert cand.item_id == 101
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "EpisodeSearch"
+
+
+def test_sonarr_adapt_cutoff_season_context_still_episode() -> None:
+    """Even with season_context setting, cutoff uses episode mode."""
+    inst = make_instance(
+        itype=InstanceType.sonarr,
+        sonarr_search_mode=SonarrSearchMode.season_context,
+    )
+    item = _missing_episode(series_id=55, season=2)
+    cand = sonarr_adapter.adapt_cutoff(item, inst)
+
+    assert cand.item_id == 101
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "EpisodeSearch"
+
+
+# ---------------------------------------------------------------------------
+# Radarr adapter
+# ---------------------------------------------------------------------------
+
+
+def test_radarr_adapt_missing_movie_payload() -> None:
+    """Radarr missing: command=MoviesSearch, group_key=None."""
+    inst = make_instance(itype=InstanceType.radarr)
+    item = _missing_movie()
+    cand = radarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 201
+    assert cand.item_type == "movie"
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "MoviesSearch"
+    assert cand.search_payload["movie_id"] == 201
+
+
+def test_radarr_adapt_cutoff_delegates_to_missing() -> None:
+    """Radarr adapt_cutoff produces the same result as adapt_missing."""
+    inst = make_instance(itype=InstanceType.radarr)
+    item = _missing_movie()
+    missing_cand = radarr_adapter.adapt_missing(item, inst)
+    cutoff_cand = radarr_adapter.adapt_cutoff(item, inst)
+
+    assert missing_cand.item_id == cutoff_cand.item_id
+    assert missing_cand.search_payload == cutoff_cand.search_payload
+    assert missing_cand.group_key == cutoff_cand.group_key
+
+
+def test_radarr_adapt_upgrade_no_unreleased_reason() -> None:
+    """Radarr upgrade candidates always have unreleased_reason=None."""
+    inst = make_instance(itype=InstanceType.radarr)
+    item = _library_movie()
+    cand = radarr_adapter.adapt_upgrade(item, inst)
+
+    assert cand.unreleased_reason is None
+    assert cand.search_payload["command"] == "MoviesSearch"
+
+
+# ---------------------------------------------------------------------------
+# Lidarr adapter
+# ---------------------------------------------------------------------------
+
+
+def test_lidarr_adapt_missing_album_mode() -> None:
+    """Album mode: album_id, group_key=None, command=AlbumSearch."""
+    inst = make_instance(
+        itype=InstanceType.lidarr,
+        lidarr_search_mode=LidarrSearchMode.album,
+    )
+    item = _missing_album()
+    cand = lidarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 301
+    assert cand.item_type == "album"
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "AlbumSearch"
+
+
+def test_lidarr_adapt_missing_artist_context() -> None:
+    """Artist-context: synthetic_id, group_key=(artist_id, 0), command=ArtistSearch."""
+    inst = make_instance(
+        itype=InstanceType.lidarr,
+        lidarr_search_mode=LidarrSearchMode.artist_context,
+    )
+    item = _missing_album(artist_id=50)
+    cand = lidarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == _artist_item_id(50)
+    assert cand.group_key == (50, 0)
+    assert cand.search_payload["command"] == "ArtistSearch"
+
+
+def test_lidarr_adapt_missing_artist_id_zero_fallback() -> None:
+    """artist_id=0 in artist_context mode falls back to album mode."""
+    inst = make_instance(
+        itype=InstanceType.lidarr,
+        lidarr_search_mode=LidarrSearchMode.artist_context,
+    )
+    item = _missing_album(artist_id=0)
+    cand = lidarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 301
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "AlbumSearch"
+
+
+def test_lidarr_adapt_cutoff_always_album_mode() -> None:
+    """Cutoff always uses album mode regardless of lidarr_search_mode."""
+    inst = make_instance(
+        itype=InstanceType.lidarr,
+        lidarr_search_mode=LidarrSearchMode.artist_context,
+    )
+    item = _missing_album(artist_id=50)
+    cand = lidarr_adapter.adapt_cutoff(item, inst)
+
+    assert cand.item_id == 301
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "AlbumSearch"
+
+
+def test_lidarr_adapt_upgrade_artist_context() -> None:
+    """Upgrade with upgrade_lidarr_search_mode=artist_context."""
+    inst = make_instance(
+        itype=InstanceType.lidarr,
+        upgrade_lidarr_search_mode=LidarrSearchMode.artist_context,
+    )
+    item = _library_album(artist_id=50)
+    cand = lidarr_adapter.adapt_upgrade(item, inst)
+
+    assert cand.item_id == _artist_item_id(50)
+    assert cand.group_key == (50, 0)
+    assert cand.unreleased_reason is None
+
+
+# ---------------------------------------------------------------------------
+# Readarr adapter
+# ---------------------------------------------------------------------------
+
+
+def test_readarr_adapt_missing_book_mode() -> None:
+    """Book mode: book_id, group_key=None, command=BookSearch."""
+    inst = make_instance(
+        itype=InstanceType.readarr,
+        readarr_search_mode=ReadarrSearchMode.book,
+    )
+    item = _missing_book()
+    cand = readarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 401
+    assert cand.item_type == "book"
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "BookSearch"
+
+
+def test_readarr_adapt_missing_author_context() -> None:
+    """Author-context: synthetic_id, group_key=(author_id, 0), command=AuthorSearch."""
+    inst = make_instance(
+        itype=InstanceType.readarr,
+        readarr_search_mode=ReadarrSearchMode.author_context,
+    )
+    item = _missing_book(author_id=60)
+    cand = readarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == _author_item_id(60)
+    assert cand.group_key == (60, 0)
+    assert cand.search_payload["command"] == "AuthorSearch"
+
+
+def test_readarr_adapt_missing_author_id_zero_fallback() -> None:
+    """author_id=0 in author_context mode falls back to book mode."""
+    inst = make_instance(
+        itype=InstanceType.readarr,
+        readarr_search_mode=ReadarrSearchMode.author_context,
+    )
+    item = _missing_book(author_id=0)
+    cand = readarr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 401
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "BookSearch"
+
+
+def test_readarr_adapt_cutoff_always_book_mode() -> None:
+    """Cutoff always uses book mode regardless of readarr_search_mode."""
+    inst = make_instance(
+        itype=InstanceType.readarr,
+        readarr_search_mode=ReadarrSearchMode.author_context,
+    )
+    item = _missing_book(author_id=60)
+    cand = readarr_adapter.adapt_cutoff(item, inst)
+
+    assert cand.item_id == 401
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "BookSearch"
+
+
+def test_readarr_adapt_upgrade_author_context() -> None:
+    """Upgrade with upgrade_readarr_search_mode=author_context."""
+    inst = make_instance(
+        itype=InstanceType.readarr,
+        upgrade_readarr_search_mode=ReadarrSearchMode.author_context,
+    )
+    item = _library_book(author_id=60)
+    cand = readarr_adapter.adapt_upgrade(item, inst)
+
+    assert cand.item_id == _author_item_id(60)
+    assert cand.group_key == (60, 0)
+    assert cand.unreleased_reason is None
+
+
+# ---------------------------------------------------------------------------
+# Whisparr adapter
+# ---------------------------------------------------------------------------
+
+
+def test_whisparr_adapt_missing_episode_mode() -> None:
+    """Episode mode: item_type=whisparr_episode, group_key=None."""
+    inst = make_instance(
+        itype=InstanceType.whisparr,
+        whisparr_search_mode=WhisparrSearchMode.episode,
+    )
+    item = _missing_whisparr_episode()
+    cand = whisparr_adapter.adapt_missing(item, inst)
+
+    assert cand.item_id == 501
+    assert cand.item_type == "whisparr_episode"
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "EpisodeSearch"
+
+
+def test_whisparr_adapt_missing_season_context() -> None:
+    """Season-context: synthetic item_id, group_key=(series_id, season)."""
+    inst = make_instance(
+        itype=InstanceType.whisparr,
+        whisparr_search_mode=WhisparrSearchMode.season_context,
+    )
+    item = _missing_whisparr_episode(series_id=70, season_number=2)
+    cand = whisparr_adapter.adapt_missing(item, inst)
+
+    expected_id = -(70 * 1000 + 2)
+    assert cand.item_id == expected_id
+    assert cand.group_key == (70, 2)
+    assert cand.search_payload["command"] == "SeasonSearch"
+
+
+def test_whisparr_adapt_cutoff_always_episode_mode() -> None:
+    """Cutoff always uses episode mode for Whisparr."""
+    inst = make_instance(
+        itype=InstanceType.whisparr,
+        whisparr_search_mode=WhisparrSearchMode.season_context,
+    )
+    item = _missing_whisparr_episode(series_id=70, season_number=2)
+    cand = whisparr_adapter.adapt_cutoff(item, inst)
+
+    assert cand.item_id == 501
+    assert cand.group_key is None
+    assert cand.search_payload["command"] == "EpisodeSearch"
+
+
+def test_whisparr_adapt_upgrade_season_context() -> None:
+    """Upgrade with upgrade_whisparr_search_mode=season_context."""
+    inst = make_instance(
+        itype=InstanceType.whisparr,
+        upgrade_whisparr_search_mode=WhisparrSearchMode.season_context,
+    )
+    item = _library_whisparr_episode(series_id=70, season_number=2)
+    cand = whisparr_adapter.adapt_upgrade(item, inst)
+
+    expected_id = -(70 * 1000 + 2)
+    assert cand.item_id == expected_id
+    assert cand.group_key == (70, 2)
+    assert cand.unreleased_reason is None
+
+
+def test_whisparr_unreleased_with_future_datetime() -> None:
+    """A future datetime produces unreleased_reason='not yet released'."""
+    inst = make_instance(
+        itype=InstanceType.whisparr,
+        whisparr_search_mode=WhisparrSearchMode.episode,
+    )
+    future_dt = datetime.now(UTC) + timedelta(days=30)
+    item = _missing_whisparr_episode(release_date=future_dt)
+    cand = whisparr_adapter.adapt_missing(item, inst)
+
+    assert cand.unreleased_reason == "not yet released"
+
+
+def test_whisparr_unreleased_with_none_release_date() -> None:
+    """release_date=None means the item is eligible (unreleased_reason=None)."""
+    inst = make_instance(
+        itype=InstanceType.whisparr,
+        whisparr_search_mode=WhisparrSearchMode.episode,
+    )
+    item = _missing_whisparr_episode(release_date=None)
+    cand = whisparr_adapter.adapt_missing(item, inst)
+
+    assert cand.unreleased_reason is None

--- a/tests/test_engine/test_api_data_handling.py
+++ b/tests/test_engine/test_api_data_handling.py
@@ -1,0 +1,611 @@
+"""Tests for edge cases in how the engine handles unusual *arr API data."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import InstanceType
+
+from .conftest import (
+    _COMMAND_RESP,
+    _EPISODE_RECORD,
+    _MOVIE_RECORD,
+    MASTER_KEY,
+    RADARR_URL,
+    SONARR_URL,
+    get_log_rows,
+    make_instance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMPTY_PAGE: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 0,
+    "records": [],
+}
+
+
+def _sonarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 1,
+        "itype": InstanceType.sonarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _radarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 2,
+        "itype": InstanceType.radarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _movie(movie_id: int = 201, **overrides: Any) -> dict[str, Any]:
+    base = {**_MOVIE_RECORD, "id": movie_id}
+    base.update(overrides)
+    return base
+
+
+def _radarr_missing_page(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "page": 1,
+        "pageSize": 50,
+        "totalRecords": len(records),
+        "records": records,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Empty list tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_empty_missing_list_no_searches(
+    seeded_instances: None,
+) -> None:
+    """Sonarr returns empty records: count=0, no error logs."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+
+    inst = _sonarr_instance()
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+    rows = await get_log_rows()
+    assert not any(r["action"] == "error" for r in rows)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_empty_cutoff_list_no_searches(
+    seeded_instances: None,
+) -> None:
+    """cutoff_enabled with empty cutoff list: count=0 for cutoff pass."""
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+
+    inst = _radarr_instance(cutoff_enabled=True)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Radarr release anchor fallback chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_digital_release_preferred(
+    seeded_instances: None,
+) -> None:
+    """Movie with past digitalRelease is eligible for search."""
+    movie = _movie(
+        digitalRelease="2023-01-15T00:00:00Z",
+        physicalRelease="2023-02-01T00:00:00Z",
+        inCinemas="2022-12-01T00:00:00Z",
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_physical_release_fallback(
+    seeded_instances: None,
+) -> None:
+    """digitalRelease=None, past physicalRelease: eligible."""
+    movie = _movie(
+        digitalRelease=None,
+        physicalRelease="2023-02-01T00:00:00Z",
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_release_date_fallback(
+    seeded_instances: None,
+) -> None:
+    """digital+physical None, past releaseDate: eligible."""
+    movie = _movie(
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate="2023-03-01T00:00:00Z",
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_in_cinemas_last_fallback(
+    seeded_instances: None,
+) -> None:
+    """Only past inCinemas set: eligible."""
+    movie = _movie(
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas="2023-01-01T00:00:00Z",
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_all_dates_none_treated_as_released(
+    seeded_instances: None,
+) -> None:
+    """All date fields None: treated as released (eligible)."""
+    movie = _movie(
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_malformed_date_treated_as_released(
+    seeded_instances: None,
+) -> None:
+    """digitalRelease='not-a-date': eligible (parse failure = released)."""
+    movie = _movie(
+        digitalRelease="not-a-date",
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Radarr unreleased status checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_tba_not_available_skipped(
+    seeded_instances: None,
+) -> None:
+    """status='tba', isAvailable=None: skipped as unreleased."""
+    movie = _movie(
+        status="tba",
+        isAvailable=None,
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+    rows = await get_log_rows()
+    skipped = [r for r in rows if r["action"] == "skipped"]
+    assert len(skipped) >= 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_announced_not_available_skipped(
+    seeded_instances: None,
+) -> None:
+    """status='announced', isAvailable=False: skipped."""
+    movie = _movie(
+        status="announced",
+        isAvailable=False,
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_future_year_not_available_skipped(
+    seeded_instances: None,
+) -> None:
+    """year=2999, status='', isAvailable=None: skipped as future title."""
+    movie = _movie(
+        year=2999,
+        status="",
+        isAvailable=None,
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_released_status_overrides_future_year(
+    seeded_instances: None,
+) -> None:
+    """year=2999, status='released': eligible despite future year."""
+    movie = _movie(
+        year=2999,
+        status="released",
+        isAvailable=None,
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_is_available_true_overrides_tba(
+    seeded_instances: None,
+) -> None:
+    """isAvailable=True, status='tba': eligible (available overrides)."""
+    movie = _movie(
+        status="tba",
+        isAvailable=True,
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_not_available_false_skipped(
+    seeded_instances: None,
+) -> None:
+    """isAvailable=False explicitly: skipped as not available."""
+    movie = _movie(
+        status="released",
+        isAvailable=False,
+        digitalRelease=None,
+        physicalRelease=None,
+        releaseDate=None,
+        inCinemas=None,
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_radarr_missing_page([movie]),
+        ),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Sonarr null air date
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_null_air_date_eligible(
+    seeded_instances: None,
+) -> None:
+    """airDateUtc=None: eligible (treated as released)."""
+    ep = {**_EPISODE_RECORD, "airDateUtc": None}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "page": 1,
+                "pageSize": 10,
+                "totalRecords": 1,
+                "records": [ep],
+            },
+        ),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Dispatch error handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_dispatch_http_500_logs_error_continues(
+    seeded_instances: None,
+) -> None:
+    """Search POST returns 500: error logged, pass continues."""
+    two_movies = _radarr_missing_page(
+        [
+            _movie(201),
+            _movie(202),
+        ]
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=two_movies),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        side_effect=[
+            httpx.Response(500, text="Internal Server Error"),
+            httpx.Response(201, json=_COMMAND_RESP),
+        ],
+    )
+
+    inst = _radarr_instance()
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    errors = [r for r in rows if r["action"] == "error"]
+    searched = [r for r in rows if r["action"] == "searched"]
+    assert len(errors) == 1
+    assert len(searched) == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_dispatch_http_400_logs_error_continues(
+    seeded_instances: None,
+) -> None:
+    """Search POST returns 400: error logged, pass continues."""
+    two_movies = _radarr_missing_page(
+        [
+            _movie(201),
+            _movie(202),
+        ]
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=two_movies),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        side_effect=[
+            httpx.Response(400, text="Bad Request"),
+            httpx.Response(201, json=_COMMAND_RESP),
+        ],
+    )
+
+    inst = _radarr_instance()
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    errors = [r for r in rows if r["action"] == "error"]
+    searched = [r for r in rows if r["action"] == "searched"]
+    assert len(errors) == 1
+    assert len(searched) == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_dispatch_transport_error_logs_error_continues(
+    seeded_instances: None,
+) -> None:
+    """ConnectError during dispatch: error logged, pass continues."""
+    two_movies = _radarr_missing_page(
+        [
+            _movie(201),
+            _movie(202),
+        ]
+    )
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=two_movies),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        side_effect=[
+            httpx.ConnectError("connection refused"),
+            httpx.Response(201, json=_COMMAND_RESP),
+        ],
+    )
+
+    inst = _radarr_instance()
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    errors = [r for r in rows if r["action"] == "error"]
+    searched = [r for r in rows if r["action"] == "searched"]
+    assert len(errors) == 1
+    assert len(searched) == 1

--- a/tests/test_engine/test_backlog_scanning.py
+++ b/tests/test_engine/test_backlog_scanning.py
@@ -1,0 +1,342 @@
+"""Tests for multi-page pagination and scan budget in _run_search_pass()."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine.search_loop import (
+    _cutoff_page_size,
+    _missing_page_size,
+    _missing_scan_budget,
+    run_instance_search,
+)
+from houndarr.services.cooldown import record_search
+from houndarr.services.instances import InstanceType
+
+from .conftest import (
+    _COMMAND_RESP,
+    _EPISODE_RECORD,
+    _MOVIE_RECORD,
+    MASTER_KEY,
+    RADARR_URL,
+    SONARR_URL,
+    get_log_rows,
+    make_instance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMPTY_PAGE: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 0,
+    "records": [],
+}
+
+
+def _sonarr_page(
+    records: list[dict[str, Any]],
+    page: int = 1,
+) -> dict[str, Any]:
+    return {
+        "page": page,
+        "pageSize": len(records),
+        "totalRecords": len(records),
+        "records": records,
+    }
+
+
+def _sonarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 1,
+        "itype": InstanceType.sonarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _radarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 2,
+        "itype": InstanceType.radarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _make_episode(episode_id: int, series_id: int = 55) -> dict[str, Any]:
+    return {
+        **_EPISODE_RECORD,
+        "id": episode_id,
+        "seriesId": series_id,
+    }
+
+
+def _make_movie(movie_id: int) -> dict[str, Any]:
+    return {**_MOVIE_RECORD, "id": movie_id}
+
+
+# ---------------------------------------------------------------------------
+# Multi-page pagination tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_page_one_all_on_cooldown_advances_to_page_two(
+    seeded_instances: None,
+) -> None:
+    """Items on cooldown on page 1 cause page 2 to be fetched."""
+    # Put page-1 items on cooldown
+    await record_search(1, 101, "episode")
+    await record_search(1, 102, "episode")
+
+    page1 = _sonarr_page([_make_episode(101), _make_episode(102)])
+    page2 = _sonarr_page([_make_episode(103), _make_episode(104)])
+
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page1),
+            httpx.Response(200, json=page2),
+        ],
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(batch_size=2)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 2
+    rows = await get_log_rows()
+    searched_ids = [r["item_id"] for r in rows if r["action"] == "searched"]
+    assert 103 in searched_ids
+    assert 104 in searched_ids
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_five_pages_all_on_cooldown_ends_gracefully(
+    seeded_instances: None,
+) -> None:
+    """5 pages of items all on cooldown returns 0 without errors."""
+    for i in range(50):
+        await record_search(2, 300 + i, "movie")
+
+    pages = []
+    for p in range(5):
+        records = [_make_movie(300 + p * 10 + j) for j in range(10)]
+        pages.append(httpx.Response(200, json=_sonarr_page(records)))
+
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=pages,
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(batch_size=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_empty_page_terminates_early(
+    seeded_instances: None,
+) -> None:
+    """An empty page stops pagination; no further pages are fetched."""
+    page1 = _sonarr_page([_make_episode(101)])
+    page2: dict[str, Any] = {
+        "page": 2,
+        "pageSize": 10,
+        "totalRecords": 0,
+        "records": [],
+    }
+    # A third page should never be requested
+    page3_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page1),
+            httpx.Response(200, json=page2),
+            httpx.Response(200, json=_sonarr_page([_make_episode(999)])),
+        ],
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(batch_size=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    # Only 2 GET calls (page 1 + empty page 2)
+    assert page3_route.call_count == 2
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_batch_target_reached_stops_pagination(
+    seeded_instances: None,
+) -> None:
+    """Once batch_size items are searched, pagination stops."""
+    page1 = _sonarr_page(
+        [
+            _make_episode(101),
+            _make_episode(102),
+            _make_episode(103),
+        ]
+    )
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=page1),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(batch_size=2)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 2
+    # Only 1 page fetched since batch filled
+    assert missing_route.call_count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_mixed_cooldown_and_fresh_same_page(
+    seeded_instances: None,
+) -> None:
+    """A page with both on-cooldown and fresh items: only fresh searched."""
+    await record_search(1, 101, "episode")
+
+    page1 = _sonarr_page([_make_episode(101), _make_episode(102)])
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=page1),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(batch_size=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched"]
+    assert searched[0]["item_id"] == 102
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_item_dedup_across_pages(seeded_instances: None) -> None:
+    """Same item_id on pages 1 and 2 is searched only once."""
+    page1 = _sonarr_page([_make_episode(101)])
+    page2 = _sonarr_page([_make_episode(101), _make_episode(102)])
+    empty = _sonarr_page([])
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page1),
+            httpx.Response(200, json=page2),
+            httpx.Response(200, json=empty),
+            httpx.Response(200, json=empty),
+            httpx.Response(200, json=empty),
+        ],
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(batch_size=5)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched"]
+    searched_ids = [r["item_id"] for r in searched]
+    assert searched_ids.count(101) == 1
+    assert 102 in searched_ids
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_context_mode_group_key_dedup_across_pages(
+    seeded_instances: None,
+) -> None:
+    """Same (series_id, season) on pages 1 and 2 triggers one SeasonSearch."""
+    from houndarr.services.instances import SonarrSearchMode
+
+    ep1 = {**_make_episode(101, series_id=55), "seasonNumber": 1}
+    ep2 = {**_make_episode(102, series_id=55), "seasonNumber": 1}
+
+    page1 = _sonarr_page([ep1])
+    page2 = _sonarr_page([ep2])
+    empty = _sonarr_page([])
+
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=page1),
+            httpx.Response(200, json=page2),
+            httpx.Response(200, json=empty),
+            httpx.Response(200, json=empty),
+            httpx.Response(200, json=empty),
+        ],
+    )
+    cmd_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(
+        batch_size=5,
+        sonarr_search_mode=SonarrSearchMode.season_context,
+    )
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    assert cmd_route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Page size and scan budget pure function tests
+# ---------------------------------------------------------------------------
+
+
+def test_page_size_min_clamped_missing() -> None:
+    """batch_size=1 yields page_size=10 (minimum)."""
+    assert _missing_page_size(1) == 10
+
+
+def test_page_size_max_clamped_missing() -> None:
+    """batch_size=100 yields page_size=50 (maximum)."""
+    assert _missing_page_size(100) == 50
+
+
+def test_page_size_min_clamped_cutoff() -> None:
+    """batch_size=1 yields cutoff page_size=5 (minimum)."""
+    assert _cutoff_page_size(1) == 5
+
+
+def test_page_size_max_clamped_cutoff() -> None:
+    """batch_size=100 yields cutoff page_size=25 (maximum)."""
+    assert _cutoff_page_size(100) == 25
+
+
+def test_scan_budget_min_clamped() -> None:
+    """batch_size=1 yields missing scan_budget=24 (minimum)."""
+    assert _missing_scan_budget(1) == 24
+
+
+def test_scan_budget_max_clamped() -> None:
+    """batch_size=100 yields missing scan_budget=120 (maximum)."""
+    assert _missing_scan_budget(100) == 120

--- a/tests/test_engine/test_cooldown_edge_cases.py
+++ b/tests/test_engine/test_cooldown_edge_cases.py
@@ -1,0 +1,354 @@
+"""Tests for cooldown boundary conditions, synthetic IDs, and item_type independence."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+
+from houndarr.database import get_db
+from houndarr.engine.adapters.lidarr import _artist_item_id
+from houndarr.engine.adapters.readarr import _author_item_id
+from houndarr.engine.adapters.sonarr import _season_item_id
+from houndarr.engine.adapters.whisparr import (
+    _season_item_id as whisparr_season_item_id,
+)
+from houndarr.services.cooldown import (
+    _iso,
+    clear_cooldowns,
+    count_searches_last_hour,
+    is_on_cooldown,
+    record_search,
+)
+
+
+@pytest_asyncio.fixture()
+async def seeded_instances(db: None) -> AsyncGenerator[None, None]:
+    """Insert two stub instance rows so FK constraints are satisfied."""
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
+            [
+                (1, "Sonarr", "sonarr", "http://sonarr:8989", "enc"),
+                (2, "Radarr", "radarr", "http://radarr:7878", "enc"),
+            ],
+        )
+        await conn.commit()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Boundary: exact expiry point (strict > means NOT on cooldown)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_exact_boundary_not_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """When searched_at + cooldown_days == now, the item is NOT on cooldown.
+
+    The query uses ``searched_at > cutoff`` (strict greater-than), so when
+    searched_at equals the cutoff exactly, it does not match.
+    """
+    cooldown_days = 7
+    boundary = datetime.now(UTC) - timedelta(days=cooldown_days)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
+            " VALUES (?, ?, ?, ?)",
+            (1, 101, "episode", _iso(boundary)),
+        )
+        await conn.commit()
+
+    result = await is_on_cooldown(1, 101, "episode", cooldown_days=cooldown_days)
+    assert result is False
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_one_second_before_boundary_on_cooldown(
+    seeded_instances: None,
+) -> None:
+    """One second after the cutoff means searched_at > cutoff: still on cooldown."""
+    cooldown_days = 7
+    just_inside = datetime.now(UTC) - timedelta(days=cooldown_days) + timedelta(seconds=1)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
+            " VALUES (?, ?, ?, ?)",
+            (1, 101, "episode", _iso(just_inside)),
+        )
+        await conn.commit()
+
+    result = await is_on_cooldown(1, 101, "episode", cooldown_days=cooldown_days)
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Zero / negative cooldown_days
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_zero_cooldown_days_always_false(seeded_instances: None) -> None:
+    """Passing cooldown_days=0 disables cooldowns; always returns False."""
+    await record_search(1, 101, "episode")
+    result = await is_on_cooldown(1, 101, "episode", cooldown_days=0)
+    assert result is False
+
+
+@pytest.mark.asyncio()
+async def test_negative_cooldown_days_always_false(seeded_instances: None) -> None:
+    """Negative cooldown_days also disables cooldowns."""
+    await record_search(1, 101, "episode")
+    result = await is_on_cooldown(1, 101, "episode", cooldown_days=-5)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Synthetic ID formula tests (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_sonarr_season_synthetic_id_format() -> None:
+    assert _season_item_id(55, 3) == -(55 * 1000 + 3)
+    assert _season_item_id(55, 3) == -55003
+
+
+def test_sonarr_season_synthetic_id_season_zero() -> None:
+    """Specials (season 0) produce a valid synthetic ID."""
+    assert _season_item_id(55, 0) == -55000
+
+
+def test_lidarr_artist_synthetic_id_format() -> None:
+    assert _artist_item_id(50) == -(50 * 1000)
+    assert _artist_item_id(50) == -50000
+
+
+def test_readarr_author_synthetic_id_format() -> None:
+    assert _author_item_id(60) == -(60 * 1000)
+    assert _author_item_id(60) == -60000
+
+
+def test_whisparr_season_synthetic_id_matches_formula() -> None:
+    """Whisparr uses the same formula as Sonarr."""
+    assert whisparr_season_item_id(70, 2) == -(70 * 1000 + 2)
+    assert whisparr_season_item_id(70, 2) == -70002
+
+
+# ---------------------------------------------------------------------------
+# item_type independence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_episode_vs_movie_independent(
+    seeded_instances: None,
+) -> None:
+    """A cooldown for item_type=episode does not affect item_type=movie."""
+    await record_search(1, 101, "episode")
+    on_cd = await is_on_cooldown(1, 101, "movie", cooldown_days=7)
+    assert on_cd is False
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_episode_vs_whisparr_episode_independent(
+    seeded_instances: None,
+) -> None:
+    """episode and whisparr_episode are tracked independently."""
+    await record_search(1, 101, "episode")
+    on_cd = await is_on_cooldown(1, 101, "whisparr_episode", cooldown_days=7)
+    assert on_cd is False
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_album_vs_book_independent(
+    seeded_instances: None,
+) -> None:
+    """album and book are tracked independently for the same item_id."""
+    await record_search(1, 301, "album")
+    on_cd = await is_on_cooldown(1, 301, "book", cooldown_days=7)
+    assert on_cd is False
+
+
+# ---------------------------------------------------------------------------
+# Synthetic negative IDs in DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_synthetic_negative_id_tracked(
+    seeded_instances: None,
+) -> None:
+    """Negative synthetic IDs (e.g. season-level) are stored and looked up correctly."""
+    synthetic_id = _season_item_id(55, 3)
+    assert synthetic_id < 0
+
+    await record_search(1, synthetic_id, "episode")
+    on_cd = await is_on_cooldown(1, synthetic_id, "episode", cooldown_days=7)
+    assert on_cd is True
+
+
+# ---------------------------------------------------------------------------
+# Different cooldown durations on same data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_14d_vs_21d_different_behavior(
+    seeded_instances: None,
+) -> None:
+    """A search 15 days ago is expired for 14-day cooldown but active for 21-day."""
+    fifteen_days_ago = datetime.now(UTC) - timedelta(days=15)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
+            " VALUES (?, ?, ?, ?)",
+            (1, 200, "movie", _iso(fifteen_days_ago)),
+        )
+        await conn.commit()
+
+    expired_14 = await is_on_cooldown(1, 200, "movie", cooldown_days=14)
+    assert expired_14 is False
+
+    active_21 = await is_on_cooldown(1, 200, "movie", cooldown_days=21)
+    assert active_21 is True
+
+
+# ---------------------------------------------------------------------------
+# Upsert behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_upsert_updates_timestamp(
+    seeded_instances: None,
+) -> None:
+    """A second record_search updates the timestamp, not duplicates the row."""
+    await record_search(1, 101, "episode")
+    await record_search(1, 101, "episode")
+
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT COUNT(*) FROM cooldowns WHERE instance_id=1 AND item_id=101"
+            " AND item_type='episode'",
+        ) as cur:
+            row = await cur.fetchone()
+
+    assert row is not None
+    assert int(row[0]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-instance isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_cooldown_per_instance_isolation(
+    seeded_instances: None,
+) -> None:
+    """A cooldown on instance 1 does not affect instance 2."""
+    await record_search(1, 101, "episode")
+    on_cd = await is_on_cooldown(2, 101, "episode", cooldown_days=7)
+    assert on_cd is False
+
+
+# ---------------------------------------------------------------------------
+# count_searches_last_hour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_count_searches_last_hour_excludes_old(
+    seeded_instances: None,
+) -> None:
+    """A cooldown record from 2 hours ago is not counted."""
+    two_hours_ago = datetime.now(UTC) - timedelta(hours=2)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
+            " VALUES (?, ?, ?, ?)",
+            (1, 101, "episode", _iso(two_hours_ago)),
+        )
+        await conn.commit()
+
+    count = await count_searches_last_hour(1)
+    assert count == 0
+
+
+@pytest.mark.asyncio()
+async def test_count_searches_last_hour_includes_recent(
+    seeded_instances: None,
+) -> None:
+    """A cooldown record from 30 minutes ago is counted."""
+    thirty_min_ago = datetime.now(UTC) - timedelta(minutes=30)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
+            " VALUES (?, ?, ?, ?)",
+            (1, 101, "episode", _iso(thirty_min_ago)),
+        )
+        await conn.commit()
+
+    count = await count_searches_last_hour(1)
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+async def test_count_searches_per_instance_independent(
+    seeded_instances: None,
+) -> None:
+    """Searches on instance 1 do not affect count for instance 2."""
+    await record_search(1, 101, "episode")
+    await record_search(1, 102, "episode")
+
+    count_1 = await count_searches_last_hour(1)
+    count_2 = await count_searches_last_hour(2)
+    assert count_1 == 2
+    assert count_2 == 0
+
+
+# ---------------------------------------------------------------------------
+# clear_cooldowns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_clear_cooldowns_only_affects_target_instance(
+    seeded_instances: None,
+) -> None:
+    """Clearing cooldowns for instance 1 does not remove instance 2 records."""
+    await record_search(1, 101, "episode")
+    await record_search(2, 201, "movie")
+
+    await clear_cooldowns(1)
+
+    on_cd_1 = await is_on_cooldown(1, 101, "episode", cooldown_days=7)
+    on_cd_2 = await is_on_cooldown(2, 201, "movie", cooldown_days=7)
+    assert on_cd_1 is False
+    assert on_cd_2 is True
+
+
+@pytest.mark.asyncio()
+async def test_clear_cooldowns_returns_deleted_count(
+    seeded_instances: None,
+) -> None:
+    """clear_cooldowns returns the number of rows deleted."""
+    await record_search(1, 101, "episode")
+    await record_search(1, 102, "episode")
+    await record_search(1, 103, "movie")
+
+    deleted = await clear_cooldowns(1)
+    assert deleted == 3
+
+
+@pytest.mark.asyncio()
+async def test_clear_cooldowns_nonexistent_returns_zero(
+    seeded_instances: None,
+) -> None:
+    """Clearing cooldowns for an instance with none returns 0."""
+    deleted = await clear_cooldowns(1)
+    assert deleted == 0

--- a/tests/test_engine/test_queue_backpressure.py
+++ b/tests/test_engine/test_queue_backpressure.py
@@ -1,0 +1,258 @@
+"""Tests for queue backpressure gate in run_instance_search()."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import InstanceType
+
+from .conftest import (
+    _COMMAND_RESP,
+    _EPISODE_RECORD,
+    MASTER_KEY,
+    SONARR_URL,
+    get_log_rows,
+    make_instance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MISSING_SONARR_1: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_EPISODE_RECORD],
+}
+
+
+def _sonarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 1,
+        "itype": InstanceType.sonarr,
+        "batch_size": 10,
+        "hourly_cap": 20,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _mock_queue_status(total_count: int) -> None:
+    respx.get(f"{SONARR_URL}/api/v3/queue/status").mock(
+        return_value=httpx.Response(
+            200,
+            json={"totalCount": total_count},
+        ),
+    )
+
+
+def _mock_missing_and_command() -> None:
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR_1),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_at_exactly_limit_skips_cycle(
+    seeded_instances: None,
+) -> None:
+    """totalCount == queue_limit means backpressure: return 0."""
+    _mock_queue_status(5)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_at_limit_minus_one_proceeds(
+    seeded_instances: None,
+) -> None:
+    """totalCount < queue_limit allows the search to proceed."""
+    _mock_queue_status(4)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_above_limit_skips(seeded_instances: None) -> None:
+    """totalCount > queue_limit skips the entire cycle."""
+    _mock_queue_status(10)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_limit_zero_disables_check(
+    seeded_instances: None,
+) -> None:
+    """queue_limit=0 means no queue check; search runs normally."""
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_transport_error_fails_open(
+    seeded_instances: None,
+) -> None:
+    """ConnectError on queue endpoint lets search proceed (fail open)."""
+    respx.get(f"{SONARR_URL}/api/v3/queue/status").mock(
+        side_effect=httpx.ConnectError("connection refused"),
+    )
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_http_500_fails_open(seeded_instances: None) -> None:
+    """HTTP 500 from queue endpoint lets search proceed (fail open)."""
+    respx.get(f"{SONARR_URL}/api/v3/queue/status").mock(
+        return_value=httpx.Response(500, text="Internal Server Error"),
+    )
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_missing_total_count_fails_open(
+    seeded_instances: None,
+) -> None:
+    """Response without totalCount raises KeyError, caught, proceeds."""
+    respx.get(f"{SONARR_URL}/api/v3/queue/status").mock(
+        return_value=httpx.Response(200, json={}),
+    )
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_backpressure_logs_info_action(
+    seeded_instances: None,
+) -> None:
+    """Backpressure skip writes an action='info' log row."""
+    _mock_queue_status(10)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    info_rows = [r for r in rows if r["action"] == "info"]
+    assert len(info_rows) == 1
+    assert "backpressure" in (info_rows[0].get("reason") or "")
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_backpressure_log_includes_counts(
+    seeded_instances: None,
+) -> None:
+    """Backpressure log message includes queue count and limit."""
+    _mock_queue_status(10)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    info_rows = [r for r in rows if r["action"] == "info"]
+    msg = info_rows[0].get("message") or ""
+    assert "10" in msg
+    assert "5" in msg
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_check_not_called_when_limit_zero(
+    seeded_instances: None,
+) -> None:
+    """When queue_limit=0, no request is made to queue/status."""
+    queue_route = respx.get(f"{SONARR_URL}/api/v3/queue/status").mock(
+        return_value=httpx.Response(200, json={"totalCount": 99}),
+    )
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=0)
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert queue_route.call_count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_below_limit_proceeds_and_searches(
+    seeded_instances: None,
+) -> None:
+    """totalCount=0 with positive limit lets search run normally."""
+    _mock_queue_status(0)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_queue_invalid_url_fails_open(
+    seeded_instances: None,
+) -> None:
+    """httpx.InvalidURL from queue endpoint lets search proceed."""
+    respx.get(f"{SONARR_URL}/api/v3/queue/status").mock(
+        side_effect=httpx.InvalidURL("bad url"),
+    )
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(queue_limit=5)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1

--- a/tests/test_engine/test_release_timing.py
+++ b/tests/test_engine/test_release_timing.py
@@ -1,0 +1,441 @@
+"""Tests for release-timing retry and grace window behavior."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine.search_loop import (
+    _is_release_timing_reason,
+    run_instance_search,
+)
+from houndarr.services.instances import InstanceType
+
+from .conftest import (
+    _COMMAND_RESP,
+    _EPISODE_RECORD,
+    _FUTURE_AIR_DATE,
+    MASTER_KEY,
+    SONARR_URL,
+    get_log_rows,
+    make_instance,
+    seed_release_timing_retry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMPTY_PAGE: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 0,
+    "records": [],
+}
+
+
+def _page(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "page": 1,
+        "pageSize": 50,
+        "totalRecords": len(records),
+        "records": records,
+    }
+
+
+def _sonarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 1,
+        "itype": InstanceType.sonarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _radarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 2,
+        "itype": InstanceType.radarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _is_release_timing_reason
+# ---------------------------------------------------------------------------
+
+
+def test_is_release_timing_reason_true_not_yet_released() -> None:
+    """'not yet released' is a release-timing reason."""
+    assert _is_release_timing_reason("not yet released") is True
+
+
+def test_is_release_timing_reason_true_grace() -> None:
+    """'post-release grace (6h)' is a release-timing reason."""
+    assert _is_release_timing_reason("post-release grace (6h)") is True
+
+
+def test_is_release_timing_reason_false_cooldown() -> None:
+    """'on cooldown (14d)' is NOT a release-timing reason."""
+    assert _is_release_timing_reason("on cooldown (14d)") is False
+
+
+def test_is_release_timing_reason_false_none() -> None:
+    """None is NOT a release-timing reason."""
+    assert _is_release_timing_reason(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Release-timing retry in missing pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_release_timing_retry_missing_pass(
+    seeded_instances: None,
+) -> None:
+    """Item on cooldown with 'not yet released' reason: retried in missing pass."""
+    await seed_release_timing_retry(
+        instance_id=1,
+        item_id=101,
+        item_type="episode",
+        reason="not yet released",
+    )
+
+    # Episode now has a past air date (released)
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_release_timing_retry_cutoff_blocked(
+    seeded_instances: None,
+) -> None:
+    """Same item in cutoff pass: stays on cooldown (no retry path)."""
+    await seed_release_timing_retry(
+        instance_id=1,
+        item_id=101,
+        item_type="episode",
+        reason="not yet released",
+    )
+
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{SONARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(
+        cutoff_enabled=True,
+        cutoff_cooldown_days=7,
+        post_release_grace_hrs=0,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    cutoff_searched = [
+        r for r in rows if r["search_kind"] == "cutoff" and r["action"] == "searched"
+    ]
+    assert len(cutoff_searched) == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_post_release_grace_reason_triggers_retry(
+    seeded_instances: None,
+) -> None:
+    """Reason 'post-release grace (6h)': allowed in missing retry."""
+    await seed_release_timing_retry(
+        instance_id=1,
+        item_id=101,
+        item_type="episode",
+        reason="post-release grace (6h)",
+    )
+
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_non_release_reason_no_retry(
+    seeded_instances: None,
+) -> None:
+    """Reason 'on cooldown (14d)': normal cooldown skip, no retry."""
+    from houndarr.services.cooldown import record_search
+
+    await record_search(1, 101, "episode")
+    # Insert a non-release-timing reason in the log
+    from .conftest import insert_search_log_row
+
+    await insert_search_log_row(
+        instance_id=1,
+        item_id=101,
+        item_type="episode",
+        search_kind="missing",
+        action="skipped",
+        reason="on cooldown (14d)",
+    )
+
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance()
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Unreleased and grace window behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_unreleased_item_skipped(seeded_instances: None) -> None:
+    """Future airDateUtc: skipped with 'not yet released'."""
+    ep = {**_EPISODE_RECORD, "airDateUtc": _FUTURE_AIR_DATE}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance()
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+    rows = await get_log_rows()
+    skipped = [r for r in rows if r["action"] == "skipped"]
+    assert any("not yet released" in (r.get("reason") or "") for r in skipped)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_within_grace_period_skipped(
+    seeded_instances: None,
+) -> None:
+    """Recently aired within grace: skipped."""
+    from datetime import UTC, datetime, timedelta
+
+    # Aired 1 hour ago, grace is 24 hours
+    recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    ep = {**_EPISODE_RECORD, "airDateUtc": recent}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=24)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+    rows = await get_log_rows()
+    skipped = [r for r in rows if r["action"] == "skipped"]
+    assert any("post-release grace" in (r.get("reason") or "") for r in skipped)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_past_grace_period_eligible(
+    seeded_instances: None,
+) -> None:
+    """Aired well past grace: eligible for search."""
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=24)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_run_now_bypasses_grace(seeded_instances: None) -> None:
+    """cycle_trigger='run_now': grace items searched."""
+    from datetime import UTC, datetime, timedelta
+
+    recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    ep = {**_EPISODE_RECORD, "airDateUtc": recent}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=24)
+    count = await run_instance_search(
+        inst,
+        MASTER_KEY,
+        cycle_trigger="run_now",
+    )
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_run_now_does_not_bypass_unreleased(
+    seeded_instances: None,
+) -> None:
+    """run_now with future date: still skipped (pre-release is unconditional)."""
+    ep = {**_EPISODE_RECORD, "airDateUtc": _FUTURE_AIR_DATE}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance()
+    count = await run_instance_search(
+        inst,
+        MASTER_KEY,
+        cycle_trigger="run_now",
+    )
+
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Release-timing retry dispatch behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_release_timing_retry_dispatch_error(
+    seeded_instances: None,
+) -> None:
+    """Retry hits dispatch error: logged as error."""
+    await seed_release_timing_retry(
+        instance_id=1,
+        item_id=101,
+        item_type="episode",
+        reason="not yet released",
+    )
+
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(500, text="error"),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=0)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    errors = [r for r in rows if r["action"] == "error" and r["search_kind"] == "missing"]
+    assert len(errors) >= 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_release_timing_retry_records_cooldown(
+    seeded_instances: None,
+) -> None:
+    """Successful retry updates cooldown record."""
+    await seed_release_timing_retry(
+        instance_id=1,
+        item_id=101,
+        item_type="episode",
+        reason="not yet released",
+    )
+
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched" and r["search_kind"] == "missing"]
+    assert len(searched) >= 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_release_timing_retry_increments_count(
+    seeded_instances: None,
+) -> None:
+    """Successful retry counts toward the searched total."""
+    await seed_release_timing_retry(
+        instance_id=1,
+        item_id=101,
+        item_type="episode",
+        reason="not yet released",
+    )
+
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=0, batch_size=1)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1

--- a/tests/test_engine/test_search_dispatch.py
+++ b/tests/test_engine/test_search_dispatch.py
@@ -1,0 +1,670 @@
+"""Tests for correct command payloads per app type and context-mode dedup."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.cooldown import record_search
+from houndarr.services.instances import (
+    InstanceType,
+    LidarrSearchMode,
+    ReadarrSearchMode,
+    SonarrSearchMode,
+    WhisparrSearchMode,
+)
+
+from .conftest import (
+    _ALBUM_RECORD,
+    _BOOK_RECORD,
+    _COMMAND_RESP,
+    _EPISODE_RECORD,
+    _MOVIE_RECORD,
+    _WHISPARR_EPISODE_RECORD,
+    LIDARR_URL,
+    MASTER_KEY,
+    RADARR_URL,
+    READARR_URL,
+    SONARR_URL,
+    WHISPARR_URL,
+    get_log_rows,
+    make_instance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMPTY_PAGE: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 0,
+    "records": [],
+}
+
+
+def _page(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "page": 1,
+        "pageSize": 50,
+        "totalRecords": len(records),
+        "records": records,
+    }
+
+
+def _sonarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 1,
+        "itype": InstanceType.sonarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _radarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 2,
+        "itype": InstanceType.radarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _lidarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 3,
+        "itype": InstanceType.lidarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _readarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 4,
+        "itype": InstanceType.readarr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _whisparr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 5,
+        "itype": InstanceType.whisparr,
+        "batch_size": 10,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _get_post_body(call_index: int = 0) -> dict[str, Any]:
+    """Extract the JSON body from the Nth POST call in respx."""
+    content = respx.calls[call_index].request.content
+    return json.loads(content)
+
+
+def _find_post_bodies() -> list[dict[str, Any]]:
+    """Collect JSON bodies from all POST calls."""
+    bodies = []
+    for call in respx.calls:
+        if call.request.method == "POST":
+            bodies.append(json.loads(call.request.content))
+    return bodies
+
+
+# ---------------------------------------------------------------------------
+# Sonarr dispatch payloads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_episode_mode_payload(
+    seeded_instances: None,
+) -> None:
+    """EpisodeSearch dispatches with episodeIds array."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([_EPISODE_RECORD])),
+    )
+    cmd_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(
+        sonarr_search_mode=SonarrSearchMode.episode,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "EpisodeSearch"
+    assert body["episodeIds"] == [101]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_season_context_payload(
+    seeded_instances: None,
+) -> None:
+    """SeasonSearch dispatches with seriesId and seasonNumber."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([_EPISODE_RECORD])),
+    )
+    cmd_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(
+        sonarr_search_mode=SonarrSearchMode.season_context,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "SeasonSearch"
+    assert body["seriesId"] == 55
+    assert body["seasonNumber"] == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_season_context_dedup(
+    seeded_instances: None,
+) -> None:
+    """Two episodes from the same series+season: one SeasonSearch."""
+    ep1 = {**_EPISODE_RECORD, "id": 101}
+    ep2 = {**_EPISODE_RECORD, "id": 102, "episodeNumber": 2}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep1, ep2])),
+    )
+    cmd_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(
+        sonarr_search_mode=SonarrSearchMode.season_context,
+    )
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    assert cmd_route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Radarr dispatch payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_radarr_movies_search_payload(
+    seeded_instances: None,
+) -> None:
+    """MoviesSearch dispatches with movieIds array."""
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([_MOVIE_RECORD])),
+    )
+    cmd_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance()
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "MoviesSearch"
+    assert body["movieIds"] == [201]
+
+
+# ---------------------------------------------------------------------------
+# Lidarr dispatch payloads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_lidarr_album_mode_payload(
+    seeded_instances: None,
+) -> None:
+    """AlbumSearch dispatches with albumIds array."""
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([_ALBUM_RECORD])),
+    )
+    cmd_route = respx.post(f"{LIDARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _lidarr_instance(
+        lidarr_search_mode=LidarrSearchMode.album,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "AlbumSearch"
+    assert body["albumIds"] == [301]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_lidarr_artist_context_payload(
+    seeded_instances: None,
+) -> None:
+    """ArtistSearch dispatches with artistId."""
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([_ALBUM_RECORD])),
+    )
+    cmd_route = respx.post(f"{LIDARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _lidarr_instance(
+        lidarr_search_mode=LidarrSearchMode.artist_context,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "ArtistSearch"
+    assert body["artistId"] == 50
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_lidarr_artist_context_dedup(
+    seeded_instances: None,
+) -> None:
+    """Two albums from the same artist: one ArtistSearch."""
+    album1 = {**_ALBUM_RECORD, "id": 301}
+    album2 = {**_ALBUM_RECORD, "id": 302, "title": "Second Album"}
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([album1, album2])),
+    )
+    cmd_route = respx.post(f"{LIDARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _lidarr_instance(
+        lidarr_search_mode=LidarrSearchMode.artist_context,
+    )
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    assert cmd_route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Readarr dispatch payloads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_readarr_book_mode_payload(
+    seeded_instances: None,
+) -> None:
+    """BookSearch dispatches with bookIds array."""
+    respx.get(f"{READARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([_BOOK_RECORD])),
+    )
+    cmd_route = respx.post(f"{READARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _readarr_instance(
+        readarr_search_mode=ReadarrSearchMode.book,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "BookSearch"
+    assert body["bookIds"] == [401]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_readarr_author_context_payload(
+    seeded_instances: None,
+) -> None:
+    """AuthorSearch dispatches with authorId."""
+    respx.get(f"{READARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([_BOOK_RECORD])),
+    )
+    cmd_route = respx.post(f"{READARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _readarr_instance(
+        readarr_search_mode=ReadarrSearchMode.author_context,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "AuthorSearch"
+    assert body["authorId"] == 60
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_readarr_author_context_dedup(
+    seeded_instances: None,
+) -> None:
+    """Two books from the same author: one AuthorSearch."""
+    book1 = {**_BOOK_RECORD, "id": 401}
+    book2 = {**_BOOK_RECORD, "id": 402, "title": "Second Book"}
+    respx.get(f"{READARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([book1, book2])),
+    )
+    cmd_route = respx.post(f"{READARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _readarr_instance(
+        readarr_search_mode=ReadarrSearchMode.author_context,
+    )
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    assert cmd_route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Whisparr dispatch payloads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_whisparr_episode_mode_payload(
+    seeded_instances: None,
+) -> None:
+    """EpisodeSearch dispatches with episodeIds for Whisparr."""
+    respx.get(f"{WHISPARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_page([_WHISPARR_EPISODE_RECORD]),
+        ),
+    )
+    cmd_route = respx.post(f"{WHISPARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _whisparr_instance(
+        whisparr_search_mode=WhisparrSearchMode.episode,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "EpisodeSearch"
+    assert body["episodeIds"] == [501]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_whisparr_season_context_payload(
+    seeded_instances: None,
+) -> None:
+    """SeasonSearch dispatches with seriesId and seasonNumber for Whisparr."""
+    respx.get(f"{WHISPARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_page([_WHISPARR_EPISODE_RECORD]),
+        ),
+    )
+    cmd_route = respx.post(f"{WHISPARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _whisparr_instance(
+        whisparr_search_mode=WhisparrSearchMode.season_context,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    assert cmd_route.call_count == 1
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "SeasonSearch"
+    assert body["seriesId"] == 70
+    assert body["seasonNumber"] == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_whisparr_item_type_is_whisparr_episode(
+    seeded_instances: None,
+) -> None:
+    """Whisparr log rows record item_type='whisparr_episode'."""
+    respx.get(f"{WHISPARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json=_page([_WHISPARR_EPISODE_RECORD]),
+        ),
+    )
+    respx.post(f"{WHISPARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _whisparr_instance()
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched"]
+    assert len(searched) == 1
+    assert searched[0]["item_type"] == "whisparr_episode"
+
+
+# ---------------------------------------------------------------------------
+# Multiple items and error handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_multiple_items_all_dispatched(
+    seeded_instances: None,
+) -> None:
+    """3 items all searched: search POST called 3 times."""
+    movies = [{**_MOVIE_RECORD, "id": 201 + i} for i in range(3)]
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page(movies)),
+    )
+    cmd_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance()
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 3
+    assert cmd_route.call_count == 3
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_skipped_item_no_search_post(
+    seeded_instances: None,
+) -> None:
+    """Item on cooldown: POST not called for that item."""
+    await record_search(2, 201, "movie")
+
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([_MOVIE_RECORD])),
+    )
+    cmd_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _radarr_instance(cooldown_days=7)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+    assert cmd_route.call_count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_errored_dispatch_continues(
+    seeded_instances: None,
+) -> None:
+    """Item 1 dispatch errors, item 2 still dispatched."""
+    movies = [
+        {**_MOVIE_RECORD, "id": 201},
+        {**_MOVIE_RECORD, "id": 202},
+    ]
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page(movies)),
+    )
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        side_effect=[
+            httpx.Response(500, text="error"),
+            httpx.Response(201, json=_COMMAND_RESP),
+        ],
+    )
+
+    inst = _radarr_instance()
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched"]
+    errors = [r for r in rows if r["action"] == "error"]
+    assert len(searched) == 1
+    assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cutoff pass always uses item-level search mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_sonarr_cutoff_uses_episode_search(
+    seeded_instances: None,
+) -> None:
+    """Cutoff pass always uses EpisodeSearch even in season_context mode."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{SONARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=_page([_EPISODE_RECORD])),
+    )
+    cmd_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(
+        cutoff_enabled=True,
+        sonarr_search_mode=SonarrSearchMode.season_context,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "EpisodeSearch"
+    assert body["episodeIds"] == [101]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_lidarr_cutoff_uses_album_search(
+    seeded_instances: None,
+) -> None:
+    """Cutoff pass always uses AlbumSearch even in artist_context mode."""
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=_page([_ALBUM_RECORD])),
+    )
+    cmd_route = respx.post(f"{LIDARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _lidarr_instance(
+        cutoff_enabled=True,
+        lidarr_search_mode=LidarrSearchMode.artist_context,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "AlbumSearch"
+    assert body["albumIds"] == [301]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_readarr_cutoff_uses_book_search(
+    seeded_instances: None,
+) -> None:
+    """Cutoff pass always uses BookSearch even in author_context mode."""
+    respx.get(f"{READARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{READARR_URL}/api/v1/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=_page([_BOOK_RECORD])),
+    )
+    cmd_route = respx.post(f"{READARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _readarr_instance(
+        cutoff_enabled=True,
+        readarr_search_mode=ReadarrSearchMode.author_context,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "BookSearch"
+    assert body["bookIds"] == [401]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_whisparr_cutoff_uses_episode_search(
+    seeded_instances: None,
+) -> None:
+    """Cutoff pass always uses EpisodeSearch even in season_context."""
+    respx.get(f"{WHISPARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{WHISPARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(
+            200,
+            json=_page([_WHISPARR_EPISODE_RECORD]),
+        ),
+    )
+    cmd_route = respx.post(f"{WHISPARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _whisparr_instance(
+        cutoff_enabled=True,
+        whisparr_search_mode=WhisparrSearchMode.season_context,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    body = json.loads(cmd_route.calls[0].request.content)
+    assert body["name"] == "EpisodeSearch"
+    assert body["episodeIds"] == [501]

--- a/tests/test_engine/test_search_pass_interactions.py
+++ b/tests/test_engine/test_search_pass_interactions.py
@@ -1,0 +1,631 @@
+"""Tests for run_instance_search() orchestration of missing + cutoff + upgrade passes."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import InstanceType
+
+from .conftest import (
+    _COMMAND_RESP,
+    _MOVIE_RECORD,
+    MASTER_KEY,
+    RADARR_URL,
+    get_log_rows,
+    make_instance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MISSING_RADARR_1: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_MOVIE_RECORD],
+}
+_CUTOFF_RADARR_1: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [
+        {
+            **_MOVIE_RECORD,
+            "id": 202,
+            "title": "Cutoff Movie",
+        },
+    ],
+}
+_EMPTY_PAGE: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 0,
+    "records": [],
+}
+_LIBRARY_MOVIE_UPGRADE: list[dict[str, Any]] = [
+    {
+        "id": 203,
+        "title": "Upgrade Movie",
+        "year": 2023,
+        "monitored": True,
+        "hasFile": True,
+        "movieFile": {"qualityCutoffNotMet": False},
+        "inCinemas": "2023-01-01T00:00:00Z",
+        "physicalRelease": None,
+        "digitalRelease": None,
+    },
+]
+
+
+def _mock_radarr_missing(payload: dict[str, Any] = _MISSING_RADARR_1) -> None:
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+
+
+def _mock_radarr_cutoff(payload: dict[str, Any] = _CUTOFF_RADARR_1) -> None:
+    respx.get(f"{RADARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+
+
+def _mock_radarr_command() -> None:
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+
+def _mock_radarr_library(
+    movies: list[dict[str, Any]] = _LIBRARY_MOVIE_UPGRADE,
+) -> None:
+    respx.get(f"{RADARR_URL}/api/v3/movie").mock(
+        return_value=httpx.Response(200, json=movies),
+    )
+
+
+def _radarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 2,
+        "itype": InstanceType.radarr,
+        "batch_size": 10,
+        "hourly_cap": 20,
+        "cooldown_days": 7,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Tests: missing + cutoff interaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_and_cutoff_both_run_combined_count(
+    seeded_instances: None,
+) -> None:
+    """When cutoff is enabled, both passes run and counts are summed."""
+    _mock_radarr_missing()
+    _mock_radarr_cutoff()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(cutoff_enabled=True)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 2
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_runs_before_cutoff(seeded_instances: None) -> None:
+    """Missing pass log rows appear before cutoff pass log rows."""
+    _mock_radarr_missing()
+    _mock_radarr_cutoff()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(cutoff_enabled=True)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched"]
+    assert len(searched) == 2
+    assert searched[0]["search_kind"] == "missing"
+    assert searched[1]["search_kind"] == "cutoff"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cutoff_disabled_skips_cutoff_pass(
+    seeded_instances: None,
+) -> None:
+    """With cutoff_enabled=False, only missing pass runs."""
+    _mock_radarr_missing()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(cutoff_enabled=False)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    rows = await get_log_rows()
+    assert all(r["search_kind"] == "missing" for r in rows)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_upgrade_disabled_skips_upgrade_pass(
+    seeded_instances: None,
+) -> None:
+    """With upgrade_enabled=False, upgrade pass is skipped entirely."""
+    _mock_radarr_missing()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(upgrade_enabled=False)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    rows = await get_log_rows()
+    assert all(r.get("search_kind") != "upgrade" for r in rows)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_all_three_passes_run_and_sum(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Missing(1) + cutoff(1) + upgrade(1) = 3."""
+    _mock_radarr_missing()
+    _mock_radarr_cutoff()
+    _mock_radarr_library()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        cutoff_enabled=True,
+        upgrade_enabled=True,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 3
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_hourly_cap_does_not_block_cutoff(
+    seeded_instances: None,
+) -> None:
+    """Missing hourly cap is independent: cutoff can still search."""
+    _mock_radarr_missing()
+    _mock_radarr_cutoff()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        cutoff_enabled=True,
+        hourly_cap=1,
+        batch_size=1,
+        cutoff_hourly_cap=5,
+        cutoff_batch_size=5,
+    )
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    # Missing searches 1 (capped at 1), cutoff searches 1
+    assert count == 2
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cutoff_hourly_cap_independent_of_missing(
+    seeded_instances: None,
+) -> None:
+    """Cutoff hourly cap does not affect missing pass."""
+    two_movies = {
+        "page": 1,
+        "pageSize": 50,
+        "totalRecords": 2,
+        "records": [
+            _MOVIE_RECORD,
+            {**_MOVIE_RECORD, "id": 205},
+        ],
+    }
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=two_movies),
+    )
+    _mock_radarr_cutoff()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        cutoff_enabled=True,
+        hourly_cap=5,
+        batch_size=5,
+        cutoff_hourly_cap=1,
+        cutoff_batch_size=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    missing_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "missing"
+    ]
+    cutoff_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "cutoff"
+    ]
+    assert len(missing_searched) == 2
+    assert len(cutoff_searched) == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_hourly_cap_independent(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Upgrade hourly cap is tracked separately from missing/cutoff."""
+    _mock_radarr_missing()
+    _mock_radarr_library(
+        [
+            {
+                "id": 210 + i,
+                "title": f"Movie {i}",
+                "year": 2023,
+                "monitored": True,
+                "hasFile": True,
+                "movieFile": {"qualityCutoffNotMet": False},
+                "inCinemas": "2023-01-01T00:00:00Z",
+                "physicalRelease": None,
+                "digitalRelease": None,
+            }
+            for i in range(5)
+        ]
+    )
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_enabled=True,
+        upgrade_batch_size=5,
+        upgrade_hourly_cap=2,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    # Upgrade cap is min(2, hard_cap=5) = 2
+    assert len(upgrade_searched) == 2
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_zero_missing_batch_size_returns_zero(
+    seeded_instances: None,
+) -> None:
+    """batch_size=0 means no missing pass, returns 0."""
+    inst = _radarr_instance(batch_size=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_zero_cutoff_batch_size_skips_cutoff(
+    seeded_instances: None,
+) -> None:
+    """cutoff_batch_size=0 means cutoff pass is skipped."""
+    _mock_radarr_missing()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(cutoff_enabled=True, cutoff_batch_size=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    rows = await get_log_rows()
+    assert all(r["search_kind"] != "cutoff" for r in rows)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_hourly_cap_zero_means_unlimited_missing(
+    seeded_instances: None,
+) -> None:
+    """hourly_cap=0 disables the cap; all items are searched."""
+    three_movies = {
+        "page": 1,
+        "pageSize": 50,
+        "totalRecords": 3,
+        "records": [{**_MOVIE_RECORD, "id": 201 + i} for i in range(3)],
+    }
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=three_movies),
+    )
+    _mock_radarr_command()
+
+    inst = _radarr_instance(hourly_cap=0, batch_size=10)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 3
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_kind_logged_correctly_missing(
+    seeded_instances: None,
+) -> None:
+    """Missing pass rows have search_kind='missing'."""
+    _mock_radarr_missing()
+    _mock_radarr_command()
+
+    inst = _radarr_instance()
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched"]
+    assert all(r["search_kind"] == "missing" for r in searched)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_search_kind_logged_correctly_cutoff(
+    seeded_instances: None,
+) -> None:
+    """Cutoff pass rows have search_kind='cutoff'."""
+    _mock_radarr_missing(_EMPTY_PAGE)
+    _mock_radarr_cutoff()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(cutoff_enabled=True, batch_size=10)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    cutoff_rows = [r for r in rows if r["search_kind"] == "cutoff"]
+    assert len(cutoff_rows) >= 1
+    assert cutoff_rows[0]["action"] == "searched"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_search_kind_logged_correctly_upgrade(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Upgrade pass rows have search_kind='upgrade'."""
+    _mock_radarr_missing(_EMPTY_PAGE)
+    _mock_radarr_library()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_enabled=True,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_rows = [r for r in rows if r["search_kind"] == "upgrade"]
+    assert len(upgrade_rows) >= 1
+    assert upgrade_rows[0]["action"] == "searched"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cycle_id_shared_across_all_passes(
+    seeded_instances: None,
+) -> None:
+    """All log rows within a cycle share the same cycle_id."""
+    _mock_radarr_missing()
+    _mock_radarr_cutoff()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(cutoff_enabled=True)
+    await run_instance_search(inst, MASTER_KEY, cycle_id="test-cycle-1")
+
+    rows = await get_log_rows()
+    assert len(rows) >= 2
+    cycle_ids = {r["cycle_id"] for r in rows}
+    assert cycle_ids == {"test-cycle-1"}
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cycle_trigger_propagated(seeded_instances: None) -> None:
+    """cycle_trigger='run_now' is recorded in all log rows."""
+    _mock_radarr_missing()
+    _mock_radarr_command()
+
+    inst = _radarr_instance()
+    await run_instance_search(
+        inst,
+        MASTER_KEY,
+        cycle_trigger="run_now",
+    )
+
+    rows = await get_log_rows()
+    assert all(r["cycle_trigger"] == "run_now" for r in rows)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_fewer_candidates_than_batch(
+    seeded_instances: None,
+) -> None:
+    """When fewer items exist than batch_size, all are searched."""
+    _mock_radarr_missing()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(batch_size=10)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_empty_missing_list_still_runs_cutoff(
+    seeded_instances: None,
+) -> None:
+    """Empty missing list does not block cutoff pass."""
+    _mock_radarr_missing(_EMPTY_PAGE)
+    _mock_radarr_cutoff()
+    _mock_radarr_command()
+
+    inst = _radarr_instance(cutoff_enabled=True)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    rows = await get_log_rows()
+    assert any(r["search_kind"] == "cutoff" for r in rows)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_dispatch_error_does_not_prevent_cutoff(
+    seeded_instances: None,
+) -> None:
+    """If missing dispatch errors, cutoff still runs."""
+    _mock_radarr_missing()
+    _mock_radarr_cutoff()
+    # Missing dispatch fails, cutoff succeeds
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        side_effect=[
+            httpx.Response(500, json={"error": "fail"}),
+            httpx.Response(201, json=_COMMAND_RESP),
+        ],
+    )
+
+    inst = _radarr_instance(cutoff_enabled=True)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    cutoff_searched = [
+        r for r in rows if r["search_kind"] == "cutoff" and r["action"] == "searched"
+    ]
+    assert len(cutoff_searched) == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_empty_upgrade_pool_logs_info(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Empty upgrade pool logs an info row with 'upgrade pool empty'."""
+    _mock_radarr_missing(_EMPTY_PAGE)
+    _mock_radarr_library([])
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_enabled=True,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    info_rows = [r for r in rows if r["action"] == "info" and r["search_kind"] == "upgrade"]
+    assert len(info_rows) == 1
+    assert "upgrade pool empty" in (info_rows[0].get("message") or "")
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_cutoff_uses_cutoff_cooldown_days(
+    seeded_instances: None,
+) -> None:
+    """Cutoff pass uses cutoff_cooldown_days, not cooldown_days."""
+    from houndarr.services.cooldown import record_search
+
+    # Put item 202 on cooldown
+    await record_search(2, 202, "movie")
+
+    _mock_radarr_missing(_EMPTY_PAGE)
+    _mock_radarr_cutoff()
+    _mock_radarr_command()
+
+    # cooldown_days=7 (missing), cutoff_cooldown_days=0 (disabled)
+    inst = _radarr_instance(
+        cutoff_enabled=True,
+        cooldown_days=7,
+        cutoff_cooldown_days=0,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    cutoff_searched = [
+        r for r in rows if r["search_kind"] == "cutoff" and r["action"] == "searched"
+    ]
+    # cutoff_cooldown_days=0 disables cooldown, so item is searched
+    assert len(cutoff_searched) == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_hourly_cap_zero_means_unlimited_cutoff(
+    seeded_instances: None,
+) -> None:
+    """cutoff_hourly_cap=0 means no limit on cutoff searches."""
+    three_cutoff = {
+        "page": 1,
+        "pageSize": 25,
+        "totalRecords": 3,
+        "records": [{**_MOVIE_RECORD, "id": 220 + i, "title": f"Cutoff {i}"} for i in range(3)],
+    }
+    _mock_radarr_missing(_EMPTY_PAGE)
+    respx.get(f"{RADARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=three_cutoff),
+    )
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        cutoff_enabled=True,
+        cutoff_hourly_cap=0,
+        cutoff_batch_size=10,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    cutoff_searched = [
+        r for r in rows if r["search_kind"] == "cutoff" and r["action"] == "searched"
+    ]
+    assert len(cutoff_searched) == 3
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_empty_missing_and_cutoff_returns_zero(
+    seeded_instances: None,
+) -> None:
+    """Empty results for both passes returns 0."""
+    _mock_radarr_missing(_EMPTY_PAGE)
+    respx.get(f"{RADARR_URL}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+
+    inst = _radarr_instance(cutoff_enabled=True)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0

--- a/tests/test_engine/test_supervisor_edge_cases.py
+++ b/tests/test_engine/test_supervisor_edge_cases.py
@@ -1,0 +1,486 @@
+"""Tests for Supervisor edge cases: lifecycle, run-now, connection recovery."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.fernet import Fernet
+
+from houndarr.database import get_db
+from houndarr.engine import supervisor as _supervisor_mod
+from houndarr.engine.supervisor import Supervisor
+from houndarr.services.instances import Instance, InstanceType, SonarrSearchMode
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SONARR_URL = "http://sonarr:8989"
+MASTER_KEY: bytes = Fernet.generate_key()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_instance(
+    *,
+    instance_id: int = 1,
+    url: str = SONARR_URL,
+    enabled: bool = True,
+    sleep_interval_mins: int = 30,
+) -> Instance:
+    return Instance(
+        id=instance_id,
+        name="Test Sonarr",
+        type=InstanceType.sonarr,
+        url=url,
+        api_key="test-api-key",
+        enabled=enabled,
+        batch_size=2,
+        sleep_interval_mins=sleep_interval_mins,
+        hourly_cap=4,
+        cooldown_days=14,
+        post_release_grace_hrs=6,
+        queue_limit=0,
+        cutoff_enabled=False,
+        cutoff_batch_size=1,
+        cutoff_cooldown_days=21,
+        cutoff_hourly_cap=1,
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        sonarr_search_mode=SonarrSearchMode.episode,
+    )
+
+
+@pytest_asyncio.fixture()
+async def seeded_instances(db: None) -> AsyncGenerator[None, None]:
+    """Seed FK-required instance rows."""
+    from houndarr.crypto import encrypt
+
+    encrypted = encrypt("test-api-key", MASTER_KEY)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
+            (1, "Test Sonarr", "sonarr", SONARR_URL, encrypted),
+        )
+        await conn.commit()
+    yield
+
+
+async def _get_log_rows() -> list[dict[str, Any]]:
+    async with get_db() as conn:
+        async with conn.execute("SELECT * FROM search_log ORDER BY id ASC") as cur:
+            rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# trigger_run_now tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_run_now_accepted_for_enabled_instance(seeded_instances: None) -> None:
+    """trigger_run_now returns 'accepted' for an enabled instance."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+    with patch.object(supervisor, "_run_search_cycle", new_callable=AsyncMock, return_value=False):
+        result = await supervisor.trigger_run_now(1)
+    assert result == "accepted"
+
+
+@pytest.mark.asyncio()
+async def test_run_now_disabled_returns_disabled(seeded_instances: None) -> None:
+    """trigger_run_now returns 'disabled' when the instance is not enabled."""
+    async with get_db() as conn:
+        await conn.execute("UPDATE instances SET enabled = 0 WHERE id = 1")
+        await conn.commit()
+
+    supervisor = Supervisor(master_key=MASTER_KEY)
+    result = await supervisor.trigger_run_now(1)
+    assert result == "disabled"
+
+
+@pytest.mark.asyncio()
+async def test_run_now_not_found_returns_not_found(seeded_instances: None) -> None:
+    """trigger_run_now returns 'not_found' for a nonexistent instance."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+    result = await supervisor.trigger_run_now(999)
+    assert result == "not_found"
+
+
+@pytest.mark.asyncio()
+async def test_run_now_duplicate_returns_accepted(seeded_instances: None) -> None:
+    """A second trigger_run_now for the same instance returns 'accepted' without double-task."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+    long_running = asyncio.Event()
+
+    async def _slow_cycle(*args: object, **kwargs: object) -> bool:
+        await long_running.wait()
+        return False
+
+    with patch.object(supervisor, "_run_search_cycle", side_effect=_slow_cycle):
+        r1 = await supervisor.trigger_run_now(1)
+        r2 = await supervisor.trigger_run_now(1)
+
+    assert r1 == "accepted"
+    assert r2 == "accepted"
+    # Only one manual task should exist
+    assert len(supervisor._manual_runs) <= 1  # noqa: SLF001
+
+    # Cleanup: release the event and cancel tasks
+    long_running.set()
+    for task in list(supervisor._manual_runs.values()):  # noqa: SLF001
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+# ---------------------------------------------------------------------------
+# start_instance_task tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_start_instance_task_idempotent(seeded_instances: None) -> None:
+    """Calling start_instance_task twice returns False the second time."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    # Patch the loop so it waits indefinitely
+    async def _wait_forever(self: object, iid: int, startup_offset: int = 0) -> None:
+        await asyncio.Event().wait()
+
+    with patch.object(Supervisor, "_instance_loop", _wait_forever):
+        first = await supervisor.start_instance_task(1)
+        second = await supervisor.start_instance_task(1)
+
+    assert first is True
+    assert second is False
+
+    await supervisor.stop()
+
+
+@pytest.mark.asyncio()
+async def test_start_instance_task_disabled_returns_false(seeded_instances: None) -> None:
+    """start_instance_task returns False for a disabled instance."""
+    async with get_db() as conn:
+        await conn.execute("UPDATE instances SET enabled = 0 WHERE id = 1")
+        await conn.commit()
+
+    supervisor = Supervisor(master_key=MASTER_KEY)
+    result = await supervisor.start_instance_task(1)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# stop_instance_task tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_stop_instance_task_cancels_task(seeded_instances: None) -> None:
+    """stop_instance_task cancels a running scheduled task."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    async def _wait_forever(self: object, iid: int, startup_offset: int = 0) -> None:
+        await asyncio.Event().wait()
+
+    with patch.object(Supervisor, "_instance_loop", _wait_forever):
+        await supervisor.start_instance_task(1)
+        result = await supervisor.stop_instance_task(1)
+
+    assert result is True
+    assert 1 not in supervisor._tasks  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# reconcile_instance tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_reconcile_starts_for_enabled(seeded_instances: None) -> None:
+    """reconcile_instance starts a task for an enabled instance."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    async def _wait_forever(self: object, iid: int, startup_offset: int = 0) -> None:
+        await asyncio.Event().wait()
+
+    with patch.object(Supervisor, "_instance_loop", _wait_forever):
+        await supervisor.reconcile_instance(1)
+
+    assert 1 in supervisor._tasks  # noqa: SLF001
+    await supervisor.stop()
+
+
+@pytest.mark.asyncio()
+async def test_reconcile_stops_for_disabled(seeded_instances: None) -> None:
+    """reconcile_instance stops the task when instance is disabled."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    async def _wait_forever(self: object, iid: int, startup_offset: int = 0) -> None:
+        await asyncio.Event().wait()
+
+    with patch.object(Supervisor, "_instance_loop", _wait_forever):
+        await supervisor.start_instance_task(1)
+
+    async with get_db() as conn:
+        await conn.execute("UPDATE instances SET enabled = 0 WHERE id = 1")
+        await conn.commit()
+
+    await supervisor.reconcile_instance(1)
+    assert 1 not in supervisor._tasks  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Connection error dedup and recovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_connection_error_first_failure_logs_error(seeded_instances: None) -> None:
+    """First TransportError writes one error log row."""
+    instance = _make_instance()
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    call_count = 0
+
+    async def _run_search_side_effect(inst: Instance, mk: bytes, **kwargs: object) -> int:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.TransportError("Connection refused")
+        return 0
+
+    async def _sleep_then_cancel(secs: float) -> None:
+        if secs == _supervisor_mod._CONNECT_RETRY_SECS:  # noqa: SLF001
+            raise asyncio.CancelledError
+
+    with (
+        patch.object(_supervisor_mod, "run_instance_search", side_effect=_run_search_side_effect),
+        patch.object(_supervisor_mod, "get_instance", return_value=instance),
+        patch("asyncio.sleep", side_effect=_sleep_then_cancel),
+    ):
+        with contextlib.suppress(asyncio.CancelledError):
+            await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+
+    rows = await _get_log_rows()
+    error_rows = [r for r in rows if r["action"] == "error"]
+    assert len(error_rows) == 1
+    assert "Could not reach" in (error_rows[0]["message"] or "")
+
+
+@pytest.mark.asyncio()
+async def test_connection_recovery_logs_info(seeded_instances: None) -> None:
+    """After error then success, a recovery info row is logged."""
+    instance = _make_instance()
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    call_count = 0
+
+    async def _run_search_side_effect(inst: Instance, mk: bytes, **kwargs: object) -> int:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.TransportError("Connection refused")
+        return 0
+
+    cycle = 0
+
+    async def _controlled_sleep(secs: float) -> None:
+        nonlocal cycle
+        cycle += 1
+        if cycle >= 3:
+            raise asyncio.CancelledError
+
+    with (
+        patch.object(_supervisor_mod, "run_instance_search", side_effect=_run_search_side_effect),
+        patch.object(_supervisor_mod, "get_instance", return_value=instance),
+        patch("asyncio.sleep", side_effect=_controlled_sleep),
+    ):
+        with contextlib.suppress(asyncio.CancelledError):
+            await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+
+    rows = await _get_log_rows()
+    info_rows = [r for r in rows if r["action"] == "info" and r.get("message")]
+    recovery = [r for r in info_rows if "reachable again" in (r["message"] or "")]
+    assert len(recovery) == 1
+
+
+# ---------------------------------------------------------------------------
+# Staggered startup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_staggered_startup_uses_offset(seeded_instances: None) -> None:
+    """start() uses _STARTUP_STAGGER_SECS as offset between instances."""
+    # Insert a second instance
+    from houndarr.crypto import encrypt
+
+    encrypted = encrypt("test-api-key", MASTER_KEY)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
+            (2, "Test Sonarr 2", "sonarr", SONARR_URL, encrypted),
+        )
+        await conn.commit()
+
+    offsets: list[int] = []
+
+    async def _capture_offset(
+        self: Supervisor, iid: int, *, instance: Instance | None = None, startup_offset: int = 0
+    ) -> bool:
+        offsets.append(startup_offset)
+        return True
+
+    supervisor = Supervisor(master_key=MASTER_KEY)
+    with patch.object(Supervisor, "start_instance_task", _capture_offset):
+        await supervisor.start()
+
+    assert offsets == [0, 30]
+
+
+# ---------------------------------------------------------------------------
+# Graceful shutdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_graceful_shutdown_cancels_tasks(seeded_instances: None) -> None:
+    """stop() cancels all running tasks."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    async def _wait_forever(self: object, iid: int, startup_offset: int = 0) -> None:
+        await asyncio.Event().wait()
+
+    with patch.object(Supervisor, "_instance_loop", _wait_forever):
+        await supervisor.start_instance_task(1)
+
+    assert 1 in supervisor._tasks  # noqa: SLF001
+    await supervisor.stop()
+    assert len(supervisor._tasks) == 0  # noqa: SLF001
+
+
+@pytest.mark.asyncio()
+async def test_instance_deleted_exits_loop(seeded_instances: None) -> None:
+    """Loop exits when get_instance returns None (instance deleted)."""
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    async def _controlled_sleep(secs: float) -> None:
+        pass
+
+    with (
+        patch.object(_supervisor_mod, "get_instance", return_value=None),
+        patch("asyncio.sleep", side_effect=_controlled_sleep),
+    ):
+        await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+
+    # Loop should have exited without error
+
+
+@pytest.mark.asyncio()
+async def test_instance_disabled_exits_loop(seeded_instances: None) -> None:
+    """Loop exits when instance is disabled."""
+    instance = _make_instance(enabled=False)
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    async def _controlled_sleep(secs: float) -> None:
+        pass
+
+    with (
+        patch.object(_supervisor_mod, "get_instance", return_value=instance),
+        patch("asyncio.sleep", side_effect=_controlled_sleep),
+    ):
+        await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+
+
+@pytest.mark.asyncio()
+async def test_normal_cycle_sleeps_instance_interval(seeded_instances: None) -> None:
+    """After a successful cycle, sleeps for sleep_interval_mins * 60."""
+    instance = _make_instance(sleep_interval_mins=5)
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    sleep_values: list[float] = []
+    call_count = 0
+
+    async def _capture_sleep(secs: float) -> None:
+        nonlocal call_count
+        sleep_values.append(secs)
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError
+
+    with (
+        patch.object(
+            _supervisor_mod,
+            "run_instance_search",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch.object(_supervisor_mod, "get_instance", return_value=instance),
+        patch("asyncio.sleep", side_effect=_capture_sleep),
+    ):
+        with contextlib.suppress(asyncio.CancelledError):
+            await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+
+    # First sleep is startup grace (10 + 0), second is interval (5 * 60 = 300)
+    assert len(sleep_values) >= 2
+    assert sleep_values[0] == 10  # _STARTUP_GRACE_SECS + offset(0)
+    assert sleep_values[1] == 300  # 5 * 60
+
+
+@pytest.mark.asyncio()
+async def test_connection_retry_sleeps_30s(seeded_instances: None) -> None:
+    """After a connection error, sleeps _CONNECT_RETRY_SECS (30s)."""
+    instance = _make_instance()
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    sleep_values: list[float] = []
+    call_count = 0
+
+    async def _capture_sleep(secs: float) -> None:
+        nonlocal call_count
+        sleep_values.append(secs)
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError
+
+    async def _always_error(inst: Instance, mk: bytes, **kwargs: object) -> int:
+        raise httpx.TransportError("Connection refused")
+
+    with (
+        patch.object(_supervisor_mod, "run_instance_search", side_effect=_always_error),
+        patch.object(_supervisor_mod, "get_instance", return_value=instance),
+        patch("asyncio.sleep", side_effect=_capture_sleep),
+    ):
+        with contextlib.suppress(asyncio.CancelledError):
+            await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+
+    # First sleep is startup grace, second is retry interval
+    assert len(sleep_values) >= 2
+    assert sleep_values[1] == 30  # _CONNECT_RETRY_SECS
+
+
+@pytest.mark.asyncio()
+async def test_no_enabled_instances_logs_warning(
+    seeded_instances: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """start() with no enabled instances logs a warning."""
+    async with get_db() as conn:
+        await conn.execute("UPDATE instances SET enabled = 0 WHERE id = 1")
+        await conn.commit()
+
+    supervisor = Supervisor(master_key=MASTER_KEY)
+    with caplog.at_level("WARNING"):
+        await supervisor.start()
+
+    assert any("no enabled instances" in r.message.lower() for r in caplog.records)

--- a/tests/test_engine/test_upgrade_pass.py
+++ b/tests/test_engine/test_upgrade_pass.py
@@ -1,0 +1,1092 @@
+"""Tests for _run_upgrade_pass() hard caps, rotation, and offset persistence."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.cooldown import record_search
+from houndarr.services.instances import InstanceType
+
+from .conftest import (
+    _COMMAND_RESP,
+    MASTER_KEY,
+    RADARR_URL,
+    SONARR_URL,
+    WHISPARR_URL,
+    get_log_rows,
+    make_instance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EMPTY_PAGE: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 0,
+    "records": [],
+}
+
+
+def _radarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 2,
+        "itype": InstanceType.radarr,
+        "batch_size": 0,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+        "upgrade_enabled": True,
+        "upgrade_batch_size": 3,
+        "upgrade_hourly_cap": 5,
+        "upgrade_cooldown_days": 90,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _sonarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 1,
+        "itype": InstanceType.sonarr,
+        "batch_size": 0,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+        "upgrade_enabled": True,
+        "upgrade_batch_size": 3,
+        "upgrade_hourly_cap": 5,
+        "upgrade_cooldown_days": 90,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _whisparr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 5,
+        "itype": InstanceType.whisparr,
+        "batch_size": 0,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+        "upgrade_enabled": True,
+        "upgrade_batch_size": 3,
+        "upgrade_hourly_cap": 5,
+        "upgrade_cooldown_days": 90,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _lidarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 3,
+        "itype": InstanceType.lidarr,
+        "batch_size": 0,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+        "upgrade_enabled": True,
+        "upgrade_batch_size": 3,
+        "upgrade_hourly_cap": 5,
+        "upgrade_cooldown_days": 90,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _readarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 4,
+        "itype": InstanceType.readarr,
+        "batch_size": 0,
+        "hourly_cap": 0,
+        "cooldown_days": 7,
+        "upgrade_enabled": True,
+        "upgrade_batch_size": 3,
+        "upgrade_hourly_cap": 5,
+        "upgrade_cooldown_days": 90,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _library_movie(movie_id: int, cutoff_met: bool = True) -> dict[str, Any]:
+    """Radarr library movie record eligible for upgrade."""
+    return {
+        "id": movie_id,
+        "title": f"Movie {movie_id}",
+        "year": 2023,
+        "monitored": True,
+        "hasFile": True,
+        "movieFile": {"qualityCutoffNotMet": not cutoff_met},
+        "inCinemas": "2023-01-01T00:00:00Z",
+        "physicalRelease": None,
+        "digitalRelease": None,
+    }
+
+
+def _mock_radarr_empty_missing() -> None:
+    respx.get(f"{RADARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+
+
+def _mock_radarr_library(movies: list[dict[str, Any]]) -> None:
+    respx.get(f"{RADARR_URL}/api/v3/movie").mock(
+        return_value=httpx.Response(200, json=movies),
+    )
+
+
+def _mock_radarr_command() -> None:
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch size hard cap tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_batch_size_clamped_to_5(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """upgrade_batch_size=10 is clamped to hard cap of 5."""
+    movies = [_library_movie(200 + i) for i in range(8)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(upgrade_batch_size=10, upgrade_hourly_cap=5)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    assert len(upgrade_searched) == 5
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_batch_size_3_not_clamped(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """upgrade_batch_size=3 is under hard cap; 3 items searched."""
+    movies = [_library_movie(200 + i) for i in range(5)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(upgrade_batch_size=3, upgrade_hourly_cap=5)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    assert len(upgrade_searched) == 3
+
+
+# ---------------------------------------------------------------------------
+# Hourly cap hard cap tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_hourly_cap_clamped_to_5(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """upgrade_hourly_cap=10 is clamped to 5."""
+    movies = [_library_movie(200 + i) for i in range(8)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_batch_size=5,
+        upgrade_hourly_cap=10,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    assert len(upgrade_searched) == 5
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_hourly_cap_1_not_clamped(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """upgrade_hourly_cap=1: only 1 item searched despite 3 available."""
+    movies = [_library_movie(200 + i) for i in range(3)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_batch_size=5,
+        upgrade_hourly_cap=1,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    assert len(upgrade_searched) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cooldown days min clamp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_cooldown_days_clamped_to_min_7(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """upgrade_cooldown_days=3 is clamped to minimum 7."""
+    from datetime import UTC, datetime, timedelta
+
+    from houndarr.database import get_db
+
+    # Record a search 4 days ago (within 7-day window, outside 3-day window)
+    four_days_ago = (datetime.now(UTC) - timedelta(days=4)).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+    movies = [_library_movie(200)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    # Manually insert cooldown 4 days old
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
+            " VALUES (?, ?, ?, ?)",
+            (2, 200, "movie", four_days_ago),
+        )
+        await conn.commit()
+
+    inst = _radarr_instance(upgrade_cooldown_days=3)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    # Clamped to 7 days, so 4-day-old cooldown still blocks
+    assert len(upgrade_searched) == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_cooldown_days_90_not_clamped(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """upgrade_cooldown_days=90 stays at 90 (above min)."""
+    from datetime import UTC, datetime, timedelta
+
+    from houndarr.database import get_db
+
+    # Record a search 10 days ago (within 90-day window)
+    ten_days_ago = (datetime.now(UTC) - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+    movies = [_library_movie(200)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
+            " VALUES (?, ?, ?, ?)",
+            (2, 200, "movie", ten_days_ago),
+        )
+        await conn.commit()
+
+    inst = _radarr_instance(upgrade_cooldown_days=90)
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    # 10 days < 90 day cooldown, so still blocked
+    assert len(upgrade_searched) == 0
+
+
+# ---------------------------------------------------------------------------
+# Zero batch size
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_zero_batch_size_returns_zero(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """upgrade_batch_size=0 returns 0 immediately."""
+    _mock_radarr_empty_missing()
+    _mock_radarr_library([_library_movie(200)])
+    _mock_radarr_command()
+
+    inst = _radarr_instance(upgrade_batch_size=0)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Empty pool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_empty_pool_logs_info(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Empty library logs 'upgrade pool empty'."""
+    _mock_radarr_empty_missing()
+    _mock_radarr_library([])
+    _mock_radarr_command()
+
+    inst = _radarr_instance()
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    info_rows = [r for r in rows if r["action"] == "info" and r["search_kind"] == "upgrade"]
+    assert len(info_rows) == 1
+    assert "upgrade pool empty" in (info_rows[0].get("message") or "")
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_empty_pool_returns_zero(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Empty library returns 0."""
+    _mock_radarr_empty_missing()
+    _mock_radarr_library([])
+    _mock_radarr_command()
+
+    inst = _radarr_instance()
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Pool fetch error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_pool_fetch_error_returns_zero(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Exception from fetch: logged, returns 0."""
+    _mock_radarr_empty_missing()
+    respx.get(f"{RADARR_URL}/api/v3/movie").mock(
+        side_effect=httpx.ConnectError("timeout"),
+    )
+
+    inst = _radarr_instance()
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+    rows = await get_log_rows()
+    error_rows = [r for r in rows if r["action"] == "error" and r["search_kind"] == "upgrade"]
+    assert len(error_rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Offset rotation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_offset_rotation(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """offset=2, pool=[200,201,202,203,204]: starts searching from 202."""
+    movies = [_library_movie(200 + i) for i in range(5)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_item_offset=2,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"]
+    assert len(searched) == 1
+    assert searched[0]["item_id"] == 202
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_offset_wraparound(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """offset=7, pool size 5: wraps to offset 2."""
+    movies = [_library_movie(200 + i) for i in range(5)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_item_offset=7,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"]
+    assert len(searched) == 1
+    # 7 % 5 = 2, so item 202
+    assert searched[0]["item_id"] == 202
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_offset_persisted(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """update_instance is called to persist the new item offset."""
+    movies = [_library_movie(200 + i) for i in range(5)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_item_offset=0,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    # update_instance should be called at least once with upgrade_item_offset
+    calls_with_offset = [c for c in mock_update.call_args_list if "upgrade_item_offset" in c.kwargs]
+    assert len(calls_with_offset) >= 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_offset_zero_no_rotation(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """offset=0: first item (lowest ID) searched first."""
+    movies = [_library_movie(203), _library_movie(201), _library_movie(202)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_item_offset=0,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"]
+    assert len(searched) == 1
+    # Pool sorted by ID: [201, 202, 203]; offset=0 gives 201
+    assert searched[0]["item_id"] == 201
+
+
+# ---------------------------------------------------------------------------
+# Series offset for Sonarr and Whisparr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_sonarr_series_offset_advanced_by_5(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Sonarr: update_instance called with series_offset+5."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{SONARR_URL}/api/v3/series").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"id": 55, "monitored": True, "title": "Show"},
+            ],
+        ),
+    )
+    respx.get(f"{SONARR_URL}/api/v3/episode").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 101,
+                    "seriesId": 55,
+                    "title": "Ep",
+                    "seasonNumber": 1,
+                    "episodeNumber": 1,
+                    "monitored": True,
+                    "hasFile": True,
+                    "episodeFile": {"qualityCutoffNotMet": False},
+                    "series": {"id": 55, "title": "Show"},
+                },
+            ],
+        ),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(
+        upgrade_series_offset=0,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    calls_with_series = [
+        c for c in mock_update.call_args_list if "upgrade_series_offset" in c.kwargs
+    ]
+    assert len(calls_with_series) >= 1
+    assert calls_with_series[0].kwargs["upgrade_series_offset"] == 5
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_whisparr_series_offset_advanced_by_5(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Whisparr: update_instance called with series_offset+5."""
+    respx.get(f"{WHISPARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{WHISPARR_URL}/api/v3/series").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {"id": 70, "monitored": True, "title": "Show"},
+            ],
+        ),
+    )
+    respx.get(f"{WHISPARR_URL}/api/v3/episode").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 501,
+                    "seriesId": 70,
+                    "title": "Scene",
+                    "seasonNumber": 1,
+                    "monitored": True,
+                    "hasFile": True,
+                    "episodeFile": {"qualityCutoffNotMet": False},
+                    "series": {"id": 70, "title": "Show"},
+                },
+            ],
+        ),
+    )
+    respx.post(f"{WHISPARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _whisparr_instance(
+        upgrade_series_offset=0,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    calls_with_series = [
+        c for c in mock_update.call_args_list if "upgrade_series_offset" in c.kwargs
+    ]
+    assert len(calls_with_series) >= 1
+    assert calls_with_series[0].kwargs["upgrade_series_offset"] == 5
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_radarr_series_offset_not_advanced(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """No series_offset update for Radarr."""
+    movies = [_library_movie(200)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(upgrade_batch_size=1, upgrade_hourly_cap=5)
+    await run_instance_search(inst, MASTER_KEY)
+
+    calls_with_series = [
+        c for c in mock_update.call_args_list if "upgrade_series_offset" in c.kwargs
+    ]
+    assert len(calls_with_series) == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_lidarr_series_offset_not_advanced(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """No series_offset update for Lidarr."""
+    from .conftest import LIDARR_URL
+
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    # Lidarr upgrade pool fetches cutoff exclusion then library
+    respx.get(f"{LIDARR_URL}/api/v1/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{LIDARR_URL}/api/v1/album").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 301,
+                    "artistId": 50,
+                    "title": "Album",
+                    "monitored": True,
+                    "statistics": {"trackFileCount": 1},
+                    "releaseDate": "2023-03-15T00:00:00Z",
+                    "artist": {"id": 50, "artistName": "Artist"},
+                },
+            ],
+        ),
+    )
+    respx.post(f"{LIDARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _lidarr_instance(upgrade_batch_size=1, upgrade_hourly_cap=5)
+    await run_instance_search(inst, MASTER_KEY)
+
+    calls_with_series = [
+        c for c in mock_update.call_args_list if "upgrade_series_offset" in c.kwargs
+    ]
+    assert len(calls_with_series) == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_readarr_series_offset_not_advanced(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """No series_offset update for Readarr."""
+    from .conftest import READARR_URL
+
+    respx.get(f"{READARR_URL}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{READARR_URL}/api/v1/wanted/cutoff").mock(
+        return_value=httpx.Response(200, json=_EMPTY_PAGE),
+    )
+    respx.get(f"{READARR_URL}/api/v1/book").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 401,
+                    "authorId": 60,
+                    "title": "Book",
+                    "monitored": True,
+                    "statistics": {"bookFileCount": 1},
+                    "releaseDate": "2023-06-01T00:00:00Z",
+                    "author": {"id": 60, "authorName": "Author"},
+                },
+            ],
+        ),
+    )
+    respx.post(f"{READARR_URL}/api/v1/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _readarr_instance(upgrade_batch_size=1, upgrade_hourly_cap=5)
+    await run_instance_search(inst, MASTER_KEY)
+
+    calls_with_series = [
+        c for c in mock_update.call_args_list if "upgrade_series_offset" in c.kwargs
+    ]
+    assert len(calls_with_series) == 0
+
+
+# ---------------------------------------------------------------------------
+# Hourly cap blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_hourly_cap_blocks(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """3 items, cap=2: 2 searched, 1 skipped."""
+    movies = [_library_movie(200 + i) for i in range(3)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_batch_size=5,
+        upgrade_hourly_cap=2,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    upgrade_skipped = [
+        r for r in rows if r["action"] == "skipped" and r["search_kind"] == "upgrade"
+    ]
+    assert len(upgrade_searched) == 2
+    assert len(upgrade_skipped) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Cooldown blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_cooldown_blocks_item(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Item on cooldown is skipped in upgrade pass."""
+    await record_search(2, 200, "movie")
+
+    movies = [_library_movie(200)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+        upgrade_cooldown_days=90,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    assert len(upgrade_searched) == 0
+
+
+# ---------------------------------------------------------------------------
+# Dispatch error continues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_dispatch_error_continues(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Error on item 1, item 2 still searched."""
+    movies = [_library_movie(200), _library_movie(201)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        side_effect=[
+            httpx.Response(500, text="error"),
+            httpx.Response(201, json=_COMMAND_RESP),
+        ],
+    )
+
+    inst = _radarr_instance(
+        upgrade_batch_size=5,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"]
+    errors = [r for r in rows if r["action"] == "error" and r["search_kind"] == "upgrade"]
+    assert len(searched) == 1
+    assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pool sort order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_pool_sorted_by_item_id(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Items arrive unsorted; searched in sorted (by ID) order."""
+    movies = [
+        _library_movie(205),
+        _library_movie(201),
+        _library_movie(203),
+    ]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_item_offset=0,
+        upgrade_batch_size=3,
+        upgrade_hourly_cap=5,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"]
+    searched_ids = [r["item_id"] for r in searched]
+    assert searched_ids == [201, 203, 205]
+
+
+# ---------------------------------------------------------------------------
+# Offset advances on cooldown skip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_offset_advances_on_cooldown_skip(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Offset moves even for skipped (cooldown) items."""
+    await record_search(2, 200, "movie")
+
+    # Use 3 movies so (offset + scanned) % 3 != 0 after processing
+    movies = [_library_movie(200), _library_movie(201), _library_movie(202)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_item_offset=0,
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+        upgrade_cooldown_days=90,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    # update_instance called; offset advanced past the cooldown skip
+    calls_with_offset = [c for c in mock_update.call_args_list if "upgrade_item_offset" in c.kwargs]
+    assert len(calls_with_offset) >= 1
+    persisted_offset = calls_with_offset[-1].kwargs["upgrade_item_offset"]
+    # Skip item 200 (cooldown) + search item 201 = scanned 2 items, (0+2)%3 = 2
+    assert persisted_offset == 2
+
+
+# ---------------------------------------------------------------------------
+# Offset persist failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+    side_effect=RuntimeError("db error"),
+)
+async def test_upgrade_offset_persist_failure_no_crash(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """update_instance raises: warning logged, no crash."""
+    movies = [_library_movie(200)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(upgrade_batch_size=1, upgrade_hourly_cap=5)
+    # Should not raise
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    assert len(upgrade_searched) == 1
+
+
+# ---------------------------------------------------------------------------
+# Scan budget limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_scan_budget_limits(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """scan_budget reached before batch: stops iteration."""
+    # batch_size=1 => scan_budget = clamp(1*8, 8, 40) = 8
+    # Put 7 items on cooldown so they consume scan budget
+    for i in range(7):
+        await record_search(2, 200 + i, "movie")
+
+    movies = [_library_movie(200 + i) for i in range(10)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    _mock_radarr_command()
+
+    inst = _radarr_instance(
+        upgrade_batch_size=1,
+        upgrade_hourly_cap=5,
+        upgrade_cooldown_days=90,
+    )
+    await run_instance_search(inst, MASTER_KEY)
+
+    rows = await get_log_rows()
+    upgrade_searched = [
+        r for r in rows if r["action"] == "searched" and r["search_kind"] == "upgrade"
+    ]
+    # scan_budget=8: 7 on cooldown consume 7, then item 207 consumes 8th
+    assert len(upgrade_searched) == 1

--- a/tests/test_routes/test_log_filters.py
+++ b/tests/test_routes/test_log_filters.py
@@ -1,0 +1,277 @@
+"""Tests for GET /api/logs filter validation and edge cases.
+
+Complements test_logs.py with input-validation boundaries (422 on invalid
+search_kind/cycle_trigger/hide_system), the 'upgrade' search_kind filter,
+and empty-param handling.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from houndarr.database import get_db
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def seeded_filter_data(db: None) -> AsyncGenerator[None, None]:
+    """Seed search_log with rows covering all search_kind and cycle_trigger values."""
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url) VALUES (?, ?, ?, ?)",
+            [
+                (1, "Sonarr Test", "sonarr", "http://sonarr:8989"),
+                (2, "Radarr Test", "radarr", "http://radarr:7878"),
+            ],
+        )
+        await conn.executemany(
+            """
+            INSERT INTO search_log
+                (instance_id, item_id, item_type, search_kind,
+                 cycle_id, cycle_trigger, action, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                # missing + scheduled
+                (
+                    1,
+                    101,
+                    "episode",
+                    "missing",
+                    "c-1",
+                    "scheduled",
+                    "searched",
+                    "2024-01-01T12:00:00.000Z",
+                ),
+                # cutoff + scheduled
+                (
+                    1,
+                    102,
+                    "episode",
+                    "cutoff",
+                    "c-1",
+                    "scheduled",
+                    "skipped",
+                    "2024-01-01T12:01:00.000Z",
+                ),
+                # upgrade + scheduled
+                (
+                    1,
+                    103,
+                    "episode",
+                    "upgrade",
+                    "c-2",
+                    "scheduled",
+                    "searched",
+                    "2024-01-01T12:02:00.000Z",
+                ),
+                # missing + run_now
+                (
+                    2,
+                    201,
+                    "movie",
+                    "missing",
+                    "c-3",
+                    "run_now",
+                    "searched",
+                    "2024-01-01T12:03:00.000Z",
+                ),
+                # missing + run_now (error)
+                (2, 202, "movie", "missing", "c-3", "run_now", "error", "2024-01-01T12:04:00.000Z"),
+                # system info row (no instance, no search_kind)
+                (None, None, None, None, None, "system", "info", "2024-01-01T11:59:00.000Z"),
+            ],
+        )
+        await conn.commit()
+    yield
+
+
+async def _login_async(client: AsyncClient) -> None:
+    await client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+
+# ---------------------------------------------------------------------------
+# Validation: invalid search_kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_invalid_search_kind_returns_422(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """An unrecognised search_kind value triggers a 422 response."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?search_kind=bogus")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio()
+async def test_invalid_search_kind_partial_returns_422(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """The HTMX partial endpoint also validates search_kind."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs/partial?search_kind=bogus")
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Validation: invalid cycle_trigger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_invalid_cycle_trigger_returns_422(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """An unrecognised cycle_trigger value triggers a 422 response."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?cycle_trigger=bogus")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio()
+async def test_invalid_cycle_trigger_partial_returns_422(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """The HTMX partial endpoint also validates cycle_trigger."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs/partial?cycle_trigger=bogus")
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Validation: invalid hide_system
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_invalid_hide_system_returns_422(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """A non-boolean hide_system value triggers a 422 response."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?hide_system=maybe")
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# search_kind filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_filter_search_kind_missing(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """search_kind=missing returns only rows with search_kind='missing'."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?search_kind=missing&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+    assert all(r["search_kind"] == "missing" for r in data)
+
+
+@pytest.mark.asyncio()
+async def test_filter_search_kind_upgrade(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """search_kind=upgrade returns only the upgrade row."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?search_kind=upgrade&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["search_kind"] == "upgrade"
+    assert data[0]["item_id"] == 103
+
+
+# ---------------------------------------------------------------------------
+# cycle_trigger filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_filter_cycle_trigger_scheduled(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """cycle_trigger=scheduled returns only scheduled rows."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?cycle_trigger=scheduled&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+    assert all(r["cycle_trigger"] == "scheduled" for r in data)
+
+
+@pytest.mark.asyncio()
+async def test_filter_cycle_trigger_system(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """cycle_trigger=system returns only system lifecycle rows."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?cycle_trigger=system&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["action"] == "info"
+    assert data[0]["instance_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Empty-param handling (no filter applied)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_empty_search_kind_treated_as_no_filter(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """Empty search_kind param (HTMX default) returns all rows."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?search_kind=&limit=200")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 6
+
+
+@pytest.mark.asyncio()
+async def test_empty_cycle_trigger_treated_as_no_filter(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """Empty cycle_trigger param returns all rows."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?cycle_trigger=&limit=200")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 6
+
+
+# ---------------------------------------------------------------------------
+# Combined filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_combined_search_kind_and_cycle_trigger(
+    seeded_filter_data: None, async_client: AsyncClient
+) -> None:
+    """Combining search_kind + cycle_trigger narrows to the intersection."""
+    await _login_async(async_client)
+    resp = await async_client.get("/api/logs?search_kind=missing&cycle_trigger=run_now&limit=200")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    for row in data:
+        assert row["search_kind"] == "missing"
+        assert row["cycle_trigger"] == "run_now"

--- a/tests/test_routes/test_run_now.py
+++ b/tests/test_routes/test_run_now.py
@@ -1,0 +1,175 @@
+"""Tests for POST /api/instances/{id}/run-now edge cases.
+
+Complements the basic run-now assertions in test_status.py with supervisor
+availability, CSRF enforcement, response body shape, and path-param validation.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+from houndarr.clients.base import ArrClient
+from houndarr.engine import supervisor as supervisor_module
+from tests.conftest import csrf_headers
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_AUTH_LOCATIONS = {"/setup", "/login", "http://testserver/setup", "http://testserver/login"}
+
+_VALID_FORM = {
+    "name": "My Sonarr",
+    "type": "sonarr",
+    "url": "http://sonarr:8989",
+    "api_key": "test-api-key",
+    "connection_verified": "true",
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_connection_ping(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _always_true(self: ArrClient) -> bool:
+        return True
+
+    monkeypatch.setattr(ArrClient, "ping", _always_true)
+
+
+@pytest.fixture(autouse=True)
+def _mock_supervisor_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _no_op_run_instance_search(*args: object, **kwargs: object) -> int:
+        return 0
+
+    monkeypatch.setattr(supervisor_module, "run_instance_search", _no_op_run_instance_search)
+
+
+def _login(client: TestClient) -> None:
+    client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+
+# ---------------------------------------------------------------------------
+# Supervisor availability (503)
+# ---------------------------------------------------------------------------
+
+
+def test_run_now_503_when_supervisor_missing(app: TestClient) -> None:
+    """Returns 503 when app.state has no supervisor attribute."""
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM, headers=csrf_headers(app))
+    status = app.get("/api/status").json()
+    inst_id = status[0]["id"]
+
+    # Remove the supervisor from app state
+    original = getattr(app.app.state, "supervisor", None)  # type: ignore[union-attr]
+    try:
+        app.app.state.supervisor = None  # type: ignore[union-attr]
+        resp = app.post(f"/api/instances/{inst_id}/run-now", headers=csrf_headers(app))
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "Supervisor unavailable"
+    finally:
+        app.app.state.supervisor = original  # type: ignore[union-attr]
+
+
+def test_run_now_503_when_supervisor_wrong_type(app: TestClient) -> None:
+    """Returns 503 when supervisor is set but not a Supervisor instance."""
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM, headers=csrf_headers(app))
+    status = app.get("/api/status").json()
+    inst_id = status[0]["id"]
+
+    original = getattr(app.app.state, "supervisor", None)  # type: ignore[union-attr]
+    try:
+        app.app.state.supervisor = "not-a-supervisor"  # type: ignore[union-attr]
+        resp = app.post(f"/api/instances/{inst_id}/run-now", headers=csrf_headers(app))
+        assert resp.status_code == 503
+    finally:
+        app.app.state.supervisor = original  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# CSRF enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_run_now_requires_csrf_token(app: TestClient) -> None:
+    """POST /api/instances/{id}/run-now without CSRF token is rejected."""
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM, headers=csrf_headers(app))
+    status = app.get("/api/status").json()
+    inst_id = status[0]["id"]
+
+    # POST without CSRF headers
+    resp = app.post(f"/api/instances/{inst_id}/run-now")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Response body shape
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_run_now_202_response_body_shape(app: TestClient) -> None:
+    """202 response body contains exactly 'status' and 'instance_id' keys."""
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM, headers=csrf_headers(app))
+    status = app.get("/api/status").json()
+    inst_id = status[0]["id"]
+
+    respx.get("http://sonarr:8989/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": []})
+    )
+
+    resp = app.post(f"/api/instances/{inst_id}/run-now", headers=csrf_headers(app))
+    assert resp.status_code == 202
+    body = resp.json()
+    assert set(body.keys()) == {"status", "instance_id"}
+    assert body["status"] == "accepted"
+    assert isinstance(body["instance_id"], int)
+    assert body["instance_id"] == inst_id
+
+
+def test_run_now_404_response_body(app: TestClient) -> None:
+    """404 response includes a descriptive detail field."""
+    _login(app)
+    resp = app.post("/api/instances/9999/run-now", headers=csrf_headers(app))
+    assert resp.status_code == 404
+    body = resp.json()
+    assert "detail" in body
+    assert "not found" in body["detail"].lower()
+
+
+def test_run_now_409_response_body(app: TestClient) -> None:
+    """409 response includes a descriptive detail field."""
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM, headers=csrf_headers(app))
+    status = app.get("/api/status").json()
+    inst_id = status[0]["id"]
+
+    # Disable the instance
+    app.post(f"/settings/instances/{inst_id}/toggle-enabled", headers=csrf_headers(app))
+
+    resp = app.post(f"/api/instances/{inst_id}/run-now", headers=csrf_headers(app))
+    assert resp.status_code == 409
+    body = resp.json()
+    assert "detail" in body
+    assert "disabled" in body["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Path parameter validation
+# ---------------------------------------------------------------------------
+
+
+def test_run_now_non_integer_id_returns_422(app: TestClient) -> None:
+    """Non-integer instance_id in the URL path returns 422."""
+    _login(app)
+    resp = app.post("/api/instances/abc/run-now", headers=csrf_headers(app))
+    assert resp.status_code == 422

--- a/website/docs/concepts/test-coverage.md
+++ b/website/docs/concepts/test-coverage.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 4
+title: Test Coverage
+description: What Houndarr's test suite covers and how quality is enforced on every change.
+---
+
+# Test Coverage
+
+Houndarr has a comprehensive test suite that runs automatically on every change before it can ship. No code merges without all tests passing.
+
+## What is covered
+
+**Search engine.** Missing, cutoff, and upgrade passes are tested end to end, including how they share a cycle without starving each other's caps, and how the engine handles bad or incomplete API responses from your *arr instances.
+
+**Scheduling rules.** Cooldown windows, hourly caps, batch sizes, post-release grace periods, and the upgrade hard caps are all exercised at their boundary conditions.
+
+**Supervisor.** Graceful shutdown, connection loss and recovery, staggered startup, and idempotent task management. Connection errors produce exactly one log entry per failure sequence; recovery produces exactly one.
+
+**Clients.** All five client types (Sonarr, Radarr, Lidarr, Readarr, Whisparr) are tested for correct API paths, request payloads, queue status checks, and error propagation.
+
+**Database.** Log purge, settings, and cooldown tracking are verified at their boundaries, including concurrent access.
+
+**Routes and auth.** Every mutating endpoint is tested for CSRF enforcement, authentication guards, and correct response codes across all outcomes.
+
+**Security.** A dedicated set of integration tests verifies immunity to every finding from the [Huntarr security review](../security/trust-and-security.md#huntarr-vulnerability-audit). A live smoke test also runs against a real Docker container in CI on every PR.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -102,6 +102,10 @@ const config: Config = {
               label: 'How Houndarr Works',
               to: '/docs/concepts/how-houndarr-works',
             },
+            {
+              label: 'Test Coverage',
+              to: '/docs/concepts/test-coverage',
+            },
           ],
         },
         {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
         'concepts/how-houndarr-works',
         'concepts/troubleshooting',
         'concepts/faq',
+        'concepts/test-coverage',
       ],
     },
     {


### PR DESCRIPTION
## Summary

Extends the test suite with 14 new files covering behavioral edge cases across the search engine, supervisor, adapters, clients, database, and routes. Also adds a Test Coverage page to the docs website.

Closes #283

## Changes

- New shared `tests/test_engine/conftest.py` with common fixtures and helpers for engine tests
- Search engine: pass interaction tests (independent caps per `search_kind`), queue backpressure fail-open, multi-page backlog scanning with dedup, API data handling edge cases, command payload verification, release timing retry path, upgrade pass hard caps and offset rotation
- Supervisor: connection error state machine (exactly one error log per failure sequence, one recovery log), staggered startup, graceful shutdown, idempotent start/stop
- Adapters: context-mode switching, cutoff always item-level, fallback when IDs are missing, for all five types
- Clients: correct API path selection (v1 vs v3), payload shapes, error propagation, for all five types
- Routes: run-now 503 path, CSRF enforcement, response shape; log filter 422 validation
- Docs: Test Coverage page under Concepts, wired into sidebar and footer

## Testing

All checks pass.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)
- [x] Test (`test:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way