### PR TITLE
feat: 'what's new' modal once per update

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,6 +30,9 @@ tests/
 # Documentation
 docs/
 *.md
+# CHANGELOG.md is bundled into the image so the "What's new" modal can
+# render release notes at runtime; re-include it after the *.md exclusion.
+!CHANGELOG.md
 
 # Dev compose and data
 docker-compose.dev.yml

--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,9 @@ Thumbs.db
 *.manifest
 *.spec
 
-# Data directory (runtime state — never commit)
+# Data directories (runtime state — never commit)
 data/
+data-*/
 *.db
 *.masterkey
 
@@ -86,6 +87,14 @@ website/.docusaurus/
 
 # Research artifacts
 .opencode/
+.firecrawl/
+
+# Browser-automation artifacts (Playwright MCP, screenshots from local QA)
+.playwright-mcp/
+/*.png
+/*.jpg
+/*.jpeg
+/*.gif
 
 # Claude Code (local state ignored; settings.json and commands/ are tracked)
 .claude/settings.local.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN pip install --no-cache-dir --upgrade pip \
 # Copy application source
 COPY src/ ./src/
 COPY VERSION ./
+COPY CHANGELOG.md ./
 
 # Create non-root runtime user and data directory
 RUN groupadd -g 1000 appgroup \

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -165,6 +165,7 @@ def create_app() -> FastAPI:
     # -----------------------------------------------------------------------
     from houndarr.routes.api.logs import router as logs_router
     from houndarr.routes.api.status import router as status_router
+    from houndarr.routes.changelog import router as changelog_router
     from houndarr.routes.health import router as health_router
     from houndarr.routes.pages import router as pages_router
     from houndarr.routes.settings import router as settings_router
@@ -174,5 +175,6 @@ def create_app() -> FastAPI:
     app.include_router(logs_router)
     app.include_router(pages_router)
     app.include_router(settings_router)
+    app.include_router(changelog_router)
 
     return app

--- a/src/houndarr/routes/changelog.py
+++ b/src/houndarr/routes/changelog.py
@@ -97,17 +97,17 @@ def _empty_slot_response() -> HTMLResponse:
 
 
 def _range_label(releases: list[ReleaseEntry], *, manual: bool, last_seen: str | None) -> str:
-    """Build the modal's subtitle."""
-    if not releases:
+    """Build the modal's subtitle.
+
+    Only returns a non-empty label when it adds information beyond what the
+    first release heading already shows.  Single-release renders (manual
+    re-open, pre-feature catch-up) suppress the subtitle entirely.
+    """
+    if manual or len(releases) < 2:
         return ""
-    newest = releases[0]
-    if manual:
-        return f"v{newest.version} · Released {newest.date}"
-    if last_seen and len(releases) > 1:
-        return f"v{last_seen} → v{newest.version} · Released {newest.date}"
-    if last_seen is None:
-        return f"Up to v{newest.version} · Released {newest.date}"
-    return f"v{newest.version} · Released {newest.date}"
+    if last_seen:
+        return f"Since v{last_seen}"
+    return ""
 
 
 @router.get("/popup", response_class=HTMLResponse)
@@ -154,7 +154,9 @@ async def popup(request: Request, force: int = 0) -> HTMLResponse:
             "manual": is_manual,
         },
     )
-    response.headers["HX-Trigger"] = "houndarr-show-changelog"
+    # After-Swap fires once the <dialog> is actually in the DOM; plain
+    # HX-Trigger fires before the swap, so getElementById would return null.
+    response.headers["HX-Trigger-After-Swap"] = "houndarr-show-changelog"
     return response
 
 

--- a/src/houndarr/routes/changelog.py
+++ b/src/houndarr/routes/changelog.py
@@ -1,0 +1,192 @@
+"""Changelog modal routes: auto-open popup, dismiss, disable, preferences toggle.
+
+Four endpoints, all authenticated (handled by ``AuthMiddleware``):
+
+- ``GET  /settings/changelog/popup`` — returns the modal HTML partial if the
+  running version is newer than ``changelog_last_seen_version`` and popups
+  are not disabled; otherwise returns an empty placeholder div.  Supports
+  ``?force=1`` to bypass the decision and always render (used by the
+  Settings page "Show last changelog" button).
+- ``POST /settings/changelog/dismiss`` — writes ``changelog_last_seen_version``
+  to the running version.  Idempotent.
+- ``POST /settings/changelog/disable`` — writes the last-seen marker AND
+  ``changelog_popups_disabled = "1"``.
+- ``POST /settings/changelog/preferences`` — toggles
+  ``changelog_popups_disabled`` from the Settings page; re-renders the
+  Settings section partial.
+"""
+
+from __future__ import annotations
+
+import re
+from html import escape
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, Response
+from fastapi.templating import Jinja2Templates
+from markupsafe import Markup
+
+from houndarr import __version__
+from houndarr.database import get_setting, set_setting
+from houndarr.services.changelog import ReleaseEntry, releases_between, should_show
+
+router = APIRouter(prefix="/settings/changelog", tags=["changelog"])
+
+_templates: Jinja2Templates | None = None
+
+_GITHUB_ISSUES_URL = "https://github.com/av1155/houndarr/issues"
+
+# Order: matches newline lookups that would otherwise be eaten by the
+# escaping pass.  We escape the whole bullet first, then re-introduce the
+# known-safe subset of markdown back in (inline code, bold, links, issue
+# refs).  This keeps the vocabulary bounded and avoids pulling in a full
+# markdown library for a closed set of patterns.
+_INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+_BOLD_RE = re.compile(r"\*\*([^*]+)\*\*")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_ISSUE_REF_RE = re.compile(r"\(#(\d+)\)")
+
+
+def _render_changelog_bullet(raw: str) -> Markup:
+    """Return a safe HTML fragment for a single CHANGELOG bullet.
+
+    Escapes the input, then re-applies the small vocabulary actually used
+    in ``CHANGELOG.md``: `` `inline code` ``, ``**bold**``, ``[text](url)``,
+    and ``(#123)`` issue references (linked to GitHub).
+    """
+    safe = escape(raw)
+    safe = _INLINE_CODE_RE.sub(r'<code class="text-brand-300">\1</code>', safe)
+    safe = _BOLD_RE.sub(r"<strong>\1</strong>", safe)
+    # Link targets are HTML-escaped by the preceding escape() pass, so the
+    # URL is already safe for insertion into an href attribute.
+    safe = _LINK_RE.sub(
+        r'<a href="\2" target="_blank" rel="noopener noreferrer" '
+        r'class="text-brand-300 hover:text-brand-200 underline underline-offset-2">\1</a>',
+        safe,
+    )
+    safe = _ISSUE_REF_RE.sub(
+        (
+            r'(<a href="' + _GITHUB_ISSUES_URL + r'/\1" target="_blank" rel="noopener noreferrer" '
+            r'class="text-brand-300 hover:text-brand-200 underline underline-offset-2">#\1</a>)'
+        ),
+        safe,
+    )
+    # Input was escape()d first, then a closed vocabulary of markdown patterns
+    # (code, bold, links, issue refs) was re-applied with escaped capture groups.
+    # No user-authored raw HTML reaches the template context.
+    return Markup(safe)  # noqa: S704  # nosec B704
+
+
+def _get_templates() -> Jinja2Templates:
+    """Lazy Jinja2Templates singleton, matches ``routes/pages.py:get_templates``."""
+    global _templates  # noqa: PLW0603
+    if _templates is None:
+        _templates = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
+        _templates.env.filters["changelog_bullet"] = _render_changelog_bullet
+    return _templates
+
+
+def _empty_slot_response() -> HTMLResponse:
+    """Return a no-op placeholder that replaces ``#changelog-slot`` without a trigger."""
+    return HTMLResponse(
+        content='<div id="changelog-slot" aria-hidden="true"></div>',
+        status_code=200,
+    )
+
+
+def _range_label(releases: list[ReleaseEntry], *, manual: bool, last_seen: str | None) -> str:
+    """Build the modal's subtitle."""
+    if not releases:
+        return ""
+    newest = releases[0]
+    if manual:
+        return f"v{newest.version} · Released {newest.date}"
+    if last_seen and len(releases) > 1:
+        return f"v{last_seen} → v{newest.version} · Released {newest.date}"
+    if last_seen is None:
+        return f"Up to v{newest.version} · Released {newest.date}"
+    return f"v{newest.version} · Released {newest.date}"
+
+
+@router.get("/popup", response_class=HTMLResponse)
+async def popup(request: Request, force: int = 0) -> HTMLResponse:
+    """Return the modal partial or an empty placeholder div.
+
+    When ``force=0`` (auto-open flow), the decision respects
+    ``changelog_popups_disabled`` and the ``last_seen``/``running``
+    comparison.  When ``force=1`` (manual re-open from Settings), always
+    renders the modal with only the current running version's block.  In
+    either case, persistence is never mutated by this endpoint.
+    """
+    last_seen = await get_setting("changelog_last_seen_version")
+    disabled = (await get_setting("changelog_popups_disabled")) == "1"
+    is_manual = force == 1
+
+    if not is_manual and not should_show(
+        last_seen=last_seen, running=__version__, disabled=disabled
+    ):
+        return _empty_slot_response()
+
+    if is_manual:
+        releases = releases_between(last_seen=None, running=__version__)
+    else:
+        releases = releases_between(last_seen=last_seen, running=__version__)
+
+    if not releases:
+        # Running version has no CHANGELOG entry (dev build, missing block).
+        # Auto-open suppresses silently; manual open still returns empty so
+        # the caller does not see a broken modal.
+        return _empty_slot_response()
+
+    newest = releases[0]
+    older = releases[1:]
+
+    response = _get_templates().TemplateResponse(
+        request=request,
+        name="partials/changelog_modal.html",
+        context={
+            "releases": releases,
+            "newest": newest,
+            "older": older,
+            "range_label": _range_label(releases, manual=is_manual, last_seen=last_seen),
+            "manual": is_manual,
+        },
+    )
+    response.headers["HX-Trigger"] = "houndarr-show-changelog"
+    return response
+
+
+@router.post("/dismiss", response_class=Response)
+async def dismiss(request: Request) -> Response:
+    """Persist ``changelog_last_seen_version = __version__``.  Returns 204."""
+    await set_setting("changelog_last_seen_version", __version__)
+    return Response(status_code=204)
+
+
+@router.post("/disable", response_class=Response)
+async def disable(request: Request) -> Response:
+    """Persist both last-seen and disabled=1.  Returns 204."""
+    await set_setting("changelog_last_seen_version", __version__)
+    await set_setting("changelog_popups_disabled", "1")
+    return Response(status_code=204)
+
+
+@router.post("/preferences", response_class=HTMLResponse)
+async def preferences(
+    request: Request,
+    enabled: Annotated[str, Form()] = "",
+) -> HTMLResponse:
+    """Toggle ``changelog_popups_disabled`` from the Settings page checkbox.
+
+    Checkbox sends ``enabled=on`` when checked, omits the field when
+    unchecked.  Re-renders the Settings section partial for outerHTML swap.
+    """
+    new_disabled = "0" if enabled == "on" else "1"
+    await set_setting("changelog_popups_disabled", new_disabled)
+    return _get_templates().TemplateResponse(
+        request=request,
+        name="partials/changelog_settings_section.html",
+        context={"changelog_popups_enabled": new_disabled == "0"},
+    )

--- a/src/houndarr/routes/changelog.py
+++ b/src/houndarr/routes/changelog.py
@@ -117,12 +117,21 @@ async def popup(request: Request, force: int = 0) -> HTMLResponse:
     When ``force=0`` (auto-open flow), the decision respects
     ``changelog_popups_disabled`` and the ``last_seen``/``running``
     comparison.  When ``force=1`` (manual re-open from Settings), always
-    renders the modal with only the current running version's block.  In
-    either case, persistence is never mutated by this endpoint.
+    renders the modal with only the current running version's block.
+
+    Silent tracking: when popups are disabled, the endpoint silently
+    advances ``changelog_last_seen_version`` to the running version on
+    every poll so that re-enabling popups later does not surface a
+    backlog of releases the admin chose to skip.
     """
     last_seen = await get_setting("changelog_last_seen_version")
     disabled = (await get_setting("changelog_popups_disabled")) == "1"
     is_manual = force == 1
+
+    if not is_manual and disabled:
+        if last_seen != __version__:
+            await set_setting("changelog_last_seen_version", __version__)
+        return _empty_slot_response()
 
     if not is_manual and not should_show(
         last_seen=last_seen, running=__version__, disabled=disabled

--- a/src/houndarr/routes/changelog.py
+++ b/src/houndarr/routes/changelog.py
@@ -45,8 +45,44 @@ _GITHUB_ISSUES_URL = "https://github.com/av1155/houndarr/issues"
 # markdown library for a closed set of patterns.
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 _BOLD_RE = re.compile(r"\*\*([^*]+)\*\*")
-_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+# URL pattern allows one level of nested parentheses so links like
+# https://en.wikipedia.org/wiki/Foo_(bar) render correctly.
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(((?:[^()]|\([^)]*\))+)\)")
 _ISSUE_REF_RE = re.compile(r"\(#(\d+)\)")
+
+# Defense-in-depth: only accept these URL schemes inside [text](url).
+# CHANGELOG.md is maintainer-authored and bundled into the image so the
+# trust boundary covers this, but the allowlist prevents javascript:,
+# data:, vbscript: from ever reaching an href even if a future entry
+# contains an unsafe link.  Schemeless / fragment / relative URLs are
+# allowed (no colon → no scheme).
+_ALLOWED_URL_SCHEMES = ("http://", "https://", "mailto:", "/", "#")
+
+
+def _is_safe_url(url: str) -> bool:
+    """Return True if *url* is safe to put in an href."""
+    lowered = url.strip().lower()
+    if any(lowered.startswith(s) for s in _ALLOWED_URL_SCHEMES):
+        return True
+    # Schemeless URLs (no colon before the first slash/hash/end) are safe.
+    colon = lowered.find(":")
+    if colon == -1:
+        return True
+    slash = lowered.find("/")
+    return slash != -1 and slash < colon
+
+
+def _link_substitution(match: re.Match[str]) -> str:
+    """Return either an <a> tag or the original text if the URL is unsafe."""
+    text, url = match.group(1), match.group(2)
+    if not _is_safe_url(url):
+        # Re-emit the original markdown so the raw text is visible but
+        # not clickable.  The captures came from already-escape()d text.
+        return f"[{text}]({url})"
+    return (
+        f'<a href="{url}" target="_blank" rel="noopener noreferrer" '
+        f'class="text-brand-300 hover:text-brand-200 underline underline-offset-2">{text}</a>'
+    )
 
 
 def _render_changelog_bullet(raw: str) -> Markup:
@@ -60,12 +96,10 @@ def _render_changelog_bullet(raw: str) -> Markup:
     safe = _INLINE_CODE_RE.sub(r'<code class="text-brand-300">\1</code>', safe)
     safe = _BOLD_RE.sub(r"<strong>\1</strong>", safe)
     # Link targets are HTML-escaped by the preceding escape() pass, so the
-    # URL is already safe for insertion into an href attribute.
-    safe = _LINK_RE.sub(
-        r'<a href="\2" target="_blank" rel="noopener noreferrer" '
-        r'class="text-brand-300 hover:text-brand-200 underline underline-offset-2">\1</a>',
-        safe,
-    )
+    # URL is already safe for insertion into an href attribute.  The
+    # callback also gates on a scheme allowlist so javascript:/data:
+    # URLs never reach an href even if CHANGELOG.md contains them.
+    safe = _LINK_RE.sub(_link_substitution, safe)
     safe = _ISSUE_REF_RE.sub(
         (
             r'(<a href="' + _GITHUB_ISSUES_URL + r'/\1" target="_blank" rel="noopener noreferrer" '

--- a/src/houndarr/routes/pages.py
+++ b/src/houndarr/routes/pages.py
@@ -20,6 +20,7 @@ from houndarr.auth import (
     set_username,
     validate_username,
 )
+from houndarr.database import set_setting
 from houndarr.services.instances import list_instances
 
 router = APIRouter()
@@ -119,6 +120,10 @@ async def setup_post(
 
     await set_username(normalize_username(username))
     await set_password(password)
+    # Silently seed the changelog last-seen marker so fresh installs never
+    # see the "What's new" modal on their first dashboard load.  Upgraders
+    # (no stored value yet) fall through to the pre-feature catch-up path.
+    await set_setting("changelog_last_seen_version", __version__)
     return RedirectResponse(url="/login", status_code=303)  # type: ignore[return-value]
 
 

--- a/src/houndarr/routes/settings.py
+++ b/src/houndarr/routes/settings.py
@@ -384,8 +384,11 @@ async def _render_settings_page(
     account_success: str | None = None,
 ) -> HTMLResponse:
     """Render settings page with common account and instance context."""
+    from houndarr.database import get_setting
+
     instances = await list_instances(master_key=_master_key(request))
     username = await get_username()
+    changelog_popups_enabled = (await get_setting("changelog_popups_disabled")) != "1"
     template_name = (
         "partials/pages/settings_content.html" if _is_hx_request(request) else "settings.html"
     )
@@ -398,6 +401,7 @@ async def _render_settings_page(
         auth_mode=get_settings().auth_mode,
         account_error=account_error,
         account_success=account_success,
+        changelog_popups_enabled=changelog_popups_enabled,
     )
 
 

--- a/src/houndarr/services/changelog.py
+++ b/src/houndarr/services/changelog.py
@@ -1,0 +1,246 @@
+"""Parse CHANGELOG.md and decide when the "What's new" modal should render.
+
+The parser expects the strict subset of Keep a Changelog that
+``.github/workflows/version-check.yml`` enforces on every release PR:
+
+- ``## [X.Y.Z] - YYYY-MM-DD`` opens a block.
+- ``### Added|Changed|Fixed|Removed`` (or any other ``###`` header, rendered
+  permissively) opens a section within a block.
+- ``- `` starts a bullet (may continue onto wrapped lines).
+- ``---`` closes the block.
+
+Unexpected content is skipped rather than raising; a malformed file
+degrades to an empty changelog so the modal short-circuits instead of
+crashing the app on startup.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+# services/changelog.py → src/houndarr/services/ → src/houndarr/ → src/ → <root>
+CHANGELOG_PATH: Path = Path(__file__).resolve().parent.parent.parent.parent / "CHANGELOG.md"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class ReleaseSection:
+    """A single ``### Heading`` section within a release block."""
+
+    heading: str
+    bullets: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseEntry:
+    """One ``## [X.Y.Z] - YYYY-MM-DD`` release block."""
+
+    version: str
+    version_tuple: tuple[int, int, int]
+    date: str
+    sections: list[ReleaseSection]
+
+
+# ---------------------------------------------------------------------------
+# Regexes (module-level so the compile cost is paid once)
+# ---------------------------------------------------------------------------
+_VERSION_HEADING = re.compile(r"^## \[(?P<ver>\d+\.\d+\.\d+)\] - (?P<date>\d{4}-\d{2}-\d{2})\s*$")
+_SECTION_HEADING = re.compile(r"^### (?P<heading>\S.*\S|\S)\s*$")
+_BULLET_START = re.compile(r"^- (?P<text>.+)$")
+_BLOCK_TERMINATOR = re.compile(r"^---\s*$")
+
+
+# ---------------------------------------------------------------------------
+# Version helpers
+# ---------------------------------------------------------------------------
+def _parse_version(s: str | None) -> tuple[int, int, int] | None:
+    """Return ``(major, minor, patch)`` or ``None`` for any non-strict-semver input.
+
+    Houndarr versions are enforced as ``^\\d+\\.\\d+\\.\\d+$`` by
+    ``version-check.yml`` on every release PR, so the universe of valid
+    values is closed.  Anything else (``"dev"``, ``"1.0.0rc1"``, corrupted
+    settings rows) returns ``None`` and is treated as "unknown".
+    """
+    if not s:
+        return None
+    try:
+        parts = s.strip().split(".")
+        if len(parts) != 3:
+            return None
+        return int(parts[0]), int(parts[1]), int(parts[2])
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+def _parse_changelog(path: Path) -> list[ReleaseEntry]:
+    """Parse *path* and return release entries in descending version order.
+
+    Returns ``[]`` if the file is missing or contains no parseable blocks.
+    Emits a single WARNING log when the file is missing entirely.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning("CHANGELOG.md not found at %s", path)
+        return []
+    except OSError:
+        logger.warning("CHANGELOG.md unreadable at %s", path, exc_info=True)
+        return []
+
+    entries: list[ReleaseEntry] = []
+    current_version: str | None = None
+    current_tuple: tuple[int, int, int] | None = None
+    current_date: str | None = None
+    current_sections: list[ReleaseSection] = []
+    current_heading: str | None = None
+    current_bullets: list[str] = []
+
+    def _flush_section() -> None:
+        if current_heading is not None:
+            current_sections.append(
+                ReleaseSection(heading=current_heading, bullets=list(current_bullets))
+            )
+
+    def _flush_block() -> None:
+        if current_version is None or current_tuple is None or current_date is None:
+            return
+        entries.append(
+            ReleaseEntry(
+                version=current_version,
+                version_tuple=current_tuple,
+                date=current_date,
+                sections=list(current_sections),
+            )
+        )
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+
+        version_match = _VERSION_HEADING.match(line)
+        if version_match is not None:
+            _flush_section()
+            _flush_block()
+            current_version = version_match.group("ver")
+            current_tuple = _parse_version(current_version)
+            current_date = version_match.group("date")
+            current_sections = []
+            current_heading = None
+            current_bullets = []
+            continue
+
+        if current_version is None:
+            continue
+
+        if _BLOCK_TERMINATOR.match(line):
+            _flush_section()
+            _flush_block()
+            current_version = None
+            current_tuple = None
+            current_date = None
+            current_sections = []
+            current_heading = None
+            current_bullets = []
+            continue
+
+        section_match = _SECTION_HEADING.match(line)
+        if section_match is not None:
+            _flush_section()
+            current_heading = section_match.group("heading")
+            current_bullets = []
+            continue
+
+        bullet_match = _BULLET_START.match(line)
+        if bullet_match is not None and current_heading is not None:
+            current_bullets.append(bullet_match.group("text"))
+            continue
+
+        # Continuation of a wrapped bullet: indented line following a bullet.
+        if current_bullets and line.startswith("  "):
+            current_bullets[-1] = f"{current_bullets[-1]} {line.strip()}"
+
+    # End-of-file: flush any unterminated trailing block (defensive).
+    _flush_section()
+    _flush_block()
+
+    entries.sort(key=lambda e: e.version_tuple, reverse=True)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Lazy singleton cache
+# ---------------------------------------------------------------------------
+_cache: list[ReleaseEntry] | None = None
+
+
+def get_changelog() -> list[ReleaseEntry]:
+    """Return parsed release entries, cached for the lifetime of the process.
+
+    Matches the lazy-initialisation pattern used by ``get_templates()`` in
+    ``routes/pages.py`` so parse failures surface on the route that needs
+    them, not during app startup.
+    """
+    global _cache  # noqa: PLW0603
+    if _cache is None:
+        _cache = _parse_changelog(CHANGELOG_PATH)
+    return _cache
+
+
+def _reset_changelog_cache() -> None:
+    """Clear the cache. Test-only hook."""
+    global _cache  # noqa: PLW0603
+    _cache = None
+
+
+# ---------------------------------------------------------------------------
+# Decision helpers
+# ---------------------------------------------------------------------------
+def releases_between(*, last_seen: str | None, running: str | None) -> list[ReleaseEntry]:
+    """Return release entries with ``last_seen < version <= running``, newest first.
+
+    - If *running* is unparseable, returns ``[]`` (we cannot know what to
+      show and must not guess).
+    - If *last_seen* is absent or unparseable, returns only the single entry
+      matching *running* (the pre-feature-upgrade case: we cannot reconstruct
+      the user's prior version, so we show a one-time marker of the current
+      release and let the dismiss handler seed the stored value).
+    """
+    running_tuple = _parse_version(running)
+    if running_tuple is None:
+        return []
+
+    entries = get_changelog()
+
+    last_seen_tuple = _parse_version(last_seen)
+    if last_seen_tuple is None:
+        for entry in entries:
+            if entry.version_tuple == running_tuple:
+                return [entry]
+        return []
+
+    return [entry for entry in entries if last_seen_tuple < entry.version_tuple <= running_tuple]
+
+
+def should_show(*, last_seen: str | None, running: str | None, disabled: bool) -> bool:
+    """Return True iff the modal should auto-open on this dashboard load."""
+    if disabled:
+        return False
+    running_tuple = _parse_version(running)
+    if running_tuple is None:
+        return False
+    last_seen_tuple = _parse_version(last_seen)
+    if last_seen_tuple is None:
+        return True
+    return running_tuple > last_seen_tuple

--- a/src/houndarr/static/js/changelog.js
+++ b/src/houndarr/static/js/changelog.js
@@ -67,9 +67,13 @@
       document.body.style.overflow = '';
       isClosing = false;
       restoreFocus();
-      // Remove the dialog from the DOM so a subsequent auto-open cycle
-      // can HTMX-inject a fresh one without stale listeners.
-      dialog.remove();
+      // Replace the dialog with a fresh empty #changelog-slot so future
+      // force-opens from Settings (or another auto-trigger after full
+      // reload) still have an HTMX target to swap into.
+      const slot = document.createElement('div');
+      slot.id = 'changelog-slot';
+      slot.setAttribute('aria-hidden', 'true');
+      dialog.replaceWith(slot);
     };
 
     if (prefersReducedMotion) {

--- a/src/houndarr/static/js/changelog.js
+++ b/src/houndarr/static/js/changelog.js
@@ -95,11 +95,12 @@
     { signal },
   );
 
-  // Native <dialog> Escape key fires a `cancel` event.  We preventDefault
-  // so the close animation runs, then dispatch the dismiss POST through
-  // HTMX by clicking the primary button (keeps persistence logic in one
-  // place).
-  document.body.addEventListener(
+  // Native <dialog> Escape key fires a `cancel` event that does NOT bubble,
+  // so we listen in the capture phase (which still reaches non-bubbling
+  // events on descendants) on document.  preventDefault so the close
+  // animation runs, then dispatch the dismiss POST through HTMX by
+  // clicking the primary button (keeps persistence logic in one place).
+  document.addEventListener(
     'cancel',
     function (event) {
       const target = event.target;
@@ -114,7 +115,7 @@
         closeDialog();
       }
     },
-    { signal },
+    { signal, capture: true },
   );
 
   // Backdrop click (the <dialog> itself is the click target when the
@@ -168,6 +169,107 @@
       ) {
         closeDialog();
       }
+    },
+    { signal },
+  );
+
+  // Animated <details> accordion for older releases.  Native <details> has
+  // no open/close animation, so we intercept the summary click, handle the
+  // open attribute ourselves, and animate the body's height + opacity.
+  // The Station ease (heavy ease-out) makes the motion feel snappy at
+  // small distances; for the full older-releases panel (often 1500+ px)
+  // it reads as "instant" because 75% of the height change happens in
+  // the first 100ms.  A balanced standard easing at 480ms gives the
+  // expand a deliberate, controlled feel without being sluggish.
+  const accordionAnimationMs = 480;
+  const accordionEase = 'cubic-bezier(0.4, 0, 0.2, 1)';
+
+  function animateAccordion(details, body, shouldOpen) {
+    if (prefersReducedMotion) {
+      details.open = shouldOpen;
+      body.style.height = '';
+      body.style.opacity = '';
+      body.style.transition = '';
+      return;
+    }
+
+    if (body.dataset.animating === '1') {
+      return;
+    }
+    body.dataset.animating = '1';
+
+    const transitionValue =
+      `height ${accordionAnimationMs}ms ${accordionEase}, ` +
+      `opacity ${accordionAnimationMs}ms ${accordionEase}`;
+
+    if (shouldOpen) {
+      // Lock the collapsed state INLINE before flipping details.open so
+      // the browser never paints a frame of the natural-height content.
+      body.style.transition = 'none';
+      body.style.height = '0px';
+      body.style.opacity = '0';
+      details.open = true;
+      // Two RAFs: first lets the browser commit the display:block + 0px
+      // inline height.  Second starts the transition from that committed
+      // state to the natural height.  A single RAF is not enough because
+      // the display change from `<details>` toggling needs a style recalc
+      // that the browser may defer.
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          const targetHeight = body.scrollHeight;
+          body.style.transition = transitionValue;
+          body.style.height = `${targetHeight}px`;
+          body.style.opacity = '1';
+          window.setTimeout(() => {
+            body.style.transition = '';
+            body.style.height = 'auto';
+            body.style.opacity = '';
+            body.dataset.animating = '0';
+          }, accordionAnimationMs);
+        });
+      });
+      return;
+    }
+
+    // Closing: lock current height, reflow, transition to 0.
+    const startHeight = body.getBoundingClientRect().height;
+    body.style.transition = 'none';
+    body.style.height = `${startHeight}px`;
+    body.style.opacity = '1';
+    void body.offsetHeight;
+    body.style.transition = transitionValue;
+    body.style.height = '0px';
+    body.style.opacity = '0';
+    window.setTimeout(() => {
+      details.open = false;
+      body.style.transition = '';
+      body.style.height = '';
+      body.style.opacity = '';
+      body.dataset.animating = '0';
+    }, accordionAnimationMs);
+  }
+
+  document.addEventListener(
+    'click',
+    function (event) {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      const summary = target.closest('.changelog-accordion > summary');
+      if (!(summary instanceof HTMLElement)) {
+        return;
+      }
+      const details = summary.parentElement;
+      if (!(details instanceof HTMLDetailsElement)) {
+        return;
+      }
+      const body = details.querySelector('.changelog-accordion-body');
+      if (!(body instanceof HTMLElement)) {
+        return;
+      }
+      event.preventDefault();
+      animateAccordion(details, body, !details.open);
     },
     { signal },
   );

--- a/src/houndarr/static/js/changelog.js
+++ b/src/houndarr/static/js/changelog.js
@@ -1,0 +1,170 @@
+// Client controller for the "What's new" changelog modal.
+// Listens for the HX-Trigger dispatched by /settings/changelog/popup and
+// calls showModal() on the injected <dialog>.  Mirrors the AbortController
+// cleanup pattern used in settings_content.html so HTMX partial swaps do
+// not double-register listeners.
+//
+// The modal DOM is injected by HTMX replacing #changelog-slot; the buttons
+// inside carry their own hx-post attributes, so dismiss/disable writes go
+// through the standard HTMX pipeline (CSRF token added by app.js).  This
+// file only handles open/close lifecycle and focus restoration.
+
+(function () {
+  if (window.__houndarrChangelogController) {
+    window.__houndarrChangelogController.abort();
+  }
+  const controller = new AbortController();
+  window.__houndarrChangelogController = controller;
+  const { signal } = controller;
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const closeAnimationMs = 160;
+  let previouslyFocused = null;
+  let isClosing = false;
+
+  function getDialog() {
+    return document.getElementById('changelog-modal');
+  }
+
+  function openDialog() {
+    const dialog = getDialog();
+    if (!dialog || dialog.open) {
+      return;
+    }
+    // Guard: never stack on top of another open dialog (e.g. the
+    // instance-add modal on the Settings page).  The auto-open trigger
+    // should lose cleanly when the admin is mid-task.
+    const existingOpen = document.querySelector('dialog[open]');
+    if (existingOpen && existingOpen !== dialog) {
+      return;
+    }
+    previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    isClosing = false;
+    dialog.classList.remove('is-closing');
+    dialog.showModal();
+    document.body.style.overflow = 'hidden';
+  }
+
+  function restoreFocus() {
+    if (previouslyFocused && document.contains(previouslyFocused)) {
+      previouslyFocused.focus();
+    }
+    previouslyFocused = null;
+  }
+
+  function closeDialog() {
+    const dialog = getDialog();
+    if (!dialog || !dialog.open || isClosing) {
+      return;
+    }
+
+    const finalize = () => {
+      dialog.classList.remove('is-closing');
+      if (dialog.open) {
+        dialog.close();
+      }
+      document.body.style.overflow = '';
+      isClosing = false;
+      restoreFocus();
+      // Remove the dialog from the DOM so a subsequent auto-open cycle
+      // can HTMX-inject a fresh one without stale listeners.
+      dialog.remove();
+    };
+
+    if (prefersReducedMotion) {
+      finalize();
+      return;
+    }
+
+    isClosing = true;
+    dialog.classList.add('is-closing');
+    window.setTimeout(finalize, closeAnimationMs);
+  }
+
+  // Server-triggered custom event (fired by HX-Trigger response header).
+  document.body.addEventListener(
+    'houndarr-show-changelog',
+    function () {
+      openDialog();
+    },
+    { signal },
+  );
+
+  // Native <dialog> Escape key fires a `cancel` event.  We preventDefault
+  // so the close animation runs, then dispatch the dismiss POST through
+  // HTMX by clicking the primary button (keeps persistence logic in one
+  // place).
+  document.body.addEventListener(
+    'cancel',
+    function (event) {
+      const target = event.target;
+      if (!(target instanceof HTMLDialogElement) || target.id !== 'changelog-modal') {
+        return;
+      }
+      event.preventDefault();
+      const dismissBtn = target.querySelector('[data-changelog-dismiss="true"]');
+      if (dismissBtn instanceof HTMLElement) {
+        dismissBtn.click();
+      } else {
+        closeDialog();
+      }
+    },
+    { signal },
+  );
+
+  // Backdrop click (the <dialog> itself is the click target when the
+  // backdrop is clicked, because the inner content stops propagation at
+  // the dialog box).  Treat as equivalent to dismiss.
+  document.body.addEventListener(
+    'click',
+    function (event) {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      // Close button inside the modal header
+      if (target.closest('[data-close-changelog-modal="true"]')) {
+        const dialog = getDialog();
+        const dismissBtn = dialog?.querySelector('[data-changelog-dismiss="true"]');
+        if (dismissBtn instanceof HTMLElement) {
+          dismissBtn.click();
+        } else {
+          closeDialog();
+        }
+        return;
+      }
+
+      // Backdrop click: event.target is the <dialog> itself.
+      if (target.id === 'changelog-modal' && target instanceof HTMLDialogElement) {
+        const dismissBtn = target.querySelector('[data-changelog-dismiss="true"]');
+        if (dismissBtn instanceof HTMLElement) {
+          dismissBtn.click();
+        } else {
+          closeDialog();
+        }
+      }
+    },
+    { signal },
+  );
+
+  // After dismiss/disable POSTs complete (hx-swap="none"), close the
+  // dialog.  htmx:afterRequest fires even on 204 responses.
+  document.body.addEventListener(
+    'htmx:afterRequest',
+    function (evt) {
+      const triggerEl = evt.detail?.elt;
+      if (!(triggerEl instanceof Element)) {
+        return;
+      }
+      if (
+        triggerEl.matches('[data-changelog-dismiss="true"]') ||
+        triggerEl.matches('[data-changelog-disable="true"]')
+      ) {
+        closeDialog();
+      }
+    },
+    { signal },
+  );
+})();

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -200,7 +200,16 @@
 
   {% block scripts %}{% endblock %}
 
+  {% if show_nav is not defined or show_nav %}
+  <div id="changelog-slot"
+       hx-get="/settings/changelog/popup"
+       hx-trigger="load once delay:800ms"
+       hx-swap="outerHTML"
+       hx-target="this"></div>
+  {% endif %}
+
   <script src="/static/js/app.js"></script>
+  <script src="/static/js/changelog.js"></script>
 
 </body>
 </html>

--- a/src/houndarr/templates/partials/changelog_content.html
+++ b/src/houndarr/templates/partials/changelog_content.html
@@ -23,9 +23,9 @@
 
   {% if older %}
   {# Accordion for older releases when span is 2+ extra entries #}
-  <details class="border-t border-[#1e2638] pt-4 group">
+  <details class="changelog-accordion border-t border-[#1e2638] pt-4 group">
     <summary
-      class="cursor-pointer list-none text-sm font-medium text-slate-300 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30 rounded-sm flex items-center gap-2"
+      class="cursor-pointer list-none text-sm font-medium text-slate-300 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 rounded-sm flex items-center gap-2"
     >
       <svg
         class="w-3.5 h-3.5 transition-transform group-open:rotate-90"
@@ -42,7 +42,7 @@
       Show older releases ({{ older | length }})
     </summary>
 
-    <div class="mt-4 space-y-6">
+    <div class="changelog-accordion-body mt-4 space-y-6">
       {% for release in older %}
       <section class="space-y-3" data-changelog-release="{{ release.version }}">
         <header class="flex items-baseline gap-3">

--- a/src/houndarr/templates/partials/changelog_content.html
+++ b/src/houndarr/templates/partials/changelog_content.html
@@ -1,0 +1,71 @@
+<article class="space-y-6">
+  {# Newest release: always expanded, visible without scrolling #}
+  <section class="space-y-3" data-changelog-release="{{ newest.version }}">
+    <header class="flex items-baseline gap-3">
+      <h3 class="text-lg font-semibold text-white">v{{ newest.version }}</h3>
+      <time class="text-xs text-slate-500 font-mono">{{ newest.date }}</time>
+    </header>
+    {% for section in newest.sections %}
+    <div>
+      <h4
+        class="text-xs uppercase tracking-widest text-brand-300 font-medium mb-1.5"
+      >
+        {{ section.heading }}
+      </h4>
+      <ul class="space-y-1.5 text-sm text-slate-300 list-disc pl-5">
+        {% for bullet in section.bullets %}
+        <li>{{ bullet | changelog_bullet }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endfor %}
+  </section>
+
+  {% if older %}
+  {# Accordion for older releases when span is 2+ extra entries #}
+  <details class="border-t border-[#1e2638] pt-4 group">
+    <summary
+      class="cursor-pointer list-none text-sm font-medium text-slate-300 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30 rounded-sm flex items-center gap-2"
+    >
+      <svg
+        class="w-3.5 h-3.5 transition-transform group-open:rotate-90"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M7.21 5.23a.75.75 0 0 1 1.06-.02l4.46 4.25a.75.75 0 0 1 0 1.08l-4.46 4.25a.75.75 0 1 1-1.04-1.08L11.118 10 7.23 6.29a.75.75 0 0 1-.02-1.06Z"
+          clip-rule="evenodd"
+        />
+      </svg>
+      Show older releases ({{ older | length }})
+    </summary>
+
+    <div class="mt-4 space-y-6">
+      {% for release in older %}
+      <section class="space-y-3" data-changelog-release="{{ release.version }}">
+        <header class="flex items-baseline gap-3">
+          <h3 class="text-base font-semibold text-slate-200">v{{ release.version }}</h3>
+          <time class="text-xs text-slate-500 font-mono">{{ release.date }}</time>
+        </header>
+        {% for section in release.sections %}
+        <div>
+          <h4
+            class="text-xs uppercase tracking-widest text-brand-300 font-medium mb-1.5"
+          >
+            {{ section.heading }}
+          </h4>
+          <ul class="space-y-1.5 text-sm text-slate-300 list-disc pl-5">
+            {% for bullet in section.bullets %}
+            <li>{{ bullet | changelog_bullet }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endfor %}
+      </section>
+      {% endfor %}
+    </div>
+  </details>
+  {% endif %}
+</article>

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -2,7 +2,7 @@
   id="changelog-modal"
   class="m-auto p-0 w-[min(94vw,38rem)] rounded-2xl border border-[#1e2638] bg-[#0e1117] text-slate-100"
   aria-labelledby="changelog-modal-title"
-  aria-describedby="changelog-modal-subtitle"
+  {% if range_label %}aria-describedby="changelog-modal-subtitle"{% endif %}
   style="box-shadow: 0 30px 80px rgba(0,0,0,0.7), 0 0 0 1px rgba(30,38,56,0.8);"
 >
   <style>

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -87,11 +87,19 @@
       }
     }
 
+    /* Accordion body: smooth open/close via JS-controlled height + opacity. */
+    #changelog-modal .changelog-accordion-body {
+      overflow: hidden;
+      will-change: height, opacity;
+    }
+
     @media (prefers-reduced-motion: reduce) {
       #changelog-modal,
       #changelog-modal[open],
       #changelog-modal::backdrop,
-      #changelog-modal[open]::backdrop {
+      #changelog-modal[open]::backdrop,
+      #changelog-modal .changelog-accordion-body,
+      #changelog-modal svg.transition-transform {
         animation: none;
         transition: none;
         transform: none;
@@ -100,7 +108,7 @@
     }
   </style>
 
