### PR TITLE
docs: correct inaccurate 1.9.0 changelog bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Houndarr now has a [Discord server](https://discord.gg/t29AhAarYk) for questions and discussion. (#411)
-- `What's New` modal surfaces the CHANGELOG block for the current version on first load after an update, and is dismissible. (#409)
+- `What's New` modal surfaces every CHANGELOG block between your last-seen and the running version on first load after an update, with older entries collapsed into an accordion. (#409)
 - `Reset to Defaults` button in the instance settings modal restores every search setting for an instance type. (#405)
-- Per-instance search order: `random` (new default for newly added instances) spreads picks across the whole backlog each cycle, `chronological` walks oldest-first. (#395)
+- Per-instance search order: `random` (new default for newly added instances) picks a random page of the wanted list each cycle and shuffles items within it, so coverage spreads across the backlog over time; `chronological` walks oldest-first. (#395)
 
 ### Changed
 
-- Documentation site was rebuilt on the [Diataxis](https://diataxis.fr/) structure with a redesigned light mode, migrated images, and rendered diagrams. (#399, #401)
+- Documentation site rebuilt on the [Diataxis](https://diataxis.fr/) structure with a Technical Paper light-mode redesign, expanded coverage (Unraid install guide, `your-first-cycle` tutorial, 4-page security section), offline search, click-to-zoom images, and rendered Mermaid diagrams. (#399, #401)
 
 ### Fixed
 


### PR DESCRIPTION
Closes #419

Rewrites three bullets in the 1.9.0 CHANGELOG that didn't match what the code does. No code changes.

The #409 line said the What's New modal shows "the CHANGELOG block for the current version." `releases_between` in `src/houndarr/services/changelog.py:233` returns every block between `last_seen` and `running`; the template collapses older ones into an accordion.

The #395 line said random "spreads picks across the whole backlog each cycle." `search_loop.py:284` picks one random page of the wanted list per cycle, and `:292` shuffles within that page. Coverage works out across many cycles.

The #399/#401 line was accurate but incomplete. It mentioned the Diataxis restructure, light mode redesign, migrated images, and rendered diagrams, but left out the `your-first-cycle` tutorial, Unraid install guide, four-page security split, offline search, and click-to-zoom images.

## After merge

Delete the GitHub Release and the `v1.9.0` tag, re-cut the tag at the new `main` HEAD, and push. `docker.yml` rebuilds the image so the modal ships corrected text. `release.yml` creates a fresh Release from the corrected block. `chart.yml` will try to re-push the Helm chart; if that fails on a duplicate OCI tag it's safe to ignore.

## Test plan

- [x] `CHANGELOG.md` still passes `version-check.yml`.
- [x] Only `CHANGELOG.md` changed.