### PR TITLE
ci: optimize workflows, add dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,17 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    groups:
+      production-deps:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-deps:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ai-moderator.yml
+++ b/.github/workflows/ai-moderator.yml
@@ -15,6 +15,7 @@ jobs:
   moderate:
     name: Moderate content
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Skip bot-created events to avoid unnecessary API calls.
     if: >-
       github.actor != 'github-actions[bot]'

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -13,6 +13,7 @@ jobs:
   triage:
     name: AI triage
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Skip bot-created issues to prevent loops and unnecessary API calls.
     if: >-
       github.actor != 'github-actions[bot]'

--- a/.github/workflows/api-snapshot-refresh.yml
+++ b/.github/workflows/api-snapshot-refresh.yml
@@ -17,6 +17,7 @@ jobs:
   refresh:
     name: Refresh *arr OpenAPI snapshots
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -11,6 +11,7 @@ jobs:
   publish:
     name: Package and push Helm chart
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -15,88 +15,58 @@ on:
       - ".claude/**"
 
 permissions:
-  contents: read
+  checks: write
 
 concurrency:
   group: ci-skip-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # ---------- Quality (quality.yml) ----------
-  lint:
-    name: Lint (ruff)
+  skip-checks:
+    name: CI Skip (docs-only)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - run: echo "Docs-only change — lint not required"
-
-  format:
-    name: Format (ruff)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — format check not required"
-
-  typecheck:
-    name: Type check (mypy)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — type check not required"
-
-  # ---------- Tests (tests.yml) ----------
-  test:
-    name: Test (Python 3.12)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — tests not required"
-
-  # ---------- Security (security.yml) ----------
-  dependency-audit:
-    name: Dependency audit (pip-audit)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — dependency audit not required"
-
-  sast:
-    name: SAST (bandit)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — SAST not required"
-
-  trivy-fs:
-    name: Trivy filesystem scan
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — Trivy filesystem scan not required"
-
-  # ---------- Dependency Review (dependency-review.yml) ----------
-  dependency-review:
-    name: Dependency review
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — dependency review not required"
-
-  # ---------- Docker (docker.yml) ----------
-  docker:
-    name: Build (no push)
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — Docker build not required"
-
-  trivy-image:
-    name: Trivy image scan
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — Trivy image scan not required"
-
-  # ---------- Version Check (version-check.yml) ----------
-  version-check:
-    name: Version consistency
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — version check not required"
-
-  # ---------- Security Smoke Test (security-smoke-test.yml) ----------
-  smoke-test:
-    name: Security smoke test
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Docs-only change — security smoke test not required"
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const checks = [
+              'Lint (ruff)',
+              'Format (ruff)',
+              'Type check (mypy)',
+              'Test (Python 3.12)',
+              'Dependency audit (pip-audit)',
+              'SAST (bandit)',
+              'Trivy filesystem scan',
+              'Dependency review',
+              'Build (no push)',
+              'Trivy image scan',
+              'Security smoke test',
+              'Version consistency',
+            ];
+            const sha = context.payload.pull_request.head.sha;
+            const now = new Date().toISOString();
+            for (const name of checks) {
+              try {
+                await github.rest.checks.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  head_sha: sha,
+                  name,
+                  status: 'completed',
+                  conclusion: 'success',
+                  completed_at: now,
+                  output: {
+                    title: 'Skipped (docs-only)',
+                    summary: 'Docs-only change; CI check not required.',
+                  },
+                });
+                core.info(`Created check run: ${name}`);
+              } catch (error) {
+                core.setFailed(
+                  `Failed to create check run "${name}": ${error.message}`
+                );
+                throw error;
+              }
+            }
+            core.info(`All ${checks.length} check runs created`);

--- a/.github/workflows/cleanup-actions-cache.yml
+++ b/.github/workflows/cleanup-actions-cache.yml
@@ -20,8 +20,8 @@ name: Cleanup Actions Cache
 
 on:
   schedule:
