### PR TITLE
docs: site followups (review fixes, link check, typecheck)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,46 @@
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "**/*.mdx"
+      - "lychee.toml"
+      - ".github/workflows/link-check.yml"
+  schedule:
+    # Weekly sweep in case external sites move after a merge.
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lychee:
+    name: Check external links
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Link check
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config lychee.toml
+            './**/*.md'
+            './**/*.mdx'
+          fail: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
+          key: cache-lychee-${{ hashFiles('**/*.md', '**/*.mdx', 'lychee.toml') }}
           restore-keys: cache-lychee-
 
       - name: Link check
@@ -41,6 +41,3 @@ jobs:
           args: >-
             --config lychee.toml
             './**/*.md'
-            './**/*.mdx'
-          fail: true
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ uv.lock
 
 # Git worktrees (local development only)
 .worktrees/
+
+# Lychee link-check cache
+.lycheecache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ identical check names so branch protection is satisfied.
 | `api-snapshot-refresh.yml` | Weekly (Monday 10:00 UTC) + manual | Fetches upstream Radarr/Sonarr/Whisparr/Lidarr/Readarr OpenAPI specs, updates `docs/api/` snapshots and `tests/test_docs_api.py` hashes, opens a PR if changed |
 | `pages.yml` | Pushes to `main` touching `website/**` | Deploys docs site to GitHub Pages |
 | `test-deploy.yml` | PRs touching `website/**` | Tests Docusaurus build without deploying |
