### PR TITLE
feat: add per-instance random search order

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Houndarr fixes this by searching slowly, politely, and automatically. It works t
 - Download-queue backpressure gate skips cycles when the queue is full
 - Bounded multi-page scanning so deep backlog items are not starved
 - Optional per-instance time windows so scheduled searches only run during configured hours
+- Per-instance search order: random (default) spreads picks across the whole backlog each cycle, chronological walks oldest-first
 
 **Web UI**
 

--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -135,3 +135,12 @@ class ArrClient(ABC):
     @abstractmethod
     async def search(self, item_id: int) -> None:
         """Trigger an automatic search for the item identified by *item_id*."""
+
+    @abstractmethod
+    async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
+        """Return the total number of records in the wanted/*kind* list.
+
+        Used by the engine's random-start-page computation to size the
+        random page range.  Implementations should use the cheapest available
+        probe (``pageSize=1`` for paged APIs; cached counts for Whisparr v3).
+        """

--- a/src/houndarr/clients/lidarr.py
+++ b/src/houndarr/clients/lidarr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -124,6 +124,18 @@ class LidarrClient(ArrClient):
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_album(r) for r in records]
+
+    async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
+        data: dict[str, Any] = await self._get(
+            f"/api/v1/wanted/{kind}",
+            page=1,
+            pageSize=1,
+            sortKey="releaseDate",
+            sortDirection="ascending",
+            monitored="true",
+        )
+        return int(data.get("totalRecords", 0) or 0)
 
     async def get_albums(self) -> list[LibraryAlbum]:
         """Return the full album library.

--- a/src/houndarr/clients/radarr.py
+++ b/src/houndarr/clients/radarr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -115,6 +115,18 @@ class RadarrClient(ArrClient):
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_movie(r) for r in records]
+
+    async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
+        data: dict[str, Any] = await self._get(
+            f"/api/v3/wanted/{kind}",
+            page=1,
+            pageSize=1,
+            sortKey="inCinemas",
+            sortDirection="ascending",
+            monitored="true",
+        )
+        return int(data.get("totalRecords", 0) or 0)
 
     async def get_library(self) -> list[LibraryMovie]:
         """Return the full movie library.

--- a/src/houndarr/clients/readarr.py
+++ b/src/houndarr/clients/readarr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -124,6 +124,18 @@ class ReadarrClient(ArrClient):
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_book(r) for r in records]
+
+    async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
+        data: dict[str, Any] = await self._get(
+            f"/api/v1/wanted/{kind}",
+            page=1,
+            pageSize=1,
+            sortKey="releaseDate",
+            sortDirection="ascending",
+            monitored="true",
+        )
+        return int(data.get("totalRecords", 0) or 0)
 
     async def get_books(self) -> list[LibraryBook]:
         """Return the full book library.

--- a/src/houndarr/clients/sonarr.py
+++ b/src/houndarr/clients/sonarr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -127,6 +127,18 @@ class SonarrClient(ArrClient):
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_episode(r) for r in records]
+
+    async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
+        data: dict[str, Any] = await self._get(
+            f"/api/v3/wanted/{kind}",
+            page=1,
+            pageSize=1,
+            sortKey="airDateUtc",
+            sortDirection="ascending",
+            monitored="true",
+        )
+        return int(data.get("totalRecords", 0) or 0)
 
     async def get_series(self) -> list[dict[str, Any]]:
         """Return the full series list.

--- a/src/houndarr/clients/whisparr_v2.py
+++ b/src/houndarr/clients/whisparr_v2.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -132,6 +132,18 @@ class WhisparrClient(ArrClient):
         )
         records: list[dict[str, Any]] = data.get("records", [])
         return [_parse_episode(r) for r in records]
+
+    async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
+        data: dict[str, Any] = await self._get(
+            f"/api/v3/wanted/{kind}",
+            page=1,
+            pageSize=1,
+            sortKey="releaseDate",
+            sortDirection="ascending",
+            monitored="true",
+        )
+        return int(data.get("totalRecords", 0) or 0)
 
     async def get_series(self) -> list[dict[str, Any]]:
         """Return the full series list.

--- a/src/houndarr/clients/whisparr_v3.py
+++ b/src/houndarr/clients/whisparr_v3.py
@@ -10,7 +10,7 @@ full library via ``GET /api/v3/movie`` and filtering client-side.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 
@@ -148,6 +148,26 @@ class WhisparrV3Client(ArrClient):
         cutoff.sort(key=lambda m: m.in_cinemas or "")
         start = (page - 1) * page_size
         return cutoff[start : start + page_size]
+
+    async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
+        """Return the count of wanted items for *kind* from the cached library.
+
+        Reuses :meth:`_get_all_movies` (one fetch per client lifetime) so the
+        probe does not trigger an extra network call during a pass.
+        """
+        movies = await self._get_all_movies()
+        if kind == "missing":
+            return sum(
+                1 for r in movies if r.get("monitored", False) and not r.get("hasFile", False)
+            )
+        count = 0
+        for r in movies:
+            if not r.get("monitored", False) or not r.get("hasFile", False):
+                continue
+            movie_file: dict[str, Any] = r.get("movieFile") or {}
+            if movie_file.get("qualityCutoffNotMet", True):
+                count += 1
+        return count
 
     async def get_library(self) -> list[LibraryWhisparrV3Movie]:
         """Return the full movie/scene library.

--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -252,6 +252,7 @@ DEFAULT_READARR_SEARCH_MODE: str = "book"
 DEFAULT_WHISPARR_SEARCH_MODE: str = "episode"
 DEFAULT_QUEUE_LIMIT: int = 0
 DEFAULT_ALLOWED_TIME_WINDOW: str = ""