-    # Every day at 05:00 UTC (low-traffic window).
-    - cron: "0 5 * * *"
+    # Every Monday at 05:00 UTC.
+    - cron: "0 5 * * 1"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -45,6 +45,7 @@ jobs:
   cleanup:
     name: Prune stale caches
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Prune caches
         env:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,6 +24,7 @@ jobs:
   dependency-review:
     name: Dependency review
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,13 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: ["main"]
     tags: ["v*"]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "website/**"
-      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
@@ -30,6 +24,7 @@ jobs:
   build:
     name: Build ${{ startsWith(github.ref, 'refs/tags/v') && '+ Push' || '(no push)' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -80,6 +75,7 @@ jobs:
   scan:
     name: Trivy image scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: build
     permissions:
       contents: read

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -22,6 +22,7 @@ jobs:
   hadolint:
     name: Lint Dockerfile (hadolint)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -16,6 +16,7 @@ jobs:
   lock:
     name: Lock old threads
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: dessant/lock-threads@v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     name: Build docs site
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -47,6 +48,7 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,13 +1,6 @@
 name: Quality
 
 on:
-  push:
-    branches: ["main"]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "website/**"
-      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
@@ -26,6 +19,7 @@ jobs:
   lint:
     name: Lint (ruff)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -47,6 +41,7 @@ jobs:
   format:
     name: Format (ruff)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -68,6 +63,7 @@ jobs:
   typecheck:
     name: Type check (mypy)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/security-smoke-test.yml
+++ b/.github/workflows/security-smoke-test.yml
@@ -1,13 +1,6 @@
 name: Security Smoke Test
 
 on:
-  push:
-    branches: ["main"]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "website/**"
-      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
@@ -26,6 +19,7 @@ jobs:
   smoke-test:
     name: Security smoke test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,13 +1,6 @@
 name: Security
 
 on:
-  push:
-    branches: ["main"]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "website/**"
-      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
@@ -29,6 +22,7 @@ jobs:
   dependency-audit:
     name: Dependency audit (pip-audit)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -62,6 +56,7 @@ jobs:
   sast:
     name: SAST (bandit)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -83,6 +78,7 @@ jobs:
   trivy-fs:
     name: Trivy filesystem scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
   stale:
     name: Close stale issues
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/stale@v10

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Test docs build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,6 @@
 name: Tests
 
 on:
-  push:
-    branches: ["main"]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "website/**"
-      - ".claude/**"
   pull_request:
     paths-ignore:
       - "docs/**"
@@ -26,6 +19,7 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -17,6 +17,7 @@ jobs:
       github.event.issue.state == 'open'
       && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       # github.event.issue.number is a GitHub-controlled integer,

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -22,6 +22,7 @@ jobs:
   version-check:
     name: Version consistency
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -20,6 +20,7 @@ jobs:
   actionlint:
     name: Lint GitHub Actions workflows (actionlint)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Apply the same CI optimizations shipped for invest-platform to
Houndarr. Public repo so minutes are free, but these changes
improve speed, reduce noise, and enforce operational hygiene.

## Changes

- Add `timeout-minutes` to all 26 jobs across 21 workflow files
  (prevents hung Docker multi-arch builds from consuming runner
  slots for 6 hours)
- Consolidate `ci-skip.yml` from 12 echo jobs to 1 job using the
  Checks API (12 to 1 in the checks tab for docs-only PRs)
- Remove redundant `push: branches: ["main"]` triggers from 5
  workflows (quality, tests, security, docker, smoke-test). Branch
  protection requires PRs with enforce_admins, so direct pushes are
  impossible. docker.yml retains `push: tags: ["v*"]` for releases.
- Reduce cache cleanup from daily to weekly (GitHub auto-evicts at
  10GB limit)
- Add `production-deps` and `dev-deps` grouping to Dependabot npm
  ecosystem for the Docusaurus website

## Testing

- actionlint passes on all workflow files (exit 0)
- No job `name:` fields changed (branch protection compatible)
- ci-skip Checks API approach validated on invest-platform PR #143
  (same pattern, same `app_id: 15368` source filter)
- ci-skip should be validated on a docs-only test PR after merge

## Checklist

- [x] `actionlint` passes
- [x] No job names changed
- [x] No secrets or PII exposed
- [x] Changes scoped to CI optimization