+| `link-check.yml` | PRs touching `**/*.md`, `**/*.mdx`, `lychee.toml` + weekly (Monday 08:00 UTC) + manual | Runs `lychee` against every Markdown file to catch broken external links; rules live in `lychee.toml` |
 | `cleanup-actions-cache.yml` | Daily (05:00 UTC) + manual | Prunes stale GitHub Actions caches |
 
 ### Branch protection on `main`

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Small batches. Polite intervals. Zero indexer abuse.
 
 [Documentation](https://av1155.github.io/houndarr/)
 &ensp;&bull;&ensp;
-[Quick Start](https://av1155.github.io/houndarr/docs/getting-started/quick-start)
+[Quick Start](https://av1155.github.io/houndarr/docs/guides/installation/docker-compose)
 &ensp;&bull;&ensp;
 [Docker](https://github.com/av1155/houndarr/pkgs/container/houndarr)
 &ensp;&bull;&ensp;
-[Helm Chart](https://av1155.github.io/houndarr/docs/getting-started/helm)
+[Helm Chart](https://av1155.github.io/houndarr/docs/guides/installation/helm)
 &ensp;&bull;&ensp;
 [Report Bug](https://github.com/av1155/houndarr/issues/new/choose)
 
@@ -124,7 +124,7 @@ Replace `/path/to/data` with an absolute path on your host where Houndarr should
 
 </details>
 
-For environment variables, reverse proxy setup, Kubernetes, Helm, and building from source, see the [full documentation](https://av1155.github.io/houndarr/docs/getting-started/installation).
+For environment variables, reverse proxy setup, Kubernetes, Helm, and building from source, see the [full documentation](https://av1155.github.io/houndarr/docs/guides/installation/docker).
 
 <details>
 <summary><strong>What Houndarr Does NOT Do</strong></summary>
@@ -147,7 +147,7 @@ For environment variables, reverse proxy setup, Kubernetes, Helm, and building f
 - The container runs as a non-root user after PUID/PGID remapping.
 - 63 integration tests validate immunity to every finding from the Huntarr.io security review; a live smoke test runs in CI on every PR.
 
-For details on how Houndarr handles credentials, network behavior, and trust boundaries, see [Trust and Security](https://av1155.github.io/houndarr/docs/security/trust-and-security). To report a vulnerability, see [SECURITY.md](SECURITY.md).
+For details on how Houndarr handles credentials, network behavior, and trust boundaries, see [Security Overview](https://av1155.github.io/houndarr/docs/security/overview). To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## Contributing and Community
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Security fixes target the latest release on `main` and the most recent
 published container image tag.
 
 For details on how Houndarr handles credentials, encryption, and network
-behavior, see [Trust & Security](https://av1155.github.io/houndarr/docs/security/trust-and-security).
+behavior, see [Security Overview](https://av1155.github.io/houndarr/docs/security/overview).
 
 ## Reporting a vulnerability
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,39 @@
+# Lychee link-checker configuration.
+# https://lychee.cli.rs/configuration/
+
+max_retries = 2
+retry_wait_time = 2
+timeout = 20
+no_progress = true
+
+# 2xx is fine; 403 and 429 usually mean the host rate-limited an
+# unauthenticated HEAD, not a broken link.
+accept = ["200..=299", "403", "429"]
+
+cache = true
+max_cache_age = "1d"
+
+# Sentinel base under the reserved `.invalid` TLD (RFC 6761).
+# Root-relative links (Docusaurus internal routes like `/docs/...`
+# and static assets like `/img/...`) resolve against this host so
+# URL construction succeeds, and the host is then excluded below.
+# Internal routes are validated by `onBrokenLinks: 'throw'` at build.
+base_url = "https://houndarr-internal.invalid"
+
+exclude_path = [
+  "node_modules",
+  "website/.docusaurus",
+  ".venv",
+]
+
+# Placeholder hosts shown in configuration examples, local-dev URLs,
+# and the sentinel base above.
+exclude = [
+  "^https?://houndarr-internal\\.invalid(/|$)",
+  "^https?://(localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0)",
+  "^https?://(mock-)?(sonarr|radarr|lidarr|readarr|whisparr|houndarr)([:./]|$)",
+  "^https?://host\\.(docker|containers)\\.internal",
+  "^https?://authentik-proxy([:./]|$)",
+  "^https?://[^/]*\\.example\\.com",
+  "^https?://your-host",
+]

--- a/src/houndarr/templates/partials/pages/settings_help_content.html
+++ b/src/houndarr/templates/partials/pages/settings_help_content.html
@@ -330,7 +330,7 @@
   <p class="help-reveal text-xs text-slate-500 pt-1">
     Full documentation:
     <a
-      href="https://av1155.github.io/houndarr/docs/configuration/instance-settings"
+      href="https://av1155.github.io/houndarr/docs/reference/instance-settings"
       class="text-brand-400 hover:text-brand-300 underline underline-offset-2"
       target="_blank"
       rel="noopener noreferrer"

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -142,7 +142,7 @@ def test_settings_help_page_renders(app: TestClient) -> None:
     resp = app.get("/settings/help")
     assert resp.status_code == 200
     assert b"Instance Settings Help" in resp.content
-    assert b"https://av1155.github.io/houndarr/docs/configuration/instance-settings" in resp.content
+    assert b"https://av1155.github.io/houndarr/docs/reference/instance-settings" in resp.content
 
 
 def test_settings_page_hx_request_returns_content_fragment(app: TestClient) -> None:

--- a/website/docs/concepts/how-scheduling-works.md
+++ b/website/docs/concepts/how-scheduling-works.md
@@ -30,7 +30,7 @@ flowchart TD
     C --> E
 ```
 
-Your *arr instances do all the actual searching. Houndarr controls the pacing.
+Each cycle asks the *arr instance for missing, cutoff-unmet, or upgrade-eligible items, reads back the wanted list of monitored items, applies scheduling rules (cooldown, hourly cap, post-release grace, batch size), sends a search command for each eligible item, and logs the rest as skipped for retry next cycle. Your *arr instances do all the actual searching. Houndarr controls the pacing.
 
 ## Monitored vs. wanted
 
@@ -58,7 +58,7 @@ If you want to build, test, and deploy quality profiles and custom formats acros
 
 ## Why only a few items get searched each cycle
 
-Think of it as a funnel:
+Think of it as a funnel: your monitored library narrows to the wanted list (the *arr filter keeps only missing, cutoff-unmet, or upgrade-eligible items), then narrows again to what's eligible this cycle (the Houndarr filter applies cooldown, post-release grace, and hourly cap), and finally to what's actually searched (capped by batch size, often just 1 to 3 items).
 
 ```mermaid
 flowchart TD

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -21,6 +21,7 @@ const config: Config = {
   trailingSlash: false,
 
   onBrokenLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   markdown: {
     mermaid: true,

--- a/website/package.json
+++ b/website/package.json
@@ -33,6 +33,8 @@
     "@docusaurus/module-type-aliases": "3.10.0",
     "@docusaurus/tsconfig": "3.10.0",
     "@docusaurus/types": "3.10.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "typescript": "~6.0.2"
   },
   "browserslist": {

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -60,6 +60,12 @@ importers:
       '@docusaurus/types':
         specifier: 3.10.0
         version: 3.10.0(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
@@ -2230,6 +2236,11 @@ packages:
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
 
   '@types/react-router-config@5.0.11':
     resolution: {integrity: sha512-WmSAg7WgqW7m4x8Mt4N6ZyKz0BubSj/2tVUMsAHp+Yd2AMwcSbeFq9WympT19p5heCFmF97R9eD5uUR/t4HEqw==}
@@ -9407,6 +9418,10 @@ snapshots:
   '@types/qs@6.15.0': {}
 
   '@types/range-parser@1.2.7': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
 
   '@types/react-router-config@5.0.11':
     dependencies:

--- a/website/src/docusaurus-plugin.d.ts
+++ b/website/src/docusaurus-plugin.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@docusaurus/plugin-ideal-image" />

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import type {ComponentProps, ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -11,7 +11,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 type ScreenshotItem = {
-  img: string;
+  img: ComponentProps<typeof Image>['img'];
   alt: string;
   caption: string;
 };

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -2,7 +2,8 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0"
   },
   "exclude": [".docusaurus", "build"]
 }


### PR DESCRIPTION
## Summary

Bundle of docs-site followups after #399 and #401 landed: review findings, a new link-check workflow, and a fix for the broken `pnpm typecheck` pipeline.

Closes #402

## Changes

**Review findings (from the adversarial pass on #399 and #401):**
- Mermaid SEO regression closed: added prose summaries adjacent to both diagrams in `how-scheduling-works.md`. Key vocabulary now lands in SSR HTML and `search-index.json`; no-JS visitors see content where the diagrams sit.
- Stale pre-Diataxis URLs updated in `README.md` (×4), `SECURITY.md`, `settings_help_content.html`, and the coupled test assertion in `test_settings.py`. External bookmarks and search results now hit the new paths directly.
- `ScreenshotItem.img` typed with the real IdealImage loader input type instead of `string` (drift, not a runtime error).
- TS 6.0 `baseUrl` deprecation silenced in `website/tsconfig.json`.

**Link-check pipeline (new):**
- `onBrokenAnchors: 'throw'` alongside the existing `onBrokenLinks` / `onBrokenMarkdownLinks` throws; no existing anchors break.
- `lychee.toml` + `.github/workflows/link-check.yml` sweep every Markdown file on PRs that touch `.md` / `.mdx` / the config, plus weekly on Monday 08:00 UTC and on manual dispatch. A `.invalid` sentinel base lets root-relative Docusaurus routes parse cleanly and get excluded, so the check only flags real external failures.
- `.lycheecache` added to `.gitignore`.
- `AGENTS.md` lists the new workflow in the non-required table.

**pnpm typecheck restoration:**
- `@types/react` and `@types/react-dom` added as explicit devDeps so tsc can find them at the project root (pnpm strict hoist was hiding them).
- One-line triple-slash reference in `website/src/docusaurus-plugin.d.ts` pulls in the `declare module '@theme/IdealImage'` augmentation that `@docusaurus/module-type-aliases` doesn't cover.
- `pnpm typecheck` now exits clean; an injected type-error probe fails tsc as expected.

## Testing

All local gates pass:
- `pnpm typecheck`, `pnpm build`: clean
- `lychee --config lychee.toml './**/*.md'`: 60 OK, 0 errors, 66 excluded, 9 redirects
- `actionlint`: clean
- `ruff check`, `ruff format --check`, `mypy src/`, `bandit -r src/`: all pass
- `pytest`: 1134 passed

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: keeps the docs pipeline honest so users find accurate search guidance