### PR TITLE
test: add browser end-to-end workflow with mock *arr

### DIFF
--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install browser test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-playwright pytest-rerunfailures playwright fastapi 'uvicorn[standard]' httpx
+          pip install -r tests/e2e_browser/requirements.txt
 
       - name: Resolve Playwright version
         id: pw
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache Playwright browser binaries
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-${{ matrix.browser }}
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload playwright artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-${{ matrix.browser }}
           path: test-results

--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -65,12 +65,14 @@ jobs:
         run: |
           docker run -d --name mock-sonarr --network arr-net \
             -v "${WORKSPACE}/tests/e2e_browser/mock_arr.py:/app/mock_arr.py:ro" \
-            python:3.12-slim \
-            bash -c "pip install --quiet fastapi 'uvicorn[standard]' && python /app/mock_arr.py --app Sonarr --port 8989"
+            --entrypoint python \
+            houndarr:e2e \
+            /app/mock_arr.py --app Sonarr --port 8989
           docker run -d --name mock-radarr --network arr-net \
             -v "${WORKSPACE}/tests/e2e_browser/mock_arr.py:/app/mock_arr.py:ro" \
-            python:3.12-slim \
-            bash -c "pip install --quiet fastapi 'uvicorn[standard]' && python /app/mock_arr.py --app Radarr --port 7878"
+            --entrypoint python \
+            houndarr:e2e \
+            /app/mock_arr.py --app Radarr --port 7878
 
       - name: Wait for mock services
         run: |
@@ -78,7 +80,7 @@ jobs:
             name="${target%:*}"
             port="${target#*:}"
             for i in $(seq 1 60); do
-              if docker exec "$name" python -c "import httpx; httpx.get('http://localhost:${port}/api/v3/system/status').raise_for_status()" 2>/dev/null; then
+              if docker exec "$name" python -c "from urllib.request import urlopen; urlopen('http://localhost:${port}/api/v3/system/status').read()" 2>/dev/null; then
                 echo "$name is ready"
                 break
               fi

--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -44,24 +44,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r tests/e2e_browser/requirements.txt
 
-      - name: Resolve Playwright version
-        id: pw
-        run: echo "version=$(pip show playwright | awk '/^Version:/ {print $2}')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browser binaries
-        id: pw-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-${{ matrix.browser }}
-
-      - name: Install Playwright browser (cache miss)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
+      # Playwright upstream recommends against caching the browser
+      # binaries themselves: restore cost is comparable to a fresh
+      # download, and partial-restore semantics risk pairing mismatched
+      # binary and library versions.  See
+      # https://playwright.dev/docs/ci#caching-browsers.
+      - name: Install Playwright browser
         run: playwright install --with-deps "$BROWSER"
-
-      - name: Install Playwright system deps (cache hit)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: playwright install-deps "$BROWSER"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -42,8 +42,26 @@ jobs:
       - name: Install browser test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-playwright playwright fastapi 'uvicorn[standard]' httpx
