### PR TITLE
refactor(types): introduce HoundarrError + enums + ItemRef foundation

### DIFF
--- a/src/houndarr/enums.py
+++ b/src/houndarr/enums.py
@@ -1,0 +1,66 @@
+"""Consolidated enums for string literals used across the engine and routes.
+
+Previously scattered as ``Literal[...]`` type aliases in ``engine/search_loop.py``
+and ``engine/candidates.py``, and as bare string literals in route parsers and
+the database CHECK constraints.  This module collects them into ``StrEnum``
+subclasses so typos at call sites are caught by mypy, while values remain
+backward-compatible with every existing ``CHECK`` constraint and log row
+(``StrEnum`` instances compare equal to their string values).
+
+Values are chosen to match the pre-existing strings exactly; no CHECK constraint
+or migration is touched.  The enums here are byte-for-byte equivalent to the
+``Literal`` aliases they replace.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class SearchKind(StrEnum):
+    """Pass kind for the search engine: missing / cutoff / upgrade."""
+
+    missing = "missing"
+    cutoff = "cutoff"
+    upgrade = "upgrade"
+
+
+class SearchAction(StrEnum):
+    """Row action persisted to ``search_log.action``.
+
+    Mirrors the ``CHECK(action IN ('searched','skipped','error','info'))``
+    constraint on the ``search_log`` table.
+    """
+
+    searched = "searched"
+    skipped = "skipped"
+    error = "error"
+    info = "info"
+
+
+class CycleTrigger(StrEnum):
+    """Why the current cycle started.
+
+    Mirrors the ``CHECK(cycle_trigger IN ('scheduled','run_now','system'))``
+    constraint on the ``search_log`` table.
+    """
+
+    scheduled = "scheduled"
+    run_now = "run_now"
+    system = "system"
+
+
+class ItemType(StrEnum):
+    """*arr item kind carried on a ``SearchCandidate`` and stored in DB rows.
+
+    Mirrors the ``CHECK(item_type IN ('episode','movie','album','book',
+    'whisparr_episode','whisparr_v3_movie'))`` constraint on the
+    ``cooldowns`` and ``search_log`` tables.
+    """
+
+    episode = "episode"
+    movie = "movie"
+    album = "album"
+    book = "book"
+    whisparr_episode = "whisparr_episode"
+    whisparr_v3_movie = "whisparr_v3_movie"

--- a/src/houndarr/errors.py
+++ b/src/houndarr/errors.py
@@ -1,0 +1,155 @@
+"""Houndarr's exception hierarchy.
+
+Previously the codebase had zero custom exceptions; error handling
+relied on ``except Exception  # noqa: BLE001`` at 12+ sites.  This
+module introduces a single root (``HoundarrError``) plus four layer-
+specific branches so call sites can switch to named exceptions
+incrementally in Tracks B.11-B.17.
+
+The hierarchy is declaration-only in this batch; no raise site is
+migrated yet.  Each concrete class documents which existing
+``except Exception`` block it will eventually replace.
+"""
+
+from __future__ import annotations
+
+
+class HoundarrError(Exception):
+    """Root of every Houndarr-specific exception.
+
+    Callers that want to distinguish Houndarr-originated errors from
+    third-party exceptions (e.g. ``httpx.HTTPError``, ``aiosqlite.Error``)
+    should catch this base.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Client-layer errors (clients/*.py)
+# ---------------------------------------------------------------------------
+
+
+class ClientError(HoundarrError):
+    """Any failure raised from a ``*arr`` HTTP client."""
+
+
+class ClientHTTPError(ClientError):
+    """Non-2xx response from an ``*arr`` instance.
+
+    Replaces ``httpx.HTTPStatusError`` bubble-ups at call sites that
+    want to distinguish HTTP status failures from network errors.
+    """
+
+
+class ClientTransportError(ClientError):
+    """TCP / DNS / TLS failure talking to an ``*arr`` instance.
+
+    Replaces ``httpx.TransportError`` bubble-ups at call sites that
+    want to distinguish network failures from HTTP status failures.
+    """
+
+
+class ClientValidationError(ClientError):
+    """The wire payload failed Pydantic validation.
+
+    Replaces bare ``pydantic.ValidationError`` bubble-ups at call
+    sites that want to attribute the failure to the wire boundary.
+    """
+
+
+class ClientUnreachableError(ClientError):
+    """Catch-all for ``ArrClient.ping`` swallow-all failures.
+
+    Currently ``ping()`` collapses four distinct errors
+    (``httpx.HTTPError``, ``httpx.InvalidURL``, ``ValueError``,
+    ``ValidationError``) to ``None``.  This class gives callers a
+    typed way to re-raise the unreachable-state, for example from
+    the supervisor's reconnect loop.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Engine-layer errors (engine/*.py)
+# ---------------------------------------------------------------------------
+
+
+class EngineError(HoundarrError):
+    """Any failure raised inside the search engine pipeline."""
+
+
+class EngineDispatchError(EngineError):
+    """A search dispatch (adapter.dispatch_search) raised.
+
+    Replaces ``except Exception`` at ``engine/search_loop.py:400-420``
+    and ``:477-500`` (release-timing-retry and normal dispatch paths).
+    """
+
+
+class EnginePoolFetchError(EngineError):
+    """fetch_upgrade_pool raised while building the upgrade candidate pool.
+
+    Replaces ``except Exception`` at ``engine/search_loop.py:576``.
+    """
+
+
+class EngineOffsetPersistError(EngineError):
+    """Persisting a ``*_page_offset`` / ``upgrade_item_offset`` failed.
+
+    Replaces ``except Exception`` at ``engine/search_loop.py:608, 771,
+    928, 971``.  Non-fatal (the next cycle retries); we log + continue.
+    """
+
+
+class EngineQueueProbeError(EngineError):
+    """The queue-backpressure probe (``get_queue_status``) failed."""
+
+
+# ---------------------------------------------------------------------------
+# Service-layer errors (services/*.py, routes/admin.py)
+# ---------------------------------------------------------------------------
+
+
+class ServiceError(HoundarrError):
+    """Any failure raised inside a Houndarr service."""
+
+
+class InstanceValidationError(ServiceError):
+    """An instance config failed service-level validation.
+
+    Distinct from the form-level validators in
+    ``routes/settings/_helpers.py``; those run before the service is
+    called.
+    """
+
+
+class CooldownStateError(ServiceError):
+    """Cooldown state is inconsistent (e.g. negative days).
+
+    Defensive: the service should never raise this today, but adding
+    it gives Track B.17 a target for the ``except Exception`` guard.
+    """
+
+
+class TimeWindowSpecError(ServiceError):
+    """``allowed_time_window`` spec could not be parsed by the service.
+
+    Mirrors ``parse_time_window`` raising ``ValueError``; wrapping
+    into a typed service error lets callers distinguish it from
+    other validation paths.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Route-layer errors (routes/*.py, auth.py)
+# ---------------------------------------------------------------------------
+
+
+class RouteError(HoundarrError):
+    """Any failure raised inside a FastAPI route handler."""
+
+
+class CsrfValidationError(RouteError):
+    """CSRF validation failed for a mutating request."""
+
+
+class AuthRejectedError(RouteError):
+    """Authentication check rejected the current request."""

--- a/src/houndarr/value_objects.py
+++ b/src/houndarr/value_objects.py
@@ -1,0 +1,41 @@
+"""Value objects used across the engine + services + routes.
+
+Currently the engine pipeline and the cooldown service pass the same
+three-tuple ``(instance_id, item_id, item_type)`` around at ~30 call
+sites.  ``ItemRef`` collapses that tuple into a single frozen value
+object so future refactors cannot silently reorder the fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from houndarr.enums import ItemType
+
+
+@dataclass(frozen=True, slots=True)
+class ItemRef:
+    """A reference to an *arr library item that the search engine tracks.
+
+    Attributes:
+        instance_id: Owning instance primary key (``instances.id``).
+        item_id: App-specific item ID (episode/movie/album/book ID or
+            the synthetic negative ID used for season/artist/author
+            context groups).
+        item_type: One of the values registered on the
+            ``cooldowns.item_type`` and ``search_log.item_type`` CHECK
+            constraints.
+    """
+
+    instance_id: int
+    item_id: int
+    item_type: ItemType
+
+    def as_tuple(self) -> tuple[int, int, str]:
+        """Return the legacy tuple shape used by SQL call sites.
+
+        The string form of ``item_type`` is used because SQLite stores
+        the CHECK-constrained column as TEXT; ``StrEnum`` comparison is
+        value-identical to plain strings.
+        """
+        return (self.instance_id, self.item_id, self.item_type.value)

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,71 @@
+"""Tests for the consolidated houndarr.enums module.
+
+Verifies that each StrEnum value compares equal to its legacy string
+literal, keeping every CHECK constraint and log-row value untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.enums import CycleTrigger, ItemType, SearchAction, SearchKind
+
+
+class TestSearchKind:
+    @pytest.mark.parametrize("value", ["missing", "cutoff", "upgrade"])
+    def test_values_match_literal(self, value: str) -> None:
+        assert SearchKind(value).value == value
+
+    def test_str_equality_with_literal(self) -> None:
+        """StrEnum members are equal to their string values for legacy call sites."""
+        assert SearchKind.missing == "missing"
+        assert SearchKind.cutoff == "cutoff"
+        assert SearchKind.upgrade == "upgrade"
+
+    def test_unknown_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            SearchKind("bogus")
+
+
+class TestSearchAction:
+    @pytest.mark.parametrize("value", ["searched", "skipped", "error", "info"])
+    def test_values_match_literal(self, value: str) -> None:
+        assert SearchAction(value).value == value
+
+    def test_str_equality_with_literal(self) -> None:
+        assert SearchAction.searched == "searched"
+        assert SearchAction.skipped == "skipped"
+        assert SearchAction.error == "error"
+        assert SearchAction.info == "info"
+
+
+class TestCycleTrigger:
+    @pytest.mark.parametrize("value", ["scheduled", "run_now", "system"])
+    def test_values_match_literal(self, value: str) -> None:
+        assert CycleTrigger(value).value == value
+
+    def test_str_equality_with_literal(self) -> None:
+        assert CycleTrigger.scheduled == "scheduled"
+        assert CycleTrigger.run_now == "run_now"
+        assert CycleTrigger.system == "system"
+
+
+class TestItemType:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "episode",
+            "movie",
+            "album",
+            "book",
+            "whisparr_episode",
+            "whisparr_v3_movie",
+        ],
+    )
+    def test_values_match_literal(self, value: str) -> None:
+        assert ItemType(value).value == value
+
+    def test_str_equality_with_literal(self) -> None:
+        assert ItemType.episode == "episode"
+        assert ItemType.movie == "movie"
+        assert ItemType.whisparr_v3_movie == "whisparr_v3_movie"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,106 @@
+"""Tests for the houndarr.errors hierarchy."""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.errors import (
+    AuthRejectedError,
+    ClientError,
+    ClientHTTPError,
+    ClientTransportError,
+    ClientUnreachableError,
+    ClientValidationError,
+    CooldownStateError,
+    CsrfValidationError,
+    EngineDispatchError,
+    EngineError,
+    EngineOffsetPersistError,
+    EnginePoolFetchError,
+    EngineQueueProbeError,
+    HoundarrError,
+    InstanceValidationError,
+    RouteError,
+    ServiceError,
+    TimeWindowSpecError,
+)
+
+
+class TestRootInheritance:
+    @pytest.mark.parametrize(
+        "cls",
+        [
+            ClientError,
+            EngineError,
+            ServiceError,
+            RouteError,
+        ],
+    )
+    def test_layer_bases_inherit_root(self, cls: type[Exception]) -> None:
+        assert issubclass(cls, HoundarrError)
+        assert issubclass(cls, Exception)
+
+
+class TestClientBranch:
+    @pytest.mark.parametrize(
+        "cls",
+        [
+            ClientHTTPError,
+            ClientTransportError,
+            ClientValidationError,
+            ClientUnreachableError,
+        ],
+    )
+    def test_concretes_inherit_client_error(self, cls: type[Exception]) -> None:
+        assert issubclass(cls, ClientError)
+        assert issubclass(cls, HoundarrError)
+
+
+class TestEngineBranch:
+    @pytest.mark.parametrize(
+        "cls",
+        [
+            EngineDispatchError,
+            EnginePoolFetchError,
+            EngineOffsetPersistError,
+            EngineQueueProbeError,
+        ],
+    )
+    def test_concretes_inherit_engine_error(self, cls: type[Exception]) -> None:
+        assert issubclass(cls, EngineError)
+        assert issubclass(cls, HoundarrError)
+
+
+class TestServiceBranch:
+    @pytest.mark.parametrize(
+        "cls",
+        [
+            InstanceValidationError,
+            CooldownStateError,
+            TimeWindowSpecError,
+        ],
+    )
+    def test_concretes_inherit_service_error(self, cls: type[Exception]) -> None:
+        assert issubclass(cls, ServiceError)
+        assert issubclass(cls, HoundarrError)
+
+
+class TestRouteBranch:
+    @pytest.mark.parametrize("cls", [CsrfValidationError, AuthRejectedError])
+    def test_concretes_inherit_route_error(self, cls: type[Exception]) -> None:
+        assert issubclass(cls, RouteError)
+        assert issubclass(cls, HoundarrError)
+
+
+class TestRaiseAndCatch:
+    def test_catch_by_layer_base(self) -> None:
+        with pytest.raises(EngineError):
+            raise EngineDispatchError("dispatch boom")
+
+    def test_catch_by_root(self) -> None:
+        with pytest.raises(HoundarrError):
+            raise ClientTransportError("network down")
+
+    def test_does_not_catch_framework_exception(self) -> None:
+        """Built-in ``ValueError`` is NOT a HoundarrError."""
+        assert not issubclass(ValueError, HoundarrError)

--- a/tests/test_value_objects.py
+++ b/tests/test_value_objects.py
@@ -1,0 +1,41 @@
+"""Tests for houndarr.value_objects."""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.enums import ItemType
+from houndarr.value_objects import ItemRef
+
+
+class TestItemRef:
+    def test_frozen(self) -> None:
+        ref = ItemRef(instance_id=1, item_id=100, item_type=ItemType.movie)
+        with pytest.raises(AttributeError):
+            ref.instance_id = 2  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        ref = ItemRef(instance_id=7, item_id=42, item_type=ItemType.episode)
+        assert ref.instance_id == 7
+        assert ref.item_id == 42
+        assert ref.item_type == ItemType.episode
+
+    def test_slots(self) -> None:
+        """Slots dataclass rejects arbitrary attribute assignment."""
+        ref = ItemRef(instance_id=1, item_id=1, item_type=ItemType.movie)
+        with pytest.raises(AttributeError):
+            ref.extra = "no"  # type: ignore[attr-defined]
+
+    def test_as_tuple_returns_str_valued_item_type(self) -> None:
+        ref = ItemRef(instance_id=1, item_id=5, item_type=ItemType.album)
+        assert ref.as_tuple() == (1, 5, "album")
+
+    def test_equal_when_fields_match(self) -> None:
+        a = ItemRef(instance_id=1, item_id=100, item_type=ItemType.movie)
+        b = ItemRef(instance_id=1, item_id=100, item_type=ItemType.movie)
+        assert a == b
+
+    def test_hashable(self) -> None:
+        """Frozen dataclasses with hashable fields are usable as set/dict keys."""
+        ref = ItemRef(instance_id=1, item_id=1, item_type=ItemType.movie)
+        assert {ref: 1}[ref] == 1

--- a/tests/test_value_objects.py
+++ b/tests/test_value_objects.py
@@ -20,11 +20,13 @@ class TestItemRef:
         assert ref.item_id == 42
         assert ref.item_type == ItemType.episode
 
-    def test_slots(self) -> None:
-        """Slots dataclass rejects arbitrary attribute assignment."""
+    def test_slots_limits_attribute_surface(self) -> None:
+        """slots=True restricts which attributes the dataclass exposes."""
         ref = ItemRef(instance_id=1, item_id=1, item_type=ItemType.movie)
+        assert set(ItemRef.__slots__) == {"instance_id", "item_id", "item_type"}
+        # Frozen dataclass rejects even the declared attrs at runtime.
         with pytest.raises(AttributeError):
-            ref.extra = "no"  # type: ignore[attr-defined]
+            ref.item_id = 2  # type: ignore[misc]
 
     def test_as_tuple_returns_str_valued_item_type(self) -> None:
         ref = ItemRef(instance_id=1, item_id=5, item_type=ItemType.album)


### PR DESCRIPTION
## Summary

Adds three small foundation modules: `errors.py` (HoundarrError hierarchy), `enums.py` (SearchKind, CycleTrigger, ItemType, SearchAction StrEnums), and `value_objects.py` (frozen `ItemRef`).  Pure addition.  Modules are inert until later PRs migrate consumers.

Closes #447

## Changes

- Add `src/houndarr/errors.py` with `HoundarrError` base + client / engine / service / route subclasses.
- Add `src/houndarr/enums.py` with `SearchKind`, `CycleTrigger`, `ItemType`, `SearchAction` StrEnums.
- Add `src/houndarr/value_objects.py` with frozen, slots-enabled `ItemRef`.
- Add `tests/test_errors.py`, `tests/test_enums.py`, `tests/test_value_objects.py` (47 tests).

## Testing

- `just check` clean: ruff, ruff format, mypy strict, bandit all pass.
- 47 new tests pass under `pytest -n auto`.

## Type of Change

- [x] Refactoring (`refactor:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #447`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`refactor/types-foundation`)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (N/A; modules not yet wired in)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: Inert scaffolding for the typed-seam refactors that follow.  Same product behaviour.