### PR TITLE
docs: add ghcr pulls badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Small batches. Polite intervals. Zero indexer abuse.
 [![License: AGPL-3.0](https://img.shields.io/github/license/av1155/houndarr?style=flat)](LICENSE)
 [![Last commit](https://img.shields.io/github/last-commit/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/commits/main)
 [![GitHub release](https://img.shields.io/github/v/release/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/releases/latest)
+[![GHCR pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fghcr-badge.elias.eu.org%2Fapi%2Fav1155%2Fhoundarr&query=downloadCount&label=ghcr%20pulls&color=2496ed&logo=docker&logoColor=white&style=flat)](https://github.com/av1155/houndarr/pkgs/container/houndarr)
 [![Contributors](https://img.shields.io/github/contributors/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/graphs/contributors)
 [![Discord](https://img.shields.io/discord/1495186820806213743?style=flat&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.gg/t29AhAarYk)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Small batches. Polite intervals. Zero indexer abuse.
 [![License: AGPL-3.0](https://img.shields.io/github/license/av1155/houndarr?style=flat)](LICENSE)
 [![Last commit](https://img.shields.io/github/last-commit/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/commits/main)
 [![GitHub release](https://img.shields.io/github/v/release/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/releases/latest)
-[![GHCR pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fghcr-badge.elias.eu.org%2Fapi%2Fav1155%2Fhoundarr&query=downloadCount&label=ghcr%20pulls&color=2496ed&logo=docker&logoColor=white&style=flat)](https://github.com/av1155/houndarr/pkgs/container/houndarr)
+[![GHCR pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fhoundarr-ghcr-badge.andrea-venti12.workers.dev%2Fapi%2Fav1155%2Fhoundarr&query=downloadCount&label=ghcr%20pulls&color=2496ed&logo=docker&logoColor=white&style=flat)](https://github.com/av1155/houndarr/pkgs/container/houndarr)
 [![Contributors](https://img.shields.io/github/contributors/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/graphs/contributors)
 [![Discord](https://img.shields.io/discord/1495186820806213743?style=flat&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.gg/t29AhAarYk)
 


### PR DESCRIPTION
## Summary

- Adds a GHCR download-count badge to the README header, placed between the `GitHub release` and `Contributors` badges so the distribution stats sit together.
- The badge is served by a self-hosted Cloudflare Worker at [av1155/ghcr-badge](https://github.com/av1155/ghcr-badge) (forked from [eliasbenb/ghcr-badge](https://github.com/eliasbenb/ghcr-badge), MIT, cleaned up and renamed). The worker lives at \`houndarr-ghcr-badge.andrea-venti12.workers.dev\`; the shields.io URL uses \`dynamic/json\` against the \`/api\` endpoint so the badge style stays consistent with the existing \`style=flat\` shields.

## Why self-host

shields.io has no native GHCR pulls endpoint (see [badges/shields#5594](https://github.com/badges/shields/issues/5594)). The public eliasbenb service works but is a single person's free Cloudflare Worker, so this avoids a third-party single-point-of-failure.

Closes #412

## Test plan

- [x] \`curl\` the worker returns the same count shown on the GitHub Packages page.
- [x] shields.io renders the badge (HTTP 200, SVG with the count).
- [ ] Confirm the badge renders correctly on the merged README on github.com.