### PR TITLE
chore: configurable triage model, upgrade to gpt-4.1-mini

### DIFF
--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           GH_TOKEN: ${{ github.token }}
+          AI_MODEL: ${{ vars.AI_TRIAGE_MODEL || 'openai/gpt-4.1-mini' }}
         with:
           script: |
             const fs = require('fs');
@@ -111,7 +112,7 @@ jobs:
                     'Content-Type': 'application/json',
                   },
                   body: JSON.stringify({
-                    model: 'openai/gpt-4o-mini',
+                    model: process.env.AI_MODEL,
                     messages: [
                       { role: 'system', content: systemPrompt },
                       { role: 'user', content: userMessage },


### PR DESCRIPTION
## Summary

Make the AI triage model configurable and upgrade the default.

Closes #357

## Changes

- Default model upgraded from `openai/gpt-4o-mini` to `openai/gpt-4.1-mini` (better at instruction following and structured JSON output)
- Model is now read from the `AI_TRIAGE_MODEL` repository variable, falling back to `openai/gpt-4.1-mini` if not set
- To change the model: go to repo Settings > Secrets and variables > Actions > Variables tab > add `AI_TRIAGE_MODEL` with any GitHub Models ID (e.g., `openai/gpt-4.1-nano` for lower latency)

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A
- [ ] Type check passes (`mypy src/`) — N/A
- [ ] Lint passes (`ruff check .`) — N/A
- [ ] Format passes (`ruff format --check .`) — N/A
- [ ] Documentation updated (if applicable)
- [ ] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way