### PR TITLE
ci(docker): amd64-only on PR + skip attestations + arm64 canary

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,11 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+  schedule:
+    # Weekly arm64 canary every Sunday at 06:00 UTC.  PR builds skip arm64
+    # for speed, so this run is the regular safety net for arm64 regressions
+    # outside the release path.  Not a required check.
+    - cron: "0 6 * * 0"
 
 # Permissions set at job level for least-privilege.
 permissions: {}
@@ -23,16 +28,25 @@ env:
 jobs:
   build:
     name: Build ${{ startsWith(github.ref, 'refs/tags/v') && '+ Push' || '(no push)' }}
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       contents: read
       packages: write
+    env:
+      # Avoid the post-build summary upload that has caused workflow hangs.
+      # See docker/build-push-action#1156.
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # QEMU is only needed when an arm64 build will actually run.
+      # PR builds are amd64 native, so the runner does not need emulation.
       - name: Set up QEMU
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -59,12 +73,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # PR builds: amd64 only, no attestations.  Fast feedback is the goal;
+      # the Trivy image scan still runs against the amd64 build.
+      # Tag pushes: full multi-arch with provenance + SBOM for release artifacts.
       - name: Build (and push on tag)
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ startsWith(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
+          provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/v') }}
           build-args: |
             HOUNDARR_VERSION=${{ steps.meta.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -72,8 +91,42 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  arm64-canary:
+    name: arm64 canary build
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build linux/arm64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/arm64
+          push: false
+          provenance: false
+          sbom: false
+          build-args: |
+            HOUNDARR_VERSION=arm64-canary
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   scan:
     name: Trivy image scan
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,9 +44,10 @@ jobs:
         uses: actions/checkout@v6
 
       # QEMU is only needed when an arm64 build will actually run.
-      # PR builds are amd64 native, so the runner does not need emulation.
+      # Regular PRs are amd64 native; bump PRs (chore/bump-*) and tag pushes
+      # build the full multi-arch image and need emulation.
       - name: Set up QEMU
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'chore/bump-')
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -73,17 +74,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # PR builds: amd64 only, no attestations.  Fast feedback is the goal;
-      # the Trivy image scan still runs against the amd64 build.
-      # Tag pushes: full multi-arch with provenance + SBOM for release artifacts.
+      # Regular PRs: amd64 only, no attestations (fast feedback; Trivy still scans).
+      # Bump PRs (chore/bump-*): full multi-arch + provenance/sbom so any arm64
+      # break is caught before the tag push (the actual release).
+      # Tag pushes: same as bump PRs, plus push to GHCR.
       - name: Build (and push on tag)
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: ${{ startsWith(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: ${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'chore/bump-')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
-          provenance: ${{ startsWith(github.ref, 'refs/tags/v') && 'mode=max' || 'false' }}
-          sbom: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          provenance: ${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'chore/bump-')) && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'chore/bump-') }}
           build-args: |
             HOUNDARR_VERSION=${{ steps.meta.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary

Trims the Docker job on every code-touching PR.  Regular PRs build `linux/amd64` only with `provenance` and `sbom` disabled.  Bump PRs (`chore/bump-*` branches) and tag pushes build the full `linux/amd64,linux/arm64` image with `provenance: mode=max` and `sbom: true`, so any arm64 regression is caught before the release tag is cut.  A weekly Sunday cron also builds the arm64 image as a canary.

Closes #443

## Changes

- `docker.yml` regular PRs drop `linux/arm64` from `platforms`.  arm64 emulation under QEMU was the dominant cost on every PR; native amd64 keeps the Trivy image scan working without it.
- `docker.yml` regular PRs set `provenance: false` and `sbom: false`.  `docker/build-push-action@v7` defaults to `provenance: mode=max` on public repos, which adds wall time per platform.
- `docker.yml` bump PRs (`startsWith(github.head_ref, 'chore/bump-')`) build `linux/amd64,linux/arm64` with `provenance: mode=max` and `sbom: true`.  This validates the release artifact end-to-end before the tag push, since the tag push is the actual release and is too late to find a broken build.  Push stays gated on tag.
- `docker.yml` skips `docker/setup-qemu-action` on regular PRs since no emulation is needed.
- Adds env `DOCKER_BUILD_SUMMARY: "false"` and `DOCKER_BUILD_RECORD_UPLOAD: "false"` to suppress the post-build summary upload that has caused workflow hangs (docker/build-push-action#1156).
- New `arm64-canary` job triggers on a weekly Sunday cron (06:00 UTC) and builds `linux/arm64` only.  Not a required check.
- The `build` job and the `scan` job both gate on `github.event_name != 'schedule'` so the cron only runs the canary.

## Testing

This PR is itself the test: the Docker job should complete amd64-only and noticeably faster than recent merged PRs.  All required check display names stay unchanged: `Build (no push)`, `Trivy image scan`, `Security smoke test`.

`actionlint` clean locally.

## Type of Change

- [x] CI/CD (`ci:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #443`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`ci/docker-pr-amd64-only`)
- [ ] Tests added/updated for all changes (N/A; CI workflow change)
- [x] Type check passes (`mypy src/`) (N/A for YAML)
- [x] Lint passes (`ruff check .`) (N/A for YAML; `actionlint` clean)
- [x] Format passes (`ruff format --check .`) (N/A for YAML)
- [x] Documentation updated (if applicable; AGENTS.md updates land later)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: Same security and container coverage; shorter feedback loop for the search-for-missing-media work that follows.