### PR TITLE
ci: add AI issue triage and moderation workflows

### DIFF
--- a/.github/prompts/triage-system.md
+++ b/.github/prompts/triage-system.md
@@ -1,0 +1,62 @@
+You are a GitHub issue triage assistant for Houndarr.
+
+Houndarr is a self-hosted companion for Radarr, Sonarr, Lidarr, Readarr, and
+Whisparr that automatically searches for missing, cutoff-unmet, and
+upgrade-eligible media in small, rate-limited batches. It runs as a single
+Docker container alongside an existing *arr stack.
+
+Analyze the new issue below and compare it against the list of existing issues.
+
+## Duplicate Detection Rules
+
+- Two issues are duplicates if they describe the SAME root cause or request
+  the SAME feature, even if worded differently.
+- Issues about the same *arr service experiencing the same symptom are likely
+  duplicates (e.g., "cutoff search downloads wrong file" and "cutoff upgrade
+  grabs lower quality" describe the same problem).
+- An issue is NOT a duplicate just because it involves the same service or
+  feature area. The specific problem or request must match.
+- Closed issues count as duplicates. If the problem was already reported and
+  resolved (or closed as out of scope), the new issue is still a duplicate.
+- Prefer false negatives over false positives. Only mark "high" confidence
+  when the root cause or feature request is clearly the same.
+
+## Quality Assessment Rules
+
+A complete bug report (title starts with "fix:") needs:
+- A description of what happened
+- Steps to reproduce (or enough context to understand the trigger)
+- Expected vs actual behavior
+- Houndarr version number
+
+Feature requests (title starts with "feat:") have different requirements.
+Set quality to "not_applicable" for feature requests.
+
+Mark as "incomplete" ONLY when critical information is genuinely missing.
+Do not flag issues as incomplete just because optional fields (Docker version,
+*arr version, logs) are empty.
+
+## Response Format
+
+Respond with ONLY a JSON object. No markdown fences, no explanation, no text
+before or after the JSON.
+
+{
+  "duplicate_of": null,
+  "confidence": "none",
+  "similar_issues": [],
+  "quality": "complete",
+  "missing_info": [],
+  "summary": "Brief one-sentence assessment"
+}
+
+Field definitions:
+- duplicate_of: The issue number of the original issue, or null if not a duplicate.
+- confidence: "high" (clearly same problem), "medium" (same area, possibly same
+  root cause), "low" (loosely related), or "none" (no match found).
+- similar_issues: Array of up to 3 related issue numbers that are not duplicates
+  but may provide useful context. Empty array if none.
+- quality: "complete", "incomplete", or "not_applicable" (for feature requests).
+- missing_info: Array of strings describing what information is missing.
+  Empty array if quality is "complete" or "not_applicable".
+- summary: One sentence explaining your assessment.

--- a/.github/workflows/ai-moderator.yml
+++ b/.github/workflows/ai-moderator.yml
@@ -1,0 +1,38 @@
+name: AI Spam Moderator
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  models: read
+  contents: read
+
+jobs:
+  moderate:
+    name: Moderate content
+    runs-on: ubuntu-latest
+    # Skip bot-created events to avoid unnecessary API calls.
+    if: >-
+      github.actor != 'github-actions[bot]'
+      && github.actor != 'dependabot[bot]'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # continue-on-error so forks without GitHub Models access
+      # do not see hard failures on every issue or comment.
+      - uses: github/ai-moderator@v1
+        continue-on-error: true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          spam-label: "spam"
+          minimize-detected-comments: true
+          enable-spam-detection: true
+          enable-link-spam-detection: true
+          # Legitimate users may use AI to write clear bug reports.
+          # Flagging AI-generated content would be counterproductive.
+          enable-ai-detection: false

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -1,0 +1,217 @@
+name: AI Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  models: read
+  contents: read
+
+jobs:
+  triage:
+    name: AI triage
+    runs-on: ubuntu-latest
+    # Skip bot-created issues to prevent loops and unnecessary API calls.
+    if: >-
+      github.actor != 'github-actions[bot]'
+      && github.actor != 'dependabot[bot]'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/prompts
+          sparse-checkout-cone-mode: false
+
+      # All issue data is accessed via context.payload (JavaScript), never
+      # interpolated into shell commands. No injection risk.
+      - name: Triage issue
+        uses: actions/github-script@v7
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const fs = require('fs');
+
+            // ── 1. Read system prompt ────────────────────────────────
+            const systemPrompt = fs.readFileSync(
+              '.github/prompts/triage-system.md',
+              'utf8',
+            );
+
+            // ── 2. Collect issue data ────────────────────────────────
+            const issue = context.payload.issue;
+            const issueBody = (issue.body || '').slice(0, 3000);
+
+            // ── 3. Fetch existing issues for comparison ──────────────
+            const [closed, open] = await Promise.all([
+              github.rest.issues.listForRepo({
+                ...context.repo,
+                state: 'closed',
+                per_page: 100,
+                sort: 'updated',
+                direction: 'desc',
+              }),
+              github.rest.issues.listForRepo({
+                ...context.repo,
+                state: 'open',
+                per_page: 100,
+                sort: 'updated',
+                direction: 'desc',
+              }),
+            ]);
+
+            const existing = [...closed.data, ...open.data]
+              .filter(i => i.number !== issue.number && !i.pull_request)
+              .map(i => {
+                const labels = i.labels.map(l => l.name).join(', ');
+                const tag = labels ? ` (${labels})` : '';
+                return `#${i.number} [${i.state}]${tag}: ${i.title}`;
+              })
+              .join('\n');
+
+            // ── 4. Build prompt ──────────────────────────────────────
+            const userMessage = [
+              `NEW ISSUE #${issue.number}:`,
+              `Title: ${issue.title}`,
+              'Body:',
+              issueBody,
+              '',
+              'EXISTING ISSUES:',
+              existing,
+            ].join('\n');
+
+            // ── 5. Call GitHub Models ─────────────────────────────────
+            let response;
+            try {
+              response = await fetch(
+                'https://models.github.ai/inference/chat/completions',
+                {
+                  method: 'POST',
+                  headers: {
+                    Authorization: `Bearer ${process.env.GH_TOKEN}`,
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                    model: 'openai/gpt-4o-mini',
+                    messages: [
+                      { role: 'system', content: systemPrompt },
+                      { role: 'user', content: userMessage },
+                    ],
+                    max_tokens: 500,
+                    temperature: 0.1,
+                  }),
+                },
+              );
+            } catch (err) {
+              core.warning(`GitHub Models request failed: ${err.message}`);
+              return;
+            }
+
+            if (!response.ok) {
+              const text = await response.text().catch(() => '');
+              core.warning(
+                `GitHub Models returned ${response.status}: ${text.slice(0, 200)}`,
+              );
+              return;
+            }
+
+            const result = await response.json();
+            const content = result.choices?.[0]?.message?.content;
+            if (!content) {
+              core.warning('Empty response from GitHub Models');
+              return;
+            }
+
+            // ── 6. Parse structured response ─────────────────────────
+            let assessment;
+            try {
+              const jsonMatch = content.match(/\{[\s\S]*\}/);
+              assessment = JSON.parse(jsonMatch ? jsonMatch[0] : content);
+            } catch {
+              core.warning(
+                `Failed to parse AI response: ${content.slice(0, 300)}`,
+              );
+              return;
+            }
+
+            const {
+              duplicate_of: dupOf,
+              confidence,
+              similar_issues: similar,
+              quality,
+              missing_info: missing,
+            } = assessment;
+
+            core.info(`AI assessment: ${JSON.stringify(assessment)}`);
+
+            // ── 7. Act on assessment ─────────────────────────────────
+
+            // High-confidence duplicate: label and comment.
+            if (dupOf && confidence === 'high') {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issue.number,
+                labels: ['duplicate'],
+              });
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: [
+                  `This issue appears to be a duplicate of #${dupOf}.`,
+                  '',
+                  'Please check the linked issue for context and any',
+                  'existing resolution. If your problem is different,',
+                  'please reopen with details explaining the difference.',
+                ].join('\n'),
+              });
+              return;
+            }
+
+            // Medium-confidence: informational comment only.
+            if (
+              confidence === 'medium'
+              && Array.isArray(similar)
+              && similar.length > 0
+            ) {
+              const refs = similar.map(n => `#${n}`).join(', ');
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: [
+                  `This issue may be related to ${refs}.`,
+                  'Please check those issues for context that might',
+                  'help with diagnosis.',
+                ].join('\n'),
+              });
+            }
+
+            // Incomplete bug report: request missing info.
+            // Only for bug reports (title starts with "fix:").
+            if (
+              quality === 'incomplete'
+              && Array.isArray(missing)
+              && missing.length > 0
+              && issue.title.toLowerCase().startsWith('fix:')
+            ) {
+              const missingList = missing.map(m => `- ${m}`).join('\n');
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issue.number,
+                labels: ['waiting-for-reporter'],
+              });
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: [
+                  'Thanks for opening this issue. To help with diagnosis,',
+                  'could you provide the following:',
+                  '',
+                  missingList,
+                  '',
+                  'This issue will be closed automatically if there is no',
+                  'response within 7 days.',
+                ].join('\n'),
+              });
+            }

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,31 @@
+name: Lock old threads
+
+on:
+  schedule:
+    # Daily at 04:12 UTC (staggered from stale bot at 03:37).
+    - cron: "12 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  lock:
+    name: Lock old threads
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: dessant/lock-threads@v6
+        with:
+          issue-inactive-days: 90
+          issue-comment: >-
+            This issue has been automatically locked since there has not been
+            any recent activity after it was closed. Please open a new issue
+            for related bugs and reference this one.
+          issue-lock-reason: "resolved"
+          exclude-any-issue-labels: "help wanted"
+          # Only process closed issues; leave PRs alone.
+          process-only: "issues"

