### PR TITLE
ci: widen paths-ignore glob scope

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -1,16 +1,18 @@
 name: CI Skip (docs-only)
 
 # Provide passing required-check statuses when a PR touches only
-# documentation files.  Every other workflow uses paths-ignore to skip
-# docs/** and *.md, so without this shim those required checks would
-# never report and the PR would stay blocked by branch protection.
+# documentation or agent-config files.  Every other workflow uses
+# paths-ignore to skip these paths, so without this shim those required
+# checks would never report and the PR would stay blocked by branch
+# protection.
 
 on:
   pull_request:
     paths:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,8 +9,9 @@ on:
   pull_request:
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,13 +6,15 @@ on:
     tags: ["v*"]
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
 
 # Permissions set at job level for least-privilege.
 permissions: {}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,13 +5,15 @@ on:
     branches: ["main"]
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
 
 permissions:
   contents: read

--- a/.github/workflows/security-smoke-test.yml
+++ b/.github/workflows/security-smoke-test.yml
@@ -5,13 +5,15 @@ on:
     branches: ["main"]
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,13 +5,15 @@ on:
     branches: ["main"]
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
   schedule:
     # Every Monday at 09:00 UTC
     - cron: "0 9 * * 1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,15 @@ on:
     branches: ["main"]
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
       - "website/**"
+      - ".claude/**"
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ security and container checks.
 | Security smoke test | `security-smoke-test.yml` | Live container: unauthenticated sweep, CSRF, XFF, rate limiting, API key exposure, container security |
 
 The six main workflows (`quality`, `tests`, `security`, `dependency-review`,
-`docker`, `security-smoke-test`) use `paths-ignore: ["docs/**", "*.md", "website/**"]`. When a PR
+`docker`, `security-smoke-test`) use `paths-ignore: ["docs/**", "**/*.md", "website/**", ".claude/**"]`. When a PR
 touches only those paths, `ci-skip.yml` provides passing no-op jobs with
 identical check names so branch protection is satisfied.
 
@@ -601,7 +601,7 @@ someone comments, so reporters get immediate feedback.
   extracts content between `## [X.Y.Z]` headings
 - Do not change `ci-skip.yml` job names without updating branch protection
 - If mypy CI fails with "merge ref not found": push an empty commit to retrigger
-- Keep `paths-ignore` patterns in sync across the five main workflows
+- Keep `paths-ignore` patterns in sync across the six main workflows
 
 ### Handling conflicts between docs and practice
 


### PR DESCRIPTION
## Summary

Closes #326

## Changes

- Change `*.md` to `**/*.md` in `paths-ignore` across all six main workflows so subdirectory markdown (e.g. `.claude/commands/*.md`) is correctly ignored
- Add `.claude/**` to `paths-ignore` so agent config changes skip code checks
- Update `ci-skip.yml` inverse `paths:` filter to match
- Update AGENTS.md to document the new patterns

## Testing

All modified workflow files pass `actionlint`. Pattern sync verified across all 7 files.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes
- [ ] Type check passes (`mypy src/`)
- [ ] Lint passes (`ruff check .`)
- [ ] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way