### PR TITLE
fix: duplicate copy in changelog settings

### DIFF
--- a/src/houndarr/templates/partials/changelog_settings_section.html
+++ b/src/houndarr/templates/partials/changelog_settings_section.html
@@ -2,11 +2,8 @@
   id="changelog-section"
   class="mt-8 rounded-xl border border-[#1e2638] bg-[#0e1117] p-4 sm:p-5"
 >
-  <div class="space-y-1 mb-4">
+  <div class="mb-4">
     <h2 class="text-base font-semibold text-slate-200">Changelog notifications</h2>
-    <p class="text-sm text-slate-400">
-      Show a summary of what changed after each update.
-    </p>
   </div>
 
   <form


### PR DESCRIPTION
Closes #421

The changelog notifications section on the Settings page had two lines that said the same thing. The section description read \"Show a summary of what changed after each update.\" and the only checkbox below it read \"Show a changelog summary after each update\".

Since the section has a single toggle, the description was not describing a group of settings, just paraphrasing the toggle label. Dropping it so the heading and checkbox carry the section on their own.

## Test plan

- [x] Settings page renders with the heading, checkbox, and \`Show last changelog\` button; the duplicate description is gone.
- [x] Toggle still persists via \`/settings/changelog/preferences\`.