### PR TITLE
test: drain aiosqlite workers before per-test loop teardown

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,15 +44,8 @@ jobs:
       # Run pytest under xdist with worker-per-CPU.  Each test gets its own
       # tmp_data_dir + per-call respx mocks, so worker isolation holds.
       # The browser e2e suite is excluded by `norecursedirs` in pyproject.toml.
-      #
-      # `-p no:threadexception` disables pytest's automatic annotation of
-      # background-thread exceptions.  Under xdist scheduling on the GitHub-
-      # hosted Linux runner, an aiosqlite worker thread occasionally tries to
-      # write to a closed event loop during fixture teardown; the test itself
-      # passes but the runner promotes the traceback to a red annotation.
-      # Tests still fail loudly via non-zero exit on real assertion errors.
       - name: Run tests
-        run: python -m pytest -q --tb=short -n auto -p no:threadexception
+        run: python -m pytest -q --tb=short -n auto
 
       - name: Sanity checks
         run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import gc
 import os
 import tempfile
 from collections.abc import AsyncGenerator, Generator
@@ -43,11 +45,28 @@ def tmp_data_dir() -> Generator[str, None, None]:
 
 @pytest_asyncio.fixture()
 async def db(tmp_data_dir: str) -> AsyncGenerator[None, None]:
-    """Initialize a fresh in-memory-style SQLite DB for each test."""
+    """Initialize a fresh in-memory-style SQLite DB for each test.
+
+    Each test gets its own SQLite file under a fresh ``tmp_data_dir``.
+    The finalizer drains lingering aiosqlite background work before the
+    per-test event loop closes; without it, a worker thread whose
+    ``call_soon_threadsafe`` callback is pending can fire after loop
+    teardown under xdist on the GitHub-hosted Linux runner and trip a
+    cosmetic ``PytestUnhandledThreadExceptionWarning``.
+    """
     db_path = os.path.join(tmp_data_dir, "test.db")
     set_db_path(db_path)
     await init_db()
-    yield
+    try:
+        yield
+    finally:
+        # Reclaim any aiosqlite Connection still held by the test or its
+        # fixtures so its worker thread shuts down while the loop is
+        # alive.  The single ``await asyncio.sleep(0)`` then yields back
+        # to the loop one last time so any queued thread-safe callbacks
+        # land before pytest-asyncio closes it.
+        gc.collect()
+        await asyncio.sleep(0)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

Fixes the aiosqlite background-thread race that surfaced as `PytestUnhandledThreadExceptionWarning` under `pytest -n auto` in CI.  With the race gone, the `-p no:threadexception` suppression added in #451 is dropped in the same change.

Closes #452

## Root cause

`tests/conftest.py`'s `db` fixture initialises a fresh SQLite file under `tmp_data_dir`, but never gives lingering aiosqlite Connections a chance to drain before pytest-asyncio closes the per-test event loop.  Under xdist scheduling on the GitHub-hosted Linux runner, a worker thread occasionally finishes its work after the loop has closed and tries to call `call_soon_threadsafe(...)` against a closed loop.  Pytest captures the resulting `RuntimeError: Event loop is closed` as a thread-exception warning; GitHub's annotator promotes the traceback to a red `##[error]` line on otherwise-green builds.

## Fix

Add an explicit `gc.collect()` + `await asyncio.sleep(0)` to the `db` fixture finalizer:

- `gc.collect()` reclaims any aiosqlite Connection still held by the test or its fixtures, so its worker thread shuts down while the loop is still alive.
- `await asyncio.sleep(0)` yields the loop one last time so any thread-safe callbacks queued by the worker land before pytest-asyncio closes it.

Drop `-p no:threadexception` from `.github/workflows/tests.yml` since the suppression is no longer needed.

## Testing

`pytest -n 4 --tb=line` runs the full 1239-test suite green locally in 30.99s.  No `PytestUnhandledThreadExceptionWarning` in the warnings summary.  CI on this PR will confirm the same on the GitHub-hosted runner.

## Type of Change

- [x] Test (`test:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #452`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`test/aiosqlite-teardown-fix`)
- [x] Tests added/updated for all changes (fixture finalizer extended)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (N/A; test infra only)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: Test infrastructure only.  Production behaviour unchanged.