+DEFAULT_SEARCH_ORDER: str = "random"
 DEFAULT_LOG_RETENTION_DAYS: int = 30
 
 # Upgrade search defaults (third, opt-in pass; very conservative)

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Schema version: bump when adding new migrations
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -69,6 +69,8 @@ CREATE TABLE IF NOT EXISTS instances (
     missing_page_offset  INTEGER NOT NULL DEFAULT 1,
     cutoff_page_offset   INTEGER NOT NULL DEFAULT 1,
     allowed_time_window  TEXT    NOT NULL DEFAULT '',
+    search_order         TEXT    NOT NULL DEFAULT 'random'
+                                CHECK(search_order IN ('chronological', 'random')),
     enabled              INTEGER NOT NULL DEFAULT 1,
     created_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
@@ -173,6 +175,7 @@ async def init_db() -> None:
             await _migrate_to_v9(db)
             await _migrate_to_v10(db)
             await _migrate_to_v11(db)
+            await _migrate_to_v12(db)
             await _ensure_v3_indexes(db)
             await db.commit()
 
@@ -199,6 +202,8 @@ async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
         await _migrate_to_v10(db)
     if from_version < 11:
         await _migrate_to_v11(db)
+    if from_version < 12:
+        await _migrate_to_v12(db)
 
     logger.info("Migrated database from schema version %d to %d", from_version, SCHEMA_VERSION)
     await db.execute(
@@ -700,6 +705,24 @@ async def _migrate_to_v11(db: aiosqlite.Connection) -> None:
     if not await _column_exists(db, "instances", "allowed_time_window"):
         await db.execute(
             "ALTER TABLE instances ADD COLUMN allowed_time_window TEXT NOT NULL DEFAULT ''"
+        )
+
+
+async def _migrate_to_v12(db: aiosqlite.Connection) -> None:
+    """Add ``search_order`` column for per-instance random search ordering.
+
+    Fresh installs default to ``'random'`` (see ``_SCHEMA_SQL``); the
+    migration keeps existing rows on ``'chronological'`` so upgrades do not
+    silently change behaviour for instances that have been running for
+    months.  New instances added via the UI always get the ``config.py``
+    default (currently ``'random'``).  The CHECK constraint lives in
+    ``_SCHEMA_SQL``; SQLite's ``ALTER TABLE ADD COLUMN`` cannot add a CHECK,
+    so migrated rows rely on the service layer (which only accepts
+    ``SearchOrder`` enum values) for validation.
+    """
+    if not await _column_exists(db, "instances", "search_order"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN search_order TEXT NOT NULL DEFAULT 'chronological'"
         )
 
 

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -737,15 +737,18 @@ async def _run_upgrade_pass(
         )
         await asyncio.sleep(_INTER_SEARCH_DELAY_SECONDS)
 
-    # Persist new offset
-    try:
-        await update_instance(
-            instance.id,
-            master_key=master_key,
-            upgrade_item_offset=new_offset,
-        )
-    except Exception:  # noqa: BLE001
-        logger.warning("[%s] failed to persist upgrade_item_offset", instance.name)
+    # Persist new offset.  In random mode the offset concept does not apply
+    # (the pool was shuffled, not rotated), so skip the write entirely to
+    # keep the column meaningful and avoid per-cycle row churn.
+    if instance.search_order == SearchOrder.chronological:
+        try:
+            await update_instance(
+                instance.id,
+                master_key=master_key,
+                upgrade_item_offset=new_offset,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("[%s] failed to persist upgrade_item_offset", instance.name)
 
     return searched
 
@@ -889,14 +892,19 @@ async def run_instance_search(
                 total_fn=lambda: client.get_wanted_total("missing"),
             )
         searched += missing_searched
-        try:
-            await update_instance(
-                instance.id,
-                master_key=master_key,
-                missing_page_offset=next_missing_page,
-            )
-        except Exception:  # noqa: BLE001
-            logger.warning("[%s] failed to persist missing_page_offset", instance.name)
+        # In random mode the "next page" returned by the pass is derived from
+        # a random pick, not a rotation offset, so persisting it would write
+        # a misleading value to the column and churn the row every cycle.
+        # Only advance the offset in chronological mode.
+        if instance.search_order == SearchOrder.chronological:
+            try:
+                await update_instance(
+                    instance.id,
+                    master_key=master_key,
+                    missing_page_offset=next_missing_page,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning("[%s] failed to persist missing_page_offset", instance.name)
 
     logger.info("[%s] cycle complete: %d searched", instance.name, searched)
 
@@ -929,14 +937,17 @@ async def run_instance_search(
                     total_fn=lambda: cutoff_client.get_wanted_total("cutoff"),
                 )
             logger.info("[%s] cutoff pass complete: %d searched", instance.name, cutoff_searched)
-            try:
-                await update_instance(
-                    instance.id,
-                    master_key=master_key,
-                    cutoff_page_offset=next_cutoff_page,
-                )
-            except Exception:  # noqa: BLE001
-                logger.warning("[%s] failed to persist cutoff_page_offset", instance.name)
+            # Mirror the missing-pass gate: only advance the offset in
+            # chronological mode.  See the missing pass for rationale.
+            if instance.search_order == SearchOrder.chronological:
+                try:
+                    await update_instance(
+                        instance.id,
+                        master_key=master_key,
+                        cutoff_page_offset=next_cutoff_page,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning("[%s] failed to persist cutoff_page_offset", instance.name)
             searched += cutoff_searched
 
     # --- Upgrade pass ---

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
+import random
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
@@ -24,7 +26,7 @@ from houndarr.services.cooldown import (
     is_on_cooldown,
     record_search,
 )
-from houndarr.services.instances import Instance, InstanceType, update_instance
+from houndarr.services.instances import Instance, InstanceType, SearchOrder, update_instance
 from houndarr.services.time_window import (
     format_ranges,
     is_within_window,
@@ -213,6 +215,7 @@ async def _run_search_pass(  # noqa: C901
     cycle_id: str,
     cycle_trigger: CycleTrigger,
     start_page: int = 1,
+    total_fn: Callable[[], Awaitable[int]] | None = None,
 ) -> tuple[int, int]:
     """Execute a single search pass (missing or cutoff) using the adapter.
 
@@ -240,6 +243,11 @@ async def _run_search_pass(  # noqa: C901
         cycle_trigger: How this cycle was initiated.
         start_page: 1-based page number to begin fetching from (for
             offset rotation across cycles).
+        total_fn: Optional probe returning the total record count for this
+            pass.  When ``instance.search_order == SearchOrder.random`` the
+            probe is used to pick a random start page each cycle; the
+            persisted offset is then ignored.  Probe failure falls back to
+            *start_page* with a warning.
 
     Returns:
         Tuple of (items_searched, next_start_page).
@@ -259,11 +267,29 @@ async def _run_search_pass(  # noqa: C901
     page = max(1, start_page)
     wrapped = False
 
+    if instance.search_order == SearchOrder.random and total_fn is not None:
+        try:
+            total = await total_fn()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[%s] %stotal probe failed (%s); falling back to page %d",
+                instance.name,
+                log_prefix,
+                exc,
+                page,
+            )
+        else:
+            if total > 0:
+                max_page = max(1, math.ceil(total / page_size))
+                page = random.randint(1, max_page)  # noqa: S311  # nosec B311
+
     for _ in range(_MAX_LIST_PAGES_PER_PASS):
         if searched >= target or scanned >= scan_budget:
             break
 
         items = await fetch_fn(page=page, page_size=page_size)
+        if instance.search_order == SearchOrder.random and items:
+            random.shuffle(items)  # noqa: S311  # nosec B311
         logger.debug(
             "[%s] fetched %d %sitem(s) from page %d",
             instance.name,
@@ -577,21 +603,27 @@ async def _run_upgrade_pass(
         )
         return 0
 
-    # Sort by item ID for stable ordering
-    def _item_sort_key(item: object) -> int:
-        return (
-            getattr(item, "movie_id", None)
-            or getattr(item, "episode_id", None)
-            or getattr(item, "album_id", None)
-            or getattr(item, "book_id", None)
-            or 0
-        )
+    # Random mode shuffles the pool and bypasses id-sort + offset-rotation.
+    # Chronological mode keeps the deterministic rotation so coverage is
+    # guaranteed over time.
+    if instance.search_order == SearchOrder.random:
+        random.shuffle(pool)  # noqa: S311  # nosec B311
+        offset = 0
+        rotated = pool
+    else:
 
-    pool.sort(key=_item_sort_key)
+        def _item_sort_key(item: object) -> int:
+            return (
+                getattr(item, "movie_id", None)
+                or getattr(item, "episode_id", None)
+                or getattr(item, "album_id", None)
+                or getattr(item, "book_id", None)
+                or 0
+            )
 
-    # Apply offset-based rotation
-    offset = instance.upgrade_item_offset % len(pool) if pool else 0
-    rotated = pool[offset:] + pool[:offset]
+        pool.sort(key=_item_sort_key)
+        offset = instance.upgrade_item_offset % len(pool) if pool else 0
+        rotated = pool[offset:] + pool[:offset]
 
     searches_this_hour = await _count_searches_last_hour(instance.id, "upgrade")
     searched = 0
@@ -854,6 +886,7 @@ async def run_instance_search(
                 cycle_id=cycle_id_value,
                 cycle_trigger=cycle_trigger,
                 start_page=instance.missing_page_offset,
+                total_fn=lambda: client.get_wanted_total("missing"),
             )
         searched += missing_searched
         try:
@@ -893,6 +926,7 @@ async def run_instance_search(
                     cycle_id=cycle_id_value,
                     cycle_trigger=cycle_trigger,
                     start_page=instance.cutoff_page_offset,
+                    total_fn=lambda: cutoff_client.get_wanted_total("cutoff"),
                 )
             logger.info("[%s] cutoff pass complete: %d searched", instance.name, cutoff_searched)
             try:

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -577,7 +577,12 @@ async def _run_upgrade_pass(
         )
         return 0
 
-    # Advance series offset for series-based apps (Sonarr/Whisparr)
+    # Advance series offset for series-based apps (Sonarr/Whisparr).
+    # Unlike upgrade_item_offset, this advances in both chronological and
+    # random modes on purpose: the series offset decides which slice of
+    # series feeds the upgrade pool, so continuing to rotate it in random
+    # mode preserves whole-library coverage while the shuffle happens
+    # within each rotated slice.
     if instance.type in (InstanceType.sonarr, InstanceType.whisparr_v2):
         new_series_offset = instance.upgrade_series_offset + 5
         try:

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -32,6 +32,7 @@ from houndarr.config import (
     DEFAULT_POST_RELEASE_GRACE_HOURS,
     DEFAULT_QUEUE_LIMIT,
     DEFAULT_READARR_SEARCH_MODE,
+    DEFAULT_SEARCH_ORDER,
     DEFAULT_SLEEP_INTERVAL_MINUTES,
     DEFAULT_SONARR_SEARCH_MODE,
     DEFAULT_UPGRADE_BATCH_SIZE,
@@ -50,6 +51,7 @@ from houndarr.services.instances import (
     InstanceType,
     LidarrSearchMode,
     ReadarrSearchMode,
+    SearchOrder,
     SonarrSearchMode,
     WhisparrSearchMode,
     create_instance,
@@ -553,6 +555,7 @@ async def instance_create(
     upgrade_readarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_READARR_SEARCH_MODE,
     upgrade_whisparr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     allowed_time_window: Annotated[str, Form()] = DEFAULT_ALLOWED_TIME_WINDOW,
+    search_order: Annotated[str, Form()] = DEFAULT_SEARCH_ORDER,
     connection_verified: Annotated[str, Form()] = "false",
 ) -> HTMLResponse:
     """Create a new instance and return the updated instance table body."""
@@ -616,6 +619,11 @@ async def instance_create(
     if isinstance(upgrade_modes, str):
         return _connection_guard_response(upgrade_modes)
 
+    try:
+        parsed_search_order = SearchOrder(search_order)
+    except ValueError:
+        return _connection_guard_response("Invalid search order.")
+
     instance = await create_instance(
         master_key=_master_key(request),
         name=name,
@@ -646,6 +654,7 @@ async def instance_create(
         upgrade_readarr_search_mode=upgrade_modes.readarr,
         upgrade_whisparr_search_mode=upgrade_modes.whisparr,
         allowed_time_window=canonical_window,
+        search_order=parsed_search_order,
     )
 
     supervisor = getattr(request.app.state, "supervisor", None)
@@ -707,6 +716,7 @@ async def instance_update(
     upgrade_readarr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_READARR_SEARCH_MODE,
     upgrade_whisparr_search_mode: Annotated[str, Form()] = DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     allowed_time_window: Annotated[str, Form()] = DEFAULT_ALLOWED_TIME_WINDOW,
+    search_order: Annotated[str, Form()] = DEFAULT_SEARCH_ORDER,
     connection_verified: Annotated[str, Form()] = "false",
 ) -> HTMLResponse:
     """Update an existing instance and return the refreshed row partial.
@@ -784,6 +794,11 @@ async def instance_update(
     if isinstance(upgrade_modes, str):
         return _connection_guard_response(upgrade_modes)
 
+    try:
+        parsed_search_order = SearchOrder(search_order)
+    except ValueError:
+        return _connection_guard_response("Invalid search order.")
+
     # Reset offsets when upgrade is toggled off
     new_upgrade_enabled = upgrade_enabled == "on"
     upgrade_fields: dict[str, object] = {
@@ -825,6 +840,7 @@ async def instance_update(
         missing_page_offset=1,
         cutoff_page_offset=1,
         allowed_time_window=canonical_window,
+        search_order=parsed_search_order,
         **upgrade_fields,
     )
     if updated is None:

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -133,6 +133,7 @@ def _blank_instance() -> Instance:
         created_at="",
         updated_at="",
         allowed_time_window=DEFAULT_ALLOWED_TIME_WINDOW,
+        search_order=SearchOrder(DEFAULT_SEARCH_ORDER),
     )
 
 

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -22,6 +22,7 @@ from houndarr.config import (
     DEFAULT_POST_RELEASE_GRACE_HOURS,
     DEFAULT_QUEUE_LIMIT,
     DEFAULT_READARR_SEARCH_MODE,
+    DEFAULT_SEARCH_ORDER,
     DEFAULT_SLEEP_INTERVAL_MINUTES,
     DEFAULT_SONARR_SEARCH_MODE,
     DEFAULT_UPGRADE_BATCH_SIZE,
@@ -76,6 +77,13 @@ class WhisparrSearchMode(StrEnum):
     season_context = "season_context"
 
 
+class SearchOrder(StrEnum):
+    """Order in which the engine iterates items within a search pass."""
+
+    chronological = "chronological"
+    random = "random"
+
+
 @dataclass
 class Instance:
     """In-memory representation of a configured *arr instance.
@@ -119,6 +127,7 @@ class Instance:
     missing_page_offset: int = 1
     cutoff_page_offset: int = 1
     allowed_time_window: str = ""
+    search_order: SearchOrder = SearchOrder.chronological
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +173,7 @@ def _row_to_instance(row: Any, master_key: bytes) -> Instance:
         missing_page_offset=row["missing_page_offset"],
         cutoff_page_offset=row["cutoff_page_offset"],
         allowed_time_window=row["allowed_time_window"],
+        search_order=SearchOrder(row["search_order"]),
     )
 
 
@@ -211,6 +221,7 @@ async def create_instance(
         DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE
     ),
     allowed_time_window: str = DEFAULT_ALLOWED_TIME_WINDOW,
+    search_order: SearchOrder = SearchOrder(DEFAULT_SEARCH_ORDER),
 ) -> Instance:
     """Insert a new instance row and return the populated :class:`Instance`.
 
@@ -247,6 +258,11 @@ async def create_instance(
         allowed_time_window: Optional schedule spec (e.g. ``"09:00-23:00"``)
             restricting scheduled cycles to configured windows.  Empty
             string disables the gate (24/7 operation).
+        search_order: Order in which the engine iterates items within a
+            pass.  ``chronological`` (default) preserves the legacy oldest
+            first behaviour; ``random`` picks a random start page and
+            shuffles items within each fetched page, and replaces the
+            upgrade-pool offset rotation with a shuffle.
 
     Returns:
         The newly created :class:`Instance` with its database-assigned *id*.
@@ -266,10 +282,10 @@ async def create_instance(
                 upgrade_hourly_cap,
                 upgrade_sonarr_search_mode, upgrade_lidarr_search_mode,
                 upgrade_readarr_search_mode, upgrade_whisparr_search_mode,
-                allowed_time_window
+                allowed_time_window, search_order
             ) VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                ?, ?, ?, ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
             """,
             (
@@ -301,6 +317,7 @@ async def create_instance(
                 upgrade_readarr_search_mode.value,
                 upgrade_whisparr_search_mode.value,
                 allowed_time_window,
+                search_order.value,
             ),
         )
         await db.commit()
@@ -374,7 +391,7 @@ async def update_instance(
             ``upgrade_readarr_search_mode``, ``upgrade_whisparr_search_mode``,
             ``upgrade_item_offset``, ``upgrade_series_offset``,
             ``missing_page_offset``, ``cutoff_page_offset``,
-            ``allowed_time_window``.
+            ``allowed_time_window``, ``search_order``.
 
     Returns:
         Updated :class:`Instance`, or ``None`` if *id* does not exist.
@@ -413,6 +430,7 @@ async def update_instance(
         "missing_page_offset": "missing_page_offset",
         "cutoff_page_offset": "cutoff_page_offset",
         "allowed_time_window": "allowed_time_window",
+        "search_order": "search_order",
     }
 
     _search_mode_fields = {
@@ -424,6 +442,7 @@ async def update_instance(
         "upgrade_lidarr_search_mode",
         "upgrade_readarr_search_mode",
         "upgrade_whisparr_search_mode",
+        "search_order",
     }
 
     assignments: list[str] = []

--- a/src/houndarr/static/css/app.css
+++ b/src/houndarr/static/css/app.css
@@ -28,6 +28,18 @@ html {
   background: #3d4f6b; /* border-strong */
 }
 
+/* ── Instance form select chevron ───────────────────────────────────────── */
+/* Native <select> chevrons sit flush against the right border and render at
+   subtly different positions across browsers.  On the settings instance
+   form the custom SVG keeps every dropdown aligned with consistent
+   padding-right.  The class is applied via ``select_cls`` in
+   templates/partials/instance_form.html. */
+.hd-select-chevron {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20' stroke='%2394a3b8' stroke-width='1.75'><polyline points='6 8 10 12 14 8' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-position: right 0.75rem center;
+  background-size: 1rem 1rem;
+}
+
 /* ── Mobile nav backdrop ────────────────────────────────────────────────── */
 .mobile-nav-backdrop {
   background: rgba(2, 6, 23, 0);

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -13,6 +13,11 @@
 {# Shared input class: Station style #}
 {% set input_cls = "w-full h-11 bg-[#0e1117] border border-[#2a3448] rounded-lg px-3 text-base text-white placeholder:text-slate-600 font-sans focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors" %}
 {% set mono_input_cls = "w-full h-11 bg-[#0e1117] border border-[#2a3448] rounded-lg px-3 text-base text-white placeholder:text-slate-600 font-mono focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors" %}
+{# Select variant: strip the native chevron so every dropdown in this form
+   gets the same inset SVG chevron and padding-right.  Native chevron
+   positions diverge across browsers and option widths, so a custom chevron
+   keeps the form visually consistent. #}
+{% set select_cls = input_cls + " hd-select-chevron appearance-none pr-10 bg-no-repeat" %}
 
 <div id="{{ 'edit-instance-form-shell-' ~ instance.id if is_edit else 'add-instance-form-shell' }}">
   {% if error is defined and error %}
@@ -58,7 +63,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-type">Type</label>
           <select id="{{ form_id }}-type" name="type" required
                   data-instance-field="type"
-                  class="{{ input_cls }}">
+                  class="{{ select_cls }}">
             <option value="radarr"   {% if is_edit and instance.type.value == 'radarr'   %}selected{% endif %}>Radarr</option>
             <option value="sonarr"   {% if is_edit and instance.type.value == 'sonarr'   %}selected{% endif %}>Sonarr</option>
             <option value="lidarr"   {% if is_edit and instance.type.value == 'lidarr'   %}selected{% endif %}>Lidarr</option>
@@ -150,12 +155,23 @@
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Restrict scheduled cycles to one or more <code>HH:MM-HH:MM</code> windows (container local time via <code>TZ</code>). Blank = always allowed. Run Now bypasses the window.</p>
         </div>
+        <div class="sm:col-span-2">
+          <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-order">
+            Search Order
+          </label>
+          <select id="{{ form_id }}-order" name="search_order"
+                  class="{{ select_cls }}">
+            <option value="chronological" {% if instance.search_order.value == 'chronological' %}selected{% endif %}>Chronological</option>
+            <option value="random"        {% if instance.search_order.value == 'random'        %}selected{% endif %}>Random (default)</option>
+          </select>
+          <p class="mt-1.5 text-xs text-slate-600">Chronological walks the library oldest-first in small rotations. Random picks a different slice of the library each cycle, so searches feel spread across the catalogue instead of clustered by release date.</p>
+        </div>
         <div class="sm:col-span-2" data-sonarr-only="true"
              {% if instance.type.value != 'sonarr' %}style="display:none;"{% endif %}>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-sonarr-mode">
             Sonarr Missing Search Mode
           </label>
-          <select id="{{ form_id }}-sonarr-mode" name="sonarr_search_mode" class="{{ input_cls }}">
+          <select id="{{ form_id }}-sonarr-mode" name="sonarr_search_mode" class="{{ select_cls }}">
             <option value="episode"        {% if instance.sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
             <option value="season_context" {% if instance.sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search (advanced)</option>
           </select>
@@ -166,7 +182,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-lidarr-mode">
             Lidarr Missing Search Mode
           </label>
-          <select id="{{ form_id }}-lidarr-mode" name="lidarr_search_mode" class="{{ input_cls }}">
+          <select id="{{ form_id }}-lidarr-mode" name="lidarr_search_mode" class="{{ select_cls }}">
             <option value="album"          {% if instance.lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
             <option value="artist_context" {% if instance.lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search (advanced)</option>
           </select>
@@ -177,7 +193,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-readarr-mode">
             Readarr Missing Search Mode
           </label>
-          <select id="{{ form_id }}-readarr-mode" name="readarr_search_mode" class="{{ input_cls }}">
+          <select id="{{ form_id }}-readarr-mode" name="readarr_search_mode" class="{{ select_cls }}">
             <option value="book"           {% if instance.readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
             <option value="author_context" {% if instance.readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search (advanced)</option>
           </select>
@@ -188,7 +204,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-whisparr-mode">
             Whisparr v2 Missing Search Mode
           </label>
-          <select id="{{ form_id }}-whisparr-mode" name="whisparr_search_mode" class="{{ input_cls }}">
+          <select id="{{ form_id }}-whisparr-mode" name="whisparr_search_mode" class="{{ select_cls }}">
             <option value="episode"        {% if instance.whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
             <option value="season_context" {% if instance.whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search (advanced)</option>
           </select>
@@ -276,7 +292,7 @@
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-sonarr-mode">
           Sonarr Upgrade Search Mode
         </label>
-        <select id="{{ form_id }}-upgrade-sonarr-mode" name="upgrade_sonarr_search_mode" class="{{ input_cls }}">
+        <select id="{{ form_id }}-upgrade-sonarr-mode" name="upgrade_sonarr_search_mode" class="{{ select_cls }}">
           <option value="episode"        {% if instance.upgrade_sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
           <option value="season_context" {% if instance.upgrade_sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
         </select>
@@ -286,7 +302,7 @@
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-lidarr-mode">
           Lidarr Upgrade Search Mode
         </label>
-        <select id="{{ form_id }}-upgrade-lidarr-mode" name="upgrade_lidarr_search_mode" class="{{ input_cls }}">
+        <select id="{{ form_id }}-upgrade-lidarr-mode" name="upgrade_lidarr_search_mode" class="{{ select_cls }}">
           <option value="album"          {% if instance.upgrade_lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
           <option value="artist_context" {% if instance.upgrade_lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search</option>
         </select>
@@ -296,7 +312,7 @@
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-readarr-mode">
           Readarr Upgrade Search Mode
         </label>
-        <select id="{{ form_id }}-upgrade-readarr-mode" name="upgrade_readarr_search_mode" class="{{ input_cls }}">
+        <select id="{{ form_id }}-upgrade-readarr-mode" name="upgrade_readarr_search_mode" class="{{ select_cls }}">
           <option value="book"           {% if instance.upgrade_readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
           <option value="author_context" {% if instance.upgrade_readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search</option>
         </select>
@@ -306,7 +322,7 @@
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-whisparr-mode">
           Whisparr v2 Upgrade Search Mode
         </label>
-        <select id="{{ form_id }}-upgrade-whisparr-mode" name="upgrade_whisparr_search_mode" class="{{ input_cls }}">
+        <select id="{{ form_id }}-upgrade-whisparr-mode" name="upgrade_whisparr_search_mode" class="{{ select_cls }}">
           <option value="episode"        {% if instance.upgrade_whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
           <option value="season_context" {% if instance.upgrade_whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
         </select>

--- a/tests/test_clients/test_lidarr.py
+++ b/tests/test_clients/test_lidarr.py
@@ -278,3 +278,12 @@ async def test_context_manager() -> None:
     async with LidarrClient(url=BASE, api_key=API_KEY) as c:
         result = await c.ping()
     assert result is not None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_wanted_total_missing(client: LidarrClient) -> None:
+    respx.get(f"{BASE}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"totalRecords": 21, "records": []})
+    )
+    assert await client.get_wanted_total("missing") == 21

--- a/tests/test_clients/test_radarr.py
+++ b/tests/test_clients/test_radarr.py
@@ -272,3 +272,12 @@ async def test_context_manager() -> None:
     async with RadarrClient(url=BASE, api_key=API_KEY) as c:
         result = await c.ping()
     assert result is not None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_wanted_total_missing(client: RadarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"totalRecords": 88, "records": []})
+    )
+    assert await client.get_wanted_total("missing") == 88

--- a/tests/test_clients/test_readarr.py
+++ b/tests/test_clients/test_readarr.py
@@ -278,3 +278,12 @@ async def test_context_manager() -> None:
     async with ReadarrClient(url=BASE, api_key=API_KEY) as c:
         result = await c.ping()
     assert result is not None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_wanted_total_missing(client: ReadarrClient) -> None:
+    respx.get(f"{BASE}/api/v1/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"totalRecords": 150, "records": []})
+    )
+    assert await client.get_wanted_total("missing") == 150

--- a/tests/test_clients/test_sonarr.py
+++ b/tests/test_clients/test_sonarr.py
@@ -249,3 +249,42 @@ async def test_context_manager() -> None:
     async with SonarrClient(url=BASE, api_key=API_KEY) as c:
         result = await c.ping()
     assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# get_wanted_total (#394)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_wanted_total_missing(client: SonarrClient) -> None:
+    route = respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(
+            200,
+            json={"page": 1, "pageSize": 1, "totalRecords": 437, "records": []},
+        )
+    )
+    assert await client.get_wanted_total("missing") == 437
+    assert route.calls[0].request.url.params["pageSize"] == "1"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_wanted_total_cutoff(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/cutoff").mock(
+        return_value=httpx.Response(
+            200,
+            json={"page": 1, "pageSize": 1, "totalRecords": 12, "records": []},
+        )
+    )
+    assert await client.get_wanted_total("cutoff") == 12
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_wanted_total_defaults_to_zero(client: SonarrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"records": []})
+    )
+    assert await client.get_wanted_total("missing") == 0

--- a/tests/test_clients/test_whisparr.py
+++ b/tests/test_clients/test_whisparr.py
@@ -346,3 +346,12 @@ async def test_context_manager() -> None:
     async with WhisparrClient(url=BASE, api_key=API_KEY) as c:
         result = await c.ping()
     assert result is not None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_wanted_total_missing(client: WhisparrClient) -> None:
+    respx.get(f"{BASE}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json={"totalRecords": 33, "records": []})
+    )
+    assert await client.get_wanted_total("missing") == 33

--- a/tests/test_clients/test_whisparr_v3.py
+++ b/tests/test_clients/test_whisparr_v3.py
@@ -265,3 +265,33 @@ async def test_context_manager() -> None:
     async with WhisparrV3Client(url=BASE, api_key=API_KEY) as c:
         result = await c.ping()
     assert result is not None
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_wanted_total_counts_from_cache(client: WhisparrV3Client) -> None:
+    movies = [
+        {"id": 1, "monitored": True, "hasFile": False, "title": "A", "year": 2020},
+        {"id": 2, "monitored": True, "hasFile": False, "title": "B", "year": 2020},
+        {"id": 3, "monitored": False, "hasFile": False, "title": "C", "year": 2020},
+        {
+            "id": 4,
+            "monitored": True,
+            "hasFile": True,
+            "title": "D",
+            "year": 2020,
+            "movieFile": {"qualityCutoffNotMet": True},
+        },
+        {
+            "id": 5,
+            "monitored": True,
+            "hasFile": True,
+            "title": "E",
+            "year": 2020,
+            "movieFile": {"qualityCutoffNotMet": False},
+        },
+    ]
+    respx.get(f"{BASE}/api/v3/movie").mock(return_value=httpx.Response(200, json=movies))
+
+    assert await client.get_wanted_total("missing") == 2
+    assert await client.get_wanted_total("cutoff") == 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,7 +29,7 @@ async def test_schema_created(db: None) -> None:
 async def test_schema_version_set(db: None) -> None:
     """Schema version should be set after init."""
     version = await get_setting("schema_version")
-    assert version == "11"
+    assert version == "12"
 
 
 @pytest.mark.asyncio()
@@ -110,7 +110,7 @@ async def test_init_db_migrates_v1_schema_to_v3(tmp_path: Path) -> None:
         search_log_columns = {row[1] async for row in search_log_cur}
         instance_columns = {row[1] async for row in instances_cur}
 
-    assert await get_setting("schema_version") == "11"
+    assert await get_setting("schema_version") == "12"
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
     assert "cycle_id" in search_log_columns
@@ -179,7 +179,7 @@ async def test_init_db_migrates_v2_schema_to_v4(tmp_path: Path) -> None:
         async with conn.execute("PRAGMA table_info(search_log)") as cur:
             search_log_columns = {row[1] async for row in cur}
 
-    assert await get_setting("schema_version") == "11"
+    assert await get_setting("schema_version") == "12"
     assert "cycle_id" in search_log_columns
     assert "cycle_trigger" in search_log_columns
 
@@ -246,7 +246,7 @@ async def test_init_db_migrates_v3_schema_to_v4(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "11"
+    assert await get_setting("schema_version") == "12"
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
             instance_columns = {row[1] async for row in cur}
@@ -329,7 +329,7 @@ async def test_init_db_migrates_v4_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "11"
+    assert await get_setting("schema_version") == "12"
 
     async with get_db() as conn:
         # Verify new columns exist
@@ -463,7 +463,7 @@ async def test_init_db_migrates_v5_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "11"
+    assert await get_setting("schema_version") == "12"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -560,7 +560,7 @@ async def test_init_db_migrates_v6_schema_to_v7(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "11"
+    assert await get_setting("schema_version") == "12"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -673,7 +673,7 @@ async def test_init_db_self_heals_v9_and_v10_when_version_already_current(
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "11"
+    assert await get_setting("schema_version") == "12"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -701,6 +701,227 @@ async def test_init_db_self_heals_v9_and_v10_when_version_already_current(
             " VALUES (?, 1, 'whisparr_v3_movie', '2024-01-01T00:00:00Z')",
             (v3_id,),
         )
+
+
+@pytest.mark.asyncio()
+async def test_init_db_self_heals_v12_when_column_missing(tmp_path: Path) -> None:
+    """init_db must add ``search_order`` when the version is stamped at 12 but
+    the column is missing (simulates a partially-applied migration from an
+    interrupted hot-reload or WAL checkpoint).
+    """
+    db_path = tmp_path / "corrupt-v12.db"
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await conn.executescript(
+            """
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO settings (key, value) VALUES ('schema_version', '12');
+
+            CREATE TABLE instances (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL CHECK(type IN (
+                    'radarr','sonarr','lidarr','readarr','whisparr_v2','whisparr_v3'
+                )),
+                url TEXT NOT NULL,
+                encrypted_api_key TEXT NOT NULL DEFAULT '',
+                batch_size INTEGER NOT NULL DEFAULT 2,
+                sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+                hourly_cap INTEGER NOT NULL DEFAULT 4,
+                cooldown_days INTEGER NOT NULL DEFAULT 14,
+                post_release_grace_hrs INTEGER NOT NULL DEFAULT 6,
+                queue_limit INTEGER NOT NULL DEFAULT 0,
+                cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+                cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+                cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+                cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+                sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+                readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+                whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_enabled INTEGER NOT NULL DEFAULT 0,
+                upgrade_batch_size INTEGER NOT NULL DEFAULT 1,
+                upgrade_cooldown_days INTEGER NOT NULL DEFAULT 90,
+                upgrade_hourly_cap INTEGER NOT NULL DEFAULT 1,
+                upgrade_sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+                upgrade_readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+                upgrade_whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_item_offset INTEGER NOT NULL DEFAULT 0,
+                upgrade_series_offset INTEGER NOT NULL DEFAULT 0,
+                missing_page_offset INTEGER NOT NULL DEFAULT 1,
+                cutoff_page_offset INTEGER NOT NULL DEFAULT 1,
+                allowed_time_window TEXT NOT NULL DEFAULT '',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z',
+                updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+            );
+
+            INSERT INTO instances (name, type, url)
+            VALUES ('Ghost Sonarr', 'sonarr', 'http://sonarr:8989');
+
+            CREATE TABLE cooldowns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
+                item_id INTEGER NOT NULL,
+                item_type TEXT NOT NULL,
+                searched_at TEXT NOT NULL,
+                UNIQUE(instance_id, item_id, item_type)
+            );
+
+            CREATE TABLE search_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER,
+                item_id INTEGER,
+                item_type TEXT,
+                search_kind TEXT,
+                cycle_id TEXT,
+                cycle_trigger TEXT,
+                item_label TEXT,
+                action TEXT NOT NULL,
+                reason TEXT,
+                message TEXT,
+                timestamp TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+            );
+            """
+        )
+        await conn.commit()
+
+    set_db_path(str(db_path))
+    await init_db()
+
+    async with get_db() as conn:
+        async with conn.execute("PRAGMA table_info(instances)") as cur:
+            columns = {row[1] async for row in cur}
+        assert "search_order" in columns
+
+        async with conn.execute(
+            "SELECT search_order FROM instances WHERE name = 'Ghost Sonarr'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == "chronological"
+
+
+@pytest.mark.asyncio()
+async def test_init_db_is_idempotent_on_healthy_v12(tmp_path: Path) -> None:
+    """Running init_db twice on a healthy v12 database must not error or drift."""
+    db_path = tmp_path / "healthy-v12.db"
+
+    set_db_path(str(db_path))
+    await init_db()  # fresh install
+    first_version = await get_setting("schema_version")
+
+    # Second call: should be a no-op through the self-heal branch.
+    await init_db()
+    assert await get_setting("schema_version") == first_version == "12"
+
+    async with get_db() as conn:
+        async with conn.execute("PRAGMA table_info(instances)") as cur:
+            columns = {row[1] async for row in cur}
+    # Spot-check a few expected columns to ensure nothing was dropped.
+    for col in ("search_order", "allowed_time_window", "missing_page_offset"):
+        assert col in columns
+
+
+@pytest.mark.asyncio()
+async def test_migrate_to_v12_adds_search_order_column(tmp_path: Path) -> None:
+    """init_db on a v11-shaped DB should add ``search_order`` with default ``chronological``."""
+    db_path = tmp_path / "migrate-v11-to-v12.db"
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await conn.executescript(
+            """
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO settings (key, value) VALUES ('schema_version', '11');
+
+            CREATE TABLE instances (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL CHECK(type IN (
+                    'radarr','sonarr','lidarr','readarr','whisparr_v2','whisparr_v3'
+                )),
+                url TEXT NOT NULL,
+                encrypted_api_key TEXT NOT NULL DEFAULT '',
+                batch_size INTEGER NOT NULL DEFAULT 2,
+                sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+                hourly_cap INTEGER NOT NULL DEFAULT 4,
+                cooldown_days INTEGER NOT NULL DEFAULT 14,
+                post_release_grace_hrs INTEGER NOT NULL DEFAULT 6,
+                queue_limit INTEGER NOT NULL DEFAULT 0,
+                cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+                cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+                cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+                cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+                sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+                readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+                whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_enabled INTEGER NOT NULL DEFAULT 0,
+                upgrade_batch_size INTEGER NOT NULL DEFAULT 1,
+                upgrade_cooldown_days INTEGER NOT NULL DEFAULT 90,
+                upgrade_hourly_cap INTEGER NOT NULL DEFAULT 1,
+                upgrade_sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+                upgrade_readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+                upgrade_whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_item_offset INTEGER NOT NULL DEFAULT 0,
+                upgrade_series_offset INTEGER NOT NULL DEFAULT 0,
+                missing_page_offset INTEGER NOT NULL DEFAULT 1,
+                cutoff_page_offset INTEGER NOT NULL DEFAULT 1,
+                allowed_time_window TEXT NOT NULL DEFAULT '',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z',
+                updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+            );
+
+            INSERT INTO instances (name, type, url)
+            VALUES ('Pre-v12 Sonarr', 'sonarr', 'http://sonarr:8989');
+
+            CREATE TABLE cooldowns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER NOT NULL
+                    REFERENCES instances(id) ON DELETE CASCADE,
+                item_id INTEGER NOT NULL,
+                item_type TEXT NOT NULL,
+                searched_at TEXT NOT NULL,
+                UNIQUE(instance_id, item_id, item_type)
+            );
+
+            CREATE TABLE search_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER,
+                item_id INTEGER,
+                item_type TEXT,
+                search_kind TEXT,
+                cycle_id TEXT,
+                cycle_trigger TEXT,
+                item_label TEXT,
+                action TEXT NOT NULL,
+                reason TEXT,
+                message TEXT,
+                timestamp TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+            );
+            """
+        )
+        await conn.commit()
+
+    set_db_path(str(db_path))
+    await init_db()
+
+    assert await get_setting("schema_version") == "12"
+
+    async with get_db() as conn:
+        async with conn.execute("PRAGMA table_info(instances)") as cur:
+            columns = {row[1] async for row in cur}
+        assert "search_order" in columns
+
+        async with conn.execute(
+            "SELECT search_order FROM instances WHERE name = 'Pre-v12 Sonarr'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == "chronological"
 
 
 @pytest.mark.asyncio()

--- a/tests/test_e2e/test_search_cycle.py
+++ b/tests/test_e2e/test_search_cycle.py
@@ -23,7 +23,7 @@ from houndarr.engine import supervisor as _supervisor_mod
 from houndarr.engine.search_loop import run_instance_search
 from houndarr.engine.supervisor import Supervisor
 from houndarr.services.cooldown import record_search
-from houndarr.services.instances import Instance, InstanceType, create_instance
+from houndarr.services.instances import Instance, InstanceType, SearchOrder, create_instance
 
 # ---------------------------------------------------------------------------
 # Shared test data
@@ -447,6 +447,10 @@ async def test_missing_list_calls_are_bounded_per_cycle(
         return_value=httpx.Response(201, json=_CMD_OK)
     )
 
+    # This test measures the ``_MAX_LIST_PAGES_PER_PASS`` page-fetch bound.
+    # Random mode adds one probe call which would muddy the assertion, so
+    # pin the instance to chronological for this specific check.
+    sonarr_instance.search_order = SearchOrder.chronological
     sonarr_instance.batch_size = 2
     count = await run_instance_search(sonarr_instance, master_key)
 

--- a/tests/test_engine/conftest.py
+++ b/tests/test_engine/conftest.py
@@ -15,6 +15,7 @@ from houndarr.services.instances import (
     InstanceType,
     LidarrSearchMode,
     ReadarrSearchMode,
+    SearchOrder,
     SonarrSearchMode,
     WhisparrSearchMode,
 )
@@ -159,6 +160,7 @@ def make_instance(
     missing_page_offset: int = 1,
     cutoff_page_offset: int = 1,
     allowed_time_window: str = "",
+    search_order: SearchOrder = SearchOrder.chronological,
 ) -> Instance:
     """Build an Instance with sensible defaults for testing."""
     resolved_url = url or URL_FOR_TYPE.get(itype, SONARR_URL)
@@ -198,6 +200,7 @@ def make_instance(
         missing_page_offset=missing_page_offset,
         cutoff_page_offset=cutoff_page_offset,
         allowed_time_window=allowed_time_window,
+        search_order=search_order,
     )
 
 

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -20,6 +20,7 @@ from houndarr.services.instances import (
     InstanceType,
     LidarrSearchMode,
     ReadarrSearchMode,
+    SearchOrder,
     SonarrSearchMode,
     WhisparrSearchMode,
 )
@@ -119,6 +120,7 @@ def _make_instance(
     lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album,
     readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book,
     whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode,
+    search_order: SearchOrder = SearchOrder.chronological,
 ) -> Instance:
     return Instance(
         id=instance_id,
@@ -143,6 +145,7 @@ def _make_instance(
         lidarr_search_mode=lidarr_search_mode,
         readarr_search_mode=readarr_search_mode,
         whisparr_search_mode=whisparr_search_mode,
+        search_order=search_order,
     )
 
 
@@ -2656,3 +2659,143 @@ async def test_cutoff_hourly_cap_stops_additional_page_fetches(seeded_instances:
     assert count == 0
     assert cutoff_route.call_count == 1
     assert not search_route.called
+
+
+# ---------------------------------------------------------------------------
+# Random search order (#394)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_random_shuffles_page_items(seeded_instances: None) -> None:
+    """Random order shuffles items within a fetched page before dispatch."""
+    import json
+    import random as _random
+
+    records = [{**_EPISODE_RECORD, "id": 2500 + i, "episodeNumber": i + 1} for i in range(6)]
+    page_response = {
+        "page": 1,
+        "pageSize": 50,
+        "totalRecords": len(records),
+        "records": records,
+    }
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=page_response)
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    _random.seed(42)
+    instance = _make_instance(
+        batch_size=len(records),
+        hourly_cap=len(records),
+        search_order=SearchOrder.random,
+    )
+    with patch("houndarr.engine.search_loop._INTER_SEARCH_DELAY_SECONDS", 0):
+        await run_instance_search(instance, MASTER_KEY)
+
+    searched_ids = [
+        json.loads(call.request.content)["episodeIds"][0] for call in search_route.calls
+    ]
+    original_ids = [r["id"] for r in records]
+    assert sorted(searched_ids) == sorted(original_ids)
+    assert searched_ids != original_ids, "random order should differ from fetched order"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_chronological_preserves_order(seeded_instances: None) -> None:
+    """Chronological mode (default) dispatches items in fetched order."""
+    import json
+
+    records = [{**_EPISODE_RECORD, "id": 2600 + i, "episodeNumber": i + 1} for i in range(4)]
+    page_response = {
+        "page": 1,
+        "pageSize": 50,
+        "totalRecords": len(records),
+        "records": records,
+    }
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=page_response)
+    )
+    search_route = respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(batch_size=len(records), hourly_cap=len(records))
+    with patch("houndarr.engine.search_loop._INTER_SEARCH_DELAY_SECONDS", 0):
+        await run_instance_search(instance, MASTER_KEY)
+
+    searched_ids = [
+        json.loads(call.request.content)["episodeIds"][0] for call in search_route.calls
+    ]
+    assert searched_ids == [2600, 2601, 2602, 2603]
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_random_picks_random_start_page(seeded_instances: None) -> None:
+    """Random mode probes total records and starts at a random page."""
+    import random as _random
+
+    # Probe returns totalRecords=1000.  With batch_size=1 the engine uses
+    # page_size=10 (_MISSING_PAGE_SIZE_MIN), so max_page = ceil(1000/10) = 100.
+    probe_response = {"page": 1, "pageSize": 1, "totalRecords": 1000, "records": []}
+    page_response = {
+        "page": 1,
+        "pageSize": 10,
+        "totalRecords": 1000,
+        "records": [_EPISODE_RECORD],
+    }
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=probe_response),
+            httpx.Response(200, json=page_response),
+            httpx.Response(200, json={"records": []}),
+        ]
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    _random.seed(0)
+    expected_page = _random.randint(1, 100)
+    _random.seed(0)
+
+    instance = _make_instance(batch_size=1, hourly_cap=1, search_order=SearchOrder.random)
+    with patch("houndarr.engine.search_loop._INTER_SEARCH_DELAY_SECONDS", 0):
+        await run_instance_search(instance, MASTER_KEY)
+
+    # Second call is the real fetch (after the probe). Its page param is the
+    # random start page, not the persisted offset of 1.
+    fetch_call = missing_route.calls[1]
+    assert fetch_call.request.url.params["page"] == str(expected_page)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_missing_random_falls_back_when_probe_fails(seeded_instances: None) -> None:
+    """Probe failure in random mode falls back to the persisted page offset."""
+    # First call (probe) fails; subsequent calls succeed.
+    missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(500),
+            httpx.Response(
+                200,
+                json={"page": 1, "pageSize": 50, "totalRecords": 1, "records": [_EPISODE_RECORD]},
+            ),
+        ]
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    instance = _make_instance(batch_size=1, hourly_cap=1, search_order=SearchOrder.random)
+    with patch("houndarr.engine.search_loop._INTER_SEARCH_DELAY_SECONDS", 0):
+        count = await run_instance_search(instance, MASTER_KEY)
+
+    assert count == 1
+    # Probe was attempted and the fetch still happened (second call).
+    assert missing_route.call_count >= 2

--- a/tests/test_engine/test_upgrade_pass.py
+++ b/tests/test_engine/test_upgrade_pass.py
@@ -1090,3 +1090,49 @@ async def test_upgrade_scan_budget_limits(
     ]
     # scan_budget=8: 7 on cooldown consume 7, then item 207 consumes 8th
     assert len(upgrade_searched) == 1
+
+
+# ---------------------------------------------------------------------------
+# Random search order for upgrade pass (#394)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+@patch(
+    "houndarr.engine.search_loop.update_instance",
+    new_callable=AsyncMock,
+)
+async def test_upgrade_random_shuffles_pool(
+    mock_update: AsyncMock,
+    seeded_instances: None,
+) -> None:
+    """Random mode bypasses id-sort + rotation; the pool is shuffled."""
+    import json
+    import random as _random
+
+    from houndarr.services.instances import SearchOrder
+
+    movies = [_library_movie(200 + i) for i in range(8)]
+    _mock_radarr_empty_missing()
+    _mock_radarr_library(movies)
+    search_route = respx.post(f"{RADARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    _random.seed(7)
+    inst = _radarr_instance(
+        upgrade_batch_size=5,
+        upgrade_hourly_cap=5,
+        search_order=SearchOrder.random,
+    )
+    with patch("houndarr.engine.search_loop._INTER_SEARCH_DELAY_SECONDS", 0):
+        await run_instance_search(inst, MASTER_KEY)
+
+    searched_ids = [json.loads(call.request.content)["movieIds"][0] for call in search_route.calls]
+    chronological_first_five = [200, 201, 202, 203, 204]
+    assert len(searched_ids) == 5
+    assert set(searched_ids).issubset({200 + i for i in range(8)})
+    assert searched_ids != chronological_first_five, (
+        "random order should differ from sorted-by-id chronological order"
+    )

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -676,3 +676,60 @@ def test_update_rejects_malformed_time_window(app: TestClient) -> None:
     # The stored value must still be the original.
     edit_resp = app.get("/settings/instances/1/edit")
     assert b'value="09:00-18:00"' in edit_resp.content
+
+
+# ---------------------------------------------------------------------------
+# search_order (#394)
+# ---------------------------------------------------------------------------
+
+
+def test_create_instance_accepts_random_search_order(app: TestClient) -> None:
+    _login(app)
+    form = {**_VALID_FORM, "search_order": "random"}
+    resp = app.post("/settings/instances", data=form, headers=csrf_headers(app))
+    assert resp.status_code == 200
+    edit = app.get("/settings/instances/1/edit")
+    assert b'name="search_order"' in edit.content
+    assert b'value="random"        selected' in edit.content or (
+        b'<option value="random"' in edit.content and b"selected" in edit.content
+    )
+
+
+def test_create_instance_defaults_to_random(app: TestClient) -> None:
+    _login(app)
+    resp = app.post("/settings/instances", data=_VALID_FORM, headers=csrf_headers(app))
+    assert resp.status_code == 200
+    edit = app.get("/settings/instances/1/edit")
+    # Random option should be preselected when no override was sent.
+    assert b'value="random"        selected' in edit.content or (
+        b'<option value="random"' in edit.content and b"selected" in edit.content
+    )
+
+
+def test_create_instance_rejects_invalid_search_order(app: TestClient) -> None:
+    _login(app)
+    form = {**_VALID_FORM, "search_order": "backwards"}
+    resp = app.post("/settings/instances", data=form, headers=csrf_headers(app))
+    assert resp.status_code == 422
+    assert b"Invalid search order" in resp.content
+
+
+def test_update_instance_toggles_search_order(app: TestClient) -> None:
+    _login(app)
+    app.post("/settings/instances", data=_VALID_FORM, headers=csrf_headers(app))
+
+    update_form = {**_VALID_FORM, "search_order": "random"}
+    resp = app.post("/settings/instances/1", data=update_form, headers=csrf_headers(app))
+    assert resp.status_code == 200
+
+    edit = app.get("/settings/instances/1/edit")
+    assert b'<option value="random"' in edit.content
+    # Round-trip to chronological.
+    revert = app.post(
+        "/settings/instances/1",
+        data={**_VALID_FORM, "search_order": "chronological"},
+        headers=csrf_headers(app),
+    )
+    assert revert.status_code == 200
+    edit_after = app.get("/settings/instances/1/edit")
+    assert b'<option value="chronological"' in edit_after.content

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -683,6 +683,35 @@ def test_update_rejects_malformed_time_window(app: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _option_selected(content: bytes, value: str) -> bool:
+    """Return True when `<option value="{value}" ... selected ...>` appears in *content*.
+
+    Matches `selected` strictly inside the opening tag of the target option so
+    that "option exists" and "something else is selected" cannot both be true
+    simultaneously and pass the assertion.
+    """
+    import re
+
+    pattern = rb'<option\s+value="' + re.escape(value).encode("ascii") + rb'"[^>]*\sselected\b'
+    return re.search(pattern, content) is not None
+
+
+def test_add_form_preselects_random_by_default(app: TestClient) -> None:
+    """A fresh Add Instance form pre-selects Random.
+
+    Regression guard for the case where ``_blank_instance()`` or the Instance
+    dataclass default silently falls back to chronological.  A real browser
+    submits the selected option's ``value``; if this renders chronological,
+    new instances get chronological persisted without user interaction.
+    """
+    _login(app)
+    resp = app.get("/settings/instances/add-form")
+    assert resp.status_code == 200
+    assert b'name="search_order"' in resp.content
+    assert _option_selected(resp.content, "random"), resp.content
+    assert not _option_selected(resp.content, "chronological")
+
+
 def test_create_instance_accepts_random_search_order(app: TestClient) -> None:
     _login(app)
     form = {**_VALID_FORM, "search_order": "random"}
@@ -690,9 +719,7 @@ def test_create_instance_accepts_random_search_order(app: TestClient) -> None:
     assert resp.status_code == 200
     edit = app.get("/settings/instances/1/edit")
     assert b'name="search_order"' in edit.content
-    assert b'value="random"        selected' in edit.content or (
-        b'<option value="random"' in edit.content and b"selected" in edit.content
-    )
+    assert _option_selected(edit.content, "random"), edit.content
 
 
 def test_create_instance_defaults_to_random(app: TestClient) -> None:
@@ -700,10 +727,7 @@ def test_create_instance_defaults_to_random(app: TestClient) -> None:
     resp = app.post("/settings/instances", data=_VALID_FORM, headers=csrf_headers(app))
     assert resp.status_code == 200
     edit = app.get("/settings/instances/1/edit")
-    # Random option should be preselected when no override was sent.
-    assert b'value="random"        selected' in edit.content or (
-        b'<option value="random"' in edit.content and b"selected" in edit.content
-    )
+    assert _option_selected(edit.content, "random"), edit.content
 
 
 def test_create_instance_rejects_invalid_search_order(app: TestClient) -> None:
@@ -723,8 +747,8 @@ def test_update_instance_toggles_search_order(app: TestClient) -> None:
     assert resp.status_code == 200
 
     edit = app.get("/settings/instances/1/edit")
-    assert b'<option value="random"' in edit.content
-    # Round-trip to chronological.
+    assert _option_selected(edit.content, "random")
+
     revert = app.post(
         "/settings/instances/1",
         data={**_VALID_FORM, "search_order": "chronological"},
@@ -732,4 +756,4 @@ def test_update_instance_toggles_search_order(app: TestClient) -> None:
     )
     assert revert.status_code == 200
     edit_after = app.get("/settings/instances/1/edit")
-    assert b'<option value="chronological"' in edit_after.content
+    assert _option_selected(edit_after.content, "chronological")

--- a/tests/test_services/test_instances.py
+++ b/tests/test_services/test_instances.py
@@ -308,3 +308,42 @@ async def test_update_allowed_time_window(db: None, master_key: bytes) -> None:
     )
     assert cleared is not None
     assert cleared.allowed_time_window == ""
+
+
+# ---------------------------------------------------------------------------
+# search_order (#394)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_create_applies_search_order_default(db: None, master_key: bytes) -> None:
+    from houndarr.services.instances import SearchOrder
+
+    inst = await _make(master_key)
+    assert inst.search_order == SearchOrder.random
+
+
+@pytest.mark.asyncio()
+async def test_update_search_order_to_random(db: None, master_key: bytes) -> None:
+    from houndarr.services.instances import SearchOrder
+
+    inst = await _make(master_key)
+    updated = await update_instance(
+        inst.id,
+        master_key=master_key,
+        search_order=SearchOrder.random,
+    )
+    assert updated is not None
+    assert updated.search_order == SearchOrder.random
+
+    refetched = await get_instance(inst.id, master_key=master_key)
+    assert refetched is not None
+    assert refetched.search_order == SearchOrder.random
+
+    reverted = await update_instance(
+        inst.id,
+        master_key=master_key,
+        search_order=SearchOrder.chronological,
+    )
+    assert reverted is not None
+    assert reverted.search_order == SearchOrder.chronological

--- a/website/docs/concepts/faq.md
+++ b/website/docs/concepts/faq.md
@@ -44,6 +44,8 @@ If you set a **Queue Limit** on an instance, Houndarr checks the download queue 
 
 It searches items from `wanted/missing` and `wanted/cutoff`, rotating through the list over time so every item gets evaluated even if the first pages are on cooldown. If upgrade search is enabled, it also re-searches library items that already meet cutoff, rotating through your library with a separate offset. Everything else is untouched.
 
+The default `Search Order` is `Random`, which picks a random page each cycle and shuffles the items on it. Switch to `Chronological` if you prefer deterministic oldest-first rotation. See [Search Order](/docs/configuration/instance-settings#search-order) for the trade-off.
+
 ## "Why is Houndarr searching so slowly?"
 
 The defaults are conservative on purpose (batch size 2, hourly cap 4, 14-day cooldown). With a large backlog, clearing it takes weeks. You can increase throughput gradually; see [Increasing throughput](/docs/configuration/instance-settings#increasing-throughput).
@@ -69,6 +71,10 @@ No. Houndarr only triggers searches within your *arr instances for items already
 ## "I deleted files to free up space. Will Houndarr re-download them?"
 
 If the items are still monitored in your *arr instance, yes: they will appear in the wanted/missing list and Houndarr will eventually search for them. To prevent re-downloads, unmonitor the items in your *arr instance before or after deleting the files. Houndarr only acts on what your *arr instance reports as wanted.
+
+## "Why are the same few series or movies showing up over and over in the logs?"
+
+That pattern used to be common with chronological search order: same-day releases cluster together in the *arr wanted list (it falls back to title order within equal dates), so the logs looked like long alphabetical runs of the same show or studio. The default is now `Random`, which picks a random page of your wanted list each cycle and shuffles items on it before searching. If you still prefer the old deterministic behaviour, switch `Search Order` to `Chronological` in the Edit Instance form.
 
 ## "Does Houndarr respect custom format scores?"
 

--- a/website/docs/configuration/instance-settings.md
+++ b/website/docs/configuration/instance-settings.md
@@ -130,6 +130,59 @@ Strategy for Whisparr v2 missing-pass commands (v3 has no search mode; it always
 
 Season-context mode sends at most one `SeasonSearch` per `(series, season)` per pass, same as Sonarr's season-context mode.
 
+## Search Order
+
+Controls how items are picked from the wanted list each cycle. Applies to all
+three passes (missing, cutoff, and upgrade) for the instance.
+
+- **Default:** `Random`
+- **Alternative:** `Chronological`
+
+### Random (default)
+
+Each cycle, Houndarr probes the wanted-list total, picks a random page in that
+range, fetches it, and shuffles the items before evaluation. Over many cycles
+the search distribution spreads evenly across the catalogue instead of moving
+one shelf at a time.
+
+Recommended for most users, especially anyone whose library has long
+alphabetical runs of similarly-dated items (e.g. a full series binge-added
+the same day, or a back catalogue imported in one go). Without shuffling,
+those items tend to appear as a clustered wall in the logs.
+
+For the upgrade pass, random replaces the id-sort-plus-offset rotation with a
+plain shuffle of the upgrade pool. The persisted offset is still maintained so
+switching back to chronological resumes from a sane position.
+
+### Chronological
+
+Walks the wanted list oldest-first, paged against the persisted offset
+(`missing_page_offset` / `cutoff_page_offset`). Deterministic and easy to
+reason about: you can predict which items will come up next. The trade-off is
+that same-day releases cluster visibly because the *arr API falls back to
+title order within equal dates.
+
+Pick this mode if you value predictable coverage for debugging, or if you
+rotate through a relatively small wanted list where chronological order
+already gives reasonable spread.
+
+### What random mode does not change
+
+- Cooldowns, hourly caps, post-release grace, queue backpressure and the
+  allowed time window all apply identically in both modes.
+- Shuffling happens after the page is fetched from your *arr instance, so no
+  extra indexer pressure is introduced.
+- Random mode adds one lightweight probe call per pass (a `pageSize=1` request
+  to read `totalRecords`); Whisparr v3 reuses its cached movie list for this
+  count at no extra cost.
+
+:::info Existing instances keep their setting after upgrade
+Only fresh installs default to `Random`. If you upgraded from an earlier
+Houndarr version, existing instances keep whatever search order you had
+before (originally `Chronological`). Toggle to `Random` from the Edit
+Instance form when you want to switch.
+:::
+
 ## Cutoff upgrade controls
 
 ### Cutoff search
@@ -207,9 +260,13 @@ Per-app strategy for upgrade-pass search commands. Each app type (Sonarr, Lidarr
 
 ### Offset-based rotation
 
+Applies only when `Search Order` is set to `Chronological` for an instance.
+
 The upgrade pass uses a persistent offset to rotate through your library over time rather than always starting from the beginning. This ensures fair coverage across your entire library. Offsets reset to zero when upgrade search is toggled off.
 
 The missing and cutoff passes also use page-based rotation. Each pass remembers which API page it reached and starts from there on the next cycle. This prevents items further down the list from being starved when earlier items are all on cooldown. Offsets reset to page 1 when you save instance settings.
+
+When `Search Order` is `Random`, Houndarr picks a fresh random page each cycle rather than advancing the offset. The offset columns are still written but go unused until you switch the instance back to chronological mode.
 
 ## Queue backpressure
 
@@ -283,6 +340,7 @@ Skips are normal. See [How Houndarr Works](/docs/concepts/how-houndarr-works#wha
 | Post-Release Grace (hrs) | `6` |
 | Queue Limit | `0` (disabled) |
 | Allowed Search Window | (blank, 24/7) |
+| Search Order | `Random` |
 | Cutoff search | Off |
 | Cutoff Batch | `1` |
 | Cutoff Cooldown | `21` |


### PR DESCRIPTION
## Summary

Adds per-instance `Search Order` (`random` or `chronological`) so searches spread across the full backlog instead of marching alphabetically through the `wanted/*` list. Random is the new default for fresh installs; existing instances keep their prior behaviour through the v12 migration.

Closes #394

## Changes

- New `search_order` column on `instances` (schema v12) with CHECK enforcement on fresh schemas and an idempotent, self-healing migration for existing installs.
- `DEFAULT_SEARCH_ORDER = "random"` plus a `SearchOrder` `StrEnum` on the service layer.
- Engine: random mode probes the wanted-list total via a `pageSize=1` request, picks a random page in `[1, ceil(total/page_size)]`, and shuffles items on every fetched page. Whisparr v3 reuses its cached movie list for the probe. Probe failure falls back to the persisted offset.
- Upgrade pass: random replaces the id-sort + offset rotation with a plain shuffle of the upgrade pool. `upgrade_series_offset` still advances in both modes to preserve whole-library coverage.
- Offset columns (`missing_page_offset`, `cutoff_page_offset`, `upgrade_item_offset`) are only written in chronological mode, so random mode stops churning those rows with meaningless values.
- Add Instance / Edit Instance forms get a `Search Order` dropdown with a custom SVG chevron applied uniformly to every select in the form.
- `_blank_instance()` carries the config default so the add form pre-selects Random (regression guard added at `/settings/instances/add-form`).
- Docs: README feature bullet, FAQ entries, and a new `Search Order` section in the instance settings reference.

## Testing

All checks pass. Also sanity-checked across chromium, firefox, and webkit (login → dashboard → settings → add-form preselection → edit form for each instance type → Run Now → logs), and ran a live cycle against a real Sonarr and Radarr that exercised all three passes with the probe and shuffle visible in the search log.

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way