### PR TITLE
fix: avoid leaking ValueError messages from time-window parse

### DIFF
--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -60,7 +60,11 @@ from houndarr.services.instances import (
     list_instances,
     update_instance,
 )
-from houndarr.services.time_window import format_ranges, parse_time_window
+from houndarr.services.time_window import (
+    format_ranges,
+    parse_time_window,
+    validate_allowed_time_window,
+)
 from houndarr.services.url_validation import validate_instance_url
 
 router = APIRouter()
@@ -574,10 +578,10 @@ async def instance_create(
     if url_error is not None:
         return _connection_guard_response(url_error)
 
-    try:
-        canonical_window = format_ranges(parse_time_window(allowed_time_window))
-    except ValueError as exc:
-        return _connection_guard_response(str(exc))
+    window_error = validate_allowed_time_window(allowed_time_window)
+    if window_error is not None:
+        return _connection_guard_response(window_error)
+    canonical_window = format_ranges(parse_time_window(allowed_time_window))
 
     validation_error = _validate_cutoff_controls(
         cutoff_batch_size,
@@ -747,10 +751,10 @@ async def instance_update(
     if url_error is not None:
         return _connection_guard_response(url_error)
 
-    try:
-        canonical_window = format_ranges(parse_time_window(allowed_time_window))
-    except ValueError as exc:
-        return _connection_guard_response(str(exc))
+    window_error = validate_allowed_time_window(allowed_time_window)
+    if window_error is not None:
+        return _connection_guard_response(window_error)
+    canonical_window = format_ranges(parse_time_window(allowed_time_window))
 
     validation_error = _validate_cutoff_controls(
         cutoff_batch_size,

--- a/src/houndarr/services/time_window.py
+++ b/src/houndarr/services/time_window.py
@@ -32,6 +32,47 @@ def _to_minutes(t: time) -> int:
     return t.hour * 60 + t.minute
 
 
+def validate_allowed_time_window(spec: str) -> str | None:
+    """Validate an allowed-time-window *spec* supplied by an operator.
+
+    Returns ``None`` if the spec is valid (including empty or whitespace-only,
+    which means "always allowed"). Otherwise returns a user-facing error
+    message chosen from a finite set of constant strings, so no exception
+    state can flow into HTTP responses.
+
+    Kept in sync with :func:`parse_time_window`'s rules: a spec that passes
+    this validator is safe to pass to ``parse_time_window`` without catching
+    ``ValueError``.
+    """
+    if spec is None:
+        return None
+
+    stripped = spec.strip()
+    if not stripped:
+        return None
+
+    pieces = [p.strip() for p in stripped.split(",")]
+    if len(pieces) > _MAX_RANGES:
+        return f"Too many time ranges (max {_MAX_RANGES})."
+
+    for piece in pieces:
+        if not piece:
+            return "Empty time range in allowed-window spec."
+
+        match = _RANGE_RE.fullmatch(piece)
+        if match is None:
+            return "Invalid time range format. Use HH:MM-HH:MM (e.g. 09:00-23:00)."
+
+        sh, sm, eh, em = (int(x) for x in match.groups())
+        if not (0 <= sh <= 23 and 0 <= eh <= 23 and 0 <= sm <= 59 and 0 <= em <= 59):
+            return "Out-of-range hour or minute. Hours 00-23, minutes 00-59."
+
+        if sh * 60 + sm == eh * 60 + em:
+            return "Time range has no duration (start equals end)."
+
+    return None
+
+
 def parse_time_window(spec: str) -> list[tuple[time, time]]:
     """Parse an allowed-time-window *spec* into a list of ``(start, end)`` tuples.
 

--- a/tests/test_services/test_time_window.py
+++ b/tests/test_services/test_time_window.py
@@ -10,6 +10,7 @@ from houndarr.services.time_window import (
     format_ranges,
     is_within_window,
     parse_time_window,
+    validate_allowed_time_window,
 )
 
 # ---------------------------------------------------------------------------
@@ -233,3 +234,99 @@ def test_format_ranges_multiple() -> None:
 
 def test_format_ranges_empty() -> None:
     assert format_ranges([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# validate_allowed_time_window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "",
+        "   ",
+        "09:00-23:00",
+        "09:00-12:00,14:00-22:00",
+        "22:00-06:00",
+        "00:00-06:00",
+        "22:00-00:00",
+    ],
+)
+def test_validate_accepts_valid_specs(spec: str) -> None:
+    assert validate_allowed_time_window(spec) is None
+
+
+def test_validate_rejects_too_many_ranges() -> None:
+    spec = ",".join(["09:00-10:00"] * 25)
+    msg = validate_allowed_time_window(spec)
+    assert msg is not None
+    assert "Too many" in msg
+
+
+@pytest.mark.parametrize("spec", ["09:00-12:00,,14:00-22:00", "09:00-12:00,"])
+def test_validate_rejects_empty_piece(spec: str) -> None:
+    msg = validate_allowed_time_window(spec)
+    assert msg is not None
+    assert "Empty time range" in msg
+
+
+@pytest.mark.parametrize(
+    "spec",
+    ["9:00-17:00", "09:0-17:00", "09:00", "abc", "09:00-17:00-20:00", "09.00-17.00"],
+)
+def test_validate_rejects_malformed_format(spec: str) -> None:
+    msg = validate_allowed_time_window(spec)
+    assert msg is not None
+    assert "Invalid time range format" in msg
+
+
+@pytest.mark.parametrize("spec", ["25:00-30:00", "09:60-10:00", "09:00-10:99"])
+def test_validate_rejects_out_of_range(spec: str) -> None:
+    msg = validate_allowed_time_window(spec)
+    assert msg is not None
+    assert "Out-of-range" in msg
+
+
+@pytest.mark.parametrize("spec", ["09:00-09:00", "00:00-00:00"])
+def test_validate_rejects_zero_duration(spec: str) -> None:
+    msg = validate_allowed_time_window(spec)
+    assert msg is not None
+    assert "no duration" in msg
+
+
+def test_validate_messages_do_not_echo_user_input() -> None:
+    """Error strings must be constants, so nothing from the raw spec flows
+    into HTTP responses. Regression guard for CodeQL py/stack-trace-exposure."""
+    suspicious_token = "<script>EVIL</script>"  # noqa: S105 - literal marker
+    probe = f"09:00-12:00,{suspicious_token}"
+    msg = validate_allowed_time_window(probe)
+    assert msg is not None
+    assert suspicious_token not in msg
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "",
+        "   ",
+        "09:00-23:00",
+        "09:00-12:00,14:00-22:00",
+        "22:00-06:00",
+        "00:00-06:00",
+        "not-a-range",
+        "25:00-30:00",
+        "09:00-09:00",
+        "09:00-12:00,,14:00-22:00",
+        ",".join(["09:00-10:00"] * 25),
+    ],
+)
+def test_validator_agrees_with_parser(spec: str) -> None:
+    """validate_* returns None iff parse_time_window does not raise."""
+    validator_ok = validate_allowed_time_window(spec) is None
+    try:
+        parse_time_window(spec)
+        parser_ok = True
+    except ValueError:
+        parser_ok = False
+    assert validator_ok is parser_ok


### PR DESCRIPTION
## Summary

- Replaces `try: parse_time_window(...) except ValueError as exc: return str(exc)` in both instance handlers with a `validate_allowed_time_window()` helper that returns `None` on success or a constant error message on failure.
- Closes CodeQL [py/stack-trace-exposure #6](https://github.com/av1155/houndarr/security/code-scanning/6). No exception state flows into the HTTP response body anymore.
- `parse_time_window` itself is unchanged, so the engine caller that catches and fails open continues to work.

## Test plan

- [x] New unit tests in `tests/test_services/test_time_window.py` cover every error category (too many, empty piece, malformed format, out-of-range, zero-duration) plus valid-path specs and a regression test asserting validator output never echoes user input.
- [x] New parametrised cross-check asserts the validator returns `None` iff `parse_time_window` does not raise.
- [x] Existing route tests (`test_create_rejects_malformed_time_window`, `test_create_rejects_out_of_range_hour`, `test_update_rejects_malformed_time_window`) continue to pass: the new constant messages still contain the substrings those tests look for.
- [x] Full quality gates green (ruff, mypy, bandit, pytest).

Closes #406