-  <div class="flex items-start justify-between border-b border-[#1e2638] px-6 py-5">
+  <div class="flex items-center justify-between border-b border-[#1e2638] px-6 py-4">
     <div class="min-w-0">
       <h2
         id="changelog-modal-title"
@@ -118,7 +126,7 @@
       type="button"
       aria-label="Close changelog"
       data-close-changelog-modal="true"
-      class="ml-4 flex-shrink-0 rounded-lg border border-[#2a3448] bg-[#151b27] p-3 text-slate-400 hover:bg-[#1e2638] hover:text-slate-200 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+      class="ml-4 flex-shrink-0 rounded-lg border border-[#2a3448] bg-[#151b27] p-2 text-slate-400 hover:bg-[#1e2638] hover:text-slate-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30"
     >
       <span aria-hidden="true" class="block leading-none text-xl">&times;</span>
     </button>
@@ -135,7 +143,7 @@
       href="https://github.com/av1155/houndarr/blob/main/CHANGELOG.md"
       target="_blank"
       rel="noopener noreferrer"
-      class="text-xs font-medium text-brand-300 hover:text-brand-200 underline underline-offset-4 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30 rounded-sm"
+      class="text-xs font-medium text-brand-300 hover:text-brand-200 underline underline-offset-4 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 rounded-sm"
     >
       Full changelog on GitHub
     </a>
@@ -146,7 +154,7 @@
         data-changelog-disable="true"
         hx-post="/settings/changelog/disable"
         hx-swap="none"
-        class="px-3 py-2 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-surface-2 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+        class="px-3 py-2 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-surface-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30"
       >
         Don't show again
       </button>
@@ -157,7 +165,7 @@
         data-changelog-dismiss="true"
         hx-post="/settings/changelog/dismiss"
         hx-swap="none"
-        class="px-4 py-2 rounded-lg bg-brand-500 hover:bg-brand-400 text-white text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/35"
+        class="px-4 py-2 rounded-lg bg-brand-500 hover:bg-brand-400 text-white text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/35"
       >
         Got it
       </button>

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -1,0 +1,166 @@
+<dialog
+  id="changelog-modal"
+  class="m-auto p-0 w-[min(94vw,38rem)] rounded-2xl border border-[#1e2638] bg-[#0e1117] text-slate-100"
+  aria-labelledby="changelog-modal-title"
+  aria-describedby="changelog-modal-subtitle"
+  style="box-shadow: 0 30px 80px rgba(0,0,0,0.7), 0 0 0 1px rgba(30,38,56,0.8);"
+>
+  <style>
+    #changelog-modal {
+      opacity: 0;
+      transform: translateY(12px) scale(0.98);
+    }
+
+    #changelog-modal[open] {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+      animation: changelog-modal-in 180ms ease-out;
+    }
+
+    #changelog-modal[open].is-closing {
+      animation: changelog-modal-out 160ms ease-in forwards;
+    }
+
+    #changelog-modal::backdrop {
+      background: rgba(2, 6, 23, 0);
+    }
+
+    #changelog-modal[open]::backdrop {
+      animation: changelog-backdrop-in var(--dur-base, 180ms)
+        var(--ease-station, cubic-bezier(0.16, 1, 0.3, 1)) forwards;
+      backdrop-filter: blur(3px);
+    }
+
+    #changelog-modal[open].is-closing::backdrop {
+      animation: changelog-backdrop-out 160ms ease-in forwards;
+    }
+
+    @keyframes changelog-modal-in {
+      from { opacity: 0; transform: translateY(12px) scale(0.98); }
+      to   { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    @keyframes changelog-backdrop-in {
+      from { background: rgba(2, 6, 23, 0); }
+      to   { background: rgba(2, 6, 23, 0.65); }
+    }
+
+    @keyframes changelog-modal-out {
+      from { opacity: 1; transform: translateY(0) scale(1); }
+      to   { opacity: 0; transform: translateY(8px) scale(0.985); }
+    }
+
+    @keyframes changelog-backdrop-out {
+      from { background: rgba(2, 6, 23, 0.65); }
+      to   { background: rgba(2, 6, 23, 0); }
+    }
+
+    /* Mobile: bottom sheet */
+    @media (max-width: 639px) {
+      #changelog-modal {
+        position: fixed;
+        inset: auto 0 0 0;
+        margin: 0;
+        max-height: 90dvh;
+        width: 100vw;
+        border-radius: 16px 16px 0 0;
+        transform: translateY(100%);
+      }
+
+      #changelog-modal[open] {
+        transform: translateY(0);
+        animation: changelog-sheet-in 220ms var(--ease-station, cubic-bezier(0.16, 1, 0.3, 1));
+      }
+
+      #changelog-modal[open].is-closing {
+        animation: changelog-sheet-out 180ms ease-in forwards;
+      }
+
+      @keyframes changelog-sheet-in {
+        from { transform: translateY(100%); }
+        to   { transform: translateY(0); }
+      }
+
+      @keyframes changelog-sheet-out {
+        from { transform: translateY(0); }
+        to   { transform: translateY(100%); }
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      #changelog-modal,
+      #changelog-modal[open],
+      #changelog-modal::backdrop,
+      #changelog-modal[open]::backdrop {
+        animation: none;
+        transition: none;
+        transform: none;
+        opacity: 1;
+      }
+    }
+  </style>
+
+  <div class="flex items-start justify-between border-b border-[#1e2638] px-6 py-5">
+    <div class="min-w-0">
+      <h2
+        id="changelog-modal-title"
+        class="text-xl font-semibold tracking-tight text-white"
+      >
+        What's new
+      </h2>
+      {% if range_label %}
+      <p id="changelog-modal-subtitle" class="text-sm text-slate-400 mt-0.5 font-mono">
+        {{ range_label }}
+      </p>
+      {% endif %}
+    </div>
+    <button
+      type="button"
+      aria-label="Close changelog"
+      data-close-changelog-modal="true"
+      class="ml-4 flex-shrink-0 rounded-lg border border-[#2a3448] bg-[#151b27] p-3 text-slate-400 hover:bg-[#1e2638] hover:text-slate-200 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+    >
+      <span aria-hidden="true" class="block leading-none text-xl">&times;</span>
+    </button>
+  </div>
+
+  <div class="max-h-[min(calc(100dvh-14rem),36rem)] overflow-y-auto px-6 py-5">
+    {% include "partials/changelog_content.html" %}
+  </div>
+
+  <div
+    class="flex flex-wrap items-center justify-between gap-3 border-t border-[#1e2638] px-6 py-4"
+  >
+    <a
+      href="https://github.com/av1155/houndarr/blob/main/CHANGELOG.md"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-xs font-medium text-brand-300 hover:text-brand-200 underline underline-offset-4 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30 rounded-sm"
+    >
+      Full changelog on GitHub
+    </a>
+    <div class="flex items-center gap-2">
+      {% if not manual %}
+      <button
+        type="button"
+        data-changelog-disable="true"
+        hx-post="/settings/changelog/disable"
+        hx-swap="none"
+        class="px-3 py-2 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-surface-2 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+      >
+        Don't show again
+      </button>
+      {% endif %}
+      <button
+        type="button"
+        autofocus
+        data-changelog-dismiss="true"
+        hx-post="/settings/changelog/dismiss"
+        hx-swap="none"
+        class="px-4 py-2 rounded-lg bg-brand-500 hover:bg-brand-400 text-white text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/35"
+      >
+        Got it
+      </button>
+    </div>
+  </div>
+</dialog>

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -57,8 +57,11 @@
 
     /* Mobile: bottom sheet.  The native <dialog> UA stylesheet sets
        max-width: calc(100% - 38px) and centers via inset; we override
-       both so the sheet can span the full viewport width and pin to the
-       bottom edge. */
+       both so the sheet can pin to the bottom edge and span the full
+       containing-block width.  Use `width: 100%` (not 100vw) because
+       `scrollbar-gutter: stable both-edges` on <html> shrinks the
+       containing block for fixed-positioned elements; 100vw would
+       overshoot the right edge by the gutter width. */
     @media (max-width: 639px) {
       #changelog-modal {
         position: fixed;
@@ -68,8 +71,8 @@
         left: 0;
         margin: 0;
         max-height: 90dvh;
-        max-width: 100vw;
-        width: 100vw;
+        max-width: 100%;
+        width: 100%;
         border-radius: 16px 16px 0 0;
         transform: translateY(100%);
       }

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -55,13 +55,20 @@
       to   { background: rgba(2, 6, 23, 0); }
     }
 
