### PR TITLE
docs: require markdown links in changelog bullets

### DIFF
--- a/.claude/commands/bump.md
+++ b/.claude/commands/bump.md
@@ -82,6 +82,10 @@ Do not create a branch, do not touch VERSION or CHANGELOG.
 - Lead with user-facing impact, not implementation details.
 - End with `(#N)` issue/PR reference.
 - Use backticks for identifiers, file names, env vars, UI elements.
+- Use markdown `[text](url)` syntax for links; bare URLs do not auto-link
+  in the in-app `What's New` modal (the modal's `_render_changelog_bullet`
+  filter only accepts the `[text](url)` form). GitHub's CHANGELOG view
+  autolinks either form, so markdown links work in both places.
 - Be specific: `Connection errors now log at WARNING with instance name`
   not `Improved error handling`.
 - Each version block ends with a `---` line (blank line before and after).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,6 +533,10 @@ releases.
 - Lead with user-facing impact, not implementation details
 - End with `(#N)` issue/PR reference
 - Use backticks for identifiers, file names, env vars, UI elements
+- Use markdown `[text](url)` syntax for links; bare URLs do not auto-link
+  in the in-app `What's New` modal (GitHub's CHANGELOG view autolinks both,
+  but the modal's `_render_changelog_bullet` filter only accepts the
+  `[text](url)` form)
 - Be specific: `Connection errors now log at WARNING with instance name`
   not `Improved error handling`
 


### PR DESCRIPTION
Closes #417

## Summary

The \`What's New\` modal added in #409 parses CHANGELOG bullets through \`_render_changelog_bullet\` (src/houndarr/routes/changelog.py:88), which HTML-escapes the raw text and then only re-applies markdown \`[text](url)\` links via a scheme-allowlisted substitution. Bare URLs are therefore rendered as plain escaped text in the modal, even though GitHub's native CHANGELOG.md view autolinks them.

This PR updates the bullet-rule lists in both \`AGENTS.md\` and \`.claude/commands/bump.md\` so future release authors and the \`/bump\` command always produce markdown links.

## Test plan

- [x] No runtime code changed; AGENTS.md and bump.md only.
- [ ] Confirm the rule renders correctly in the PR diff view.