### PR TITLE
chore: fix numbering and allowed-tools in fix-issue command

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,7 +1,7 @@
 ---
 description: Investigate a problem thoroughly and ship a well-tested fix
 argument-hint: "<issue-number | URL | description>"
-allowed-tools: Read, Write, Edit, MultiEdit, Bash(*), Grep, Glob, Agent, WebSearch, WebFetch
+allowed-tools: Read, Write, Edit, MultiEdit, Bash(*), Grep, Glob, Agent, WebSearch, WebFetch, mcp__plugin_context7_context7__*, mcp__plugin_github_github__*, mcp__plugin_playwright_playwright__*, Skill(firecrawl:*)
 ---
 
 # Fix: Thorough Investigation → Tested PR
@@ -90,7 +90,7 @@ If the triage result is A: continue.
 - What files will be touched?
 - Are there related areas that could be affected?
 
-### 2e. Identify edge cases and breaking changes
+### 2d. Identify edge cases and breaking changes
 
 Think through every scenario where the fix could go wrong:
 
@@ -106,7 +106,7 @@ Think through every scenario where the fix could go wrong:
 - If touching auth, crypto, or SSRF validation: stop and flag for
   extra review before proceeding.
 
-### 2f. Present the plan
+### 2e. Present the plan
 
 Summarize:
 - What the problem is


### PR DESCRIPTION
## Summary

Closes #327

## Changes

- Fix phase numbering gap in `/fix-issue` command (2c jumped to 2e, now sequential 2a through 2e)
- Add Context7, GitHub, Playwright MCP tool prefixes and Firecrawl skill to `allowed-tools` header so the command can actually use the research and testing tools it references in Phase 2a

## Testing

Non-code change (slash command markdown). All checks pass or skip via ci-skip.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes
- [ ] Type check passes (`mypy src/`)
- [ ] Lint passes (`ruff check .`)
- [ ] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way