### PR TITLE
feat: per-instance allowed search time windows

### DIFF
--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -251,6 +251,7 @@ DEFAULT_LIDARR_SEARCH_MODE: str = "album"
 DEFAULT_READARR_SEARCH_MODE: str = "book"
 DEFAULT_WHISPARR_SEARCH_MODE: str = "episode"
 DEFAULT_QUEUE_LIMIT: int = 0
+DEFAULT_ALLOWED_TIME_WINDOW: str = ""
 DEFAULT_LOG_RETENTION_DAYS: int = 30
 
 # Upgrade search defaults (third, opt-in pass; very conservative)

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Schema version: bump when adding new migrations
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS instances (
     upgrade_series_offset INTEGER NOT NULL DEFAULT 0,
     missing_page_offset  INTEGER NOT NULL DEFAULT 1,
     cutoff_page_offset   INTEGER NOT NULL DEFAULT 1,
+    allowed_time_window  TEXT    NOT NULL DEFAULT '',
     enabled              INTEGER NOT NULL DEFAULT 1,
     created_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
@@ -171,6 +172,7 @@ async def init_db() -> None:
             # healthy database.
             await _migrate_to_v9(db)
             await _migrate_to_v10(db)
+            await _migrate_to_v11(db)
             await _ensure_v3_indexes(db)
             await db.commit()
 
@@ -195,6 +197,8 @@ async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
         await _migrate_to_v9(db)
     if from_version < 10:
         await _migrate_to_v10(db)
+    if from_version < 11:
+        await _migrate_to_v11(db)
 
     logger.info("Migrated database from schema version %d to %d", from_version, SCHEMA_VERSION)
     await db.execute(
@@ -684,6 +688,19 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
     )
 
     await db.execute("PRAGMA foreign_keys=ON")
+
+
+async def _migrate_to_v11(db: aiosqlite.Connection) -> None:
+    """Add ``allowed_time_window`` column for per-instance search schedules.
+
+    Default is the empty string (always allowed; no gate).  When set to a
+    non-empty spec like ``"09:00-23:00"`` or ``"09:00-12:00,18:00-22:00"``,
+    the search loop skips scheduled cycles that fall outside the window.
+    """
+    if not await _column_exists(db, "instances", "allowed_time_window"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN allowed_time_window TEXT NOT NULL DEFAULT ''"
+        )
 
 
 async def _ensure_v3_indexes(db: aiosqlite.Connection) -> None:

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -25,6 +25,11 @@ from houndarr.services.cooldown import (
     record_search,
 )
 from houndarr.services.instances import Instance, InstanceType, update_instance
+from houndarr.services.time_window import (
+    format_ranges,
+    is_within_window,
+    parse_time_window,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -751,6 +756,46 @@ async def run_instance_search(
     client = adapter.make_client(instance)
     cycle_id_value = cycle_id or str(uuid4())
     searched = 0
+
+    # --- Allowed-time-window gate (scheduled cycles only) ---
+    # Manual "Run Now" clicks (cycle_trigger == "run_now") bypass this gate
+    # on purpose: the time window is an operator-preference schedule, not a
+    # safety gate.  Queue backpressure and hourly caps still apply to manual
+    # runs below.
+    if cycle_trigger == "scheduled" and instance.allowed_time_window:
+        try:
+            ranges = parse_time_window(instance.allowed_time_window)
+        except ValueError:
+            # Malformed spec should have been rejected at save time; if it
+            # slipped through (e.g. manual DB edit), fail open rather than
+            # silently skipping every cycle forever.
+            logger.warning(
+                "[%s] malformed allowed_time_window %r; ignoring gate",
+                instance.name,
+                instance.allowed_time_window,
+            )
+            ranges = []
+        if ranges:
+            now_local = datetime.now(UTC).astimezone().time()
+            if not is_within_window(now_local, ranges):
+                reason = "outside allowed time window"
+                configured = format_ranges(ranges)
+                message = (
+                    f"Local time {now_local.strftime('%H:%M')} is outside "
+                    f"configured window {configured}"
+                )
+                logger.info("[%s] skipping cycle: %s (%s)", instance.name, reason, message)
+                await _write_log(
+                    instance.id,
+                    None,
+                    None,
+                    "info",
+                    cycle_id=cycle_id_value,
+                    cycle_trigger=cycle_trigger,
+                    reason=reason,
+                    message=message,
+                )
+                return 0
 
     # --- Queue backpressure gate ---
     if instance.queue_limit > 0:

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -21,6 +21,7 @@ from houndarr.clients.sonarr import SonarrClient
 from houndarr.clients.whisparr_v2 import WhisparrClient
 from houndarr.clients.whisparr_v3 import WhisparrV3Client
 from houndarr.config import (
+    DEFAULT_ALLOWED_TIME_WINDOW,
     DEFAULT_BATCH_SIZE,
     DEFAULT_COOLDOWN_DAYS,
     DEFAULT_CUTOFF_BATCH_SIZE,
@@ -57,6 +58,7 @@ from houndarr.services.instances import (
     list_instances,
     update_instance,
 )
+from houndarr.services.time_window import parse_time_window
 from houndarr.services.url_validation import validate_instance_url
 
 router = APIRouter()
@@ -128,6 +130,7 @@ def _blank_instance() -> Instance:
         whisparr_search_mode=WhisparrSearchMode(DEFAULT_WHISPARR_SEARCH_MODE),
         created_at="",
         updated_at="",
+        allowed_time_window=DEFAULT_ALLOWED_TIME_WINDOW,
     )
 
 
@@ -549,6 +552,7 @@ async def instance_create(
     upgrade_lidarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_LIDARR_SEARCH_MODE,
     upgrade_readarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_READARR_SEARCH_MODE,
     upgrade_whisparr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
+    allowed_time_window: Annotated[str, Form()] = DEFAULT_ALLOWED_TIME_WINDOW,
     connection_verified: Annotated[str, Form()] = "false",
 ) -> HTMLResponse:
     """Create a new instance and return the updated instance table body."""
@@ -560,6 +564,11 @@ async def instance_create(
     url_error = validate_instance_url(url)
     if url_error is not None:
         return _connection_guard_response(url_error)
+
+    try:
+        parse_time_window(allowed_time_window)
+    except ValueError as exc:
+        return _connection_guard_response(str(exc))
 
     validation_error = _validate_cutoff_controls(
         cutoff_batch_size,
@@ -636,6 +645,7 @@ async def instance_create(
         upgrade_lidarr_search_mode=upgrade_modes.lidarr,
         upgrade_readarr_search_mode=upgrade_modes.readarr,
         upgrade_whisparr_search_mode=upgrade_modes.whisparr,
+        allowed_time_window=allowed_time_window.strip(),
     )
 
     supervisor = getattr(request.app.state, "supervisor", None)
@@ -696,6 +706,7 @@ async def instance_update(
     upgrade_lidarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_LIDARR_SEARCH_MODE,
     upgrade_readarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_READARR_SEARCH_MODE,
     upgrade_whisparr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
+    allowed_time_window: Annotated[str, Form()] = DEFAULT_ALLOWED_TIME_WINDOW,
     connection_verified: Annotated[str, Form()] = "false",
 ) -> HTMLResponse:
     """Update an existing instance and return the refreshed row partial.
@@ -713,6 +724,11 @@ async def instance_update(
     url_error = validate_instance_url(url)
     if url_error is not None:
         return _connection_guard_response(url_error)
+
+    try:
+        parse_time_window(allowed_time_window)
+    except ValueError as exc:
+        return _connection_guard_response(str(exc))
 
     validation_error = _validate_cutoff_controls(
         cutoff_batch_size,
@@ -808,6 +824,7 @@ async def instance_update(
         whisparr_search_mode=search_modes.whisparr,
         missing_page_offset=1,
         cutoff_page_offset=1,
+        allowed_time_window=allowed_time_window.strip(),
         **upgrade_fields,
     )
     if updated is None:

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -11,6 +11,7 @@ from enum import StrEnum
 from typing import Any
 
 from houndarr.config import (
+    DEFAULT_ALLOWED_TIME_WINDOW,
     DEFAULT_BATCH_SIZE,
     DEFAULT_COOLDOWN_DAYS,
     DEFAULT_CUTOFF_BATCH_SIZE,
@@ -117,6 +118,7 @@ class Instance:
     upgrade_series_offset: int = 0
     missing_page_offset: int = 1
     cutoff_page_offset: int = 1
+    allowed_time_window: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +163,7 @@ def _row_to_instance(row: Any, master_key: bytes) -> Instance:
         upgrade_series_offset=row["upgrade_series_offset"],
         missing_page_offset=row["missing_page_offset"],
         cutoff_page_offset=row["cutoff_page_offset"],
+        allowed_time_window=row["allowed_time_window"],
     )
 
 
@@ -207,6 +210,7 @@ async def create_instance(
     upgrade_whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode(
         DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE
     ),
+    allowed_time_window: str = DEFAULT_ALLOWED_TIME_WINDOW,
 ) -> Instance:
     """Insert a new instance row and return the populated :class:`Instance`.
 
@@ -240,6 +244,9 @@ async def create_instance(
         upgrade_lidarr_search_mode: Lidarr upgrade-search strategy mode.
         upgrade_readarr_search_mode: Readarr upgrade-search strategy mode.
         upgrade_whisparr_search_mode: Whisparr upgrade-search strategy mode.
+        allowed_time_window: Optional schedule spec (e.g. ``"09:00-23:00"``)
+            restricting scheduled cycles to configured windows.  Empty
+            string disables the gate (24/7 operation).
 
     Returns:
         The newly created :class:`Instance` with its database-assigned *id*.
@@ -258,10 +265,11 @@ async def create_instance(
                 upgrade_enabled, upgrade_batch_size, upgrade_cooldown_days,
                 upgrade_hourly_cap,
                 upgrade_sonarr_search_mode, upgrade_lidarr_search_mode,
-                upgrade_readarr_search_mode, upgrade_whisparr_search_mode
+                upgrade_readarr_search_mode, upgrade_whisparr_search_mode,
+                allowed_time_window
             ) VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                ?, ?, ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
             """,
             (
@@ -292,6 +300,7 @@ async def create_instance(
                 upgrade_lidarr_search_mode.value,
                 upgrade_readarr_search_mode.value,
                 upgrade_whisparr_search_mode.value,
+                allowed_time_window,
             ),
         )
         await db.commit()
@@ -364,7 +373,8 @@ async def update_instance(
             ``upgrade_sonarr_search_mode``, ``upgrade_lidarr_search_mode``,
             ``upgrade_readarr_search_mode``, ``upgrade_whisparr_search_mode``,
             ``upgrade_item_offset``, ``upgrade_series_offset``,
-            ``missing_page_offset``, ``cutoff_page_offset``.
+            ``missing_page_offset``, ``cutoff_page_offset``,
+            ``allowed_time_window``.
 
     Returns:
         Updated :class:`Instance`, or ``None`` if *id* does not exist.
@@ -402,6 +412,7 @@ async def update_instance(
         "upgrade_series_offset": "upgrade_series_offset",
         "missing_page_offset": "missing_page_offset",
         "cutoff_page_offset": "cutoff_page_offset",
+        "allowed_time_window": "allowed_time_window",
     }
 
     _search_mode_fields = {

--- a/src/houndarr/services/time_window.py
+++ b/src/houndarr/services/time_window.py
@@ -1,0 +1,113 @@
+"""Allowed-time-window parsing and evaluation for the search engine.
+
+An operator can restrict searches on a per-instance basis to one or more
+wall-clock time-of-day windows, e.g. ``09:00-23:00`` or
+``09:00-12:00,18:00-22:00``.  Outside any configured window, the search
+loop's gate writes a single ``info`` row and returns 0 for the cycle.
+
+Semantics
+---------
+* Format: ``HH:MM-HH:MM`` per range; comma-separated for multiple ranges.
+* Start is inclusive, end is exclusive: ``09:00-12:00`` allows searches
+  from ``09:00:00`` up to but not including ``12:00:00``.
+* Windows that span midnight are supported by putting a later start
+  before an earlier end, e.g. ``22:00-06:00``.
+* An empty or whitespace-only string means *always allowed* (no gate).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import time
+
+# Maximum number of ranges a single spec may contain.  Protects against
+# pathological inputs and keeps the DB column well under 300 chars.
+_MAX_RANGES = 24
+
+_RANGE_RE = re.compile(r"^(\d{2}):(\d{2})-(\d{2}):(\d{2})$")
+
+
+def _to_minutes(t: time) -> int:
+    """Return *t* as minutes since 00:00 (ignoring seconds/microseconds)."""
+    return t.hour * 60 + t.minute
+
+
+def parse_time_window(spec: str) -> list[tuple[time, time]]:
+    """Parse an allowed-time-window *spec* into a list of ``(start, end)`` tuples.
+
+    Raises:
+        ValueError: With an operator-facing message if the spec is malformed.
+
+    Returns:
+        A list of ``(start, end)`` tuples.  Empty list means no window is
+        configured (always allowed).  The list is returned in input order;
+        overlapping or duplicate ranges are not merged.
+    """
+    if spec is None:
+        return []
+
+    stripped = spec.strip()
+    if not stripped:
+        return []
+
+    pieces = [p.strip() for p in stripped.split(",")]
+    if len(pieces) > _MAX_RANGES:
+        raise ValueError(f"Too many time ranges (max {_MAX_RANGES}).")
+
+    ranges: list[tuple[time, time]] = []
+    for piece in pieces:
+        if not piece:
+            raise ValueError("Empty time range in allowed-window spec.")
+
+        match = _RANGE_RE.fullmatch(piece)
+        if match is None:
+            raise ValueError(f"Invalid time range '{piece}'. Use HH:MM-HH:MM (e.g. 09:00-23:00).")
+
+        sh, sm, eh, em = (int(x) for x in match.groups())
+        if not (0 <= sh <= 23 and 0 <= eh <= 23 and 0 <= sm <= 59 and 0 <= em <= 59):
+            raise ValueError(
+                f"Out-of-range hour or minute in '{piece}'. Hours 00-23, minutes 00-59."
+            )
+
+        start = time(sh, sm)
+        end = time(eh, em)
+        if _to_minutes(start) == _to_minutes(end):
+            raise ValueError(f"Time range '{piece}' has no duration (start equals end).")
+
+        ranges.append((start, end))
+
+    return ranges
+
+
+def is_within_window(now_time: time, ranges: list[tuple[time, time]]) -> bool:
+    """Return whether *now_time* falls inside any of the configured *ranges*.
+
+    An empty *ranges* list means no window is configured and the function
+    returns ``True`` (always allowed).  Ranges where ``start > end`` wrap
+    around midnight (e.g. ``22:00-06:00`` matches both 23:00 and 05:00).
+    Start is inclusive and end is exclusive.
+    """
+    if not ranges:
+        return True
+
+    now_minutes = _to_minutes(now_time)
+    for start, end in ranges:
+        start_m = _to_minutes(start)
+        end_m = _to_minutes(end)
+        if start_m < end_m:
+            if start_m <= now_minutes < end_m:
+                return True
+        else:
+            # Wraparound: allowed region is [start, 1440) ∪ [0, end)
+            if now_minutes >= start_m or now_minutes < end_m:
+                return True
+
+    return False
+
+
+def format_ranges(ranges: list[tuple[time, time]]) -> str:
+    """Render *ranges* back to a canonical ``HH:MM-HH:MM,...`` string.
+
+    Used to include the configured window in operator-facing log messages.
+    """
+    return ",".join(f"{s.strftime('%H:%M')}-{e.strftime('%H:%M')}" for s, e in ranges)

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -142,6 +142,14 @@
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Skip searches when the queue exceeds this. 0 = disabled.</p>
         </div>
+        <div class="sm:col-span-2">
+          <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-window">Allowed Search Window</label>
+          <input id="{{ form_id }}-window" name="allowed_time_window" type="text"
+                 value="{{ instance.allowed_time_window }}"
+                 placeholder="e.g. 09:00-23:00 or 09:00-12:00,18:00-22:00"
+                 class="{{ mono_input_cls }}" />
+          <p class="mt-1.5 text-xs text-slate-600">Restrict scheduled cycles to one or more <code>HH:MM-HH:MM</code> windows (container local time via <code>TZ</code>). Blank = always allowed. Run Now bypasses the window.</p>
+        </div>
         <div class="sm:col-span-2" data-sonarr-only="true"
              {% if instance.type.value != 'sonarr' %}style="display:none;"{% endif %}>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-sonarr-mode">

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,7 +29,7 @@ async def test_schema_created(db: None) -> None:
 async def test_schema_version_set(db: None) -> None:
     """Schema version should be set after init."""
     version = await get_setting("schema_version")
-    assert version == "10"
+    assert version == "11"
 
 
 @pytest.mark.asyncio()
@@ -110,7 +110,7 @@ async def test_init_db_migrates_v1_schema_to_v3(tmp_path: Path) -> None:
         search_log_columns = {row[1] async for row in search_log_cur}
         instance_columns = {row[1] async for row in instances_cur}
 
-    assert await get_setting("schema_version") == "10"
+    assert await get_setting("schema_version") == "11"
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
     assert "cycle_id" in search_log_columns
@@ -179,7 +179,7 @@ async def test_init_db_migrates_v2_schema_to_v4(tmp_path: Path) -> None:
         async with conn.execute("PRAGMA table_info(search_log)") as cur:
             search_log_columns = {row[1] async for row in cur}
 
-    assert await get_setting("schema_version") == "10"
+    assert await get_setting("schema_version") == "11"
     assert "cycle_id" in search_log_columns
     assert "cycle_trigger" in search_log_columns
 
@@ -246,7 +246,7 @@ async def test_init_db_migrates_v3_schema_to_v4(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "10"
+    assert await get_setting("schema_version") == "11"
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
             instance_columns = {row[1] async for row in cur}
@@ -329,7 +329,7 @@ async def test_init_db_migrates_v4_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "10"
+    assert await get_setting("schema_version") == "11"
 
     async with get_db() as conn:
         # Verify new columns exist
@@ -463,7 +463,7 @@ async def test_init_db_migrates_v5_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "10"
+    assert await get_setting("schema_version") == "11"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -560,7 +560,7 @@ async def test_init_db_migrates_v6_schema_to_v7(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "10"
+    assert await get_setting("schema_version") == "11"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -673,7 +673,7 @@ async def test_init_db_self_heals_v9_and_v10_when_version_already_current(
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "10"
+    assert await get_setting("schema_version") == "11"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:

--- a/tests/test_engine/conftest.py
+++ b/tests/test_engine/conftest.py
@@ -158,6 +158,7 @@ def make_instance(
     upgrade_series_offset: int = 0,
     missing_page_offset: int = 1,
     cutoff_page_offset: int = 1,
+    allowed_time_window: str = "",
 ) -> Instance:
     """Build an Instance with sensible defaults for testing."""
     resolved_url = url or URL_FOR_TYPE.get(itype, SONARR_URL)
@@ -196,6 +197,7 @@ def make_instance(
         upgrade_series_offset=upgrade_series_offset,
         missing_page_offset=missing_page_offset,
         cutoff_page_offset=cutoff_page_offset,
+        allowed_time_window=allowed_time_window,
     )
 
 

--- a/tests/test_engine/test_time_window_gate.py
+++ b/tests/test_engine/test_time_window_gate.py
@@ -1,0 +1,215 @@
+"""Tests for the allowed-time-window gate in run_instance_search()."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine import search_loop
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import InstanceType
+
+from .conftest import (
+    _COMMAND_RESP,
+    _EPISODE_RECORD,
+    MASTER_KEY,
+    SONARR_URL,
+    get_log_rows,
+    make_instance,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MISSING_SONARR_ONE: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_EPISODE_RECORD],
+}
+
+
+def _sonarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 1,
+        "itype": InstanceType.sonarr,
+        "batch_size": 10,
+        "hourly_cap": 20,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+def _mock_missing_and_command() -> None:
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_MISSING_SONARR_ONE),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+
+def _freeze_now(monkeypatch: pytest.MonkeyPatch, at_utc_hour: int, at_utc_minute: int = 0) -> None:
+    """Patch ``search_loop.datetime.now`` to return a fixed UTC moment.
+
+    The gate calls ``datetime.now(UTC).astimezone().time()`` and tests need
+    a deterministic "now" regardless of where they run.  Using UTC as the
+    fixed timezone removes any dependency on the test host's local zone:
+    ``.astimezone()`` with no arg converts to local, but our inputs are
+    already UTC-based and the gate only looks at hour/minute, so pinning
+    the local TZ to UTC via the monkeypatch keeps the comparison direct.
+    """
+    fixed = datetime(2026, 4, 16, at_utc_hour, at_utc_minute, tzinfo=UTC)
+
+    class _PinnedDatetime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:  # type: ignore[override]
+            if tz is None:
+                return fixed.replace(tzinfo=None)
+            return fixed.astimezone(tz)
+
+    # Ensure the test treats "local" as UTC so astimezone() is a no-op;
+    # this lets us reason about the configured window in UTC hours.
+    monkeypatch.setenv("TZ", "UTC")
+    # time.tzset is POSIX-only but always available on Linux/macOS CI.
+    import time
+
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+    monkeypatch.setattr(search_loop, "datetime", _PinnedDatetime)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_empty_window_allows_cycle(seeded_instances: None) -> None:
+    """Empty allowed_time_window means no gate; cycle runs normally."""
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(allowed_time_window="")
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_inside_window_allows_cycle(
+    seeded_instances: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Time inside the configured window lets the cycle proceed."""
+    _freeze_now(monkeypatch, at_utc_hour=10)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(allowed_time_window="09:00-12:00")
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_outside_window_skips_cycle_with_info_row(
+    seeded_instances: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Outside the window, the cycle returns 0 and logs an info row."""
+    _freeze_now(monkeypatch, at_utc_hour=14)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(allowed_time_window="09:00-12:00")
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+    rows = await get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "info"
+    assert rows[0]["reason"] == "outside allowed time window"
+    assert "14:00" in rows[0]["message"]
+    assert "09:00-12:00" in rows[0]["message"]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_outside_window_does_not_call_arr(
+    seeded_instances: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate must short-circuit before any HTTP call is made."""
+    _freeze_now(monkeypatch, at_utc_hour=14)
+
+    # Do NOT mock anything: if the gate is bypassed, the respx strict
+    # matcher will raise because no route matches, which surfaces the bug.
+    inst = _sonarr_instance(allowed_time_window="09:00-12:00")
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 0
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_multiple_windows_match_any(
+    seeded_instances: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If any configured range contains now, the cycle runs."""
+    _freeze_now(monkeypatch, at_utc_hour=15)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(allowed_time_window="09:00-12:00,14:00-18:00")
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_wraparound_window_allows_late_evening(
+    seeded_instances: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """22:00-06:00 matches 23:00."""
+    _freeze_now(monkeypatch, at_utc_hour=23)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(allowed_time_window="22:00-06:00")
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_run_now_bypasses_gate(
+    seeded_instances: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manual Run Now triggers bypass the time window deliberately."""
+    _freeze_now(monkeypatch, at_utc_hour=14)
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(allowed_time_window="09:00-12:00")
+    count = await run_instance_search(inst, MASTER_KEY, cycle_trigger="run_now")
+
+    assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_malformed_window_fails_open_and_logs_warning(
+    seeded_instances: None, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A bad spec (shouldn't happen via UI) fails open with a warning log."""
+    _mock_missing_and_command()
+
+    inst = _sonarr_instance(allowed_time_window="not a real spec")
+    with caplog.at_level("WARNING"):
+        count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    assert any("malformed allowed_time_window" in rec.message for rec in caplog.records)

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -596,3 +596,67 @@ def test_password_change_htmx(app: TestClient) -> None:
     )
     assert resp.status_code == 200
     assert b"Password updated successfully" in resp.content
+
+
+# ---------------------------------------------------------------------------
+# allowed_time_window validation on create + update
+# ---------------------------------------------------------------------------
+
+
+def test_create_accepts_valid_time_window(app: TestClient) -> None:
+    _login(app)
+    form = {**_VALID_FORM, "allowed_time_window": "09:00-23:00"}
+    resp = app.post("/settings/instances", data=form, headers=csrf_headers(app))
+    assert resp.status_code == 200
+
+
+def test_create_rejects_malformed_time_window(app: TestClient) -> None:
+    _login(app)
+    form = {**_VALID_FORM, "allowed_time_window": "9:00-bogus"}
+    resp = app.post("/settings/instances", data=form, headers=csrf_headers(app))
+    assert resp.status_code == 422
+    assert b"Invalid time range" in resp.content
+
+
+def test_create_rejects_out_of_range_hour(app: TestClient) -> None:
+    _login(app)
+    form = {**_VALID_FORM, "allowed_time_window": "25:00-26:00"}
+    resp = app.post("/settings/instances", data=form, headers=csrf_headers(app))
+    assert resp.status_code == 422
+    assert b"Out-of-range" in resp.content
+
+
+def test_create_persists_time_window_through_round_trip(app: TestClient) -> None:
+    """A valid window should survive round-trip to the DB and reappear in the edit form."""
+    _login(app)
+    form = {**_VALID_FORM, "allowed_time_window": "22:00-06:00"}
+    create_resp = app.post("/settings/instances", data=form, headers=csrf_headers(app))
+    assert create_resp.status_code == 200
+
+    # The first (and only) instance in this test DB has id=1.
+    edit_resp = app.get("/settings/instances/1/edit")
+    assert edit_resp.status_code == 200
+    # The form must pre-fill the value.
+    assert b'value="22:00-06:00"' in edit_resp.content
+
+
+def test_update_rejects_malformed_time_window(app: TestClient) -> None:
+    """Updating with an invalid window is a 422 and leaves the old value intact."""
+    _login(app)
+    # First create a valid instance.
+    create_resp = app.post(
+        "/settings/instances",
+        data={**_VALID_FORM, "allowed_time_window": "09:00-18:00"},
+        headers=csrf_headers(app),
+    )
+    assert create_resp.status_code == 200
+
+    # Now try to update with a bogus spec.
+    bad_form = {**_VALID_FORM, "allowed_time_window": "not-a-window"}
+    update_resp = app.post("/settings/instances/1", data=bad_form, headers=csrf_headers(app))
+    assert update_resp.status_code == 422
+    assert b"Invalid time range" in update_resp.content
+
+    # The stored value must still be the original.
+    edit_resp = app.get("/settings/instances/1/edit")
+    assert b'value="09:00-18:00"' in edit_resp.content

--- a/tests/test_services/test_instances.py
+++ b/tests/test_services/test_instances.py
@@ -80,6 +80,7 @@ async def test_create_applies_defaults(db: None, master_key: bytes) -> None:
     assert inst.cutoff_cooldown_days == 21
     assert inst.cutoff_hourly_cap == 1
     assert inst.sonarr_search_mode == SonarrSearchMode.episode
+    assert inst.allowed_time_window == ""
 
 
 @pytest.mark.asyncio()
@@ -269,3 +270,41 @@ async def test_delete_removes_from_list(db: None, master_key: bytes) -> None:
     remaining = await list_instances(master_key=master_key)
     assert len(remaining) == 1
     assert remaining[0].id == a.id
+
+
+# ---------------------------------------------------------------------------
+# allowed_time_window round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_create_persists_allowed_time_window(db: None, master_key: bytes) -> None:
+    inst = await _make(master_key, allowed_time_window="09:00-23:00")
+    fetched = await get_instance(inst.id, master_key=master_key)
+    assert fetched is not None
+    assert fetched.allowed_time_window == "09:00-23:00"
+
+
+@pytest.mark.asyncio()
+async def test_update_allowed_time_window(db: None, master_key: bytes) -> None:
+    from houndarr.services.instances import update_instance
+
+    inst = await _make(master_key)
+    assert inst.allowed_time_window == ""
+
+    updated = await update_instance(
+        inst.id,
+        master_key=master_key,
+        allowed_time_window="22:00-06:00",
+    )
+    assert updated is not None
+    assert updated.allowed_time_window == "22:00-06:00"
+
+    # Clearing works too.
+    cleared = await update_instance(
+        inst.id,
+        master_key=master_key,
+        allowed_time_window="",
+    )
+    assert cleared is not None
+    assert cleared.allowed_time_window == ""

--- a/tests/test_services/test_time_window.py
+++ b/tests/test_services/test_time_window.py
@@ -1,0 +1,235 @@
+"""Tests for the allowed-time-window parser and gate predicate."""
+
+from __future__ import annotations
+
+from datetime import time
+
+import pytest
+
+from houndarr.services.time_window import (
+    format_ranges,
+    is_within_window,
+    parse_time_window,
+)
+
+# ---------------------------------------------------------------------------
+# parse_time_window
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string_means_unlimited() -> None:
+    assert parse_time_window("") == []
+
+
+def test_whitespace_only_means_unlimited() -> None:
+    assert parse_time_window("   \t  ") == []
+
+
+def test_single_range_is_parsed() -> None:
+    assert parse_time_window("09:00-23:00") == [(time(9, 0), time(23, 0))]
+
+
+def test_multiple_ranges_are_parsed_in_order() -> None:
+    ranges = parse_time_window("09:00-12:00,14:00-22:00")
+    assert ranges == [
+        (time(9, 0), time(12, 0)),
+        (time(14, 0), time(22, 0)),
+    ]
+
+
+def test_whitespace_around_comma_is_tolerated() -> None:
+    ranges = parse_time_window("09:00-12:00 , 14:00-22:00")
+    assert ranges == [
+        (time(9, 0), time(12, 0)),
+        (time(14, 0), time(22, 0)),
+    ]
+
+
+def test_leading_and_trailing_whitespace_stripped() -> None:
+    assert parse_time_window("  09:00-23:00  ") == [(time(9, 0), time(23, 0))]
+
+
+def test_wraparound_range_is_parsed() -> None:
+    # 22:00-06:00 is valid; the gate handles the wraparound.
+    assert parse_time_window("22:00-06:00") == [(time(22, 0), time(6, 0))]
+
+
+def test_end_at_midnight_is_parsed() -> None:
+    # 22:00-00:00 is valid and means "the last two hours of the day".
+    assert parse_time_window("22:00-00:00") == [(time(22, 0), time(0, 0))]
+
+
+def test_start_at_midnight_is_parsed() -> None:
+    assert parse_time_window("00:00-06:00") == [(time(0, 0), time(6, 0))]
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "9:00-17:00",  # single-digit hour
+        "09:0-17:00",  # single-digit minute
+        "09:00",  # missing end
+        "09:00-",  # empty end
+        "-17:00",  # empty start
+        "abc",  # garbage
+        "09:00-17:00-20:00",  # extra dash
+        "09.00-17.00",  # wrong separator
+    ],
+)
+def test_malformed_range_is_rejected(spec: str) -> None:
+    with pytest.raises(ValueError, match="Invalid time range"):
+        parse_time_window(spec)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "25:00-30:00",  # hour > 23
+        "09:60-10:00",  # minute > 59
+        "09:00-10:99",
+    ],
+)
+def test_out_of_range_time_is_rejected(spec: str) -> None:
+    with pytest.raises(ValueError, match="Out-of-range"):
+        parse_time_window(spec)
+
+
+def test_zero_width_range_is_rejected() -> None:
+    with pytest.raises(ValueError, match="no duration"):
+        parse_time_window("09:00-09:00")
+
+
+def test_zero_width_at_midnight_is_rejected() -> None:
+    with pytest.raises(ValueError, match="no duration"):
+        parse_time_window("00:00-00:00")
+
+
+def test_empty_range_in_csv_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Empty time range"):
+        parse_time_window("09:00-12:00,,14:00-22:00")
+
+
+def test_trailing_comma_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Empty time range"):
+        parse_time_window("09:00-12:00,")
+
+
+def test_too_many_ranges_is_rejected() -> None:
+    spec = ",".join(["09:00-10:00"] * 25)
+    with pytest.raises(ValueError, match="Too many"):
+        parse_time_window(spec)
+
+
+def test_overlapping_ranges_are_accepted() -> None:
+    # Do not merge; any range matching is sufficient at gate time.
+    ranges = parse_time_window("09:00-12:00,11:00-13:00")
+    assert len(ranges) == 2
+
+
+# ---------------------------------------------------------------------------
+# is_within_window
+# ---------------------------------------------------------------------------
+
+
+def test_empty_ranges_always_allow() -> None:
+    assert is_within_window(time(3, 0), []) is True
+    assert is_within_window(time(23, 59), []) is True
+
+
+def test_simple_range_inside() -> None:
+    ranges = [(time(9, 0), time(17, 0))]
+    assert is_within_window(time(12, 0), ranges) is True
+
+
+def test_simple_range_outside_before() -> None:
+    ranges = [(time(9, 0), time(17, 0))]
+    assert is_within_window(time(8, 59), ranges) is False
+
+
+def test_simple_range_outside_after() -> None:
+    ranges = [(time(9, 0), time(17, 0))]
+    assert is_within_window(time(17, 30), ranges) is False
+
+
+def test_simple_range_start_inclusive() -> None:
+    ranges = [(time(9, 0), time(17, 0))]
+    assert is_within_window(time(9, 0), ranges) is True
+
+
+def test_simple_range_end_exclusive() -> None:
+    ranges = [(time(9, 0), time(17, 0))]
+    assert is_within_window(time(17, 0), ranges) is False
+
+
+def test_wraparound_allows_late_evening() -> None:
+    ranges = [(time(22, 0), time(6, 0))]
+    assert is_within_window(time(23, 0), ranges) is True
+
+
+def test_wraparound_allows_early_morning() -> None:
+    ranges = [(time(22, 0), time(6, 0))]
+    assert is_within_window(time(5, 30), ranges) is True
+
+
+def test_wraparound_rejects_midday() -> None:
+    ranges = [(time(22, 0), time(6, 0))]
+    assert is_within_window(time(12, 0), ranges) is False
+
+
+def test_wraparound_start_inclusive() -> None:
+    ranges = [(time(22, 0), time(6, 0))]
+    assert is_within_window(time(22, 0), ranges) is True
+
+
+def test_wraparound_end_exclusive() -> None:
+    ranges = [(time(22, 0), time(6, 0))]
+    assert is_within_window(time(6, 0), ranges) is False
+
+
+def test_end_at_midnight_allows_23_59() -> None:
+    ranges = [(time(22, 0), time(0, 0))]
+    assert is_within_window(time(23, 59), ranges) is True
+
+
+def test_end_at_midnight_blocks_midnight_itself() -> None:
+    # End is exclusive; 00:00 is the end of the wraparound region.
+    ranges = [(time(22, 0), time(0, 0))]
+    assert is_within_window(time(0, 0), ranges) is False
+
+
+def test_multiple_ranges_inside_first() -> None:
+    ranges = [(time(9, 0), time(12, 0)), (time(14, 0), time(22, 0))]
+    assert is_within_window(time(10, 0), ranges) is True
+
+
+def test_multiple_ranges_inside_second() -> None:
+    ranges = [(time(9, 0), time(12, 0)), (time(14, 0), time(22, 0))]
+    assert is_within_window(time(15, 0), ranges) is True
+
+
+def test_multiple_ranges_in_gap() -> None:
+    ranges = [(time(9, 0), time(12, 0)), (time(14, 0), time(22, 0))]
+    assert is_within_window(time(13, 0), ranges) is False
+
+
+def test_overlapping_ranges_any_matching_is_enough() -> None:
+    ranges = [(time(9, 0), time(12, 0)), (time(11, 0), time(13, 0))]
+    assert is_within_window(time(12, 30), ranges) is True
+
+
+# ---------------------------------------------------------------------------
+# format_ranges
+# ---------------------------------------------------------------------------
+
+
+def test_format_ranges_single() -> None:
+    assert format_ranges([(time(9, 0), time(23, 0))]) == "09:00-23:00"
+
+
+def test_format_ranges_multiple() -> None:
+    ranges = [(time(9, 0), time(12, 0)), (time(14, 0), time(22, 0))]
+    assert format_ranges(ranges) == "09:00-12:00,14:00-22:00"
+
+
+def test_format_ranges_empty() -> None:
+    assert format_ranges([]) == ""

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -221,6 +221,38 @@ the entire cycle is skipped and logged as `queue backpressure (N/M)`.
 - If the queue endpoint is unreachable, the search proceeds normally (fails open).
 - This prevents Houndarr from piling up work when the download client is already busy.
 
+## Allowed search window
+
+The `Allowed Search Window` field restricts scheduled cycles to one or more
+time-of-day windows. Use it when your NAS or host puts disks to sleep during
+off-hours and you do not want Houndarr waking them up.
+
+**Format:** `HH:MM-HH:MM` per window, comma-separated for multiple windows.
+
+- `09:00-23:00`: allow searches from 9 AM up to (but not including) 11 PM.
+- `09:00-12:00,18:00-22:00`: two separate windows in one day.
+- `22:00-06:00`: wrap-around window covering late night through early morning.
+- Leave blank for 24/7 operation.
+
+**Timezone:** Windows are interpreted in the container's local time, which
+follows the `TZ` environment variable (e.g. `TZ=America/New_York`). If `TZ`
+is unset, Houndarr falls back to UTC.
+
+**Boundary semantics:** Start is inclusive, end is exclusive. `09:00-12:00`
+allows searches at 09:00:00 but blocks them at 12:00:00.
+
+**Run Now bypass:** Manual `Run Now` clicks always run, even outside the
+window. The window is an operator-preference schedule, not a safety gate;
+queue backpressure and hourly caps still apply to manual runs.
+
+**When skipped:** The cycle writes a single `info` row to the search log with
+reason `outside allowed time window` and a message showing the current local
+time next to the configured window. The supervisor sleeps normally and
+re-checks on the next cycle, so operators who want faster re-entry can
+lower `Sleep (minutes)`.
+
+- **Default:** empty (24/7, no gate)
+
 ## Fair backlog scanning
 
 Houndarr does not stop at the first wanted page. During each cycle, it can scan
@@ -247,6 +279,7 @@ Skips are normal. See [How Houndarr Works](/docs/concepts/how-houndarr-works#wha
 | Cooldown (days) | `14` |
 | Post-Release Grace (hrs) | `6` |
 | Queue Limit | `0` (disabled) |
+| Allowed Search Window | (blank, 24/7) |
 | Cutoff search | Off |
 | Cutoff Batch | `1` |
 | Cutoff Cooldown | `21` |


### PR DESCRIPTION
## Summary

Adds an optional `Allowed Search Window` field on each instance. When non-empty, Houndarr restricts scheduled search cycles to the configured time-of-day window(s). Outside the window, the cycle writes a single `info` row to the search log and returns 0; the supervisor sleeps as usual and rechecks on the next cycle.

Empty field preserves current 24/7 behavior, so existing deployments are unaffected.

Closes #386

## Format & semantics

- `HH:MM-HH:MM` per window, comma-separated for multiple windows.
  - `09:00-23:00`
  - `09:00-12:00,18:00-22:00`
  - `22:00-06:00` (wraps midnight)
- Start inclusive, end exclusive.
- Container local time (respects `TZ` env var; falls back to UTC).
- \`Run Now\` clicks bypass the window deliberately. Queue backpressure and hourly caps still apply.
- Malformed input is rejected at save time with a 422 response and a clear error string. If a malformed value somehow reaches the engine, the gate logs a warning and fails open.

## Changes

- **New service module** \`src/houndarr/services/time_window.py\` with pure \`parse_time_window\` and \`is_within_window\` helpers.
- **Engine gate** at the top of \`run_instance_search\` (\`src/houndarr/engine/search_loop.py\`), ordered before the queue gate.
- **Schema migration v11** adds \`allowed_time_window TEXT NOT NULL DEFAULT ''\` to \`instances\`. Additive; idempotent self-heal.
- **Settings form** gains the input right after Queue Limit, with inline format hint.
- **Docs**: new section on the Instance Settings page describing format, timezone, boundary semantics, and the Run Now bypass.

## Testing

- 46 unit tests on the parser and gate predicate covering every edge case called out in the plan (midnight wraparound, case insensitivity, out-of-range hour/minute, zero-width, overlapping ranges, too-many-ranges).
- 8 integration tests on the engine gate in \`tests/test_engine/test_time_window_gate.py\` mirroring the queue-backpressure test file, including one test that exercises the respx strict-matcher to verify the gate short-circuits before any HTTP call.
- Round-trip persistence tests for create + update.
- Route-level 422 validation tests for malformed windows on both create and update.
- All 1107 tests pass. Ruff lint/format, mypy strict, and bandit all clean.

## Type of Change

- [ ] Bug fix (\`fix:\`)
- [x] New feature (\`feat:\`)
- [ ] Refactoring (\`refactor:\`)
- [ ] Documentation (\`docs:\`)
- [ ] CI/CD (\`ci:\`)
- [ ] Chore (\`chore:\`)

## Checklist

- [x] **Issue exists** and is linked above with \`Closes #N\`
- [x] Linked issue has exactly one \`type:*\` and one \`priority:*\` label
- [x] Linked issue has at most one \`phase:*\` label (or none when not roadmap work)
- [x] Branch name matches issue scope (\`feat/<slug>\`, \`fix/<slug>\`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (\`mypy src/\`)
- [x] Lint passes (\`ruff check .\`)
- [x] Format passes (\`ruff format --check .\`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way