-    /* Mobile: bottom sheet */
+    /* Mobile: bottom sheet.  The native <dialog> UA stylesheet sets
+       max-width: calc(100% - 38px) and centers via inset; we override
+       both so the sheet can span the full viewport width and pin to the
+       bottom edge. */
     @media (max-width: 639px) {
       #changelog-modal {
         position: fixed;
-        inset: auto 0 0 0;
+        top: auto;
+        right: 0;
+        bottom: 0;
+        left: 0;
         margin: 0;
         max-height: 90dvh;
+        max-width: 100vw;
         width: 100vw;
         border-radius: 16px 16px 0 0;
         transform: translateY(100%);

--- a/src/houndarr/templates/partials/changelog_settings_section.html
+++ b/src/houndarr/templates/partials/changelog_settings_section.html
@@ -26,9 +26,6 @@
       />
       Show a changelog summary after each update
     </label>
-    <span class="text-xs text-slate-500"
-      >Visible once per new version; silent on rollback.</span
-    >
   </form>
 
   <div class="mt-4">

--- a/src/houndarr/templates/partials/changelog_settings_section.html
+++ b/src/houndarr/templates/partials/changelog_settings_section.html
@@ -21,7 +21,7 @@
         name="enabled"
         value="on"
         {% if changelog_popups_enabled %}checked{% endif %}
-        class="h-4 w-4 rounded border-[#2a3448] bg-[#0e1117] accent-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+        class="h-4 w-4 rounded border-[#2a3448] bg-[#0e1117] accent-brand-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30"
         onchange="this.form.requestSubmit()"
       />
       Show a changelog summary after each update
@@ -34,7 +34,7 @@
       hx-get="/settings/changelog/popup?force=1"
       hx-swap="outerHTML"
       hx-target="#changelog-slot"
-      class="px-3 py-1.5 rounded border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+      class="px-3 py-1.5 rounded border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30"
     >
       Show last changelog
     </button>

--- a/src/houndarr/templates/partials/changelog_settings_section.html
+++ b/src/houndarr/templates/partials/changelog_settings_section.html
@@ -1,0 +1,45 @@
+<section
+  id="changelog-section"
+  class="mt-8 rounded-xl border border-[#1e2638] bg-[#0e1117] p-4 sm:p-5"
+>
+  <div class="space-y-1 mb-4">
+    <h2 class="text-base font-semibold text-slate-200">Changelog notifications</h2>
+    <p class="text-sm text-slate-400">
+      Show a summary of what changed after each update.
+    </p>
+  </div>
+
+  <form
+    hx-post="/settings/changelog/preferences"
+    hx-target="#changelog-section"
+    hx-swap="outerHTML"
+    class="flex flex-wrap items-center gap-3"
+  >
+    <label class="inline-flex items-center gap-2 text-sm text-slate-200 cursor-pointer">
+      <input
+        type="checkbox"
+        name="enabled"
+        value="on"
+        {% if changelog_popups_enabled %}checked{% endif %}
+        class="h-4 w-4 rounded border-[#2a3448] bg-[#0e1117] accent-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+        onchange="this.form.requestSubmit()"
+      />
+      Show a changelog summary after each update
+    </label>
+    <span class="text-xs text-slate-500"
+      >Visible once per new version; silent on rollback.</span
+    >
+  </form>
+
+  <div class="mt-4">
+    <button
+      type="button"
+      hx-get="/settings/changelog/popup?force=1"
+      hx-swap="outerHTML"
+      hx-target="#changelog-slot"
+      class="px-3 py-1.5 rounded border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400/30"
+    >
+      Show last changelog
+    </button>
+  </div>
+</section>

--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -388,6 +388,8 @@
     </table>
   </div>
 
+  {% include "partials/changelog_settings_section.html" %}
+
   {% if auth_mode != "proxy" %}
   <section id="account-section" class="mt-8 rounded-xl border border-[#1e2638] bg-[#0e1117] p-4 sm:p-5">
     <details id="account-settings" {% if account_error or account_success %}open{% endif %}>

--- a/tests/test_routes/test_changelog.py
+++ b/tests/test_routes/test_changelog.py
@@ -336,3 +336,60 @@ async def test_force_popup_when_changelog_missing(
     resp = app.get("/settings/changelog/popup?force=1")
     assert resp.status_code == 200
     assert "<dialog" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Bullet renderer: scheme allowlist + balanced parens
+# ---------------------------------------------------------------------------
+
+
+def test_link_substitution_blocks_javascript_scheme() -> None:
+    from houndarr.routes.changelog import _render_changelog_bullet
+
+    rendered = str(_render_changelog_bullet("[click](javascript:alert(1))"))
+    # No <a href="javascript:..."> emitted; original markdown text remains
+    # visible (escape() already neutralised the < > < etc).
+    assert 'href="javascript:' not in rendered
+    assert "<a" not in rendered
+    assert "[click]" in rendered
+
+
+def test_link_substitution_blocks_data_scheme() -> None:
+    from houndarr.routes.changelog import _render_changelog_bullet
+
+    rendered = str(_render_changelog_bullet("[x](data:text/html,<script>alert(1)</script>)"))
+    assert 'href="data:' not in rendered
+    assert "<a" not in rendered
+
+
+def test_link_substitution_allows_https() -> None:
+    from houndarr.routes.changelog import _render_changelog_bullet
+
+    rendered = str(_render_changelog_bullet("[ok](https://example.com/path)"))
+    assert '<a href="https://example.com/path"' in rendered
+
+
+def test_link_substitution_allows_mailto() -> None:
+    from houndarr.routes.changelog import _render_changelog_bullet
+
+    rendered = str(_render_changelog_bullet("[ping](mailto:dev@example.com)"))
+    assert '<a href="mailto:dev@example.com"' in rendered
+
+
+def test_link_substitution_allows_relative_and_fragment() -> None:
+    from houndarr.routes.changelog import _render_changelog_bullet
+
+    rendered = str(_render_changelog_bullet("[home](/) and [section](#anchor)"))
+    assert '<a href="/"' in rendered
+    assert '<a href="#anchor"' in rendered
+
+
+def test_link_substitution_supports_balanced_parens_in_url() -> None:
+    """URLs containing one level of nested parens (e.g. Wikipedia) render whole."""
+    from houndarr.routes.changelog import _render_changelog_bullet
+
+    raw = "see [Foo](https://en.wikipedia.org/wiki/Foo_(bar)) for details"
+    rendered = str(_render_changelog_bullet(raw))
+    assert '<a href="https://en.wikipedia.org/wiki/Foo_(bar)"' in rendered
+    # No truncated link followed by literal "(bar))"
+    assert "_bar)" not in rendered.replace('href="https://en.wikipedia.org/wiki/Foo_(bar)"', "")

--- a/tests/test_routes/test_changelog.py
+++ b/tests/test_routes/test_changelog.py
@@ -248,6 +248,26 @@ async def test_disable_then_popup_returns_empty(app: TestClient, sample_changelo
     assert "<dialog" not in resp.text
 
 
+async def test_disabled_popup_silently_advances_last_seen(
+    app: TestClient, sample_changelog: Path
+) -> None:
+    """While popups are disabled, every popup poll advances last_seen so
+    that re-enabling later does not surface a backlog of releases the
+    admin already chose to skip.
+    """
+    _login(app)
+    # Simulate: admin was on 1.6.0, disabled popups (which writes 1.6.0
+    # as last_seen via the Settings toggle path which leaves last_seen
+    # untouched), then upgraded to current.
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    await set_setting("changelog_popups_disabled", "1")
+    resp = app.get("/settings/changelog/popup")
+    assert resp.status_code == 200
+    assert "<dialog" not in resp.text
+    # Silent advance happened: last_seen now matches running.
+    assert await get_setting("changelog_last_seen_version") == __version__
+
+
 # ---------------------------------------------------------------------------
 # Preferences toggle
 # ---------------------------------------------------------------------------

--- a/tests/test_routes/test_changelog.py
+++ b/tests/test_routes/test_changelog.py
@@ -1,0 +1,318 @@
+"""Tests for the changelog modal routes and setup seeding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from houndarr import __version__
+from houndarr.database import get_setting, set_setting
+from houndarr.services import changelog as cl
+from tests.conftest import csrf_headers
+
+_SAMPLE_CHANGELOG = f"""# Changelog
+
+## [{__version__}] - 2026-04-16
+
+### Added
+
+- New feature with `backticks` and [a link](https://example.com). (#408)
+
+### Fixed
+
+- A bug. (#123)
+
+---
+
+## [1.7.0] - 2026-04-04
+
+### Added
+
+- Older feature. (#338)
+
+---
+
+## [1.6.0] - 2026-03-21
+
+### Changed
+
+- Earlier change. (#272)
+
+---
+"""
+
+
+@pytest.fixture()
+def sample_changelog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the service module at a fixture CHANGELOG.md with known content."""
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(_SAMPLE_CHANGELOG, encoding="utf-8")
+    monkeypatch.setattr(cl, "CHANGELOG_PATH", path)
+    cl._reset_changelog_cache()
+    return path
+
+
+def _login(client: TestClient) -> None:
+    """Complete setup + login so subsequent requests are authenticated."""
+    client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+
+# ---------------------------------------------------------------------------
+# Auth gates
+# ---------------------------------------------------------------------------
+
+
+def test_popup_requires_auth(app: TestClient) -> None:
+    resp = app.get("/settings/changelog/popup", follow_redirects=False)
+    assert resp.status_code == 302
+
+
+def test_dismiss_requires_auth(app: TestClient) -> None:
+    resp = app.post("/settings/changelog/dismiss", follow_redirects=False)
+    assert resp.status_code == 302
+
+
+def test_disable_requires_auth(app: TestClient) -> None:
+    resp = app.post("/settings/changelog/disable", follow_redirects=False)
+    assert resp.status_code == 302
+
+
+def test_preferences_requires_auth(app: TestClient) -> None:
+    resp = app.post("/settings/changelog/preferences", follow_redirects=False)
+    assert resp.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# CSRF gate on POST routes
+# ---------------------------------------------------------------------------
+
+
+def test_dismiss_rejects_missing_csrf(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    resp = app.post("/settings/changelog/dismiss")  # no CSRF header
+    assert resp.status_code == 403
+
+
+def test_disable_rejects_missing_csrf(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    resp = app.post("/settings/changelog/disable")
+    assert resp.status_code == 403
+
+
+def test_preferences_rejects_missing_csrf(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    resp = app.post("/settings/changelog/preferences")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Setup seeding: fresh install writes last_seen_version = current
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_seeds_changelog_last_seen_version(
+    app: TestClient, sample_changelog: Path
+) -> None:
+    _login(app)
+    stored = await get_setting("changelog_last_seen_version")
+    assert stored == __version__
+
+
+async def test_fresh_install_popup_returns_empty(app: TestClient, sample_changelog: Path) -> None:
+    """Post-setup, running == last_seen, so auto-popup returns the empty placeholder."""
+    _login(app)
+    resp = app.get("/settings/changelog/popup")
+    assert resp.status_code == 200
+    assert "<dialog" not in resp.text
+    assert 'id="changelog-slot"' in resp.text
+    assert "HX-Trigger" not in resp.headers
+
+
+# ---------------------------------------------------------------------------
+# Auto-popup: upgrade scenario
+# ---------------------------------------------------------------------------
+
+
+async def test_upgrade_popup_renders_modal(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    # Simulate a user who was on 1.6.0 before upgrading to the current version.
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    resp = app.get("/settings/changelog/popup")
+    assert resp.status_code == 200
+    assert 'id="changelog-modal"' in resp.text
+    assert "<dialog" in resp.text
+    assert resp.headers.get("HX-Trigger") == "houndarr-show-changelog"
+    # Newest and one older release should both appear.
+    assert f"v{__version__}" in resp.text
+    assert "v1.7.0" in resp.text
+
+
+async def test_upgrade_popup_renders_bullet_markdown(
+    app: TestClient, sample_changelog: Path
+) -> None:
+    _login(app)
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    resp = app.get("/settings/changelog/popup")
+    # Inline code, link, and issue ref all render as HTML.
+    assert '<code class="text-brand-300">backticks</code>' in resp.text
+    assert 'href="https://example.com"' in resp.text
+    assert 'href="https://github.com/av1155/houndarr/issues/408"' in resp.text
+
+
+async def test_disabled_popup_returns_empty(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    await set_setting("changelog_popups_disabled", "1")
+    resp = app.get("/settings/changelog/popup")
+    assert resp.status_code == 200
+    assert "<dialog" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Force mode: manual re-open from Settings
+# ---------------------------------------------------------------------------
+
+
+async def test_force_popup_renders_current_version_only(
+    app: TestClient, sample_changelog: Path
+) -> None:
+    _login(app)  # last_seen == current via setup seed
+    resp = app.get("/settings/changelog/popup?force=1")
+    assert resp.status_code == 200
+    assert 'id="changelog-modal"' in resp.text
+    assert "<dialog" in resp.text
+    assert resp.headers.get("HX-Trigger") == "houndarr-show-changelog"
+    # Only the current version renders in force mode.
+    assert f"v{__version__}" in resp.text
+    assert "v1.6.0" not in resp.text
+    # "Don't show again" is hidden in manual mode.
+    assert "Don't show again" not in resp.text
+
+
+async def test_force_popup_does_not_mutate_persistence(
+    app: TestClient, sample_changelog: Path
+) -> None:
+    _login(app)
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    app.get("/settings/changelog/popup?force=1")
+    # Last-seen unchanged.
+    assert await get_setting("changelog_last_seen_version") == "1.6.0"
+
+
+# ---------------------------------------------------------------------------
+# Dismiss: writes last_seen = current, idempotent
+# ---------------------------------------------------------------------------
+
+
+async def test_dismiss_writes_current_version(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    resp = app.post("/settings/changelog/dismiss", headers=csrf_headers(app))
+    assert resp.status_code == 204
+    assert await get_setting("changelog_last_seen_version") == __version__
+
+
+async def test_dismiss_is_idempotent(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    app.post("/settings/changelog/dismiss", headers=csrf_headers(app))
+    resp = app.post("/settings/changelog/dismiss", headers=csrf_headers(app))
+    assert resp.status_code == 204
+    assert await get_setting("changelog_last_seen_version") == __version__
+
+
+# ---------------------------------------------------------------------------
+# Disable: writes both keys
+# ---------------------------------------------------------------------------
+
+
+async def test_disable_writes_both_keys(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    resp = app.post("/settings/changelog/disable", headers=csrf_headers(app))
+    assert resp.status_code == 204
+    assert await get_setting("changelog_last_seen_version") == __version__
+    assert await get_setting("changelog_popups_disabled") == "1"
+
+
+async def test_disable_then_popup_returns_empty(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    app.post("/settings/changelog/disable", headers=csrf_headers(app))
+    resp = app.get("/settings/changelog/popup")
+    assert "<dialog" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Preferences toggle
+# ---------------------------------------------------------------------------
+
+
+async def test_preferences_enable_writes_zero(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    await set_setting("changelog_popups_disabled", "1")
+    resp = app.post(
+        "/settings/changelog/preferences",
+        data={"enabled": "on"},
+        headers=csrf_headers(app),
+    )
+    assert resp.status_code == 200
+    assert await get_setting("changelog_popups_disabled") == "0"
+    # Returns the settings section partial with the checkbox checked.
+    assert 'id="changelog-section"' in resp.text
+    assert "checked" in resp.text
+
+
+async def test_preferences_disable_writes_one(app: TestClient, sample_changelog: Path) -> None:
+    _login(app)
+    resp = app.post(
+        "/settings/changelog/preferences",
+        data={},  # unchecked = field absent
+        headers=csrf_headers(app),
+    )
+    assert resp.status_code == 200
+    assert await get_setting("changelog_popups_disabled") == "1"
+    assert 'id="changelog-section"' in resp.text
+    # The checkbox should NOT be checked when disabled.
+    # We verify by locating the input element and checking the attribute.
+    # This is a weak assertion; the stronger one is the value in the DB above.
+    import re
+
+    input_match = re.search(r'<input[^>]*name="enabled"[^>]*>', resp.text)
+    assert input_match is not None
+    assert "checked" not in input_match.group(0)
+
+
+# ---------------------------------------------------------------------------
+# Edge case: CHANGELOG.md missing at runtime
+# ---------------------------------------------------------------------------
+
+
+async def test_popup_when_changelog_missing(
+    app: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _login(app)
+    monkeypatch.setattr(cl, "CHANGELOG_PATH", tmp_path / "missing.md")
+    cl._reset_changelog_cache()
+    await set_setting("changelog_last_seen_version", "1.6.0")
+    resp = app.get("/settings/changelog/popup")
+    assert resp.status_code == 200
+    # No parseable entries → empty placeholder, no 500.
+    assert "<dialog" not in resp.text
+    assert 'id="changelog-slot"' in resp.text
+
+
+async def test_force_popup_when_changelog_missing(
+    app: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _login(app)
+    monkeypatch.setattr(cl, "CHANGELOG_PATH", tmp_path / "missing.md")
+    cl._reset_changelog_cache()
+    resp = app.get("/settings/changelog/popup?force=1")
+    assert resp.status_code == 200
+    assert "<dialog" not in resp.text

--- a/tests/test_routes/test_changelog.py
+++ b/tests/test_routes/test_changelog.py
@@ -147,7 +147,7 @@ async def test_upgrade_popup_renders_modal(app: TestClient, sample_changelog: Pa
     assert resp.status_code == 200
     assert 'id="changelog-modal"' in resp.text
     assert "<dialog" in resp.text
-    assert resp.headers.get("HX-Trigger") == "houndarr-show-changelog"
+    assert resp.headers.get("HX-Trigger-After-Swap") == "houndarr-show-changelog"
     # Newest and one older release should both appear.
     assert f"v{__version__}" in resp.text
     assert "v1.7.0" in resp.text
@@ -187,7 +187,7 @@ async def test_force_popup_renders_current_version_only(
     assert resp.status_code == 200
     assert 'id="changelog-modal"' in resp.text
     assert "<dialog" in resp.text
-    assert resp.headers.get("HX-Trigger") == "houndarr-show-changelog"
+    assert resp.headers.get("HX-Trigger-After-Swap") == "houndarr-show-changelog"
     # Only the current version renders in force mode.
     assert f"v{__version__}" in resp.text
     assert "v1.6.0" not in resp.text

--- a/tests/test_routes/test_settings.py
+++ b/tests/test_routes/test_settings.py
@@ -117,6 +117,32 @@ def test_settings_page_renders(app: TestClient) -> None:
     assert b"Account" in resp.content
     assert b"Update Password" in resp.content
     assert b"Signed in as" in resp.content
+
+
+def test_settings_page_includes_changelog_section(app: TestClient) -> None:
+    _login(app)
+    resp = app.get("/settings")
+    assert resp.status_code == 200
+    assert b'id="changelog-section"' in resp.content
+    assert b"Changelog notifications" in resp.content
+    assert b"Show last changelog" in resp.content
+    # Fresh install defaults to enabled → checkbox checked.
+    assert b"checked" in resp.content
+
+
+async def test_settings_page_reflects_disabled_changelog(app: TestClient) -> None:
+    from houndarr.database import set_setting
+
+    _login(app)
+    await set_setting("changelog_popups_disabled", "1")
+    resp = app.get("/settings")
+    assert resp.status_code == 200
+    # Locate the changelog toggle input specifically and verify it is NOT checked.
+    import re
+
+    input_match = re.search(rb'<input[^>]*name="enabled"[^>]*>', resp.content)
+    assert input_match is not None
+    assert b"checked" not in input_match.group(0)
     assert b'id="account-settings"' in resp.content
     assert b'id="account-settings" open' not in resp.content
     assert b"What do these settings mean?" in resp.content

--- a/tests/test_services/test_changelog.py
+++ b/tests/test_services/test_changelog.py
@@ -1,0 +1,308 @@
+"""Tests for changelog parsing, version comparison, and show-decision logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from houndarr.services import changelog as cl
+
+# ---------------------------------------------------------------------------
+# _parse_version
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1.8.0", (1, 8, 0)),
+        ("0.0.0", (0, 0, 0)),
+        ("10.20.30", (10, 20, 30)),
+        ("  1.2.3  ", (1, 2, 3)),
+    ],
+)
+def test_parse_version_valid(raw: str, expected: tuple[int, int, int]) -> None:
+    assert cl._parse_version(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "abc",
+        "1.2",
+        "1.2.3.4",
+        "1.2.3-rc1",
+        "1.2.3+build",
+        "v1.2.3",
+        "1.2.x",
+    ],
+)
+def test_parse_version_invalid(raw: str | None) -> None:
+    assert cl._parse_version(raw) is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_changelog
+# ---------------------------------------------------------------------------
+
+
+_SAMPLE_CHANGELOG = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.8.0] - 2026-04-16
+
+### Added
+
+- New feature. (#1)
+- Another feature with `code` and [link](https://example.com).
+
+### Fixed
+
+- A bug. (#2)
+
+---
+
+## [1.7.0] - 2026-04-04
+
+### Added
+
+- Whisparr v3 support. (#338)
+
+### Fixed
+
+- Whisparr v2 `releaseDate` parsing. (#339)
+
+---
+
+## [1.6.0] - 2026-03-21
+
+### Changed
+
+- Inserted 3-second delay between searches. (#272)
+
+---
+"""
+
+
+def _write_changelog(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_parse_changelog_valid(tmp_path: Path) -> None:
+    path = _write_changelog(tmp_path, _SAMPLE_CHANGELOG)
+    entries = cl._parse_changelog(path)
+
+    assert len(entries) == 3
+    assert [e.version for e in entries] == ["1.8.0", "1.7.0", "1.6.0"]
+    assert [e.version_tuple for e in entries] == [(1, 8, 0), (1, 7, 0), (1, 6, 0)]
+    assert entries[0].date == "2026-04-16"
+
+    sections = {s.heading: s.bullets for s in entries[0].sections}
+    assert sections["Added"] == [
+        "New feature. (#1)",
+        "Another feature with `code` and [link](https://example.com).",
+    ]
+    assert sections["Fixed"] == ["A bug. (#2)"]
+
+
+def test_parse_changelog_missing_file(tmp_path: Path) -> None:
+    entries = cl._parse_changelog(tmp_path / "does-not-exist.md")
+    assert entries == []
+
+
+def test_parse_changelog_empty_file(tmp_path: Path) -> None:
+    path = _write_changelog(tmp_path, "# Changelog\n\nNo entries yet.\n")
+    assert cl._parse_changelog(path) == []
+
+
+def test_parse_changelog_skips_malformed_heading(tmp_path: Path) -> None:
+    content = """## [1.8.0] 2026-04-16
+
+### Added
+
+- Should be skipped; missing dash separator in the heading.
+
+---
+
+## [1.7.0] - 2026-04-04
+
+### Added
+
+- Valid entry.
+
+---
+"""
+    entries = cl._parse_changelog(_write_changelog(tmp_path, content))
+    assert [e.version for e in entries] == ["1.7.0"]
+
+
+def test_parse_changelog_permissive_section_headers(tmp_path: Path) -> None:
+    content = """## [2.0.0] - 2026-05-01
+
+### Security
+
+- Patched a CVE. (#999)
+
+### Deprecated
+
+- Old flag removed in next major.
+
+---
+"""
+    entries = cl._parse_changelog(_write_changelog(tmp_path, content))
+    assert len(entries) == 1
+    headings = [s.heading for s in entries[0].sections]
+    assert headings == ["Security", "Deprecated"]
+
+
+def test_parse_changelog_wrapped_bullets(tmp_path: Path) -> None:
+    content = """## [1.8.0] - 2026-04-16
+
+### Added
+
+- First bullet that continues
+  onto a second wrapped line.
+- Second bullet.
+
+---
+"""
+    entries = cl._parse_changelog(_write_changelog(tmp_path, content))
+    assert entries[0].sections[0].bullets == [
+        "First bullet that continues onto a second wrapped line.",
+        "Second bullet.",
+    ]
+
+
+def test_parse_changelog_unterminated_trailing_block(tmp_path: Path) -> None:
+    content = """## [1.8.0] - 2026-04-16
+
+### Added
+
+- Bullet.
+"""
+    entries = cl._parse_changelog(_write_changelog(tmp_path, content))
+    assert len(entries) == 1
+    assert entries[0].version == "1.8.0"
+
+
+# ---------------------------------------------------------------------------
+# Lazy singleton cache
+# ---------------------------------------------------------------------------
+
+
+def test_get_changelog_caches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_changelog(tmp_path, _SAMPLE_CHANGELOG)
+    monkeypatch.setattr(cl, "CHANGELOG_PATH", path)
+    cl._reset_changelog_cache()
+
+    first = cl.get_changelog()
+    second = cl.get_changelog()
+    assert first is second
+
+
+def test_reset_changelog_cache_forces_reparse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write_changelog(tmp_path, _SAMPLE_CHANGELOG)
+    monkeypatch.setattr(cl, "CHANGELOG_PATH", path)
+    cl._reset_changelog_cache()
+
+    first = cl.get_changelog()
+    cl._reset_changelog_cache()
+    second = cl.get_changelog()
+    assert first is not second
+    assert [e.version for e in first] == [e.version for e in second]
+
+
+# ---------------------------------------------------------------------------
+# releases_between
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_changelog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = _write_changelog(tmp_path, _SAMPLE_CHANGELOG)
+    monkeypatch.setattr(cl, "CHANGELOG_PATH", path)
+    cl._reset_changelog_cache()
+    return path
+
+
+def test_releases_between_spans_multiple(sample_changelog: Path) -> None:
+    entries = cl.releases_between(last_seen="1.6.0", running="1.8.0")
+    assert [e.version for e in entries] == ["1.8.0", "1.7.0"]
+
+
+def test_releases_between_single_match(sample_changelog: Path) -> None:
+    entries = cl.releases_between(last_seen="1.7.0", running="1.8.0")
+    assert [e.version for e in entries] == ["1.8.0"]
+
+
+def test_releases_between_none_when_current(sample_changelog: Path) -> None:
+    assert cl.releases_between(last_seen="1.8.0", running="1.8.0") == []
+
+
+def test_releases_between_downgrade(sample_changelog: Path) -> None:
+    assert cl.releases_between(last_seen="1.8.0", running="1.6.0") == []
+
+
+def test_releases_between_unparseable_running(sample_changelog: Path) -> None:
+    assert cl.releases_between(last_seen="1.6.0", running=None) == []
+    assert cl.releases_between(last_seen="1.6.0", running="bogus") == []
+
+
+def test_releases_between_absent_last_seen_returns_current_only(
+    sample_changelog: Path,
+) -> None:
+    entries = cl.releases_between(last_seen=None, running="1.8.0")
+    assert [e.version for e in entries] == ["1.8.0"]
+
+
+def test_releases_between_unparseable_last_seen_returns_current_only(
+    sample_changelog: Path,
+) -> None:
+    entries = cl.releases_between(last_seen="corrupted", running="1.8.0")
+    assert [e.version for e in entries] == ["1.8.0"]
+
+
+def test_releases_between_absent_last_seen_no_matching_entry(
+    sample_changelog: Path,
+) -> None:
+    """Running version has no changelog entry (e.g. dev build, missing block)."""
+    assert cl.releases_between(last_seen=None, running="9.9.9") == []
+
+
+# ---------------------------------------------------------------------------
+# should_show
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("last_seen", "running", "disabled", "expected"),
+    [
+        # Happy paths
+        ("1.6.0", "1.8.0", False, True),  # upgrade → show
+        (None, "1.8.0", False, True),  # never seen → show
+        # Disabled trumps everything
+        ("1.6.0", "1.8.0", True, False),
+        (None, "1.8.0", True, False),
+        # Current version already seen
+        ("1.8.0", "1.8.0", False, False),
+        # Downgrade
+        ("1.8.0", "1.6.0", False, False),
+        # Unparseable running
+        ("1.6.0", None, False, False),
+        ("1.6.0", "bogus", False, False),
+        # Unparseable last_seen → treat as never seen
+        ("corrupted", "1.8.0", False, True),
+    ],
+)
+def test_should_show_truth_table(
+    last_seen: str | None, running: str | None, disabled: bool, expected: bool
+) -> None:
+    assert cl.should_show(last_seen=last_seen, running=running, disabled=disabled) == expected


### PR DESCRIPTION
## Summary

Adds an auto-triggered "What's new" modal that appears once after each update, surfacing the concatenated `CHANGELOG.md` blocks between the user's previously seen version and the running version. Two dismiss actions ("Got it" and "Don't show again"), both reversible from Settings, plus a "Show last changelog" admin button.

Closes #408

## Changes

- New `houndarr.services.changelog` parses `CHANGELOG.md` lazily and exposes `releases_between` + `should_show` decision helpers. Inline 3-tuple version compare; no new top-level dependency.
- New `/settings/changelog/{popup,dismiss,disable,preferences}` routes under the existing AuthMiddleware + CSRF pipeline.
- `#changelog-slot` mounted in `base.html` fires `hx-trigger="load once delay:800ms"` after every full page load (gated by `show_nav` so login/setup pages stay silent).
- Persistence: two new rows in the existing `settings` KV table (`changelog_last_seen_version`, `changelog_popups_disabled`). No schema migration; `SCHEMA_VERSION` stays at 12.
- `setup_post` silently seeds `last_seen_version = current` so fresh installs never see the modal on first dashboard load.
- Returning admins on a pre-feature upgrade see only the current version's block as a one-time welcome, then the row is seeded.
- Native `<dialog>` + `showModal()` matching the existing instance-add modal: focus trap, Escape, backdrop click, X button, "Got it" all dismiss; older releases collapse into a `<details>` accordion with smooth height + opacity transitions; bottom-sheet on mobile (<640px), centered dialog above; `prefers-reduced-motion` honoured.
- Bullet renderer: closed-vocabulary markdown subset (inline code, bold, links, `(#NNN)` issue refs linkified to GitHub) with HTML escape + scheme allowlist (defense-in-depth against `javascript:` / `data:` URLs).
- `Dockerfile` bundles `CHANGELOG.md`; `.dockerignore` re-includes it after the global `*.md` exclusion.
- `.gitignore` widened to cover `data-*/`, `.playwright-mcp/`, `.firecrawl/`, root-level images.

## Testing

All five quality gates pass. New coverage: 23 changelog-route tests + 39 service-parser tests + 3 settings integration tests; full suite is 1239 passing.

End-to-end verified in Chrome via Playwright across iPhone SE, iPhone 14 Pro, Pixel 7, iPad portrait + landscape, laptop, FullHD desktop, and ultrawide. All four dismiss paths, accordion animation, two-tab race idempotency, downgrade preservation, modal stacking against the instance-add dialog, native focus trap (Tab + Shift+Tab), `prefers-reduced-motion` CSS overrides. Built the production Docker image locally and confirmed `/app/CHANGELOG.md` is bundled and the runtime path resolves.

## Type of Change

- [x] New feature (`feat:`)

## Checklist

- [x] Issue exists and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: surfaces controlled-search behaviour changes to operators in-app instead of requiring them to leave the dashboard