-          playwright install --with-deps "$BROWSER"
+          pip install pytest pytest-playwright pytest-rerunfailures playwright fastapi 'uvicorn[standard]' httpx
+
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(pip show playwright | awk '/^Version:/ {print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browser binaries
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}-${{ matrix.browser }}
+
+      - name: Install Playwright browser (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: playwright install --with-deps "$BROWSER"
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: playwright install-deps "$BROWSER"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -128,13 +146,17 @@ jobs:
           HOUNDARR_E2E_USER: admin
           HOUNDARR_E2E_PASS: CITestPass1!
         run: |
+          mkdir -p test-results
           pytest tests/e2e_browser/ \
+            --confcutdir tests/e2e_browser \
             --browser "$BROWSER" \
             --tracing retain-on-failure \
             --screenshot only-on-failure \
             --full-page-screenshot \
             --video retain-on-failure \
             --output test-results/e2e \
+            --junitxml=test-results/junit.xml \
+            --reruns 2 \
             -v
 
       - name: Dump container logs on failure
@@ -155,7 +177,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-${{ matrix.browser }}
-          path: test-results/e2e
+          path: test-results
           retention-days: 7
 
       - name: Cleanup

--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -1,0 +1,163 @@
+name: Browser E2E
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "website/**"
+      - ".claude/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-e2e:
+    name: Browser E2E (${{ matrix.browser }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+
+    env:
+      BROWSER: ${{ matrix.browser }}
+      WORKSPACE: ${{ github.workspace }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install browser test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-playwright playwright fastapi 'uvicorn[standard]' httpx
+          playwright install --with-deps "$BROWSER"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Houndarr image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: houndarr:e2e
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create docker network
+        run: docker network create arr-net
+
+      - name: Start mock *arr services
+        run: |
+          docker run -d --name mock-sonarr --network arr-net \
+            -v "${WORKSPACE}/tests/e2e_browser/mock_arr.py:/app/mock_arr.py:ro" \
+            python:3.12-slim \
+            bash -c "pip install --quiet fastapi 'uvicorn[standard]' && python /app/mock_arr.py --app Sonarr --port 8989"
+          docker run -d --name mock-radarr --network arr-net \
+            -v "${WORKSPACE}/tests/e2e_browser/mock_arr.py:/app/mock_arr.py:ro" \
+            python:3.12-slim \
+            bash -c "pip install --quiet fastapi 'uvicorn[standard]' && python /app/mock_arr.py --app Radarr --port 7878"
+
+      - name: Wait for mock services
+        run: |
+          for target in mock-sonarr:8989 mock-radarr:7878; do
+            name="${target%:*}"
+            port="${target#*:}"
+            for i in $(seq 1 60); do
+              if docker exec "$name" python -c "import httpx; httpx.get('http://localhost:${port}/api/v3/system/status').raise_for_status()" 2>/dev/null; then
+                echo "$name is ready"
+                break
+              fi
+              if [ "$i" -eq 60 ]; then
+                docker logs "$name"
+                echo "$name did not come up"
+                exit 1
+              fi
+              sleep 1
+            done
+          done
+
+      - name: Start Houndarr container
+        run: |
+          mkdir -p /tmp/houndarr-e2e-data
+          docker run -d --name houndarr-e2e --network arr-net \
+            -p 8877:8877 \
+            -v /tmp/houndarr-e2e-data:/data \
+            -e TZ=UTC \
+            houndarr:e2e
+
+      - name: Wait for Houndarr health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8877/api/health | grep -q '"status":"ok"'; then
+              echo "Houndarr healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs houndarr-e2e
+          exit 1
+
+      - name: Create test admin account
+        run: |
+          curl -sf -X POST http://localhost:8877/setup \
+            -d 'username=admin&password=CITestPass1!&password_confirm=CITestPass1!' \
+            -o /dev/null
+
+      - name: Run browser e2e suite
+        env:
+          HOUNDARR_URL: http://localhost:8877
+          MOCK_SONARR_URL: http://mock-sonarr:8989
+          MOCK_RADARR_URL: http://mock-radarr:7878
+          HOUNDARR_E2E_USER: admin
+          HOUNDARR_E2E_PASS: CITestPass1!
+        run: |
+          pytest tests/e2e_browser/ \
+            --browser "$BROWSER" \
+            --tracing retain-on-failure \
+            --screenshot only-on-failure \
+            --full-page-screenshot \
+            --video retain-on-failure \
+            --output test-results/e2e \
+            -v
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "::group::houndarr-e2e"
+          docker logs houndarr-e2e
+          echo "::endgroup::"
+          echo "::group::mock-sonarr"
+          docker logs mock-sonarr
+          echo "::endgroup::"
+          echo "::group::mock-radarr"
+          docker logs mock-radarr
+          echo "::endgroup::"
+
+      - name: Upload playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-${{ matrix.browser }}
+          path: test-results/e2e
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f houndarr-e2e mock-sonarr mock-radarr || true
+          docker network rm arr-net || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,10 @@ skips = [
 # ---------------------------------------------------------------------------
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Browser e2e suite boots a live container and needs playwright installed;
+# skip it during the default pytest run and invoke explicitly with
+# ``pytest tests/e2e_browser/ --browser ...`` from the dedicated CI job.
+norecursedirs = ["e2e_browser"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "-q --tb=short"

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -8,7 +8,9 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from houndarr import __version__
@@ -117,6 +119,41 @@ def create_app() -> FastAPI:
     # -----------------------------------------------------------------------
     static_dir = Path(__file__).parent / "static"
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    # -----------------------------------------------------------------------
+    # Exception handlers
+    # -----------------------------------------------------------------------
+    @app.exception_handler(RequestValidationError)
+    async def _validation_error_handler(
+        request: Request, exc: RequestValidationError
+    ) -> HTMLResponse | JSONResponse:
+        """Return a harmless HTML body (never JSON) for HTMX-initiated
+        validation errors.
+
+        Base.html opts 422 into the HTMX swap so server-emitted error
+        snippets actually render.  FastAPI's default 422 body is JSON
+        (``{"detail": [...]}``), which would render as literal text
+        inside whatever slot the form targets.  For HTMX requests we
+        ship an empty body with ``HX-Reswap: none`` so the swap is
+        suppressed (same visible behaviour as before the config flip)
+        and log the validation detail server-side for the operator.
+
+        Non-HTMX clients keep FastAPI's default JSON response so API
+        consumers and tests are unaffected.
+        """
+        if request.headers.get("HX-Request") == "true":
+            logger.warning(
+                "HTMX validation error on %s %s: %s",
+                request.method,
+                request.url.path,
+                exc.errors(),
+            )
+            return HTMLResponse(
+                content="",
+                status_code=422,
+                headers={"HX-Reswap": "none"},
+            )
+        return JSONResponse(status_code=422, content={"detail": exc.errors()})
 
     # -----------------------------------------------------------------------
     # Middleware (order matters: outermost = first to receive request)

--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -108,7 +108,10 @@ def _parse_search_kind(raw: str | None) -> str | None:
     if raw is None or raw == "":
         return None
     if raw not in _SEARCH_KINDS:
-        raise HTTPException(status_code=422, detail="search_kind must be 'missing' or 'cutoff'")
+        raise HTTPException(
+            status_code=422,
+            detail="search_kind must be 'missing', 'cutoff', or 'upgrade'",
+        )
     return raw
 
 

--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -6,6 +6,7 @@ GET /api/logs/partial → server-rendered <tbody> HTMX partial (used by the /log
 
 from __future__ import annotations
 
+import html
 import logging
 from pathlib import Path
 from typing import Any
@@ -133,6 +134,26 @@ def _parse_hide_system(raw: str | None) -> bool:
     if normalized in {"0", "false", "no", "off"}:
         return False
     raise HTTPException(status_code=422, detail="hide_system must be a boolean")
+
+
+def _partial_validation_error(detail: str) -> HTMLResponse:
+    """Render a tbody-shaped 422 error for ``/api/logs/partial``.
+
+    ``#log-tbody`` is the HTMX target; swapping FastAPI's default JSON
+    error body into a ``<tbody>`` would render as raw ``{"detail":...}``
+    text.  Shape the response as a single ``<tr>`` that matches the
+    existing empty-state row (``colspan="10"``) so the swap preserves
+    table structure.
+    """
+    safe = html.escape(detail)
+    content = (
+        '<tr id="log-error-row">'
+        '<td colspan="10" class="px-3 py-14 text-center">'
+        '<p class="text-sm font-medium text-red-300 font-sans">Invalid filter value.</p>'
+        f'<p class="mt-1 text-xs text-red-400/80 font-sans">{safe}</p>'
+        "</td></tr>"
+    )
+    return HTMLResponse(content=content, status_code=422)
 
 
 # ---------------------------------------------------------------------------
@@ -378,13 +399,20 @@ async def get_logs_partial(
         limit: Max rows.
 
     Returns:
-        HTML fragment containing ``<tbody>`` rows.
+        HTML fragment containing ``<tbody>`` rows.  On a validation
+        failure, returns a ``<tr>`` error row with status 422 instead
+        of FastAPI's default JSON ``{"detail": ...}`` body so the HTMX
+        swap preserves the table structure.
     """
-    parsed_instance_id = _parse_instance_id(instance_id)
+    try:
+        parsed_instance_id = _parse_instance_id(instance_id)
+        parsed_search_kind = _parse_search_kind(search_kind)
+        parsed_cycle_trigger = _parse_cycle_trigger(cycle_trigger)
+        parsed_hide_system = _parse_hide_system(hide_system)
+    except HTTPException as exc:
+        return _partial_validation_error(str(exc.detail))
+
     parsed_action = action or None
-    parsed_search_kind = _parse_search_kind(search_kind)
-    parsed_cycle_trigger = _parse_cycle_trigger(cycle_trigger)
-    parsed_hide_system = _parse_hide_system(hide_system)
     load_more_limit = _compute_load_more_limit(limit)
     rows = await _query_logs(
         parsed_instance_id,

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -8,12 +8,14 @@
   <meta name="apple-mobile-web-app-title" content="Houndarr" />
   <meta name="theme-color" content="#07080f" />
   <meta name="color-scheme" content="dark" />
-  {# HTMX 2.x defaults skip the swap on 4xx/5xx, which silently drops every
-     validation error the server sends with HX-Retarget + HX-Reswap headers
-     (Save instance, test-connection, password change).  Override so 4xx/5xx
-     swap too; the server's existing retarget headers then render the error
-     in the right slot.  Without this, 4xx responses fail silently. #}
-  <meta name="htmx-config" content='{"responseHandling":[{"code":"204","swap":false},{"code":"[23]..","swap":true},{"code":"[45]..","swap":true,"error":true},{"code":"...","swap":false,"error":true}]}' />
+  {# HTMX 2.x defaults skip the swap on 4xx/5xx, which silently drops the
+     validation errors the server sends with HX-Retarget + HX-Reswap
+     (Save instance, test-connection, password change).  Opt 422 into
+     swapping so those errors actually render; keep the default ``swap:
+     false`` for 404 / 401 / 429 / 5xx so a stray ``HTMLResponse("Not found")``
+     or a Starlette 500 page does not land in a UI slot.  ``error: true``
+     stays so ``htmx:responseError`` listeners still fire. #}
+  <meta name="htmx-config" content='{"responseHandling":[{"code":"204","swap":false},{"code":"[23]..","swap":true},{"code":"422","swap":true,"error":true},{"code":"[45]..","swap":false,"error":true},{"code":"...","swap":false,"error":true}]}' />
   <link rel="icon" type="image/png" href="/static/img/houndarr-logo-dark.png" />
   <link rel="shortcut icon" href="/static/img/houndarr-logo-dark.png" />
   <link rel="apple-touch-icon" href="/static/img/houndarr-logo-dark.png" />

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -8,6 +8,12 @@
   <meta name="apple-mobile-web-app-title" content="Houndarr" />
   <meta name="theme-color" content="#07080f" />
   <meta name="color-scheme" content="dark" />
+  {# HTMX 2.x defaults skip the swap on 4xx/5xx, which silently drops every
+     validation error the server sends with HX-Retarget + HX-Reswap headers
+     (Save instance, test-connection, password change).  Override so 4xx/5xx
+     swap too; the server's existing retarget headers then render the error
+     in the right slot.  Without this, 4xx responses fail silently. #}
+  <meta name="htmx-config" content='{"responseHandling":[{"code":"204","swap":false},{"code":"[23]..","swap":true},{"code":"[45]..","swap":true,"error":true},{"code":"...","swap":false,"error":true}]}' />
   <link rel="icon" type="image/png" href="/static/img/houndarr-logo-dark.png" />
   <link rel="shortcut icon" href="/static/img/houndarr-logo-dark.png" />
   <link rel="apple-touch-icon" href="/static/img/houndarr-logo-dark.png" />

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -15,7 +15,7 @@
      false`` for 404 / 401 / 429 / 5xx so a stray ``HTMLResponse("Not found")``
      or a Starlette 500 page does not land in a UI slot.  ``error: true``
      stays so ``htmx:responseError`` listeners still fire. #}
-  <meta name="htmx-config" content='{"responseHandling":[{"code":"204","swap":false},{"code":"[23]..","swap":true},{"code":"422","swap":true,"error":true},{"code":"[45]..","swap":false,"error":true},{"code":"...","swap":false,"error":true}]}' />
+  <meta name="htmx-config" content='{"responseHandling":[{"code":"^204$","swap":false},{"code":"^[23]..$","swap":true},{"code":"^422$","swap":true,"error":true},{"code":"^[45]..$","swap":false,"error":true},{"code":"...","swap":false,"error":true}]}' />
   <link rel="icon" type="image/png" href="/static/img/houndarr-logo-dark.png" />
   <link rel="shortcut icon" href="/static/img/houndarr-logo-dark.png" />
   <link rel="apple-touch-icon" href="/static/img/houndarr-logo-dark.png" />

--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -999,6 +999,22 @@
           window.houndarrCloseAddInstanceModal();
         }
 
+        if (evt.detail.target.id === 'account-section') {
+          // When the password form re-renders (success or validation
+          // error), the submit button the user just clicked is
+          // replaced, so focus falls to <body>.  Keep the <details>
+          // expanded and return focus to the first password field so
+          // keyboard users do not lose their place.
+          const details = document.querySelector('#account-settings');
+          if (details) {
+            details.open = true;
+          }
+          const firstPwInput = document.querySelector('#current-password');
+          if (firstPwInput) {
+            firstPwInput.focus();
+          }
+        }
+
         if (evt.detail.target.id === 'add-instance-modal-content') {
           if (pendingModalShow) {
             pendingModalShow = false;

--- a/tests/e2e_browser/conftest.py
+++ b/tests/e2e_browser/conftest.py
@@ -1,0 +1,82 @@
+"""Browser e2e fixtures.
+
+The workflow boots Houndarr in Docker and runs the mock *arr services in
+sibling containers on the same Docker network, then invokes pytest on
+the host with the URLs passed through environment variables.  These
+fixtures read those values, attach a uniform console listener, and log
+the test user in.  Nothing here starts or stops the services; the
+workflow owns orchestration.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Generator
+
+import pytest
+from playwright.sync_api import ConsoleMessage, Page
+
+HOUNDARR_URL = os.environ.get("HOUNDARR_URL", "http://localhost:8877")
+MOCK_SONARR_URL = os.environ.get("MOCK_SONARR_URL", "http://mock-sonarr:8989")
+MOCK_RADARR_URL = os.environ.get("MOCK_RADARR_URL", "http://mock-radarr:7878")
+ADMIN_USER = os.environ.get("HOUNDARR_E2E_USER", "admin")
+ADMIN_PASS = os.environ.get("HOUNDARR_E2E_PASS", "CITestPass1!")
+
+# Console noise that predates this workflow and is unrelated to any
+# behaviour the suite verifies.  Firefox promotes the login template's
+# HTML5 ``pattern`` attribute regex to an error and aborts headless
+# Google Fonts fetches; both are accepted.
+_ALLOWED_ERROR_PATTERNS = [
+    re.compile(r"\[-A-Za-z0-9_\.\]\+ is not a valid regular expression"),
+    re.compile(r"downloadable font: download failed"),
+]
+
+
+@pytest.fixture(scope="session")
+def houndarr_url() -> str:
+    return HOUNDARR_URL
+
+
+@pytest.fixture(scope="session")
+def mock_sonarr_url() -> str:
+    return MOCK_SONARR_URL
+
+
+@pytest.fixture(scope="session")
+def mock_radarr_url() -> str:
+    return MOCK_RADARR_URL
+
+
+@pytest.fixture(autouse=True)
+def _fail_on_console_errors(page: Page) -> Generator[None, None, None]:
+    """Every browser test fails on console errors or uncaught JS exceptions.
+
+    Applied via ``autouse`` so individual tests do not need to wire up the
+    listener manually.  Filtered against ``_ALLOWED_ERROR_PATTERNS`` so
+    pre-existing third-party noise does not flake the suite.
+    """
+    collected: list[str] = []
+
+    def on_console(msg: ConsoleMessage) -> None:
+        if msg.type == "error":
+            collected.append(msg.text)
+
+    page.on("console", on_console)
+    page.on("pageerror", lambda err: collected.append(f"pageerror: {err.message}"))
+
+    yield
+
+    leftover = [e for e in collected if not any(p.search(e) for p in _ALLOWED_ERROR_PATTERNS)]
+    assert not leftover, f"Unexpected console / page errors: {leftover}"
+
+
+@pytest.fixture()
+def logged_in_page(page: Page) -> Page:
+    """A page with an authenticated session cookie."""
+    page.goto(f"{HOUNDARR_URL}/login")
+    page.get_by_role("textbox", name="Username").fill(ADMIN_USER)
+    page.get_by_role("textbox", name="Password").fill(ADMIN_PASS)
+    page.get_by_role("button", name="Sign In").click()
+    page.wait_for_url(re.compile(rf"^{re.escape(HOUNDARR_URL)}/?$"))
+    return page

--- a/tests/e2e_browser/conftest.py
+++ b/tests/e2e_browser/conftest.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Generator
+from dataclasses import dataclass, field
 
 import pytest
 from playwright.sync_api import ConsoleMessage, Page
@@ -53,15 +54,34 @@ def mock_radarr_url() -> str:
     return MOCK_RADARR_URL
 
 
+@dataclass
+class _ConsoleGuard:
+    """Per-test control over the console-error allow list.
+
+    Tests that intentionally trigger 4xx/5xx responses (HTMX logs the
+    status code to ``console.error`` when ``error: true`` in the config)
+    call ``allow(pattern)`` to whitelist the expected noise.  Everything
+    else still fails the teardown assertion.
+    """
+
+    extra_patterns: list[re.Pattern[str]] = field(default_factory=list)
+
+    def allow(self, pattern: str) -> None:
+        self.extra_patterns.append(re.compile(pattern))
+
+
 @pytest.fixture(autouse=True)
-def _fail_on_console_errors(page: Page) -> Generator[None, None, None]:
+def console_guard(page: Page) -> Generator[_ConsoleGuard, None, None]:
     """Every browser test fails on console errors or uncaught JS exceptions.
 
     Applied via ``autouse`` so individual tests do not need to wire up the
     listener manually.  Filtered against ``_ALLOWED_ERROR_PATTERNS`` so
-    pre-existing third-party noise does not flake the suite.
+    pre-existing third-party noise does not flake the suite.  Tests that
+    deliberately provoke error responses can request this fixture by
+    name and call ``console_guard.allow(<pattern>)`` to whitelist them.
     """
     collected: list[str] = []
+    guard = _ConsoleGuard()
 
     def on_console(msg: ConsoleMessage) -> None:
         if msg.type == "error":
@@ -70,9 +90,10 @@ def _fail_on_console_errors(page: Page) -> Generator[None, None, None]:
     page.on("console", on_console)
     page.on("pageerror", lambda err: collected.append(f"pageerror: {err.message}"))
 
-    yield
+    yield guard
 
-    leftover = [e for e in collected if not any(p.search(e) for p in _ALLOWED_ERROR_PATTERNS)]
+    allowed = _ALLOWED_ERROR_PATTERNS + guard.extra_patterns
+    leftover = [e for e in collected if not any(p.search(e) for p in allowed)]
     assert not leftover, f"Unexpected console / page errors: {leftover}"
 
 

--- a/tests/e2e_browser/conftest.py
+++ b/tests/e2e_browser/conftest.py
@@ -24,11 +24,16 @@ ADMIN_USER = os.environ.get("HOUNDARR_E2E_USER", "admin")
 ADMIN_PASS = os.environ.get("HOUNDARR_E2E_PASS", "CITestPass1!")
 
 # Console noise that predates this workflow and is unrelated to any
-# behaviour the suite verifies.  Firefox promotes the login template's
-# HTML5 ``pattern`` attribute regex to an error and aborts headless
-# Google Fonts fetches; both are accepted.
+# behaviour the suite verifies.  Every evergreen browser rejects the
+# login template's HTML5 ``pattern`` attribute for using a character
+# class that only validates under the ``v`` flag.  Chromium reports
+# ``Pattern attribute value ... is not a valid regular expression``;
+# Firefox reports ``Unable to check <input pattern=...> ... is not a
+# valid regexp``; WebKit wraps the same message differently.  The
+# shared substring is ``[-A-Za-z0-9_.]+`` with ``not a valid reg``.
+# Google Fonts fetches also abort in headless mode.
 _ALLOWED_ERROR_PATTERNS = [
-    re.compile(r"\[-A-Za-z0-9_\.\]\+ is not a valid regular expression"),
+    re.compile(r"\[-A-Za-z0-9_\.\]\+.*not a valid reg"),
     re.compile(r"downloadable font: download failed"),
 ]
 

--- a/tests/e2e_browser/mock_arr.py
+++ b/tests/e2e_browser/mock_arr.py
@@ -1,0 +1,130 @@
+"""Minimal *arr API mock for Houndarr's browser end-to-end tests.
+
+Serves the endpoints Houndarr actually calls: system status, queue
+status, wanted/missing, wanted/cutoff, command dispatch, and the
+library endpoints used by the upgrade pass.  One process per *arr flavor
+selected with ``--app Sonarr|Radarr``.
+
+Not a general-purpose mock; payload shapes only carry the fields
+Houndarr's clients parse.  Values are deterministic so the e2e suite
+can assert exact counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI
+
+_SONARR_MISSING_TOTAL = 10
+_RADARR_MISSING_TOTAL = 10
+
+
+def _radarr_movie(movie_id: int, *, has_file: bool = False) -> dict[str, Any]:
+    return {
+        "id": movie_id,
+        "title": f"Mock Movie {movie_id}",
+        "year": 2020 + (movie_id % 5),
+        "status": "released",
+        "minimumAvailability": "released",
+        "isAvailable": True,
+        "inCinemas": "2020-01-01T00:00:00Z",
+        "physicalRelease": "2020-06-01T00:00:00Z",
+        "digitalRelease": "2020-06-15T00:00:00Z",
+        "releaseDate": "2020-06-15T00:00:00Z",
+        "monitored": True,
+        "hasFile": has_file,
+        "movieFile": {"qualityCutoffNotMet": False} if has_file else None,
+    }
+
+
+def _sonarr_episode(episode_id: int) -> dict[str, Any]:
+    return {
+        "id": episode_id,
+        "seriesId": 1,
+        "title": f"Mock Episode {episode_id}",
+        "seasonNumber": 1,
+        "episodeNumber": episode_id,
+        "airDateUtc": "2020-01-01T00:00:00Z",
+        "monitored": True,
+        "series": {"id": 1, "title": "Mock Series", "monitored": True},
+    }
+
+
+def make_app(app_name: str, version: str = "4.0.0") -> FastAPI:
+    """Build a FastAPI app that answers the *arr endpoints Houndarr calls."""
+    app = FastAPI(title=f"Mock {app_name}", version=version)
+
+    @app.get("/api/v3/system/status")
+    async def status() -> dict[str, Any]:
+        return {
+            "appName": app_name,
+            "version": version,
+            "authentication": "none",
+            "instanceName": app_name,
+        }
+
+    @app.get("/api/v3/queue/status")
+    async def queue_status() -> dict[str, Any]:
+        return {
+            "totalCount": 0,
+            "count": 0,
+            "unknownCount": 0,
+            "errors": False,
+            "warnings": False,
+            "unknownErrors": False,
+            "unknownWarnings": False,
+        }
+
+    @app.get("/api/v3/wanted/missing")
+    async def wanted_missing(page: int = 1, pageSize: int = 10) -> dict[str, Any]:  # noqa: N803
+        if app_name == "Radarr":
+            records = [_radarr_movie(i) for i in range(1, _RADARR_MISSING_TOTAL + 1)]
+        else:
+            records = [_sonarr_episode(i) for i in range(1, _SONARR_MISSING_TOTAL + 1)]
+        start = (page - 1) * pageSize
+        return {
+            "page": page,
+            "pageSize": pageSize,
+            "totalRecords": len(records),
+            "records": records[start : start + pageSize],
+        }
+
+    @app.get("/api/v3/wanted/cutoff")
+    async def wanted_cutoff(page: int = 1, pageSize: int = 10) -> dict[str, Any]:  # noqa: N803
+        return {"page": page, "pageSize": pageSize, "totalRecords": 0, "records": []}
+
+    @app.post("/api/v3/command")
+    async def command(body: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {"id": 1, "name": "MockSearch", "status": "queued"}
+
+    @app.get("/api/v3/movie")
+    async def movie_library() -> list[dict[str, Any]]:
+        return [_radarr_movie(i, has_file=True) for i in range(100, 105)]
+
+    @app.get("/api/v3/series")
+    async def series_library() -> list[dict[str, Any]]:
+        return [{"id": 1, "title": "Mock Series", "monitored": True}]
+
+    @app.get("/api/v3/episode")
+    async def episodes(seriesId: int | None = None) -> list[dict[str, Any]]:  # noqa: N803
+        return []
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Mock *arr service for Houndarr e2e")
+    parser.add_argument("--app", required=True, choices=["Sonarr", "Radarr"])
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--host", default="0.0.0.0")  # noqa: S104
+    args = parser.parse_args()
+
+    app = make_app(args.app)
+    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e_browser/requirements.txt
+++ b/tests/e2e_browser/requirements.txt
@@ -1,0 +1,17 @@
+# Pinned dependencies for the browser end-to-end suite.
+#
+# Kept separate from requirements-dev.txt because these are only needed
+# on the GitHub Actions runner that executes the Browser E2E workflow,
+# not on contributor machines running the default pytest suite.
+#
+# Pins protect CI results from mid-PR upstream releases that silently
+# change matcher semantics, browser-binary versions, or CLI flags.
+
+pytest==9.0.3
+pytest-asyncio==1.3.0
+pytest-playwright==0.7.2
+pytest-rerunfailures==16.1
+playwright==1.58.0
+fastapi==0.136.0
+uvicorn[standard]==0.44.0
+httpx==0.28.1

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -9,7 +9,77 @@ from __future__ import annotations
 
 import re
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
+
+
+def _wait_for_connection_ui_idle(page: Page) -> None:
+    """Drain the 80 ms setTimeout scheduled by the field-change handler.
+
+    The settings JS reacts to ``input``/``change`` events on the
+    type/url/api_key fields by adding ``is-updating`` to
+    ``#instance-connection-status`` and scheduling a ~80 ms text reset.
+    Two places trigger it in this flow: ``locator.fill()`` (synchronous
+    input events) and the blur that happens when clicking Test Connection
+    (which fires ``change`` on the previously focused input).  When the
+    mock *arr runs on the same Docker network the HTMX round-trip is
+    faster than 80 ms, so the stale timer wipes out the success message
+    if we don't drain it on both sides of the click.
+    """
+    page.wait_for_function(
+        "() => !document.querySelector('#instance-connection-status')"
+        "?.classList.contains('is-updating')"
+    )
+
+
+def _wait_for_htmx_idle(page: Page) -> None:
+    """Wait until all HTMX request/swap/settle classes are gone.
+
+    Follows the maintainer-suggested pattern from bigskysoftware/htmx
+    discussion #2360 for reliable Playwright assertions after HTMX.
+    """
+    expect(
+        page.locator(".htmx-request, .htmx-settling, .htmx-swapping, .htmx-added")
+    ).to_have_count(0)
+
+
+def _test_connection_and_wait_for_success(page: Page, form: Locator, button: Locator) -> None:
+    """Trigger Test Connection and wait for the success signal.
+
+    Two races would otherwise make this flaky against a fast mock:
+
+    1. ``locator.fill()`` fires ``input`` events that schedule an 80 ms
+       ``setTimeout`` which resets ``#instance-connection-status``.
+       A real button click then fires a ``change`` event on the
+       previously focused input, scheduling another reset that races
+       with the HTMX response.  We dispatch the click synthetically so
+       no blur/change happens, and drain any residual timer afterwards.
+    2. The HTMX ``HX-Trigger`` + DOM swap + any pending reset timer must
+       all settle before we assert.  The submit button's enabled state
+       is the authoritative success signal: the JS handler for
+       ``houndarr-connection-test-success`` sets ``connection_verified``
+       and enables submit regardless of text-swap timing.
+    """
+    with page.expect_response(
+        lambda r: "/settings/instances/test-connection" in r.url and r.status == 200
+    ):
+        button.dispatch_event("click")
+    _wait_for_connection_ui_idle(page)
+    _wait_for_htmx_idle(page)
+    expect(form.locator("#instance-submit-btn")).to_be_enabled(timeout=10_000)
+
+
+def _submit_form(form: Locator) -> None:
+    """Submit the form via ``HTMLFormElement.requestSubmit``.
+
+    Clicking the submit button fires a blur/change event on the
+    previously focused field, which the settings JS interprets as
+    ``connection details changed`` and disables the submit button
+    before the native browser can forward the click to the form's
+    submit handler.  ``requestSubmit`` bypasses the click chain and
+    dispatches a real ``submit`` event that HTMX intercepts, without
+    the blur side effect.
+    """
+    form.evaluate("form => form.requestSubmit()")
 
 
 def test_login_redirects_to_dashboard(page: Page, houndarr_url: str) -> None:
@@ -63,16 +133,15 @@ def test_full_instance_lifecycle(
     add_form.locator('select[name="type"]').select_option("sonarr")
     add_form.locator('input[name="url"]').fill(mock_sonarr_url)
     add_form.locator('input[name="api_key"]').fill("e2e-sonarr-key")
+    _wait_for_connection_ui_idle(page)
 
     # Test Connection must succeed before Save is enabled.
-    add_form.locator("button[data-test-connection-btn]").click()
-    expect(page.locator("#instance-connection-status")).to_contain_text(
-        "Connected to Sonarr",
-        timeout=10_000,
+    _test_connection_and_wait_for_success(
+        page, add_form, add_form.locator("button[data-test-connection-btn]")
     )
 
     # Save.
-    add_form.locator("#instance-submit-btn").click()
+    _submit_form(add_form)
     expect(page.locator("#instance-tbody")).to_contain_text("E2E Sonarr", timeout=10_000)
 
     # Re-open to verify the default persisted as Random.
@@ -84,12 +153,11 @@ def test_full_instance_lifecycle(
     # Flip to Chronological.  The edit form always starts with
     # connection_verified=false, so re-run the connection test first.
     edit_form.locator('select[name="search_order"]').select_option("chronological")
-    edit_form.locator("button[data-test-connection-btn]").click()
-    expect(page.locator("#instance-connection-status")).to_contain_text(
-        "Connected to Sonarr",
-        timeout=10_000,
+    _wait_for_connection_ui_idle(page)
+    _test_connection_and_wait_for_success(
+        page, edit_form, edit_form.locator("button[data-test-connection-btn]")
     )
-    edit_form.locator("#instance-submit-btn").click()
+    _submit_form(edit_form)
     expect(edit_form).to_be_hidden(timeout=10_000)
 
     # Re-open and verify persistence.

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -152,3 +152,129 @@ def test_full_instance_lifecycle(
     reopened = page.locator('form[data-form-mode="edit"]')
     expect(reopened).to_be_visible()
     expect(reopened.locator('select[name="search_order"]')).to_have_value("chronological")
+
+
+# ---------------------------------------------------------------------------
+# 4xx error surface regression guards
+#
+# HTMX 2.x defaults ``responseHandling`` to ``swap: false`` for 4xx/5xx.
+# Houndarr's routes return 422 with ``HX-Retarget`` / ``HX-Reswap`` /
+# ``HX-Trigger`` headers and a rendered error body; those headers are
+# no-ops unless the client config says 4xx should swap.  ``base.html``
+# overrides ``htmx.config.responseHandling`` via a meta tag so the
+# server-emitted retargets actually land.  Each test below triggers a
+# different 4xx surface and asserts the error body is visible, so a
+# future meta-tag edit can't silently regress the whole app to silent
+# failure again.
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_422_CONSOLE_NOISE = [
+    r"Failed to load resource: the server responded with a status of 422",
+    r"Response Status Error Code 422",
+]
+
+
+def test_save_instance_4xx_renders_error(
+    logged_in_page: Page,
+    houndarr_url: str,
+    mock_sonarr_url: str,
+    console_guard,
+) -> None:
+    """Saving the add form without a verified connection should render the
+    server-provided error text in ``#instance-connection-status``."""
+    for p in _EXPECTED_422_CONSOLE_NOISE:
+        console_guard.allow(p)
+    page = logged_in_page
+    page.goto(f"{houndarr_url}/settings")
+    page.get_by_role("button", name=re.compile(r"add\s*instance", re.I)).first.click()
+    add_form = page.locator('form[data-form-mode="add"]')
+    expect(add_form).to_be_visible()
+
+    add_form.locator('input[name="name"]').fill(f"E2E Guard {uuid.uuid4().hex[:8]}")
+    add_form.locator('select[name="type"]').select_option("sonarr")
+    add_form.locator('input[name="url"]').fill(mock_sonarr_url)
+    add_form.locator('input[name="api_key"]').fill("guard-key")
+    _wait_for_connection_ui_idle(page)
+
+    # requestSubmit with ``connection_verified=false`` in the hidden input
+    # triggers the 422 guard path at routes/settings.py:594.
+    with page.expect_response(
+        lambda r: r.url.endswith("/settings/instances") and r.request.method == "POST"
+    ) as resp_info:
+        _submit_form(add_form)
+    assert resp_info.value.status == 422, resp_info.value.status
+    _wait_for_htmx_idle(page)
+
+    expect(page.locator("#instance-connection-status")).to_contain_text(
+        "Test connection successfully before adding.",
+        timeout=5_000,
+    )
+
+
+def test_test_connection_4xx_renders_error(
+    logged_in_page: Page, houndarr_url: str, console_guard
+) -> None:
+    """Test Connection against an SSRF-blocked URL (loopback) should render
+    the server-provided error text in ``#instance-connection-status``."""
+    for p in _EXPECTED_422_CONSOLE_NOISE:
+        console_guard.allow(p)
+    page = logged_in_page
+    page.goto(f"{houndarr_url}/settings")
+    page.get_by_role("button", name=re.compile(r"add\s*instance", re.I)).first.click()
+    add_form = page.locator('form[data-form-mode="add"]')
+    expect(add_form).to_be_visible()
+
+    add_form.locator('input[name="name"]').fill(f"E2E SSRF {uuid.uuid4().hex[:8]}")
+    add_form.locator('select[name="type"]').select_option("sonarr")
+    add_form.locator('input[name="url"]').fill("http://127.0.0.1")
+    add_form.locator('input[name="api_key"]').fill("guard-key")
+    _wait_for_connection_ui_idle(page)
+
+    with page.expect_response(
+        lambda r: "/settings/instances/test-connection" in r.url
+    ) as resp_info:
+        add_form.locator("button[data-test-connection-btn]").dispatch_event("click")
+    assert resp_info.value.status == 422, resp_info.value.status
+    _wait_for_connection_ui_idle(page)
+    _wait_for_htmx_idle(page)
+
+    expect(page.locator("#instance-connection-status")).to_contain_text(
+        "blocked address range",
+        timeout=5_000,
+    )
+
+
+def test_password_change_4xx_renders_error(
+    logged_in_page: Page, houndarr_url: str, console_guard
+) -> None:
+    """Submitting the password form with the wrong current password should
+    render the account-section error in-place."""
+    for p in _EXPECTED_422_CONSOLE_NOISE:
+        console_guard.allow(p)
+    page = logged_in_page
+    page.goto(f"{houndarr_url}/settings")
+    section = page.locator("#account-section")
+    expect(section).to_be_visible()
+
+    # The password form lives inside a collapsed <details>; expand it
+    # via the .open property rather than a click-on-summary so we do
+    # not depend on the summary's exact accessible name.
+    section.locator("#account-settings").evaluate("el => { el.open = true; }")
+
+    pw_form = section.locator('form[hx-post="/settings/account/password"]')
+    pw_form.locator('input[name="current_password"]').fill("WrongOldPass1!")
+    pw_form.locator('input[name="new_password"]').fill("NewValidPass1!")
+    pw_form.locator('input[name="new_password_confirm"]').fill("NewValidPass1!")
+
+    with page.expect_response(
+        lambda r: "/settings/account/password" in r.url and r.request.method == "POST"
+    ) as resp_info:
+        pw_form.evaluate("f => f.requestSubmit()")
+    assert resp_info.value.status == 422, resp_info.value.status
+    _wait_for_htmx_idle(page)
+
+    expect(page.locator("#account-section")).to_contain_text(
+        "Current password is incorrect.",
+        timeout=5_000,
+    )

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -1,0 +1,99 @@
+"""Browser end-to-end flows driven by pytest-playwright.
+
+Parametrised by the ``--browser`` flag; the workflow runs chromium,
+firefox, and webkit as separate matrix jobs.  Console errors and page
+errors are caught by an autouse fixture in ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Page, expect
+
+
+def test_login_redirects_to_dashboard(page: Page, houndarr_url: str) -> None:
+    page.goto(houndarr_url)
+    expect(page).to_have_url(re.compile(r"/login$"))
+
+    page.get_by_role("textbox", name="Username").fill("admin")
+    page.get_by_role("textbox", name="Password").fill("CITestPass1!")
+    page.get_by_role("button", name="Sign In").click()
+
+    expect(page).to_have_title("Dashboard | Houndarr")
+
+
+def test_settings_page_renders(logged_in_page: Page, houndarr_url: str) -> None:
+    logged_in_page.goto(f"{houndarr_url}/settings")
+    expect(logged_in_page).to_have_title("Settings | Houndarr")
+
+
+def test_add_form_preselects_random(logged_in_page: Page, houndarr_url: str) -> None:
+    """The blank add-instance form renders Random as the selected option.
+
+    Regression guard for the pass-1 HIGH finding on the random-search PR.
+    Checked via the API route so it catches both the rendered HTML and
+    the ``_blank_instance()`` factory state.
+    """
+    resp = logged_in_page.request.get(f"{houndarr_url}/settings/instances/add-form")
+    assert resp.ok, resp.status
+    body = resp.text()
+    assert re.search(r'<option\s+value="random"[^>]*\sselected', body), body
+    assert not re.search(r'<option\s+value="chronological"[^>]*\sselected', body)
+
+
+def test_full_instance_lifecycle(
+    logged_in_page: Page, houndarr_url: str, mock_sonarr_url: str
+) -> None:
+    """Add an instance against the mock *arr, then flip search_order and verify persistence.
+
+    Combines add and edit into one linear user story so the test does
+    not depend on any sibling test's state.
+    """
+    page = logged_in_page
+    page.goto(f"{houndarr_url}/settings")
+
+    # Open the add modal.
+    page.get_by_role("button", name=re.compile(r"add\s*instance", re.I)).first.click()
+    add_form = page.locator('form[data-form-mode="add"]')
+    expect(add_form).to_be_visible()
+
+    # Fill in the form against the mock Sonarr.
+    add_form.locator('input[name="name"]').fill("E2E Sonarr")
+    add_form.locator('select[name="type"]').select_option("sonarr")
+    add_form.locator('input[name="url"]').fill(mock_sonarr_url)
+    add_form.locator('input[name="api_key"]').fill("e2e-sonarr-key")
+
+    # Test Connection must succeed before Save is enabled.
+    add_form.locator("button[data-test-connection-btn]").click()
+    expect(page.locator("#instance-connection-status")).to_contain_text(
+        "Connected to Sonarr",
+        timeout=10_000,
+    )
+
+    # Save.
+    add_form.locator("#instance-submit-btn").click()
+    expect(page.locator("#instance-tbody")).to_contain_text("E2E Sonarr", timeout=10_000)
+
+    # Re-open to verify the default persisted as Random.
+    page.locator('#instance-tbody button[hx-get^="/settings/instances/"]').first.click()
+    edit_form = page.locator('form[data-form-mode="edit"]')
+    expect(edit_form).to_be_visible()
+    expect(edit_form.locator('select[name="search_order"]')).to_have_value("random")
+
+    # Flip to Chronological.  The edit form always starts with
+    # connection_verified=false, so re-run the connection test first.
+    edit_form.locator('select[name="search_order"]').select_option("chronological")
+    edit_form.locator("button[data-test-connection-btn]").click()
+    expect(page.locator("#instance-connection-status")).to_contain_text(
+        "Connected to Sonarr",
+        timeout=10_000,
+    )
+    edit_form.locator("#instance-submit-btn").click()
+    expect(edit_form).to_be_hidden(timeout=10_000)
+
+    # Re-open and verify persistence.
+    page.locator('#instance-tbody button[hx-get^="/settings/instances/"]').first.click()
+    reopened = page.locator('form[data-form-mode="edit"]')
+    expect(reopened).to_be_visible()
+    expect(reopened.locator('select[name="search_order"]')).to_have_value("chronological")

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -90,36 +90,6 @@ def _submit_form(form: Locator) -> None:
     form.evaluate("form => form.requestSubmit()")
 
 
-def test_login_redirects_to_dashboard(page: Page, houndarr_url: str) -> None:
-    page.goto(houndarr_url)
-    expect(page).to_have_url(re.compile(r"/login$"))
-
-    page.get_by_role("textbox", name="Username").fill("admin")
-    page.get_by_role("textbox", name="Password").fill("CITestPass1!")
-    page.get_by_role("button", name="Sign In").click()
-
-    expect(page).to_have_title("Dashboard | Houndarr")
-
-
-def test_settings_page_renders(logged_in_page: Page, houndarr_url: str) -> None:
-    logged_in_page.goto(f"{houndarr_url}/settings")
-    expect(logged_in_page).to_have_title("Settings | Houndarr")
-
-
-def test_add_form_preselects_random(logged_in_page: Page, houndarr_url: str) -> None:
-    """The blank add-instance form renders Random as the selected option.
-
-    Regression guard for the pass-1 HIGH finding on the random-search PR.
-    Checked via the API route so it catches both the rendered HTML and
-    the ``_blank_instance()`` factory state.
-    """
-    resp = logged_in_page.request.get(f"{houndarr_url}/settings/instances/add-form")
-    assert resp.ok, resp.status
-    body = resp.text()
-    assert re.search(r'<option\s+value="random"[^>]*\sselected', body), body
-    assert not re.search(r'<option\s+value="chronological"[^>]*\sselected', body)
-
-
 def test_full_instance_lifecycle(
     logged_in_page: Page, houndarr_url: str, mock_sonarr_url: str
 ) -> None:

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -278,3 +278,6 @@ def test_password_change_4xx_renders_error(
         "Current password is incorrect.",
         timeout=5_000,
     )
+    # Focus is restored to the first password input so keyboard users do
+    # not land on document.body after the submit button is replaced.
+    expect(page.locator("#current-password")).to_be_focused(timeout=5_000)

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -8,6 +8,7 @@ errors are caught by an autouse fixture in ``conftest.py``.
 from __future__ import annotations
 
 import re
+import uuid
 
 from playwright.sync_api import Locator, Page, expect
 
@@ -58,11 +59,18 @@ def _test_connection_and_wait_for_success(page: Page, form: Locator, button: Loc
        is the authoritative success signal: the JS handler for
        ``houndarr-connection-test-success`` sets ``connection_verified``
        and enables submit regardless of text-swap timing.
+
+    The response filter matches any status for the test-connection URL.
+    Filtering on ``status == 200`` would hang for the full Playwright
+    timeout on a 422 (connection failure) and surface as an opaque
+    wait-timeout instead of a legible status code.
     """
     with page.expect_response(
-        lambda r: "/settings/instances/test-connection" in r.url and r.status == 200
-    ):
+        lambda r: "/settings/instances/test-connection" in r.url
+    ) as resp_info:
         button.dispatch_event("click")
+    resp = resp_info.value
+    assert resp.status == 200, f"test-connection returned {resp.status}: {resp.text()}"
     _wait_for_connection_ui_idle(page)
     _wait_for_htmx_idle(page)
     expect(form.locator("#instance-submit-btn")).to_be_enabled(timeout=10_000)
@@ -119,8 +127,15 @@ def test_full_instance_lifecycle(
 
     Combines add and edit into one linear user story so the test does
     not depend on any sibling test's state.
+
+    The instance name is randomised per invocation so that a
+    ``pytest-rerunfailures`` retry (the CI job runs ``--reruns 2``) does
+    not collide with the row the previous attempt left behind.  The
+    edit-flow row lookup then targets the row by this unique name
+    instead of ``.first``, so retries remain idempotent.
     """
     page = logged_in_page
+    instance_name = f"E2E Sonarr {uuid.uuid4().hex[:8]}"
     page.goto(f"{houndarr_url}/settings")
 
     # Open the add modal.
@@ -129,7 +144,7 @@ def test_full_instance_lifecycle(
     expect(add_form).to_be_visible()
 
     # Fill in the form against the mock Sonarr.
-    add_form.locator('input[name="name"]').fill("E2E Sonarr")
+    add_form.locator('input[name="name"]').fill(instance_name)
     add_form.locator('select[name="type"]').select_option("sonarr")
     add_form.locator('input[name="url"]').fill(mock_sonarr_url)
     add_form.locator('input[name="api_key"]').fill("e2e-sonarr-key")
@@ -142,10 +157,12 @@ def test_full_instance_lifecycle(
 
     # Save.
     _submit_form(add_form)
-    expect(page.locator("#instance-tbody")).to_contain_text("E2E Sonarr", timeout=10_000)
+    expect(page.locator("#instance-tbody")).to_contain_text(instance_name, timeout=10_000)
 
-    # Re-open to verify the default persisted as Random.
-    page.locator('#instance-tbody button[hx-get^="/settings/instances/"]').first.click()
+    # Re-open to verify the default persisted as Random.  Scope the
+    # row lookup by the unique name so retries cannot open the wrong row.
+    row = page.locator("#instance-tbody tr").filter(has_text=instance_name)
+    row.locator('button[hx-get^="/settings/instances/"]').click()
     edit_form = page.locator('form[data-form-mode="edit"]')
     expect(edit_form).to_be_visible()
     expect(edit_form.locator('select[name="search_order"]')).to_have_value("random")
@@ -160,8 +177,8 @@ def test_full_instance_lifecycle(
     _submit_form(edit_form)
     expect(edit_form).to_be_hidden(timeout=10_000)
 
-    # Re-open and verify persistence.
-    page.locator('#instance-tbody button[hx-get^="/settings/instances/"]').first.click()
+    # Re-open the same row and verify persistence.
+    row.locator('button[hx-get^="/settings/instances/"]').click()
     reopened = page.locator('form[data-form-mode="edit"]')
     expect(reopened).to_be_visible()
     expect(reopened.locator('select[name="search_order"]')).to_have_value("chronological")

--- a/tests/test_routes/test_logs.py
+++ b/tests/test_routes/test_logs.py
@@ -864,6 +864,38 @@ async def test_logs_limit_above_max_rejected(seeded_log: None, async_client: obj
     assert resp.status_code == 422
 
 
+@pytest.mark.asyncio()
+async def test_logs_partial_returns_html_422_on_bad_filter(
+    seeded_log: None, async_client: object
+) -> None:
+    """``/api/logs/partial`` must return an HTML ``<tr>`` error row on
+    validation failure, not FastAPI's default JSON body.
+
+    Rationale: the partial is swapped into ``#log-tbody`` via HTMX.
+    With the ``422 -> swap`` config override in ``base.html``, a JSON
+    response would render as raw ``{"detail": ...}`` inside the
+    ``<tbody>``.  The endpoint shapes the error as a ``<tr>`` instead.
+    """
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    resp = await async_client.get("/api/logs/partial?search_kind=totally_invalid")
+    assert resp.status_code == 422
+    assert resp.headers["content-type"].startswith("text/html"), resp.headers
+    body = resp.text
+    assert "<tr" in body and 'colspan="10"' in body, body
+    assert "Invalid filter value" in body, body
+    # The specific detail string is surfaced so operators can see what failed.
+    assert "search_kind" in body, body
+
+
 def test_logs_page_renders_all_limit_options(app: TestClient) -> None:
     """The /logs page must include the 1000 and All (5000) options in the Rows selector."""
     _login(app)

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -221,6 +221,36 @@ def test_create_instance_missing_name_returns_422(app: TestClient) -> None:
     assert resp.status_code == 422
 
 
+def test_htmx_validation_error_returns_empty_html_with_reswap_none(app: TestClient) -> None:
+    """FastAPI's default 422 body is JSON; with the base-template config
+    opting 422 into HTMX swaps, that JSON would render as raw text in a
+    UI slot.  The app-level ``RequestValidationError`` handler returns
+    an empty HTML body with ``HX-Reswap: none`` for HTMX requests so
+    the swap is suppressed and no JSON leaks into the DOM.
+    """
+    _login(app)
+    form = {**_VALID_FORM}
+    form.pop("name")  # trigger FastAPI's automatic 422 on missing Form()
+    headers = {**csrf_headers(app), "HX-Request": "true"}
+    resp = app.post("/settings/instances", data=form, headers=headers)
+    assert resp.status_code == 422
+    assert resp.headers.get("content-type", "").startswith("text/html"), resp.headers
+    assert resp.headers.get("hx-reswap") == "none", resp.headers
+    assert resp.content == b""
+
+
+def test_non_htmx_validation_error_still_returns_json(app: TestClient) -> None:
+    """Non-HTMX API consumers must keep getting FastAPI's JSON 422."""
+    _login(app)
+    form = {**_VALID_FORM}
+    form.pop("name")
+    resp = app.post("/settings/instances", data=form, headers=csrf_headers(app))
+    assert resp.status_code == 422
+    assert resp.headers.get("content-type", "").startswith("application/json"), resp.headers
+    payload = resp.json()
+    assert "detail" in payload
+
+
 def test_create_instance_missing_api_key_returns_422(app: TestClient) -> None:
     _login(app)
     form = {k: v for k, v in _VALID_FORM.items() if k != "api_key"}


### PR DESCRIPTION
## Summary

Adds a Playwright-driven browser end-to-end suite that runs against a live Houndarr container plus sibling mock Sonarr and Radarr services on a dedicated Docker network. Matrix covers chromium, firefox, and webkit so UI regressions in any engine surface in CI. Current ``Tests`` and ``Security smoke test`` jobs are unchanged.

Closes #396

## Changes

- New ``tests/e2e_browser/`` package: mock *arr FastAPI service, pytest-playwright fixtures (session URLs, logged-in page, autouse console-error collector), and a ``test_flows.py`` covering login, settings render, add-form Random pre-selection, and a full add-instance + edit-search-order lifecycle against the mock Sonarr.
- New workflow ``browser-e2e.yml``: builds the Houndarr image, spins up mock-sonarr / mock-radarr / houndarr-e2e on a fresh Docker network, creates a test admin account, runs ``pytest tests/e2e_browser/ --browser <matrix>`` with tracing/video/screenshot retained on failure and uploaded as artifacts.
- ``pyproject.toml``: excludes ``e2e_browser`` from the default pytest run via ``norecursedirs`` so the existing Test job is untouched.
- Mock *arr answers only the endpoints Houndarr actually calls (system status, queue status, wanted/missing, wanted/cutoff, command, library endpoints used by the upgrade pass). No real indexer traffic; no secrets in CI.

## Testing

All checks pass locally. Default ``pytest`` collects 1131 tests and skips ``tests/e2e_browser/`` through ``norecursedirs``. ``pytest tests/e2e_browser/ --collect-only`` reports 4 tests per browser.

Followed the official Playwright best-practices guide for pytest-playwright: web-first ``expect(...)`` assertions everywhere (no ``wait_for_timeout`` / ``wait_for_selector``), ``locator.input_value()`` and ``to_have_value()`` for form state, autouse fixture for the console / pageerror listener.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way


---

## Also landed in this PR

Setting up the e2e suite surfaced a class of HTMX silent failures. HTMX 2.x ignores 4xx responses by default, so every `HX-Retarget` / `HX-Reswap` header the server emitted on validation errors (Save instance, Test Connection, password change) was a no-op. The error HTML never reached the DOM.

Fixes that shipped with the workflow:

- `base.html` now carries a `<meta name="htmx-config">` that opts 422 into the swap so existing server headers take effect. Scoped to 422, so 404 `Not found` bodies and Starlette 5xx pages still get ignored.
- `/api/logs/partial` returns an HTML `<tr>` error row instead of `HTTPException` JSON, so the log tbody can't render `{"detail": ...}` as text.
- App-level `RequestValidationError` handler returns `HX-Reswap: none` for HTMX clients and preserves JSON for everyone else, so framework auto-422 (a non-int posted to an int field, for example) cannot leak into a UI slot.
- Password-form swap restores focus to `#current-password` instead of dropping it on `document.body`.

Housekeeping alongside: dropped the Playwright binary cache per upstream CI guidance, pruned three redundant smoke tests that duplicated unit coverage, and added four browser regression guards (one per 4xx surface plus the focus assertion).
