### PR TITLE
fix(routes): use HTMX for password change form

### DIFF
--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -389,7 +389,7 @@
   </div>
 
   {% if auth_mode != "proxy" %}
-  <section class="mt-8 rounded-xl border border-[#1e2638] bg-[#0e1117] p-4 sm:p-5">
+  <section id="account-section" class="mt-8 rounded-xl border border-[#1e2638] bg-[#0e1117] p-4 sm:p-5">
     <details id="account-settings" {% if account_error or account_success %}open{% endif %}>
       <summary
         class="cursor-pointer list-none flex items-center justify-between rounded-lg px-2 py-2 text-slate-200 hover:bg-[#151b27] focus:outline-none focus:ring-2 focus:ring-brand-400/30"
@@ -421,11 +421,12 @@
           </div>
 
           <form
-            action="/settings/account/password"
-            method="post"
+            hx-post="/settings/account/password"
+            hx-target="#account-section"
+            hx-select="#account-section"
+            hx-swap="outerHTML"
             class="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4"
           >
-            <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
             <div>
               <label class="block text-xs font-medium text-slate-400 mb-1.5" for="current-password"
                 >Current Password</label

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -495,3 +495,19 @@ def test_password_change_requires_matching_confirmation(app: TestClient) -> None
     assert resp.status_code == 422
     assert b"New passwords do not match" in resp.content
     assert b'id="account-settings" open' in resp.content
+
+
+def test_password_change_htmx(app: TestClient) -> None:
+    """Password change via HTMX returns success message."""
+    _login(app)
+    resp = app.post(
+        "/settings/account/password",
+        data={
+            "current_password": "ValidPass1!",
+            "new_password": "BetterPass2!",
+            "new_password_confirm": "BetterPass2!",
+        },
+        headers={**csrf_headers(app), "HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    assert b"Password updated successfully" in resp.content


### PR DESCRIPTION
Closes #309

## What changed

Converted the password change form from a plain HTML `<form method="post">` to
an HTMX submission (`hx-post`), matching every other mutation in the app.

## Why

The CSRF middleware (`AuthMiddleware`, a Starlette `BaseHTTPMiddleware`) calls
`await request.form()` to validate the CSRF token when it arrives as a form
field. This consumes the request body stream. When FastAPI tries to parse the
`Form()` parameters in the route handler, the stream is exhausted and all
fields are null, producing a raw JSON 422 error.

HTMX sends CSRF via the `X-CSRF-Token` header (set by `app.js`), so the
middleware never calls `request.form()` and the body remains intact.

## Changes

- `settings_content.html`: Add `id="account-section"` to the wrapping section;
  replace `action`/`method` with `hx-post`/`hx-target`/`hx-select`/`hx-swap`;
  remove hidden `csrf_token` input
- `test_settings.py`: Add `test_password_change_htmx` regression test

## Checklist

- [x] Linked issue has `type:*` and `priority:*` labels
- [x] All five quality gates pass
- [x] Security smoke test: all checks pass (no regressions)
- [x] Regression test added