--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -11,7 +11,11 @@ jobs:
   remove-stale-label:
     name: Remove stale label
     # Only run when the commented issue is still open.
-    if: github.event.issue.state == 'open'
+    # Skip bot comments so triage automation labels are not removed
+    # immediately after being applied.
+    if: >-
+      github.event.issue.state == 'open'
+      && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Add automated issue triage using free GitHub Models inference.

Closes #344

## Changes

- Add `ai-triage.yml`: detects duplicate issues and checks bug report completeness on every new issue via GitHub Models API
- Add `ai-moderator.yml`: scans issues and comments for spam using `github/ai-moderator`
- Add `lock-threads.yml`: locks closed issues after 90 days via `dessant/lock-threads`
- Add `.github/prompts/triage-system.md`: Houndarr-specific system prompt for the AI triage
- Fix race condition in `unstale.yml` where bot comments immediately removed `waiting-for-reporter` labels

## Testing

- `actionlint` passes on all new and modified workflow files
- YAML validation passes on all files
- No existing workflows modified (except unstale.yml bot exclusion)
- No impact on the 11 required CI checks
- All workflows fail gracefully if GitHub Models is unavailable (warnings, not errors)
- Fork-safe: issue-triggered workflows don't fire on forks; `continue-on-error` on moderator

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A (CI workflows, no testable code)
- [ ] Type check passes (`mypy src/`) — N/A (no Python changes)
- [ ] Lint passes (`ruff check .`) — N/A (no Python changes)
- [ ] Format passes (`ruff format --check .`) — N/A (no Python changes)
- [ ] Documentation updated (if applicable)
- [ ] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way