### PR TITLE
fix(auth): default SameSite cookie policy to lax

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ should store its database and master key.
 | `HOUNDARR_DEV` | `false` | Enable development mode (auto-reload, API docs) |
 | `HOUNDARR_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warning`, `error` |
 | `HOUNDARR_SECURE_COOKIES` | `false` | Set `Secure` flag on cookies (enable when behind HTTPS) |
+| `HOUNDARR_COOKIE_SAMESITE` | `lax` | `SameSite` attribute for cookies: `lax` (allows dashboard links) or `strict` |
 | `HOUNDARR_TRUSTED_PROXIES` | _(empty)_ | Comma-separated trusted proxy IPs or CIDR subnets for `X-Forwarded-For` and proxy auth |
 | `HOUNDARR_AUTH_MODE` | `builtin` | Authentication method: `builtin` (default) or `proxy` (delegate to SSO reverse proxy) |
 | `HOUNDARR_AUTH_PROXY_HEADER` | _(empty)_ | Header carrying the authenticated username in proxy mode (e.g. `Remote-User`) |

--- a/charts/houndarr/templates/statefulset.yaml
+++ b/charts/houndarr/templates/statefulset.yaml
@@ -55,6 +55,10 @@ spec:
             - name: HOUNDARR_SECURE_COOKIES
               value: "true"
             {{- end }}
+            {{- if ne .Values.env.cookieSamesite "lax" }}
+            - name: HOUNDARR_COOKIE_SAMESITE
+              value: {{ .Values.env.cookieSamesite | quote }}
+            {{- end }}
             {{- if .Values.env.trustedProxies }}
             - name: HOUNDARR_TRUSTED_PROXIES
               value: {{ .Values.env.trustedProxies | quote }}

--- a/charts/houndarr/values.yaml
+++ b/charts/houndarr/values.yaml
@@ -25,6 +25,10 @@ pgid: 1000
 env:
   # -- Set HOUNDARR_SECURE_COOKIES=true. Required when serving over HTTPS.
   secureCookies: false
+  # -- SameSite attribute for session and CSRF cookies.
+  # "lax" (default) allows cookies on navigations from dashboard apps.
+  # "strict" withholds cookies on all cross-site requests.
+  cookieSamesite: lax
   # -- Comma-separated list of trusted proxy IPs or CIDR subnets.
   # Sets HOUNDARR_TRUSTED_PROXIES. Required when behind a reverse proxy or Ingress.
   trustedProxies: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - PGID=1000
       # Reverse proxy (Nginx, Caddy, Traefik, etc.); see docs/reverse-proxy for details:
       # - HOUNDARR_SECURE_COOKIES=true         # set Secure flag on cookies when behind HTTPS
+      # - HOUNDARR_COOKIE_SAMESITE=lax           # lax (default, allows dashboard links) or strict
       # - HOUNDARR_TRUSTED_PROXIES=172.18.0.0/16  # trust X-Forwarded-For from this proxy IP/subnet
       # SSO proxy auth (Authelia, Authentik, oauth2-proxy, etc.); all three required together:
       # - HOUNDARR_AUTH_MODE=proxy

