### PR TITLE
fix(deps): bump serialize-javascript override

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16293,9 +16293,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -45,6 +45,6 @@
     "node": ">=20.0"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": ">=7.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Closes #306

Raises the npm `overrides` floor for `serialize-javascript` from `>=7.0.3` to `>=7.0.5` in `website/package.json`, resolving CVE-2026-34043 (CPU exhaustion DoS). This is a transitive dependency from Docusaurus's webpack plugins; the override will become inert once upstream updates their dependency tree.

## Test plan

- [x] `npm install` resolves `serialize-javascript` to 7.0.5
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run build` succeeds
- [ ] CI checks pass