### PR TITLE
Fix login redirect when accessing via link (SameSite cookie issue)

### DIFF
--- a/src/houndarr/auth.py
+++ b/src/houndarr/auth.py
@@ -118,7 +118,7 @@ async def create_session(response: Response) -> str:
     cookie_kwargs: dict[str, Any] = {
         "max_age": SESSION_MAX_AGE_SECONDS,
         "httponly": True,
-        "samesite": "strict",
+        "samesite": "lax",
         "secure": settings.secure_cookies,
     }
 


### PR DESCRIPTION
## Summary

Houndarr currently sets session cookies with SameSite=Strict.

This prevents cookies from being sent during top-level navigation when accessing the app via a link (e.g., from dashboards like Homepage), causing users to be redirected to /login despite having a valid session.

Changing SameSite to "Lax" allows cookies to be sent on normal top-level navigations while maintaining CSRF protection for unsafe requests.

This fixes:
- Clicking links to Houndarr always redirecting to /login
- Behavior mismatch between direct URL entry vs link navigation