### PR TITLE
docs: add discord to readme and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,11 @@ body:
   - type: markdown
     attributes:
       value: |
+        > For questions and discussion, consider [Discord](https://discord.gg/t29AhAarYk) first. Open an issue here for confirmed bugs with reproduction steps.
+
+  - type: markdown
+    attributes:
+      value: |
         Thanks for taking the time to report a bug! Please fill out the form below.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,6 +6,11 @@ body:
   - type: markdown
     attributes:
       value: |
+        > For questions and discussion, consider [Discord](https://discord.gg/t29AhAarYk) first.
+
+  - type: markdown
+    attributes:
+      value: |
         ## Scope Check
 
         Houndarr is a **single-purpose tool** that searches for missing and cutoff-unmet

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Small batches. Polite intervals. Zero indexer abuse.
 [![Last commit](https://img.shields.io/github/last-commit/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/commits/main)
 [![GitHub release](https://img.shields.io/github/v/release/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/releases/latest)
 [![Contributors](https://img.shields.io/github/contributors/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/graphs/contributors)
+[![Discord](https://img.shields.io/discord/1495186820806213743?style=flat&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.gg/t29AhAarYk)
 
 [Documentation](https://av1155.github.io/houndarr/)
 &ensp;&bull;&ensp;
@@ -20,6 +21,8 @@ Small batches. Polite intervals. Zero indexer abuse.
 [Docker](https://github.com/av1155/houndarr/pkgs/container/houndarr)
 &ensp;&bull;&ensp;
 [Helm Chart](https://av1155.github.io/houndarr/docs/guides/installation/helm)
+&ensp;&bull;&ensp;
+[Discord](https://discord.gg/t29AhAarYk)
 &ensp;&bull;&ensp;
 [Report Bug](https://github.com/av1155/houndarr/issues/new/choose)
 
@@ -150,6 +153,8 @@ For environment variables, reverse proxy setup, Kubernetes, Helm, and building f
 For details on how Houndarr handles credentials, network behavior, and trust boundaries, see [Security Overview](https://av1155.github.io/houndarr/docs/security/overview). To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## Contributing and Community
+
+For questions, troubleshooting, or casual discussion, join the [Houndarr Discord](https://discord.gg/t29AhAarYk). For bug reports and feature requests, open a [GitHub issue](https://github.com/av1155/houndarr/issues/new/choose).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, coding standards, and quality gates.
 


### PR DESCRIPTION
## Summary

- Adds a Discord badge to the README header alongside the existing shields.io badges and a `Discord` link in the header link row.
- Mentions Discord as the primary venue for questions, troubleshooting, and casual discussion in the `Contributing and Community` section; GitHub issues remain the channel for bug reports and feature requests.
- Adds a one-line callout at the top of both issue templates pointing reporters toward Discord first.

## Notes

- The shields.io Discord badge reads server member count from the Discord widget. Enable Server Settings → Widget → `Enable Server Widget` on the Discord server so the badge shows a count instead of `invalid`.
- The release-notes announcement (`Houndarr now has a Discord. Come say hi: https://discord.gg/t29AhAarYk`) will land in the next version bump PR under the appropriate `### Added` or `### Changed` heading, per the usual release workflow.

Closes #410

## Test plan

- [x] `yaml.safe_load` parses both issue template files.
- [x] Discord invite URL passes the lychee config (`accept = [200..299, 403, 429]`).
- [ ] Spot-check the rendered README on the PR preview.
- [ ] Verify the Discord badge renders the server member count after the widget is enabled.