### PR TITLE
feat: reset-to-defaults button in instance modal

### DIFF
--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -448,8 +448,13 @@ async def account_password_update(
 @router.get("/settings/instances/add-form", response_class=HTMLResponse)
 async def instance_add_form(request: Request) -> HTMLResponse:
     """Return the blank add-instance form partial for HTMX modal injection."""
+    blank = _blank_instance()
     return _render(
-        request, "partials/instance_form.html", instance=_blank_instance(), editing=False
+        request,
+        "partials/instance_form.html",
+        instance=blank,
+        defaults=blank,
+        editing=False,
     )
 
 
@@ -678,7 +683,13 @@ async def instance_edit_get(request: Request, instance_id: int) -> HTMLResponse:
     instance = await get_instance(instance_id, master_key=_master_key(request))
     if instance is None:
         return HTMLResponse(content="Not found", status_code=404)
-    return _render(request, "partials/instance_form.html", instance=instance, editing=True)
+    return _render(
+        request,
+        "partials/instance_form.html",
+        instance=instance,
+        defaults=_blank_instance(),
+        editing=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -113,30 +113,35 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-batch">Batch Size</label>
           <input id="{{ form_id }}-batch" name="batch_size" type="number" min="1" max="250"
                  value="{{ instance.batch_size }}"
+                 data-default-value="{{ defaults.batch_size }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-sleep">Sleep (minutes)</label>
           <input id="{{ form_id }}-sleep" name="sleep_interval_mins" type="number" min="1"
                  value="{{ instance.sleep_interval_mins }}"
+                 data-default-value="{{ defaults.sleep_interval_mins }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-hcap">Hourly Cap</label>
           <input id="{{ form_id }}-hcap" name="hourly_cap" type="number" min="0"
                  value="{{ instance.hourly_cap }}"
+                 data-default-value="{{ defaults.hourly_cap }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-cool">Cooldown (days)</label>
           <input id="{{ form_id }}-cool" name="cooldown_days" type="number" min="0"
                  value="{{ instance.cooldown_days }}"
+                 data-default-value="{{ defaults.cooldown_days }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-delay">Post-Release Grace (hrs)</label>
           <input id="{{ form_id }}-delay" name="post_release_grace_hrs" type="number" min="0"
                  value="{{ instance.post_release_grace_hrs }}"
+                 data-default-value="{{ defaults.post_release_grace_hrs }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Hours to wait after release date. Unreleased items are always skipped.</p>
         </div>
@@ -144,6 +149,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-qlimit">Queue Limit</label>
           <input id="{{ form_id }}-qlimit" name="queue_limit" type="number" min="0"
                  value="{{ instance.queue_limit }}"
+                 data-default-value="{{ defaults.queue_limit }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Skip searches when the queue exceeds this. 0 = disabled.</p>
         </div>
@@ -151,6 +157,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-window">Allowed Search Window</label>
           <input id="{{ form_id }}-window" name="allowed_time_window" type="text"
                  value="{{ instance.allowed_time_window }}"
+                 data-default-value="{{ defaults.allowed_time_window }}"
                  placeholder="e.g. 09:00-23:00 or 09:00-12:00,18:00-22:00"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Restrict scheduled cycles to one or more <code>HH:MM-HH:MM</code> windows (container local time via <code>TZ</code>). Blank = always allowed. Run Now bypasses the window.</p>
@@ -160,6 +167,7 @@
             Search Order
           </label>
           <select id="{{ form_id }}-order" name="search_order"
+                  data-default-value="{{ defaults.search_order.value }}"
                   class="{{ select_cls }}">
             <option value="chronological" {% if instance.search_order.value == 'chronological' %}selected{% endif %}>Chronological</option>
             <option value="random"        {% if instance.search_order.value == 'random'        %}selected{% endif %}>Random (default)</option>
@@ -171,7 +179,9 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-sonarr-mode">
             Sonarr Missing Search Mode
           </label>
-          <select id="{{ form_id }}-sonarr-mode" name="sonarr_search_mode" class="{{ select_cls }}">
+          <select id="{{ form_id }}-sonarr-mode" name="sonarr_search_mode"
+                  data-default-value="{{ defaults.sonarr_search_mode.value }}"
+                  class="{{ select_cls }}">
             <option value="episode"        {% if instance.sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
             <option value="season_context" {% if instance.sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search (advanced)</option>
           </select>
@@ -182,7 +192,9 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-lidarr-mode">
             Lidarr Missing Search Mode
           </label>
-          <select id="{{ form_id }}-lidarr-mode" name="lidarr_search_mode" class="{{ select_cls }}">
+          <select id="{{ form_id }}-lidarr-mode" name="lidarr_search_mode"
+                  data-default-value="{{ defaults.lidarr_search_mode.value }}"
+                  class="{{ select_cls }}">
             <option value="album"          {% if instance.lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
             <option value="artist_context" {% if instance.lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search (advanced)</option>
           </select>
@@ -193,7 +205,9 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-readarr-mode">
             Readarr Missing Search Mode
           </label>
-          <select id="{{ form_id }}-readarr-mode" name="readarr_search_mode" class="{{ select_cls }}">
+          <select id="{{ form_id }}-readarr-mode" name="readarr_search_mode"
+                  data-default-value="{{ defaults.readarr_search_mode.value }}"
+                  class="{{ select_cls }}">
             <option value="book"           {% if instance.readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
             <option value="author_context" {% if instance.readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search (advanced)</option>
           </select>
@@ -204,7 +218,9 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-whisparr-mode">
             Whisparr v2 Missing Search Mode
           </label>
-          <select id="{{ form_id }}-whisparr-mode" name="whisparr_search_mode" class="{{ select_cls }}">
+          <select id="{{ form_id }}-whisparr-mode" name="whisparr_search_mode"
+                  data-default-value="{{ defaults.whisparr_search_mode.value }}"
+                  class="{{ select_cls }}">
             <option value="episode"        {% if instance.whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
             <option value="season_context" {% if instance.whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search (advanced)</option>
           </select>
@@ -223,6 +239,7 @@
         <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-md border border-[#2a3448] bg-[#0e1117] px-3 py-2">
           <input type="checkbox" name="cutoff_enabled" value="on"
                  {% if is_edit and instance.cutoff_enabled %}checked{% endif %}
+                 data-default-checked="{{ 1 if defaults.cutoff_enabled else 0 }}"
                  class="rounded border-[#2a3448] bg-[#0e1117] text-brand-500 focus:ring-brand-500 focus:ring-offset-[#07080f]" />
           <span class="text-xs font-medium text-slate-300">Enable cutoff search</span>
         </label>
@@ -232,18 +249,21 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-cbatch">Cutoff Batch</label>
           <input id="{{ form_id }}-cbatch" name="cutoff_batch_size" type="number" min="1" max="250"
                  value="{{ instance.cutoff_batch_size }}"
+                 data-default-value="{{ defaults.cutoff_batch_size }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-ccool">Cutoff Cooldown</label>
           <input id="{{ form_id }}-ccool" name="cutoff_cooldown_days" type="number" min="0"
                  value="{{ instance.cutoff_cooldown_days }}"
+                 data-default-value="{{ defaults.cutoff_cooldown_days }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-chcap">Cutoff Cap</label>
           <input id="{{ form_id }}-chcap" name="cutoff_hourly_cap" type="number" min="0"
                  value="{{ instance.cutoff_hourly_cap }}"
+                 data-default-value="{{ defaults.cutoff_hourly_cap }}"
                  class="{{ mono_input_cls }}" />
         </div>
       </div>
@@ -259,6 +279,7 @@
         <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-md border border-[#2a3448] bg-[#0e1117] px-3 py-2">
           <input type="checkbox" name="upgrade_enabled" value="on"
                  {% if is_edit and instance.upgrade_enabled %}checked{% endif %}
+                 data-default-checked="{{ 1 if defaults.upgrade_enabled else 0 }}"
                  class="rounded border-[#2a3448] bg-[#0e1117] text-brand-500 focus:ring-brand-500 focus:ring-offset-[#07080f]" />
           <span class="text-xs font-medium text-slate-300">Enable upgrade search</span>
         </label>
@@ -268,6 +289,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-ubatch">Upgrade Batch</label>
           <input id="{{ form_id }}-ubatch" name="upgrade_batch_size" type="number" min="1" max="250"
                  value="{{ instance.upgrade_batch_size }}"
+                 data-default-value="{{ defaults.upgrade_batch_size }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Hard cap: 5 per cycle.</p>
         </div>
@@ -275,6 +297,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-ucool">Upgrade Cooldown (days)</label>
           <input id="{{ form_id }}-ucool" name="upgrade_cooldown_days" type="number" min="7"
                  value="{{ instance.upgrade_cooldown_days }}"
+                 data-default-value="{{ defaults.upgrade_cooldown_days }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Minimum: 7 days.</p>
         </div>
@@ -282,6 +305,7 @@
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-uhcap">Upgrade Hourly Cap</label>
           <input id="{{ form_id }}-uhcap" name="upgrade_hourly_cap" type="number" min="0"
                  value="{{ instance.upgrade_hourly_cap }}"
+                 data-default-value="{{ defaults.upgrade_hourly_cap }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Hard cap: 5. 0 = unlimited.</p>
         </div>
@@ -292,7 +316,9 @@
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-sonarr-mode">
           Sonarr Upgrade Search Mode
         </label>
-        <select id="{{ form_id }}-upgrade-sonarr-mode" name="upgrade_sonarr_search_mode" class="{{ select_cls }}">
+        <select id="{{ form_id }}-upgrade-sonarr-mode" name="upgrade_sonarr_search_mode"
+                data-default-value="{{ defaults.upgrade_sonarr_search_mode.value }}"
+                class="{{ select_cls }}">
           <option value="episode"        {% if instance.upgrade_sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
           <option value="season_context" {% if instance.upgrade_sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
         </select>
@@ -302,7 +328,9 @@
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-lidarr-mode">
           Lidarr Upgrade Search Mode
         </label>
-        <select id="{{ form_id }}-upgrade-lidarr-mode" name="upgrade_lidarr_search_mode" class="{{ select_cls }}">
+        <select id="{{ form_id }}-upgrade-lidarr-mode" name="upgrade_lidarr_search_mode"
+                data-default-value="{{ defaults.upgrade_lidarr_search_mode.value }}"
+                class="{{ select_cls }}">
           <option value="album"          {% if instance.upgrade_lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
           <option value="artist_context" {% if instance.upgrade_lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search</option>
         </select>
@@ -312,7 +340,9 @@
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-readarr-mode">
           Readarr Upgrade Search Mode
         </label>
-        <select id="{{ form_id }}-upgrade-readarr-mode" name="upgrade_readarr_search_mode" class="{{ select_cls }}">
+        <select id="{{ form_id }}-upgrade-readarr-mode" name="upgrade_readarr_search_mode"
+                data-default-value="{{ defaults.upgrade_readarr_search_mode.value }}"
+                class="{{ select_cls }}">
           <option value="book"           {% if instance.upgrade_readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
           <option value="author_context" {% if instance.upgrade_readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search</option>
         </select>
@@ -322,7 +352,9 @@
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-whisparr-mode">
           Whisparr v2 Upgrade Search Mode
         </label>
-        <select id="{{ form_id }}-upgrade-whisparr-mode" name="upgrade_whisparr_search_mode" class="{{ select_cls }}">
+        <select id="{{ form_id }}-upgrade-whisparr-mode" name="upgrade_whisparr_search_mode"
+                data-default-value="{{ defaults.upgrade_whisparr_search_mode.value }}"
+                class="{{ select_cls }}">
           <option value="episode"        {% if instance.upgrade_whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
           <option value="season_context" {% if instance.upgrade_whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
         </select>
@@ -346,10 +378,16 @@
                 class="px-4 py-2.5 rounded-lg border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors sm:w-[10.5rem]">
           Test Connection
         </button>
+        <button type="button"
+                id="instance-reset-btn"
+                data-reset-instance-form="true"
+                class="px-4 py-2.5 rounded-lg border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors sm:w-[10.5rem]">
+          Reset to Defaults
+        </button>
         <button id="instance-submit-btn"
                 type="submit"
                 disabled
-                class="px-4 py-2.5 rounded-lg bg-brand-500 text-white text-sm font-semibold transition-colors
+                class="col-span-2 sm:col-auto px-4 py-2.5 rounded-lg bg-brand-500 text-white text-sm font-semibold transition-colors
                        disabled:cursor-not-allowed disabled:opacity-40 hover:enabled:bg-brand-400
                        focus:outline-none focus:ring-2 focus:ring-brand-500/35">
           {{ 'Save Changes' if is_edit else 'Add Instance' }}

--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -831,6 +831,30 @@
       setConnectionTestButtonState('neutral');
     }
 
+    function resetInstanceFormToDefaults() {
+      if (!addInstanceModalContent) {
+        return;
+      }
+
+      addInstanceModalContent.querySelectorAll('[data-default-value]').forEach(function (el) {
+        if (!(el instanceof HTMLInputElement) && !(el instanceof HTMLSelectElement)) {
+          return;
+        }
+        el.value = el.dataset.defaultValue || '';
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      addInstanceModalContent.querySelectorAll('[data-default-checked]').forEach(function (el) {
+        if (!(el instanceof HTMLInputElement)) {
+          return;
+        }
+        el.checked = el.dataset.defaultChecked === '1';
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      syncAppOnlyControls();
+    }
+
     window.houndarrOpenAddInstanceModal = function () {
       addInstanceModal.classList.remove('is-closing');
       isClosingAddInstanceModal = false;
@@ -923,6 +947,23 @@
       'input',
       function (event) {
         resetConnectionStateOnFieldChange(event.target);
+      },
+      { signal },
+    );
+
+    addInstanceModalContent.addEventListener(
+      'click',
+      function (event) {
+        const target = event.target;
+        if (!(target instanceof Element)) {
+          return;
+        }
+        const resetBtn = target.closest('[data-reset-instance-form="true"]');
+        if (!resetBtn) {
+          return;
+        }
+        event.preventDefault();
+        resetInstanceFormToDefaults();
       },
       { signal },
     );

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -431,6 +431,48 @@ def test_add_form_partial_renders(app: TestClient) -> None:
     assert b'target="_blank"' not in resp.content
 
 
+def test_add_form_exposes_reset_button_and_default_attrs(app: TestClient) -> None:
+    _login(app)
+    resp = app.get("/settings/instances/add-form")
+    assert resp.status_code == 200
+    # Reset button is present in the footer.
+    assert b'id="instance-reset-btn"' in resp.content
+    assert b'data-reset-instance-form="true"' in resp.content
+    assert b"Reset to Defaults" in resp.content
+    # Policy inputs expose their defaults via data-default-* attributes.
+    assert b'data-default-value="2"' in resp.content  # batch_size default
+    assert b'data-default-value="30"' in resp.content  # sleep_interval_mins default
+    assert b'data-default-value="14"' in resp.content  # cooldown_days default
+    assert b'data-default-checked="0"' in resp.content  # cutoff/upgrade defaults
+    # Connection fields must NOT carry default attributes.
+    assert b'name="name"' in resp.content
+    assert b'name="url"' in resp.content
+    name_segment_idx = resp.content.find(b'name="name"')
+    name_tag_end = resp.content.find(b"/>", name_segment_idx)
+    assert b"data-default-value" not in resp.content[name_segment_idx:name_tag_end]
+
+
+def test_edit_form_default_and_live_value_are_independent(app: TestClient) -> None:
+    _login(app)
+    created = app.post(
+        "/settings/instances",
+        data={**_VALID_FORM, "batch_size": "50", "cooldown_days": "99"},
+        headers=csrf_headers(app),
+    )
+    assert created.status_code == 200
+
+    resp = app.get("/settings/instances/1/edit")
+    assert resp.status_code == 200
+    # Live value reflects the saved configuration.
+    assert b'value="50"' in resp.content
+    assert b'value="99"' in resp.content
+    # Default attributes continue to expose the Houndarr defaults.
+    assert b'data-default-value="2"' in resp.content
+    assert b'data-default-value="14"' in resp.content
+    # Reset button is available in edit mode too.
+    assert b'id="instance-reset-btn"' in resp.content
+
+
 def test_create_instance_stores_sonarr_search_mode(app: TestClient) -> None:
     _login(app)
     form = {**_VALID_FORM, "sonarr_search_mode": "season_context"}


### PR DESCRIPTION
## Summary

- Adds a Reset to Defaults button to the shared add/edit instance modal that restores Search Policy, Cutoff Upgrades, and Library Upgrades to Houndarr defaults in one click.
- Preserves Connection fields (name, type, URL, API key) and the tested-connection guard, so users do not have to re-test before saving.
- Defaults are rendered from `_blank_instance()` as `data-default-*` attributes; a small client-side handler walks them on click. No new route or CSRF surface.

## Test plan

- [x] Unit: add-form exposes Reset button markup and `data-default-*` attributes on policy inputs.
- [x] Unit: edit form renders live `value` and `data-default-value` independently for a modified instance.
- [x] Full pytest suite green.
- [x] Manual (Chromium): dirty every policy field and both enable checkboxes, click Reset, confirm every field returns to the `DEFAULT_*` constant and Connection + `connection_verified` are untouched.
- [x] Manual: desktop footer (1280w) renders all four buttons inline with matched secondary widths.
- [x] Manual: mobile footer (390w) renders `[Test][Reset]` / `[Save]` / `[Cancel]` with no overflow.

Closes #404