### PR TITLE
docs: mention allowed search window in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Houndarr fixes this by searching slowly, politely, and automatically. It works t
 - Per-instance hourly API cap keeps indexer usage in check
 - Download-queue backpressure gate skips cycles when the queue is full
 - Bounded multi-page scanning so deep backlog items are not starved
+- Optional per-instance time windows so scheduled searches only run during configured hours
 
 **Web UI**
 


### PR DESCRIPTION
Closes #392

## Summary

One-line addition to the README's \"Rate Limiting and Safety\" feature list so the v1.8.0 \`Allowed Search Window\` feature is visible alongside the other polite-by-default knobs. README-only change.

## Type of Change

- [ ] Bug fix (\`fix:\`)
- [ ] New feature (\`feat:\`)
- [ ] Refactoring (\`refactor:\`)
- [x] Documentation (\`docs:\`)
- [ ] CI/CD (\`ci:\`)
- [ ] Chore (\`chore:\`)

## Checklist

- [x] **Issue exists** and is linked above with \`Closes #N\`
- [x] Linked issue has exactly one \`type:*\` and one \`priority:*\` label
- [x] Linked issue has at most one \`phase:*\` label (or none when not roadmap work)
- [x] Branch name matches issue scope (\`docs/<slug>\`)
- [ ] Tests added/updated for all changes — N/A, docs-only
- [x] Type check passes (\`mypy src/\`) — unchanged
- [x] Lint passes (\`ruff check .\`) — unchanged
- [x] Format passes (\`ruff format --check .\`) — unchanged
- [x] Documentation updated
- [x] No secrets or sensitive data committed
- [x] **Scope check**: README accuracy for an already-shipped in-scope feature