### PR TITLE
chore: address adversarial-review nits on #387/#388

### DIFF
--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -753,7 +753,6 @@ async def run_instance_search(
     )
 
     adapter = get_adapter(instance.type)
-    client = adapter.make_client(instance)
     cycle_id_value = cycle_id or str(uuid4())
     searched = 0
 
@@ -838,6 +837,7 @@ async def run_instance_search(
     # --- Missing pass ---
     missing_target = max(0, instance.batch_size)
     if missing_target > 0:
+        client = adapter.make_client(instance)
         async with client:
             missing_searched, next_missing_page = await _run_search_pass(
                 instance,

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -58,7 +58,7 @@ from houndarr.services.instances import (
     list_instances,
     update_instance,
 )
-from houndarr.services.time_window import parse_time_window
+from houndarr.services.time_window import format_ranges, parse_time_window
 from houndarr.services.url_validation import validate_instance_url
 
 router = APIRouter()
@@ -566,7 +566,7 @@ async def instance_create(
         return _connection_guard_response(url_error)
 
     try:
-        parse_time_window(allowed_time_window)
+        canonical_window = format_ranges(parse_time_window(allowed_time_window))
     except ValueError as exc:
         return _connection_guard_response(str(exc))
 
@@ -645,7 +645,7 @@ async def instance_create(
         upgrade_lidarr_search_mode=upgrade_modes.lidarr,
         upgrade_readarr_search_mode=upgrade_modes.readarr,
         upgrade_whisparr_search_mode=upgrade_modes.whisparr,
-        allowed_time_window=allowed_time_window.strip(),
+        allowed_time_window=canonical_window,
     )
 
     supervisor = getattr(request.app.state, "supervisor", None)
@@ -726,7 +726,7 @@ async def instance_update(
         return _connection_guard_response(url_error)
 
     try:
-        parse_time_window(allowed_time_window)
+        canonical_window = format_ranges(parse_time_window(allowed_time_window))
     except ValueError as exc:
         return _connection_guard_response(str(exc))
 
@@ -824,7 +824,7 @@ async def instance_update(
         whisparr_search_mode=search_modes.whisparr,
         missing_page_offset=1,
         cutoff_page_offset=1,
-        allowed_time_window=allowed_time_window.strip(),
+        allowed_time_window=canonical_window,
         **upgrade_fields,
     )
     if updated is None:

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -640,6 +640,22 @@ def test_create_persists_time_window_through_round_trip(app: TestClient) -> None
     assert b'value="22:00-06:00"' in edit_resp.content
 
 
+def test_create_canonicalizes_whitespace_and_stores_normalized_form(
+    app: TestClient,
+) -> None:
+    """Inner whitespace around the comma should be normalized out on save."""
+    _login(app)
+    form = {
+        **_VALID_FORM,
+        "allowed_time_window": "  09:00-12:00 , 14:00-22:00  ",
+    }
+    create_resp = app.post("/settings/instances", data=form, headers=csrf_headers(app))
+    assert create_resp.status_code == 200
+
+    edit_resp = app.get("/settings/instances/1/edit")
+    assert b'value="09:00-12:00,14:00-22:00"' in edit_resp.content
+
+
 def test_update_rejects_malformed_time_window(app: TestClient) -> None:
     """Updating with an invalid window is a 422 and leaves the old value intact."""
     _login(app)

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -236,7 +236,10 @@ off-hours and you do not want Houndarr waking them up.
 
 **Timezone:** Windows are interpreted in the container's local time, which
 follows the `TZ` environment variable (e.g. `TZ=America/New_York`). If `TZ`
-is unset, Houndarr falls back to UTC.
+is unset, Houndarr falls back to UTC. In zones with daylight-saving
+transitions, avoid windows that overlap the spring-forward gap (02:00-03:00
+does not exist that day) or the fall-back repeat (01:00-02:00 occurs twice);
+configure windows outside those hours if predictability matters.
 
 **Boundary semantics:** Start is inclusive, end is exclusive. `09:00-12:00`
 allows searches at 09:00:00 but blocks them at 12:00:00.


### PR DESCRIPTION
## Summary

Three low-severity findings from the post-merge adversarial review of PRs #387 and #388. None are blocking, all are scoped to tightening code flow, storage canonicalization, and operator-facing docs.

## Changes

- **\`src/houndarr/engine/search_loop.py\`**: Move the top-level httpx client construction into the missing-pass block so it is colocated with its only use. When the time-window or queue gate short-circuits, no transient client object is left hanging in scope.
- **\`src/houndarr/routes/settings.py\`**: The allowed-window spec now round-trips through \`parse_time_window\` + \`format_ranges\` on save, so inputs like \`"09:00-12:00 , 14:00-22:00"\` (inner whitespace) are persisted as the canonical \`"09:00-12:00,14:00-22:00"\`.
- **\`website/docs/configuration/instance-settings.md\`**: Brief DST note explaining the spring-forward gap and fall-back repeat for operators configuring narrow night windows in DST zones.

## Testing

- New route test \`test_create_canonicalizes_whitespace_and_stores_normalized_form\` pins the normalization behavior.
- All 1108 tests pass. Ruff lint/format, mypy strict, and bandit all clean.

## Findings explicitly skipped

- **Port validation on \`url_validation.py\`** (LOW/NIT): skipped because the synchronous connection test at \`routes/settings.py:583-585\` already catches unreachable ports before persisting the instance. Adding port-range validation to \`validate_instance_url\` would overlap with the connection test's responsibility (reachability) and muddy the validator's current crisp scope (structural safety). If operators ever report confusion from the current "Connection test failed" message on bad ports, we can revisit.
- **Cycle-ID tracing reiteration** (LOW/NIT): the reviewer explicitly noted "No action needed."

## Type of Change

- [ ] Bug fix (\`fix:\`)
- [ ] New feature (\`feat:\`)
- [ ] Refactoring (\`refactor:\`)
- [ ] Documentation (\`docs:\`)
- [ ] CI/CD (\`ci:\`)
- [x] Chore (\`chore:\`)

## Checklist

- [x] **Issue exists** — this PR addresses post-merge review findings on already-shipped work (#387 + #388); no separate issue was opened since all items are sub-threshold nits. Closes neither issue; #385 and #386 remain closed.
- [x] Branch name matches scope (\`chore/<slug>\`)
- [x] Tests added/updated for behavior changes (canonicalization)
- [x] Type check passes (\`mypy src/\`)
- [x] Lint passes (\`ruff check .\`)
- [x] Format passes (\`ruff format --check .\`)
- [x] Documentation updated (DST note)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way (preserves existing polite behavior; tightens storage and flow hygiene)