### PR TITLE
docs: point ghcr pulls badge at renamed worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Small batches. Polite intervals. Zero indexer abuse.
 [![License: AGPL-3.0](https://img.shields.io/github/license/av1155/houndarr?style=flat)](LICENSE)
 [![Last commit](https://img.shields.io/github/last-commit/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/commits/main)
 [![GitHub release](https://img.shields.io/github/v/release/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/releases/latest)
-[![GHCR pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fhoundarr-ghcr-badge.andrea-venti12.workers.dev%2Fapi%2Fav1155%2Fhoundarr&query=downloadCount&label=ghcr%20pulls&color=2496ed&logo=docker&logoColor=white&style=flat)](https://github.com/av1155/houndarr/pkgs/container/houndarr)
+[![GHCR pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fghcr-badge.andrea-venti12.workers.dev%2Fapi%2Fav1155%2Fhoundarr&query=downloadCount&label=ghcr%20pulls&color=2496ed&logo=docker&logoColor=white&style=flat)](https://github.com/av1155/houndarr/pkgs/container/houndarr)
 [![Contributors](https://img.shields.io/github/contributors/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/graphs/contributors)
 [![Discord](https://img.shields.io/discord/1495186820806213743?style=flat&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.gg/t29AhAarYk)
 


### PR DESCRIPTION
## Summary

Follow-up to #413. The self-hosted Cloudflare Worker backing the GHCR pulls badge was renamed from \`houndarr-ghcr-badge\` to \`ghcr-badge\` in [av1155/ghcr-badge@9f7c4b8](https://github.com/av1155/ghcr-badge/commit/9f7c4b8) so the deployment is no longer tied to a single project. The Worker now also enforces an owner allowlist (currently \`av1155\`) to prevent strangers from piggybacking on the free-tier quota.

This PR points the README badge at the new deployment URL: \`ghcr-badge.andrea-venti12.workers.dev\`.

## Verified

- \`curl .../api/av1155/houndarr\` returns 200 with the live count.
- \`curl .../api/other-owner/anything\` returns 403 with the allowlist error.
- shields.io renders the new badge URL (HTTP 200).

## Test plan

- [x] New worker URL returns the same data as before.
- [x] Badge renders in shields.io.
- [ ] Confirm the badge renders on the merged README.

After this merges, the old \`houndarr-ghcr-badge\` Worker will be deleted from the Cloudflare dashboard.