--- a/src/houndarr/__main__.py
+++ b/src/houndarr/__main__.py
@@ -56,6 +56,19 @@ from houndarr import __version__
     ),
 )
 @click.option(
+    "--cookie-samesite",
+    default="lax",
+    show_default=True,
+    type=click.Choice(["lax", "strict"], case_sensitive=False),
+    envvar="HOUNDARR_COOKIE_SAMESITE",
+    help=(
+        "SameSite attribute for session and CSRF cookies. "
+        "'lax' (default) allows cookies on top-level navigations from "
+        "external links (e.g. dashboard apps). 'strict' withholds cookies "
+        "on all cross-site requests."
+    ),
+)
+@click.option(
     "--trusted-proxies",
     default="",
     show_default=False,
@@ -98,6 +111,7 @@ def cli(
     dev: bool,
     log_level: str,
     secure_cookies: bool,
+    cookie_samesite: str,
     trusted_proxies: str,
     auth_mode: str,
     auth_proxy_header: str,
@@ -112,7 +126,7 @@ def cli(
 
     import uvicorn
 
-    from houndarr.config import AppSettings
+    from houndarr.config import AppSettings, _parse_samesite
 
     # Configure the root logger so that application loggers (houndarr.*)
     # respect --log-level.  Without this, only uvicorn's own loggers are
@@ -130,6 +144,7 @@ def cli(
         dev=dev,
         log_level=log_level.lower(),
         secure_cookies=secure_cookies,
+        cookie_samesite=_parse_samesite(cookie_samesite),
         trusted_proxies=trusted_proxies,
         auth_mode=auth_mode.lower(),
         auth_proxy_header=auth_proxy_header,

--- a/src/houndarr/auth.py
+++ b/src/houndarr/auth.py
@@ -118,7 +118,7 @@ async def create_session(response: Response) -> str:
     cookie_kwargs: dict[str, Any] = {
         "max_age": SESSION_MAX_AGE_SECONDS,
         "httponly": True,
-        "samesite": "strict",
+        "samesite": settings.cookie_samesite,
         "secure": settings.secure_cookies,
     }
 
@@ -130,7 +130,7 @@ async def create_session(response: Response) -> str:
         value=csrf_token,
         max_age=SESSION_MAX_AGE_SECONDS,
         httponly=False,
-        samesite="strict",
+        samesite=settings.cookie_samesite,
         secure=settings.secure_cookies,
     )
 
@@ -438,7 +438,7 @@ def _ensure_proxy_csrf_cookie(request: Request, response: Response) -> None:
         value=secrets.token_hex(32),
         max_age=SESSION_MAX_AGE_SECONDS,
         httponly=False,
-        samesite="strict",
+        samesite=settings.cookie_samesite,
         secure=settings.secure_cookies,
     )
 

--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -8,6 +8,7 @@ import os
 from dataclasses import dataclass, field
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from pathlib import Path
+from typing import Literal
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,19 @@ def _parse_trusted_proxies(raw: str) -> TrustedProxies:
 _runtime_settings: AppSettings | None = None
 
 
+SameSitePolicy = Literal["lax", "strict"]
+
+_VALID_SAMESITE: frozenset[str] = frozenset({"lax", "strict"})
+
+
+def _parse_samesite(raw: str) -> SameSitePolicy:
+    """Normalise a SameSite env/CLI value, defaulting to ``lax``."""
+    value = raw.strip().lower()
+    if value in _VALID_SAMESITE:
+        return value  # type: ignore[return-value]
+    return "lax"
+
+
 def _parse_bool_env(name: str, default: bool = False) -> bool:
     """Parse a boolean environment variable."""
     raw = os.environ.get(name, "").lower()
@@ -114,6 +128,7 @@ def get_settings() -> AppSettings:
         dev=_parse_bool_env("HOUNDARR_DEV"),
         log_level=os.environ.get("HOUNDARR_LOG_LEVEL", "info").lower(),
         secure_cookies=_parse_bool_env("HOUNDARR_SECURE_COOKIES"),
+        cookie_samesite=_parse_samesite(os.environ.get("HOUNDARR_COOKIE_SAMESITE", "lax")),
         trusted_proxies=os.environ.get("HOUNDARR_TRUSTED_PROXIES", ""),
         auth_mode=os.environ.get("HOUNDARR_AUTH_MODE", "builtin").lower(),
         auth_proxy_header=os.environ.get("HOUNDARR_AUTH_PROXY_HEADER", ""),
@@ -133,6 +148,13 @@ class AppSettings:
         secure_cookies: Set the ``Secure`` flag on session cookies.
             Enable when Houndarr is served over HTTPS via a reverse proxy.
             Corresponds to ``HOUNDARR_SECURE_COOKIES`` env var.
+        cookie_samesite: ``SameSite`` attribute for session and CSRF cookies.
+            ``lax`` (default) allows cookies on top-level navigations from
+            external links (e.g. dashboard apps) while blocking cross-site
+            form submissions.  ``strict`` withholds cookies on all
+            cross-site requests, which prevents access via external links
+            but provides an extra layer of isolation.
+            Corresponds to ``HOUNDARR_COOKIE_SAMESITE`` env var.
         trusted_proxies: Comma-separated list of trusted reverse-proxy IP
             addresses or CIDR subnets (e.g. ``10.1.1.0/24``).  When set,
             ``X-Forwarded-For`` is honoured for client-IP detection (rate
@@ -154,6 +176,7 @@ class AppSettings:
     dev: bool = False
     log_level: str = "info"
     secure_cookies: bool = False
+    cookie_samesite: Literal["lax", "strict"] = "lax"
     trusted_proxies: str = ""
     auth_mode: str = "builtin"
     auth_proxy_header: str = ""
@@ -182,6 +205,10 @@ class AppSettings:
             List of error messages.  Empty means the configuration is valid.
         """
         errors: list[str] = []
+        if self.cookie_samesite not in ("lax", "strict"):
+            errors.append(
+                f"HOUNDARR_COOKIE_SAMESITE must be 'lax' or 'strict', got '{self.cookie_samesite}'"
+            )
         if self.auth_mode not in ("builtin", "proxy"):
             errors.append(
                 f"HOUNDARR_AUTH_MODE must be 'builtin' or 'proxy', got '{self.auth_mode}'"

--- a/tests/test_huntarr_vulns.py
+++ b/tests/test_huntarr_vulns.py
@@ -450,7 +450,11 @@ class TestCookieSecurityFlags:
     """Session and CSRF cookies must carry the correct security attributes.
 
     HttpOnly prevents JS from reading the session token (XSS mitigation).
-    SameSite=strict blocks cross-origin form submissions (CSRF mitigation).
+    SameSite blocks cross-origin requests (CSRF mitigation layer).  The
+    default is ``lax``, which allows top-level GET navigations from external
+    links (dashboard apps, bookmarks) while blocking cross-site form
+    submissions.  Users may override to ``strict`` via
+    ``HOUNDARR_COOKIE_SAMESITE``.
     The CSRF cookie must NOT be HttpOnly because HTMX reads it from JS to
     include in the X-CSRF-Token request header.
     """
@@ -472,12 +476,12 @@ class TestCookieSecurityFlags:
         assert session is not None, "houndarr_session not found in login Set-Cookie headers"
         assert "httponly" in session.lower()
 
-    def test_session_cookie_has_samesite_strict(self, app: TestClient) -> None:
-        """houndarr_session cookie must have SameSite=strict."""
+    def test_session_cookie_has_samesite_lax(self, app: TestClient) -> None:
+        """houndarr_session cookie must have SameSite=lax (default)."""
         cookies = self._login_response_cookies(app)
         session = next((c for c in cookies if SESSION_COOKIE_NAME in c), None)
         assert session is not None
-        assert "samesite=strict" in session.lower()
+        assert "samesite=lax" in session.lower()
 
     def test_session_cookie_has_24h_max_age(self, app: TestClient) -> None:
         """houndarr_session cookie must expire after SESSION_MAX_AGE_SECONDS (86400 = 24h)."""
@@ -493,12 +497,12 @@ class TestCookieSecurityFlags:
         assert csrf is not None, "houndarr_csrf not found in login Set-Cookie headers"
         assert "httponly" not in csrf.lower()
 
-    def test_csrf_cookie_has_samesite_strict(self, app: TestClient) -> None:
-        """houndarr_csrf cookie must have SameSite=strict."""
+    def test_csrf_cookie_has_samesite_lax(self, app: TestClient) -> None:
+        """houndarr_csrf cookie must have SameSite=lax (default)."""
         cookies = self._login_response_cookies(app)
         csrf = next((c for c in cookies if CSRF_COOKIE_NAME in c), None)
         assert csrf is not None
-        assert "samesite=strict" in csrf.lower()
+        assert "samesite=lax" in csrf.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/configuration/environment-variables.md
+++ b/website/docs/configuration/environment-variables.md
@@ -24,6 +24,7 @@ Houndarr is configured primarily through environment variables set in your
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `HOUNDARR_SECURE_COOKIES` | `false` | Set `Secure` flag on cookies (enable when behind HTTPS) |
+| `HOUNDARR_COOKIE_SAMESITE` | `lax` | `SameSite` attribute for cookies: `lax` (allows dashboard links) or `strict` (blocks all cross-site requests) |
 | `HOUNDARR_TRUSTED_PROXIES` | _(empty)_ | Comma-separated trusted proxy IPs or CIDR subnets (e.g. `10.0.0.1,172.18.0.0/16`); used for `X-Forwarded-For` and proxy auth |
 | `HOUNDARR_AUTH_MODE` | `builtin` | Authentication method: `builtin` (default) or `proxy` (delegate to SSO reverse proxy) |
 | `HOUNDARR_AUTH_PROXY_HEADER` | _(empty)_ | Header carrying the authenticated username in proxy mode (e.g. `Remote-User`, `X-authentik-username`); required when `AUTH_MODE=proxy` |
@@ -80,6 +81,18 @@ HTTPS termination. Without this, session cookies and login credentials are
 transmitted in cleartext on the network.
 
 See [Reverse Proxy](reverse-proxy.md) for the full configuration.
+
+### Cookie SameSite policy
+
+The default `HOUNDARR_COOKIE_SAMESITE=lax` allows session cookies to be sent
+when you click a link to Houndarr from a dashboard app (Homepage, Homarr,
+Organizr) or any external page. Without this, you would be redirected to the
+login page despite having a valid session.
+
+Set `HOUNDARR_COOKIE_SAMESITE=strict` if you prefer the most restrictive
+cookie policy and do not access Houndarr via external links. State-changing
+requests (POST, PUT, PATCH, DELETE) are protected by CSRF token validation
+regardless of this setting.
 
 ### Proxy authentication mode
 

--- a/website/docs/getting-started/helm.md
+++ b/website/docs/getting-started/helm.md
@@ -123,6 +123,7 @@ The `chartRef` field (instead of `chart.spec.sourceRef`) is what connects a `Hel
 | `puid` | `1000` | UID for compat mode |
 | `pgid` | `1000` | GID for compat mode |
 | `env.secureCookies` | `false` | Set `HOUNDARR_SECURE_COOKIES=true`. Required for HTTPS |
+| `env.cookieSamesite` | `lax` | `HOUNDARR_COOKIE_SAMESITE`: `lax` (allows dashboard links) or `strict` |
 | `env.trustedProxies` | `""` | Comma-separated CIDRs for `HOUNDARR_TRUSTED_PROXIES` |
 | `env.authMode` | `builtin` | `HOUNDARR_AUTH_MODE`: `builtin` or `proxy` |
 | `env.authProxyHeader` | `""` | `HOUNDARR_AUTH_PROXY_HEADER` (e.g., `Remote-User`) |

--- a/website/docs/security/trust-and-security.md
+++ b/website/docs/security/trust-and-security.md
@@ -165,11 +165,18 @@ for setup instructions.
 
 | Cookie | HttpOnly | SameSite | Secure | Purpose |
 |--------|----------|----------|--------|---------|
-| `houndarr_session` | Yes | Strict | Configurable | Session authentication (built-in mode only) |
-| `houndarr_csrf` | No | Strict | Configurable | CSRF token for HTMX/JS (both modes) |
+| `houndarr_session` | Yes | Lax (configurable) | Configurable | Session authentication (built-in mode only) |
+| `houndarr_csrf` | No | Lax (configurable) | Configurable | CSRF token for HTMX/JS (both modes) |
 
 The CSRF cookie is intentionally not `HttpOnly` because HTMX needs to read it
 to include the token in request headers.
+
+The `SameSite` attribute defaults to `Lax`, which allows cookies on top-level
+navigations from external links (dashboard apps, bookmarks) while blocking
+cross-site form submissions. This matches the default used by Django, Rails,
+Flask, Laravel, and ASP.NET Core. Set `HOUNDARR_COOKIE_SAMESITE=strict` to
+withhold cookies on all cross-site requests; note that this prevents access
+via links from dashboard apps like Homepage or Homarr.
 
 The `Secure` flag on both cookies is controlled by `HOUNDARR_SECURE_COOKIES`.
 It defaults to `false` because Houndarr serves plain HTTP and expects HTTPS to
@@ -181,8 +188,9 @@ All state-changing requests (POST, PUT, PATCH, DELETE) require a valid CSRF
 token in both auth modes. In built-in mode, the expected token is embedded in
 the HMAC-signed session cookie and cannot be forged without the signing secret.
 In proxy mode, the double-submit cookie pattern is used: a `houndarr_csrf`
-cookie with `SameSite=Strict` is set on authenticated responses and must be
-echoed back in the `X-CSRF-Token` header or `csrf_token` form field.
+cookie with `SameSite=Lax` (configurable) is set on authenticated responses
+and must be echoed back in the `X-CSRF-Token` header or `csrf_token` form
+field.
 
 Token comparison uses `hmac.compare_digest()` in both modes to prevent timing
 attacks.
@@ -366,7 +374,8 @@ The tests and smoke script together cover:
 - API key exposure: no HTTP response includes an `api_key` field or a
   Fernet-encoded token (`gAAAAA` prefix)
 - Cookie flags: session cookie is `HttpOnly`; CSRF cookie is not `HttpOnly`
-  (needed for HTMX); both use `SameSite=Strict` and 24-hour expiry
+  (needed for HTMX); both use `SameSite=Lax` (default, configurable) and
+  24-hour expiry
 - CSRF enforcement: all mutating authenticated routes return 403 without a
   valid token; `hmac.compare_digest()` is verified in the source
 - Rate limiting: 7 rapid failed login attempts trigger HTTP 429


### PR DESCRIPTION
Closes #317

## What changed

Session and CSRF cookies now default to `SameSite=Lax` instead of `Strict`.

A new `HOUNDARR_COOKIE_SAMESITE` environment variable (`--cookie-samesite`
CLI flag) lets users opt back into `strict` if they prefer the most
restrictive policy.

## Why

`SameSite=Strict` causes the browser to withhold cookies on any cross-site
top-level navigation. Users who click a link to Houndarr from a dashboard
app (Homepage, Homarr, Organizr), a bookmark, or any external page get
redirected to `/login` despite having a valid session.

`Lax` fixes this by allowing cookies on top-level GET navigations while
still blocking cross-site POST/PUT/PATCH/DELETE. Houndarr has no
state-changing GET routes, and token-based CSRF validation (with
`hmac.compare_digest()`) remains the primary defense regardless of the
`SameSite` value.

`Lax` is the default in Django, Rails, Flask, Laravel, ASP.NET Core, and
Spring Boot. OWASP calls it "a reasonable balance between security and
usability" when paired with token-based CSRF.

Inspired by #316 (thanks @moker49).

## Files changed (11)

- `src/houndarr/config.py`: `cookie_samesite` field, `SameSitePolicy` Literal type, `_parse_samesite()` helper, startup validation
- `src/houndarr/__main__.py`: `--cookie-samesite` CLI flag
- `src/houndarr/auth.py`: all three hardcoded `samesite="strict"` replaced with `settings.cookie_samesite`
- `tests/test_huntarr_vulns.py`: updated assertions to expect `lax` default
- `website/docs/security/trust-and-security.md`: cookie table, SameSite explanation, audit summary
- `website/docs/configuration/environment-variables.md`: new env var and docs section
- `README.md`: env var table
- `docker-compose.yml`: commented-out env var
- `charts/houndarr/values.yaml`: `env.cookieSamesite: lax`
- `charts/houndarr/templates/statefulset.yaml`: conditional env injection
- `website/docs/getting-started/helm.md`: values reference table

## Checklist

- [x] Linked issue has `type:` and `priority:` labels
- [x] All five quality gates pass locally (ruff, format, mypy, bandit, pytest)
- [x] Tests updated for new default
- [x] Documentation updated (README, env vars, trust & security, Helm, docker-compose)
- [ ] N/A: No schema migration needed
- [ ] N/A: No VERSION/CHANGELOG change (not a version bump PR)