### PR TITLE
docs: explain Docker internal vs published port

### DIFF
--- a/website/docs/concepts/troubleshooting.md
+++ b/website/docs/concepts/troubleshooting.md
@@ -97,7 +97,7 @@ See [Instance Settings](/docs/configuration/instance-settings#increasing-through
 **Checks:**
 1. Verify the instance URL is reachable from the Houndarr container. Try `curl <url>/api/v3/system/status?apikey=<key>` from inside the container (use `/api/v1/` for Lidarr and Readarr instead of `/api/v3/`).
 2. Confirm the API key is correct in Houndarr's Settings page.
-3. If your *arr instance is in the same Docker Compose stack, use the container service name as the hostname (e.g., `http://sonarr:8989`, `http://radarr_hd:7878`), not `localhost`. Container names with underscores are supported.
+3. If your *arr instance is in the same Docker Compose stack, use the container service name as the hostname (e.g., `http://sonarr:8989`, `http://radarr_hd:7878`), not `localhost`. Container names with underscores are supported. The port must be the *arr's internal listen port, not the published host port from your `docker-compose.yml`. A mapping like `6970:6969` means Houndarr still reaches the *arr at `:6969`; the published `6970` only exists on your host, not on the Docker network the two containers share. Default internal ports: Sonarr `8989`, Radarr `7878`, Lidarr `8686`, Readarr `8787`, Whisparr v2 `6969`, Whisparr v3 `6969`.
 4. Check that the URL does not have a trailing slash.
 
 ### An instance is enabled but nothing is happening

--- a/website/docs/getting-started/first-run-setup.md
+++ b/website/docs/getting-started/first-run-setup.md
@@ -30,7 +30,7 @@ For each instance you need:
 
 - **Name**: a friendly label (e.g., "Radarr Movies", "Sonarr 4K", "Lidarr Music")
 - **Type**: Radarr, Sonarr, Lidarr, Readarr, Whisparr v2, or Whisparr v3
-- **URL**: the base URL of the instance (e.g., `http://sonarr:8989`)
+- **URL**: the base URL of the instance (e.g., `http://sonarr:8989`). For Docker Compose, this must be the *arr's internal container port, not the host port you published. See [Troubleshooting](/docs/concepts/troubleshooting) if the connection test fails.
 - **API Key**: found in your *arr instance under Settings > General
 
 :::tip


### PR DESCRIPTION
## Summary

The troubleshooting page mentioned using the container service name as the hostname but did not explain that the port must be the *arr's internal listen port, not the published host port from `docker-compose.yml`. Expand the existing bullet with the `6970:6969` failure case and inline the default internal ports for all six *arr types. Point the first-run setup's URL bullet at the expanded troubleshooting entry so Docker users hit the explanation before they hit the failure.

Triggered by #360, where the reporter tried `http://whisparr-v3:6970` and then fixed it themselves with `:6969` before the issue could be answered.

Docs only. No webui or code changes.

Closes #361

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/`, and the full `pytest` suite pass locally
- [x] Re-read the two modified markdown files for valid markdown and working relative link (`/docs/concepts/troubleshooting`)