### PR TITLE
fix: exclude recurring tasks from duplicate detection

### DIFF
--- a/.github/prompts/triage-system.md
+++ b/.github/prompts/triage-system.md
@@ -18,6 +18,12 @@ Analyze the new issue below and compare it against the list of existing issues.
   feature area. The specific problem or request must match.
 - Closed issues count as duplicates. If the problem was already reported and
   resolved (or closed as out of scope), the new issue is still a duplicate.
+- Recurring maintenance tasks are NOT duplicates of each other. Version bumps
+  ("chore: bump version to X.Y.Z"), dependency updates, changelog entries,
+  and similar routine tasks are distinct work items even when titles follow
+  the same pattern. Each version number, dependency name, or date represents
+  a separate task. Only mark these as duplicates if the EXACT same version or
+  change is already tracked in an open issue.
 - Prefer false negatives over false positives. Only mark "high" confidence
   when the root cause or feature request is clearly the same.
 


### PR DESCRIPTION
## Summary

Fix false positive duplicate detection for version bump issues.

Closes #349

## Changes

- Add explicit rule to `.github/prompts/triage-system.md` instructing the AI that recurring maintenance tasks (version bumps, dependency updates) are distinct work items even when titles follow the same pattern
- Only flag as duplicate if the EXACT same version or change is already tracked

## Testing

Tested empirically: the AI flagged "chore: bump version to 1.8.0" as a duplicate of "chore: bump version to 1.7.0" (#341). This prompt change fixes that false positive.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A (prompt text only)
- [ ] Type check passes (`mypy src/`) — N/A (no Python changes)
- [ ] Lint passes (`ruff check .`) — N/A (no Python changes)
- [ ] Format passes (`ruff format --check .`) — N/A (no Python changes)
- [ ] Documentation updated (if applicable)
- [ ] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way