### PR TITLE
docs: redesign README as a landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,81 @@
+<div align="center">
+
+<img src="src/houndarr/static/img/houndarr-logo-dark.png" alt="Houndarr logo" width="200" />
+
 # Houndarr
 
-<p align="center">
-  <img src="src/houndarr/static/img/houndarr-logo-dark.png" alt="Houndarr logo" width="220" />
-</p>
+**Automated missing-media search for your \*arr stack.**<br>
+Small batches. Polite intervals. Zero indexer abuse.
 
-> A focused, self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and Whisparr that automatically searches for missing and upgrade-eligible media in polite, controlled batches.
->
-> **[Documentation](https://av1155.github.io/houndarr/)** | **[Quick Start](https://av1155.github.io/houndarr/docs/getting-started/quick-start)**
+[![GitHub stars](https://img.shields.io/github/stars/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/stargazers)
+[![License: AGPL-3.0](https://img.shields.io/github/license/av1155/houndarr?style=flat)](LICENSE)
+[![Last commit](https://img.shields.io/github/last-commit/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/commits/main)
+[![GitHub release](https://img.shields.io/github/v/release/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/releases/latest)
+[![Contributors](https://img.shields.io/github/contributors/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/graphs/contributors)
+
+[Documentation](https://av1155.github.io/houndarr/)
+&ensp;&bull;&ensp;
+[Quick Start](https://av1155.github.io/houndarr/docs/getting-started/quick-start)
+&ensp;&bull;&ensp;
+[Docker](https://github.com/av1155/houndarr/pkgs/container/houndarr)
+&ensp;&bull;&ensp;
+[Helm Chart](https://av1155.github.io/houndarr/docs/getting-started/helm)
+&ensp;&bull;&ensp;
+[Report Bug](https://github.com/av1155/houndarr/issues/new/choose)
+
+</div>
 
 ---
 
-## What Houndarr Does
+<div align="center">
 
-Radarr, Sonarr, Lidarr, Readarr, and Whisparr monitor RSS feeds for new
-releases, but they do not go back and actively search for content already in
-your library that is missing or below your quality cutoff. Their built-in
-"Search All Missing" button fires every item at once, overwhelming indexer
-API limits.
+<img src="docs/images/Dashboard_Houndarr.jpeg" alt="Houndarr dashboard" width="700" />
 
-Houndarr searches **slowly, politely, and automatically**: small batches,
-configurable sleep intervals, per-item cooldowns, and hourly API caps.
-It runs as a single Docker container alongside your existing *arr stack.
+<br><br>
 
-**Key capabilities:**
+<img src="docs/images/Logs_Houndarr.jpeg" alt="Houndarr log viewer" width="340" />
+&nbsp;&nbsp;
+<img src="docs/images/Settings_Houndarr.jpeg" alt="Houndarr settings" width="340" />
 
-- Connects to one or more Radarr, Sonarr, Lidarr, Readarr, and Whisparr instances
-- Searches for **missing** episodes, movies, albums, and books in small, configurable batches
-- Searches for **cutoff-unmet** items (below your quality profile) separately
-- Optional **library upgrade** pass re-searches items that already meet cutoff, letting your *arr instance find better releases based on quality profiles and custom formats
-- Radarr: movie-level search
-- Sonarr: episode-level search by default, with optional season-context mode
-- Lidarr: album-level search by default, with optional artist-context mode
-- Readarr: book-level search by default, with optional author-context mode
-- Whisparr: episode-level search by default, with optional season-context mode
+</div>
+
+<br>
+
+## What is Houndarr?
+
+Radarr, Sonarr, Lidarr, Readarr, and Whisparr monitor RSS feeds for new releases, but they do not go back and actively search for content already in your library that is missing or below your quality cutoff. Their built-in "Search All Missing" button fires every item at once, which can overwhelm indexer API limits and get you temporarily banned.
+
+Houndarr fixes this by searching slowly, politely, and automatically. It works through your backlog in small, configurable batches with sleep intervals between cycles, per-item cooldowns, and hourly API caps. It runs as a single Docker container alongside your existing \*arr stack and stays out of the way.
+
+## Key Features
+
+**Supported Apps**
+
+- Radarr, Sonarr, Lidarr, Readarr, and Whisparr
+- Connect multiple instances of each
+
+**Search Modes**
+
+- Missing media (episodes, movies, albums, books)
+- Cutoff-unmet items below your quality profile
+- Library upgrades for items that already meet cutoff
+- Configurable search context (episode vs. season, album vs. artist, book vs. author)
+
+**Rate Limiting and Safety**
+
+- Small, configurable batch sizes with sleep intervals between cycles
 - Per-item cooldown prevents re-searching the same item too soon
 - Per-instance hourly API cap keeps indexer usage in check
-- Optional download-queue backpressure gate skips cycles when the queue is full
+- Download-queue backpressure gate skips cycles when the queue is full
 - Bounded multi-page scanning so deep backlog items are not starved
+
+**Web UI**
+
 - Live dashboard with instance status cards and run-now buttons
-- Filterable, searchable log viewer with multi-format copy/export
-- Dark-themed web UI (FastAPI + HTMX + Tailwind CSS)
+- Filterable, searchable log viewer with multi-format copy and export
+- Dark-themed interface (FastAPI + HTMX + Tailwind CSS)
 
-## What Houndarr Does Not Do
-
-- **No download-client integration**: it triggers searches in your *arr instances, which handle downloads
-- **No Prowlarr/indexer management**: your *arr instances manage their own indexers
-- **No request workflows**: no Overseerr/Ombi-style request handling
-- **No multi-user support**: single admin username and password
-- **No media file manipulation**: it never touches your library files
-
----
-
-## Screenshots
-
-| Dashboard | Logs | Settings |
-|:---------:|:----:|:--------:|
-| ![Dashboard](docs/images/Dashboard_Houndarr.jpeg) | ![Logs](docs/images/Logs_Houndarr.jpeg) | ![Settings](docs/images/Settings_Houndarr.jpeg) |
-
----
-
-## Quick Start (Docker Compose)
+## Quick Start
 
 Create a `docker-compose.yml`:
 
@@ -79,17 +95,16 @@ services:
       - PGID=1000
 ```
 
-Then run:
-
 ```bash
 docker compose up -d
 ```
 
-Open `http://<your-host>:8877` in your browser. On first launch you will be
-prompted to create an admin username and password.
+Open `http://<your-host>:8877` and create your admin account on the setup screen.
 
 <details>
 <summary>Prefer <code>docker run</code>?</summary>
+
+<br>
 
 ```bash
 docker run -d \
@@ -103,110 +118,57 @@ docker run -d \
   ghcr.io/av1155/houndarr:latest
 ```
 
-Replace `/path/to/data` with an absolute path on your host where Houndarr
-should store its database and master key.
+Replace `/path/to/data` with an absolute path on your host where Houndarr should store its database and master key.
 
 </details>
 
-## Environment Variables
+For environment variables, reverse proxy setup, Kubernetes, Helm, and building from source, see the [full documentation](https://av1155.github.io/houndarr/docs/getting-started/installation).
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `HOUNDARR_DATA_DIR` | `/data` | Directory for persistent data (SQLite DB and master key) |
-| `HOUNDARR_HOST` | `0.0.0.0` | Host address to bind the web server to |
-| `HOUNDARR_PORT` | `8877` | Port to bind the web server to |
-| `HOUNDARR_DEV` | `false` | Enable development mode (auto-reload, API docs) |
-| `HOUNDARR_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warning`, `error` |
-| `HOUNDARR_SECURE_COOKIES` | `false` | Set `Secure` flag on cookies (enable when behind HTTPS) |
-| `HOUNDARR_COOKIE_SAMESITE` | `lax` | `SameSite` attribute for cookies: `lax` (allows dashboard links) or `strict` |
-| `HOUNDARR_TRUSTED_PROXIES` | _(empty)_ | Comma-separated trusted proxy IPs or CIDR subnets for `X-Forwarded-For` and proxy auth |
-| `HOUNDARR_AUTH_MODE` | `builtin` | Authentication method: `builtin` (default) or `proxy` (delegate to SSO reverse proxy) |
-| `HOUNDARR_AUTH_PROXY_HEADER` | _(empty)_ | Header carrying the authenticated username in proxy mode (e.g. `Remote-User`) |
-| `PUID` | `1000` | User ID for file ownership inside the container |
-| `PGID` | `1000` | Group ID for file ownership inside the container |
-| `TZ` | `UTC` | Container timezone (e.g. `America/New_York`) |
+<details>
+<summary><strong>What Houndarr Does NOT Do</strong></summary>
 
-> **Note (LXC / Proxmox / root-based hosts):** If your Docker host runs containers
-> as root (a common setup in Proxmox LXC containers), set `PUID=0` and `PGID=0`.
-> Houndarr will skip the privilege-drop and run directly as root, matching the
-> security posture of the rest of your stack. A warning will be printed to stdout
-> at startup as a reminder.
+<br>
 
-## Reverse Proxy
+- **No download-client integration**: it triggers searches in your \*arr instances, which handle downloads
+- **No Prowlarr/indexer management**: your \*arr instances manage their own indexers
+- **No request workflows**: no Overseerr/Ombi-style request handling
+- **No multi-user support**: single admin username and password
+- **No media file manipulation**: it never touches your library files
 
-If you run Houndarr behind a reverse proxy (Nginx, Caddy, Traefik, etc.):
+</details>
 
-1. Set `HOUNDARR_SECURE_COOKIES=true` so session cookies require HTTPS.
-2. Set `HOUNDARR_TRUSTED_PROXIES` to your proxy's IP or subnet (e.g. `172.18.0.1`
-   or `172.18.0.0/16`) so the login rate limiter sees real client IPs via
-   `X-Forwarded-For`.
-3. Proxy all traffic to `http://houndarr:8877`.
+## Security and Trust
 
-If you run Houndarr behind an SSO proxy (Authelia, Authentik, oauth2-proxy),
-you can eliminate double-login by setting `HOUNDARR_AUTH_MODE=proxy` and
-`HOUNDARR_AUTH_PROXY_HEADER` to the header your proxy sets with the
-authenticated username. See the
-[Reverse Proxy docs](https://av1155.github.io/houndarr/docs/configuration/reverse-proxy#sso-proxy-authentication)
-for setup examples and security requirements.
+- No telemetry, analytics, or call-home. The only outbound connections go to your configured \*arr instances.
+- API keys are encrypted at rest with Fernet (AES-128-CBC + HMAC-SHA256) and never sent back to the browser.
+- Authentication uses bcrypt password hashing, signed session tokens, CSRF protection, and login rate limiting.
+- The container runs as a non-root user after PUID/PGID remapping.
+- 63 integration tests validate immunity to every finding from the Huntarr.io security review; a live smoke test runs in CI on every PR.
 
-## First-Run Setup
+For details on how Houndarr handles credentials, network behavior, and trust boundaries, see [Trust and Security](https://av1155.github.io/houndarr/docs/security/trust-and-security). To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
-1. Navigate to `http://<your-host>:8877`.
-2. Create an admin username and password on the setup screen.
-3. Log in with your new credentials.
-4. Go to **Settings** and add your *arr instances (URL + API key).
-5. Enable each instance. Houndarr will begin searching on the configured schedule.
+## Contributing and Community
 
-For detailed per-instance configuration options, see the
-[Instance Settings Guide](https://av1155.github.io/houndarr/docs/configuration/instance-settings).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, coding standards, and quality gates.
 
----
+<div align="center">
 
-## Building from Source
+<a href="https://star-history.com/#av1155/houndarr&Date">
+  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=av1155/houndarr&type=Date&theme=dark" width="600" />
+</a>
 
-```bash
-# Clone and set up
-git clone https://github.com/av1155/houndarr.git
-cd houndarr
-python3 -m venv .venv
-.venv/bin/pip install --upgrade pip
-.venv/bin/pip install -r requirements-dev.txt
-.venv/bin/pip install -e .
+<br><br>
 
-# Run locally in dev mode
-.venv/bin/python -m houndarr --data-dir ./data-dev --dev
-```
+<a href="https://github.com/av1155/houndarr/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=av1155/houndarr" alt="Contributors" />
+</a>
 
-The dev server will be available at `http://localhost:8877`.
+<br><br>
 
----
+If Houndarr is useful to you, consider giving it a <a href="https://github.com/av1155/houndarr/stargazers">star on GitHub</a>.
 
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, coding
-standards, and quality gates.
-
-## Security & Trust
-
-Houndarr is designed for self-hosters who care about what runs on their
-network:
-
-- **No telemetry, no call-home.** The only outbound connections are to your
-  configured *arr instances. There are no analytics, update checks, or
-  crash reporting.
-- **API keys are encrypted at rest** using Fernet symmetric encryption
-  (AES-128-CBC + HMAC-SHA256) and are never sent back to the browser.
-- **Authentication** uses bcrypt password hashing, signed session tokens, CSRF
-  protection, and login rate limiting.
-- **The container runs as a non-root user** after PUID/PGID remapping.
-- **Huntarr vulnerability audit**: 63 integration tests prove immunity to every finding from the Huntarr.io security review; a live smoke test runs in CI on every PR.
-
-For a detailed explanation of how Houndarr handles credentials,
-network behavior, and trust boundaries, see
-[Trust & Security](https://av1155.github.io/houndarr/docs/security/trust-and-security).
-
-To report a vulnerability, see [SECURITY.md](SECURITY.md).
+</div>
 
 ## License
 
-GNU AGPLv3. See [LICENSE](LICENSE).
+[GNU AGPLv3](LICENSE)


### PR DESCRIPTION
## Summary

Redesign the README as a conversion-oriented landing page instead of flat documentation.

Closes #330

## Changes

- Add centered hero section with shields.io badges (stars, license, last commit, release, contributors) and a quick links row
- Replace the Markdown screenshot table with HTML `<img>` tags at proper widths (700px hero, 340px secondary pair)
- Rewrite "What Houndarr Does" as two concise prose paragraphs
- Reorganize features into four scannable groups (Supported Apps, Search Modes, Rate Limiting and Safety, Web UI)
- Collapse "What Houndarr Does NOT Do" into a `<details>` block
- Tighten Security and Trust to five bullet points
- Add star history chart, contributors widget, and subtle star CTA
- Remove env vars table, reverse proxy section, first-run setup, and building from source (all already on the docs site); replace with a single link

## Testing

Visual verification: view the rendered README on the PR branch on GitHub to confirm badge rendering, image sizing, screenshot layout, collapsible sections, and link targets.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes
- [ ] Type check passes (`mypy src/`)
- [ ] Lint passes (`ruff check .`)
- [ ] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way