### PR TITLE
refactor(adapters): AppAdapterProto + /wanted template + class-form adapters

### DIFF
--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import httpx
 from pydantic import ValidationError
 
-from houndarr.clients._wire_models import QueueStatus, SystemStatus
+from houndarr.clients._wire_models import PaginatedResponse, QueueStatus, SystemStatus
+from houndarr.errors import (
+    ClientHTTPError,
+    ClientTransportError,
+    ClientValidationError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +43,11 @@ class ArrClient(ABC):
     Override :attr:`_SYSTEM_STATUS_PATH` for apps whose API version differs
     from the v3 default (e.g. Lidarr and Readarr use ``/api/v1/``).
 
+    Subclasses with ``/wanted`` endpoints (every paginated client today
+    apart from Whisparr v3) override the four ``_WANTED_*`` class-level
+    hooks and let :meth:`_fetch_wanted_page` and :meth:`_fetch_wanted_total`
+    do the request shaping, validation, and typed-error wrap.
+
     Usage::
 
         async with SonarrClient(url="http://sonarr:8989", api_key="abc") as client:
@@ -49,6 +59,15 @@ class ArrClient(ABC):
 
     _SYSTEM_STATUS_PATH: str = "/api/v3/system/status"
     _QUEUE_STATUS_PATH: str = "/api/v3/queue/status"
+
+    # Class-level hooks for the /wanted template.  Subclasses with a /wanted
+    # endpoint override these; Whisparr v3 leaves them unset because it
+    # computes totals from /api/v3/movie instead.  See _fetch_wanted_page
+    # for the per-hook contract.
+    _WANTED_BASE_PATH: ClassVar[str] = "/api/v3/wanted"
+    _WANTED_SORT_KEY: ClassVar[str] = ""
+    _WANTED_INCLUDE_PARAM: ClassVar[str | None] = None
+    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[Any]] | None] = None
 
     def __init__(
         self,
@@ -63,9 +82,7 @@ class ArrClient(ABC):
             timeout=timeout,
         )
 
-    # ------------------------------------------------------------------
     # Context-manager support
-    # ------------------------------------------------------------------
 
     async def __aenter__(self) -> ArrClient:
         await self._client.__aenter__()
@@ -78,9 +95,7 @@ class ArrClient(ABC):
         """Close the underlying HTTP client."""
         await self._client.aclose()
 
-    # ------------------------------------------------------------------
     # Low-level helpers
-    # ------------------------------------------------------------------
 
     async def _get(self, path: str, **params: Any) -> Any:
         """GET *path* with optional query *params*, raise on non-2xx."""
@@ -94,9 +109,7 @@ class ArrClient(ABC):
         response.raise_for_status()
         return response.json()
 
-    # ------------------------------------------------------------------
     # Health check
-    # ------------------------------------------------------------------
 
     async def ping(self) -> SystemStatus | None:
         """Return the parsed system status if reachable, or ``None``.
@@ -116,9 +129,7 @@ class ArrClient(ABC):
         except _PING_SAFE_ERRORS:
             return None
 
-    # ------------------------------------------------------------------
     # Queue status
-    # ------------------------------------------------------------------
 
     async def get_queue_status(self) -> QueueStatus:
         """Fetch the download queue status from the *arr instance.
@@ -139,9 +150,130 @@ class ArrClient(ABC):
         result = await self._get(self._QUEUE_STATUS_PATH)
         return QueueStatus.model_validate(result)
 
-    # ------------------------------------------------------------------
+    # /wanted template (paginated clients only; Whisparr v3 does not use it)
+
+    async def _fetch_wanted_page(
+        self,
+        kind: Literal["missing", "cutoff"],
+        *,
+        page: int,
+        page_size: int,
+        include_sort: bool = True,
+    ) -> PaginatedResponse[Any]:
+        """Fetch one page of ``/wanted/{kind}`` via the per-subclass envelope.
+
+        The four class-level hooks (override at subclass scope):
+
+        - :attr:`_WANTED_BASE_PATH`: API root that prefixes ``/{kind}``.
+          Defaults to ``/api/v3/wanted`` for v3-API clients (Sonarr, Radarr,
+          Whisparr v2); Lidarr and Readarr override to ``/api/v1/wanted``.
+        - :attr:`_WANTED_SORT_KEY`: sort field name passed when ``include_sort``
+          is true.  Required for every paginated /wanted client; the missing
+          pass on every client and the cutoff pass on Radarr include it.
+        - :attr:`_WANTED_INCLUDE_PARAM`: optional embed-parent query param
+          (``includeSeries`` for Sonarr / Whisparr v2, ``includeArtist`` for
+          Lidarr, ``includeAuthor`` for Readarr, ``None`` for Radarr).
+        - :attr:`_WANTED_ENVELOPE`: the parametrised :class:`PaginatedResponse`
+          subclass (e.g. ``PaginatedResponse[RadarrWantedMovie]``) that
+          validates the response payload.
+
+        ``include_sort`` defaults to ``True`` because the missing pass on
+        every paginated client sorts ascending by its release-date field.
+        Callers pass ``include_sort=False`` for the cutoff pass on Sonarr,
+        Lidarr, Readarr, and Whisparr v2 because those endpoints today omit
+        the sort params; Radarr's cutoff endpoint includes them so it
+        relies on the default.
+
+        Subclasses without ``/wanted`` endpoints (Whisparr v3) leave the
+        hooks unset and never call this method; calling it on a client
+        whose :attr:`_WANTED_ENVELOPE` is unset raises
+        :class:`NotImplementedError` so the misconfiguration surfaces
+        immediately rather than silently producing an empty result.
+
+        Raw ``httpx`` and ``pydantic`` errors propagate unwrapped so
+        callers can choose: page-level reads (``get_missing``,
+        ``get_cutoff_unmet``) re-raise the raw exception today; the
+        size-1 probe in :meth:`_fetch_wanted_total` wraps them into
+        typed :class:`~houndarr.errors.ClientError` subclasses.
+
+        Args:
+            kind: ``"missing"`` or ``"cutoff"``.
+            page: 1-based page number.
+            page_size: Number of records to request.
+            include_sort: When true, append ``sortKey`` and
+                ``sortDirection`` to the request.
+
+        Returns:
+            The parsed :class:`PaginatedResponse` envelope.  Records are
+            typed ``Any`` at the static-typing layer because the envelope
+            class is supplied at the class-attribute level; runtime
+            records are the per-app wire model declared in
+            :attr:`_WANTED_ENVELOPE`.
+
+        Raises:
+            NotImplementedError: :attr:`_WANTED_ENVELOPE` is unset on the
+                concrete subclass.
+            httpx.HTTPError: Non-2xx response or transport failure.
+            pydantic.ValidationError: Response payload did not match the
+                declared envelope schema.
+        """
+        envelope_cls = type(self)._WANTED_ENVELOPE
+        if envelope_cls is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} did not declare _WANTED_ENVELOPE; "
+                "the /wanted template requires a per-subclass envelope."
+            )
+        path = f"{self._WANTED_BASE_PATH}/{kind}"
+        params: dict[str, Any] = {
+            "page": page,
+            "pageSize": page_size,
+            "monitored": "true",
+        }
+        if include_sort:
+            params["sortKey"] = self._WANTED_SORT_KEY
+            params["sortDirection"] = "ascending"
+        if self._WANTED_INCLUDE_PARAM is not None:
+            params[self._WANTED_INCLUDE_PARAM] = "true"
+        data = await self._get(path, **params)
+        return envelope_cls.model_validate(data)
+
+    async def _fetch_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
+        """Default size-1 probe for ``/wanted/{kind}`` totals with typed wraps.
+
+        Subclasses with ``/wanted`` endpoints rely on this default and let
+        :meth:`get_wanted_total` collapse to a one-liner.  Whisparr v3
+        overrides :meth:`get_wanted_total` directly because it has no
+        ``/wanted`` path and computes the total from a cached
+        ``/api/v3/movie`` response.
+
+        Wraps raw ``httpx`` and ``pydantic`` failures into typed
+        :class:`~houndarr.errors.ClientError` subclasses so callers get
+        a Houndarr-specific surface they can catch.  The original
+        exception is preserved on ``__cause__`` via ``raise ... from``.
+
+        Raises:
+            ClientHTTPError: Non-2xx response.
+            ClientTransportError: Transport failure (connect, timeout,
+                malformed URL, etc.).
+            ClientValidationError: Response shape did not match the
+                paginated envelope schema.
+        """
+        path = f"{self._WANTED_BASE_PATH}/{kind}"
+        try:
+            envelope = await self._fetch_wanted_page(kind, page=1, page_size=1)
+        except httpx.HTTPStatusError as exc:
+            raise ClientHTTPError(
+                f"wanted total: HTTP {exc.response.status_code} from {path}"
+            ) from exc
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
+            raise ClientTransportError(
+                f"wanted total: transport error reaching {path}: {exc}"
+            ) from exc
+        except ValidationError as exc:
+            raise ClientValidationError(f"wanted total: malformed payload from {path}") from exc
+        return envelope.total_records
+
     # Abstract interface
-    # ------------------------------------------------------------------
 
     @abstractmethod
     async def get_missing(self, *, page: int = 1, page_size: int = 10) -> list[Any]:

--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -159,6 +159,7 @@ class ArrClient(ABC):
         page: int,
         page_size: int,
         include_sort: bool = True,
+        include_param: bool = True,
     ) -> PaginatedResponse[Any]:
         """Fetch one page of ``/wanted/{kind}`` via the per-subclass envelope.
 
@@ -184,6 +185,14 @@ class ArrClient(ABC):
         the sort params; Radarr's cutoff endpoint includes them so it
         relies on the default.
 
+        ``include_param`` defaults to ``True`` because the page reads on
+        every embed-using client want the parent aggregate inlined into
+        each record (so the parser can read ``series.title`` /
+        ``artist.artistName`` / ``author.authorName`` without an extra
+        round trip).  :meth:`_fetch_wanted_total` flips it to ``False``
+        because the size-1 probe only needs ``totalRecords``, and
+        omitting the embed matches every per-app probe pre-refactor.
+
         Subclasses without ``/wanted`` endpoints (Whisparr v3) leave the
         hooks unset and never call this method; calling it on a client
         whose :attr:`_WANTED_ENVELOPE` is unset raises
@@ -202,6 +211,9 @@ class ArrClient(ABC):
             page_size: Number of records to request.
             include_sort: When true, append ``sortKey`` and
                 ``sortDirection`` to the request.
+            include_param: When true and :attr:`_WANTED_INCLUDE_PARAM` is
+                set, append ``{_WANTED_INCLUDE_PARAM}=true`` to the
+                request.
 
         Returns:
             The parsed :class:`PaginatedResponse` envelope.  Records are
@@ -232,7 +244,7 @@ class ArrClient(ABC):
         if include_sort:
             params["sortKey"] = self._WANTED_SORT_KEY
             params["sortDirection"] = "ascending"
-        if self._WANTED_INCLUDE_PARAM is not None:
+        if include_param and self._WANTED_INCLUDE_PARAM is not None:
             params[self._WANTED_INCLUDE_PARAM] = "true"
         data = await self._get(path, **params)
         return envelope_cls.model_validate(data)
@@ -260,7 +272,15 @@ class ArrClient(ABC):
         """
         path = f"{self._WANTED_BASE_PATH}/{kind}"
         try:
-            envelope = await self._fetch_wanted_page(kind, page=1, page_size=1)
+            # The probe omits the embed-parent param because totalRecords
+            # is independent of record shape; matches every per-app
+            # get_wanted_total override pre-refactor.
+            envelope = await self._fetch_wanted_page(
+                kind,
+                page=1,
+                page_size=1,
+                include_param=False,
+            )
         except httpx.HTTPStatusError as exc:
             raise ClientHTTPError(
                 f"wanted total: HTTP {exc.response.status_code} from {path}"

--- a/src/houndarr/clients/lidarr.py
+++ b/src/houndarr/clients/lidarr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import ClassVar, Literal
 
 from houndarr.clients._wire_models import (
     LidarrLibraryAlbum,
@@ -44,6 +44,14 @@ class LidarrClient(ArrClient):
 
     _SYSTEM_STATUS_PATH: str = "/api/v1/system/status"
     _QUEUE_STATUS_PATH: str = "/api/v1/queue/status"
+    # Lidarr is a v1 API (Sonarr / Radarr / Whisparr are v3); the override
+    # routes the /wanted template at /api/v1/wanted/{kind}.
+    _WANTED_BASE_PATH: ClassVar[str] = "/api/v1/wanted"
+    _WANTED_SORT_KEY: ClassVar[str] = "releaseDate"
+    _WANTED_INCLUDE_PARAM: ClassVar[str | None] = "includeArtist"
+    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[LidarrWantedAlbum]]] = PaginatedResponse[
+        LidarrWantedAlbum
+    ]
 
     async def get_missing(
         self,
@@ -63,16 +71,7 @@ class LidarrClient(ArrClient):
         Returns:
             List of :class:`MissingAlbum` dataclasses.
         """
-        data = await self._get(
-            "/api/v1/wanted/missing",
-            page=page,
-            pageSize=page_size,
-            sortKey="releaseDate",
-            sortDirection="ascending",
-            includeArtist="true",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[LidarrWantedAlbum].model_validate(data)
+        envelope = await self._fetch_wanted_page("missing", page=page, page_size=page_size)
         return [_parse_album(w) for w in envelope.records]
 
     async def search(self, item_id: int) -> None:
@@ -110,6 +109,8 @@ class LidarrClient(ArrClient):
         """Return a page of monitored albums that have not met their quality cutoff.
 
         Calls ``GET /api/v1/wanted/cutoff`` with ``includeArtist=true``.
+        Lidarr's cutoff endpoint historically omits the sort params, so
+        the call passes ``include_sort=False`` to suppress them.
 
         Args:
             page: 1-based page number.
@@ -118,28 +119,30 @@ class LidarrClient(ArrClient):
         Returns:
             List of :class:`MissingAlbum` dataclasses.
         """
-        data = await self._get(
-            "/api/v1/wanted/cutoff",
+        envelope = await self._fetch_wanted_page(
+            "cutoff",
             page=page,
-            pageSize=page_size,
-            includeArtist="true",
-            monitored="true",
+            page_size=page_size,
+            include_sort=False,
         )
-        envelope = PaginatedResponse[LidarrWantedAlbum].model_validate(data)
         return [_parse_album(w) for w in envelope.records]
 
     async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
-        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
-        data = await self._get(
-            f"/api/v1/wanted/{kind}",
-            page=1,
-            pageSize=1,
-            sortKey="releaseDate",
-            sortDirection="ascending",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[LidarrWantedAlbum].model_validate(data)
-        return envelope.total_records
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe.
+
+        Delegates to :meth:`ArrClient._fetch_wanted_total`, which wraps
+        raw ``httpx`` and ``pydantic`` failures in typed
+        :class:`~houndarr.errors.ClientError` subclasses with the
+        original exception preserved on ``__cause__``.
+
+        Raises:
+            ClientHTTPError: Non-2xx response.
+            ClientTransportError: Transport failure (connect, timeout,
+                malformed URL, etc.).
+            ClientValidationError: Response shape did not match the
+                paginated envelope schema.
+        """
+        return await self._fetch_wanted_total(kind)
 
     async def get_albums(self) -> list[LibraryAlbum]:
         """Return the full album library.
@@ -156,9 +159,7 @@ class LidarrClient(ArrClient):
         return [_parse_library_album(LidarrLibraryAlbum.model_validate(r)) for r in records]
 
 
-# ---------------------------------------------------------------------------
 # Parsing helpers
-# ---------------------------------------------------------------------------
 
 
 def _parse_library_album(wire: LidarrLibraryAlbum) -> LibraryAlbum:

--- a/src/houndarr/clients/radarr.py
+++ b/src/houndarr/clients/radarr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import ClassVar, Literal
 
 from houndarr.clients._wire_models import (
     PaginatedResponse,
@@ -49,6 +49,15 @@ class MissingMovie:
 class RadarrClient(ArrClient):
     """Async client for the Radarr v3 REST API."""
 
+    # Radarr is the only paginated client whose cutoff endpoint includes
+    # the sort params (Sonarr, Lidarr, Readarr, and Whisparr v2 omit them
+    # for cutoff); the template's ``include_sort=True`` default captures
+    # both passes here.
+    _WANTED_SORT_KEY: ClassVar[str] = "inCinemas"
+    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[RadarrWantedMovie]]] = PaginatedResponse[
+        RadarrWantedMovie
+    ]
+
     async def get_missing(
         self,
         *,
@@ -67,15 +76,7 @@ class RadarrClient(ArrClient):
         Returns:
             List of :class:`MissingMovie` dataclasses.
         """
-        data = await self._get(
-            "/api/v3/wanted/missing",
-            page=page,
-            pageSize=page_size,
-            sortKey="inCinemas",
-            sortDirection="ascending",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[RadarrWantedMovie].model_validate(data)
+        envelope = await self._fetch_wanted_page("missing", page=page, page_size=page_size)
         return [_parse_movie(w) for w in envelope.records]
 
     async def search(self, item_id: int) -> None:
@@ -108,29 +109,25 @@ class RadarrClient(ArrClient):
         Returns:
             List of :class:`MissingMovie` dataclasses for cutoff-unmet movies.
         """
-        data = await self._get(
-            "/api/v3/wanted/cutoff",
-            page=page,
-            pageSize=page_size,
-            sortKey="inCinemas",
-            sortDirection="ascending",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[RadarrWantedMovie].model_validate(data)
+        envelope = await self._fetch_wanted_page("cutoff", page=page, page_size=page_size)
         return [_parse_movie(w) for w in envelope.records]
 
     async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
-        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
-        data = await self._get(
-            f"/api/v3/wanted/{kind}",
-            page=1,
-            pageSize=1,
-            sortKey="inCinemas",
-            sortDirection="ascending",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[RadarrWantedMovie].model_validate(data)
-        return envelope.total_records
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe.
+
+        Delegates to :meth:`ArrClient._fetch_wanted_total`, which wraps
+        raw ``httpx`` and ``pydantic`` failures in typed
+        :class:`~houndarr.errors.ClientError` subclasses with the
+        original exception preserved on ``__cause__``.
+
+        Raises:
+            ClientHTTPError: Non-2xx response.
+            ClientTransportError: Transport failure (connect, timeout,
+                malformed URL, etc.).
+            ClientValidationError: Response shape did not match the
+                paginated envelope schema.
+        """
+        return await self._fetch_wanted_total(kind)
 
     async def get_library(self) -> list[LibraryMovie]:
         """Return the full movie library.
@@ -145,9 +142,7 @@ class RadarrClient(ArrClient):
         return [_parse_library_movie(RadarrLibraryMovie.model_validate(r)) for r in records]
 
 
-# ---------------------------------------------------------------------------
 # Parsing helpers
-# ---------------------------------------------------------------------------
 
 
 def _parse_library_movie(wire: RadarrLibraryMovie) -> LibraryMovie:

--- a/src/houndarr/clients/readarr.py
+++ b/src/houndarr/clients/readarr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import ClassVar, Literal
 
 from houndarr.clients._wire_models import (
     PaginatedResponse,
@@ -44,6 +44,14 @@ class ReadarrClient(ArrClient):
 
     _SYSTEM_STATUS_PATH: str = "/api/v1/system/status"
     _QUEUE_STATUS_PATH: str = "/api/v1/queue/status"
+    # Readarr is a v1 API; the override routes the /wanted template at
+    # /api/v1/wanted/{kind} (matches Lidarr's pattern).
+    _WANTED_BASE_PATH: ClassVar[str] = "/api/v1/wanted"
+    _WANTED_SORT_KEY: ClassVar[str] = "releaseDate"
+    _WANTED_INCLUDE_PARAM: ClassVar[str | None] = "includeAuthor"
+    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[ReadarrWantedBook]]] = PaginatedResponse[
+        ReadarrWantedBook
+    ]
 
     async def get_missing(
         self,
@@ -63,16 +71,7 @@ class ReadarrClient(ArrClient):
         Returns:
             List of :class:`MissingBook` dataclasses.
         """
-        data = await self._get(
-            "/api/v1/wanted/missing",
-            page=page,
-            pageSize=page_size,
-            sortKey="releaseDate",
-            sortDirection="ascending",
-            includeAuthor="true",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[ReadarrWantedBook].model_validate(data)
+        envelope = await self._fetch_wanted_page("missing", page=page, page_size=page_size)
         return [_parse_book(w) for w in envelope.records]
 
     async def search(self, item_id: int) -> None:
@@ -110,6 +109,8 @@ class ReadarrClient(ArrClient):
         """Return a page of monitored books that have not met their quality cutoff.
 
         Calls ``GET /api/v1/wanted/cutoff`` with ``includeAuthor=true``.
+        Readarr's cutoff endpoint historically omits the sort params, so
+        the call passes ``include_sort=False`` to suppress them.
 
         Args:
             page: 1-based page number.
@@ -118,28 +119,30 @@ class ReadarrClient(ArrClient):
         Returns:
             List of :class:`MissingBook` dataclasses.
         """
-        data = await self._get(
-            "/api/v1/wanted/cutoff",
+        envelope = await self._fetch_wanted_page(
+            "cutoff",
             page=page,
-            pageSize=page_size,
-            includeAuthor="true",
-            monitored="true",
+            page_size=page_size,
+            include_sort=False,
         )
-        envelope = PaginatedResponse[ReadarrWantedBook].model_validate(data)
         return [_parse_book(w) for w in envelope.records]
 
     async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
-        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
-        data = await self._get(
-            f"/api/v1/wanted/{kind}",
-            page=1,
-            pageSize=1,
-            sortKey="releaseDate",
-            sortDirection="ascending",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[ReadarrWantedBook].model_validate(data)
-        return envelope.total_records
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe.
+
+        Delegates to :meth:`ArrClient._fetch_wanted_total`, which wraps
+        raw ``httpx`` and ``pydantic`` failures in typed
+        :class:`~houndarr.errors.ClientError` subclasses with the
+        original exception preserved on ``__cause__``.
+
+        Raises:
+            ClientHTTPError: Non-2xx response.
+            ClientTransportError: Transport failure (connect, timeout,
+                malformed URL, etc.).
+            ClientValidationError: Response shape did not match the
+                paginated envelope schema.
+        """
+        return await self._fetch_wanted_total(kind)
 
     async def get_books(self) -> list[LibraryBook]:
         """Return the full book library.
@@ -156,9 +159,7 @@ class ReadarrClient(ArrClient):
         return [_parse_library_book(ReadarrLibraryBook.model_validate(r)) for r in records]
 
 
-# ---------------------------------------------------------------------------
 # Parsing helpers
-# ---------------------------------------------------------------------------
 
 
 def _parse_library_book(wire: ReadarrLibraryBook) -> LibraryBook:

--- a/src/houndarr/clients/sonarr.py
+++ b/src/houndarr/clients/sonarr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import ClassVar, Literal
 
 from houndarr.clients._wire_models import (
     ArrSeries,
@@ -47,6 +47,12 @@ class MissingEpisode:
 class SonarrClient(ArrClient):
     """Async client for the Sonarr v3 REST API."""
 
+    _WANTED_SORT_KEY: ClassVar[str] = "airDateUtc"
+    _WANTED_INCLUDE_PARAM: ClassVar[str | None] = "includeSeries"
+    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[SonarrWantedEpisode]]] = PaginatedResponse[
+        SonarrWantedEpisode
+    ]
+
     async def get_missing(
         self,
         *,
@@ -65,16 +71,7 @@ class SonarrClient(ArrClient):
         Returns:
             List of :class:`MissingEpisode` dataclasses, oldest first.
         """
-        data = await self._get(
-            "/api/v3/wanted/missing",
-            page=page,
-            pageSize=page_size,
-            sortKey="airDateUtc",
-            sortDirection="ascending",
-            includeSeries="true",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[SonarrWantedEpisode].model_validate(data)
+        envelope = await self._fetch_wanted_page("missing", page=page, page_size=page_size)
         return [_parse_episode(w) for w in envelope.records]
 
     async def search(self, item_id: int) -> None:
@@ -113,7 +110,9 @@ class SonarrClient(ArrClient):
         """Return a page of monitored episodes that have not met their quality cutoff.
 
         Calls ``GET /api/v3/wanted/cutoff`` with ``includeSeries=true`` so that
-        series metadata is embedded in each record.
+        series metadata is embedded in each record.  Sonarr's cutoff
+        endpoint historically omits the sort params, so the call passes
+        ``include_sort=False`` to suppress them.
 
         Args:
             page: 1-based page number.
@@ -122,28 +121,30 @@ class SonarrClient(ArrClient):
         Returns:
             List of :class:`MissingEpisode` dataclasses for cutoff-unmet episodes.
         """
-        data = await self._get(
-            "/api/v3/wanted/cutoff",
+        envelope = await self._fetch_wanted_page(
+            "cutoff",
             page=page,
-            pageSize=page_size,
-            includeSeries="true",
-            monitored="true",
+            page_size=page_size,
+            include_sort=False,
         )
-        envelope = PaginatedResponse[SonarrWantedEpisode].model_validate(data)
         return [_parse_episode(w) for w in envelope.records]
 
     async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
-        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
-        data = await self._get(
-            f"/api/v3/wanted/{kind}",
-            page=1,
-            pageSize=1,
-            sortKey="airDateUtc",
-            sortDirection="ascending",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[SonarrWantedEpisode].model_validate(data)
-        return envelope.total_records
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe.
+
+        Delegates to :meth:`ArrClient._fetch_wanted_total`, which wraps
+        raw ``httpx`` and ``pydantic`` failures in typed
+        :class:`~houndarr.errors.ClientError` subclasses with the
+        original exception preserved on ``__cause__``.
+
+        Raises:
+            ClientHTTPError: Non-2xx response.
+            ClientTransportError: Transport failure (connect, timeout,
+                malformed URL, etc.).
+            ClientValidationError: Response shape did not match the
+                paginated envelope schema.
+        """
+        return await self._fetch_wanted_total(kind)
 
     async def get_series(self) -> list[ArrSeries]:
         """Return the full series list.
@@ -178,9 +179,7 @@ class SonarrClient(ArrClient):
         return [_parse_library_episode(SonarrLibraryEpisode.model_validate(r)) for r in records]
 
 
-# ---------------------------------------------------------------------------
 # Parsing helpers
-# ---------------------------------------------------------------------------
 
 
 def _parse_library_episode(wire: SonarrLibraryEpisode) -> LibraryEpisode:

--- a/src/houndarr/clients/whisparr_v2.py
+++ b/src/houndarr/clients/whisparr_v2.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Literal
+from typing import ClassVar, Literal
 
 from houndarr.clients._wire_models import (
     ArrSeries,
@@ -51,7 +51,16 @@ class MissingWhisparrEpisode:
 
 
 class WhisparrClient(ArrClient):
-    """Async client for the Whisparr v3 REST API."""
+    """Async client for the Whisparr v2 REST API."""
+
+    # Whisparr v2 is Sonarr-shaped on the v3 API surface; sortKey is
+    # ``releaseDate`` (Sonarr uses ``airDateUtc``) and episodes embed a
+    # ``series`` parent like Sonarr does.
+    _WANTED_SORT_KEY: ClassVar[str] = "releaseDate"
+    _WANTED_INCLUDE_PARAM: ClassVar[str | None] = "includeSeries"
+    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[WhisparrV2WantedEpisode]]] = (
+        PaginatedResponse[WhisparrV2WantedEpisode]
+    )
 
     async def get_missing(
         self,
@@ -71,16 +80,7 @@ class WhisparrClient(ArrClient):
         Returns:
             List of :class:`MissingWhisparrEpisode` dataclasses, oldest first.
         """
-        data = await self._get(
-            "/api/v3/wanted/missing",
-            page=page,
-            pageSize=page_size,
-            sortKey="releaseDate",
-            sortDirection="ascending",
-            includeSeries="true",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[WhisparrV2WantedEpisode].model_validate(data)
+        envelope = await self._fetch_wanted_page("missing", page=page, page_size=page_size)
         return [_parse_episode(w) for w in envelope.records]
 
     async def search(self, item_id: int) -> None:
@@ -119,6 +119,8 @@ class WhisparrClient(ArrClient):
         """Return a page of monitored episodes that have not met their quality cutoff.
 
         Calls ``GET /api/v3/wanted/cutoff`` with ``includeSeries=true``.
+        Whisparr's cutoff endpoint historically omits the sort params,
+        so the call passes ``include_sort=False`` to suppress them.
 
         Args:
             page: 1-based page number.
@@ -127,28 +129,30 @@ class WhisparrClient(ArrClient):
         Returns:
             List of :class:`MissingWhisparrEpisode` dataclasses.
         """
-        data = await self._get(
-            "/api/v3/wanted/cutoff",
+        envelope = await self._fetch_wanted_page(
+            "cutoff",
             page=page,
-            pageSize=page_size,
-            includeSeries="true",
-            monitored="true",
+            page_size=page_size,
+            include_sort=False,
         )
-        envelope = PaginatedResponse[WhisparrV2WantedEpisode].model_validate(data)
         return [_parse_episode(w) for w in envelope.records]
 
     async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
-        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe."""
-        data = await self._get(
-            f"/api/v3/wanted/{kind}",
-            page=1,
-            pageSize=1,
-            sortKey="releaseDate",
-            sortDirection="ascending",
-            monitored="true",
-        )
-        envelope = PaginatedResponse[WhisparrV2WantedEpisode].model_validate(data)
-        return envelope.total_records
+        """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe.
+
+        Delegates to :meth:`ArrClient._fetch_wanted_total`, which wraps
+        raw ``httpx`` and ``pydantic`` failures in typed
+        :class:`~houndarr.errors.ClientError` subclasses with the
+        original exception preserved on ``__cause__``.
+
+        Raises:
+            ClientHTTPError: Non-2xx response.
+            ClientTransportError: Transport failure (connect, timeout,
+                malformed URL, etc.).
+            ClientValidationError: Response shape did not match the
+                paginated envelope schema.
+        """
+        return await self._fetch_wanted_total(kind)
 
     async def get_series(self) -> list[ArrSeries]:
         """Return the full series list.
@@ -183,9 +187,7 @@ class WhisparrClient(ArrClient):
         return [_parse_library_episode(WhisparrV2LibraryEpisode.model_validate(r)) for r in records]
 
 
-# ---------------------------------------------------------------------------
 # Parsing helpers
-# ---------------------------------------------------------------------------
 
 
 def _parse_library_episode(wire: WhisparrV2LibraryEpisode) -> LibraryWhisparrEpisode:

--- a/src/houndarr/clients/whisparr_v3.py
+++ b/src/houndarr/clients/whisparr_v3.py
@@ -5,6 +5,28 @@ Its API mirrors Radarr's ``/api/v3/movie`` structure, but unlike Radarr it
 does not expose ``/api/v3/wanted/missing`` or ``/api/v3/wanted/cutoff``
 endpoints.  Missing and cutoff-unmet items are identified by fetching the
 full library via ``GET /api/v3/movie`` and filtering client-side.
+
+Outlier status (Track C.6).  Sonarr, Radarr, Lidarr, Readarr, and
+Whisparr v2 all collapsed onto the
+:meth:`~houndarr.clients.base.ArrClient._fetch_wanted_page` /
+:meth:`~houndarr.clients.base.ArrClient._fetch_wanted_total` template
+in C.1 - C.5; this module deliberately does not.  No paginated
+``/wanted`` endpoint exists upstream, so the four ``_WANTED_*`` hooks
+on the base ABC stay at their defaults (``_WANTED_ENVELOPE`` is
+``None``); calling :meth:`~ArrClient._fetch_wanted_page` here would
+raise :class:`NotImplementedError` by design.
+
+Instead, this client fetches the entire library once per client
+lifetime and filters in memory: missing = ``monitored and not
+hasFile``; cutoff = ``monitored and hasFile and qualityCutoffNotMet``.
+Pagination at the API surface (``page`` / ``page_size`` on
+:meth:`get_missing` / :meth:`get_cutoff_unmet`) slices the filtered
+list rather than triggering further network calls.
+
+The cache lives on ``self._movie_cache`` and survives for the
+context manager's lifetime (one search pass).  This keeps the
+missing pass, the cutoff pass, and the wanted-total probe from
+each issuing their own ``/api/v3/movie`` request.
 """
 
 from __future__ import annotations
@@ -54,11 +76,19 @@ class LibraryWhisparrV3Movie:
 class WhisparrV3Client(ArrClient):
     """Async client for the Whisparr v3 REST API.
 
-    Whisparr v3 has no ``wanted/missing`` or ``wanted/cutoff`` endpoints.
-    This client fetches the full library via ``GET /api/v3/movie`` and
-    filters client-side for missing and cutoff-unmet items.  The library
-    response is cached for the lifetime of the client instance (one search
-    pass) to avoid redundant fetches as pagination advances.
+    Whisparr v3 has no ``wanted/missing`` or ``wanted/cutoff`` endpoints,
+    so it does not use the shared ``/wanted`` template the other five
+    clients adopted in C.1 - C.5.  All four ``_WANTED_*`` class-level
+    hooks stay at the base defaults; ``_WANTED_ENVELOPE`` remains
+    ``None`` so an accidental call to
+    :meth:`~houndarr.clients.base.ArrClient._fetch_wanted_page` raises
+    :class:`NotImplementedError` rather than silently producing an
+    empty page.
+
+    Missing and cutoff-unmet items are computed from a one-shot
+    ``GET /api/v3/movie`` fetch, cached for the lifetime of the client
+    instance.  :meth:`get_wanted_total` reuses the same cache so a
+    single network call answers every per-pass query.
     """
 
     def __init__(
@@ -150,6 +180,11 @@ class WhisparrV3Client(ArrClient):
 
     async def get_wanted_total(self, kind: Literal["missing", "cutoff"]) -> int:
         """Return the count of wanted items for *kind* from the cached library.
+
+        Overrides the base default
+        (:meth:`~houndarr.clients.base.ArrClient._fetch_wanted_total`)
+        because there is no ``/wanted`` endpoint to probe here; the
+        total is derived from the cached ``/api/v3/movie`` payload.
 
         Reuses :meth:`_get_all_movies` (one fetch per client lifetime) so the
         probe does not trigger an extra network call during a pass.

--- a/src/houndarr/engine/adapters/__init__.py
+++ b/src/houndarr/engine/adapters/__init__.py
@@ -1,107 +1,52 @@
-"""Adapter registry mapping instance types to their adapter functions.
+"""Adapter registry mapping instance types to their adapter classes.
 
-Each :class:`AppAdapter` bundles the four functions the engine pipeline needs
-to work with a specific *arr application: candidate conversion (missing and
-cutoff), search dispatch, and client construction.
+Each per-app adapter module exposes an ``XAdapter`` class that
+structurally satisfies
+:class:`~houndarr.engine.adapters.protocols.AppAdapterProto` via six
+staticmethod attributes (``adapt_missing``, ``adapt_cutoff``,
+``adapt_upgrade``, ``fetch_upgrade_pool``, ``dispatch_search``,
+``make_client``).  The :data:`ADAPTERS` dict maps each
+:class:`~houndarr.services.instances.InstanceType` to a single
+process-lifetime instance of the matching adapter class; per-cycle
+state lives on the *arr clients themselves, not on the adapters.
 
-The :data:`ADAPTERS` dict is the single lookup table used by the pipeline.
+Track C.10 replaced the previous frozen ``AppAdapter`` dataclass-of-
+callables shape with these per-app classes.  ``AppAdapter`` remains as
+a backward-compatible alias for :class:`AppAdapterProto` so callers
+still type-hint or :func:`isinstance`-check with the historical name.
 """
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
-from typing import Any
-
-from houndarr.clients.base import ArrClient
 from houndarr.engine.adapters import lidarr, radarr, readarr, sonarr, whisparr_v2, whisparr_v3
-from houndarr.engine.candidates import SearchCandidate
-from houndarr.services.instances import Instance, InstanceType
+from houndarr.engine.adapters.protocols import AppAdapterProto
+from houndarr.services.instances import InstanceType
+
+# Backward-compatible alias for callers that type-hinted the registry
+# via ``AppAdapter``.  The dataclass form is gone; the structural
+# Protocol takes its place.
+AppAdapter = AppAdapterProto
 
 
-@dataclass(frozen=True)
-class AppAdapter:
-    """Bundle of adapter functions for a single *arr application.
-
-    Attributes:
-        adapt_missing: Convert a raw missing item into a :class:`SearchCandidate`.
-        adapt_cutoff: Convert a raw cutoff-unmet item into a :class:`SearchCandidate`.
-        adapt_upgrade: Convert a library item into a :class:`SearchCandidate`
-            for the upgrade pass.
-        fetch_upgrade_pool: Fetch and filter the library for upgrade-eligible
-            items.  Returns a list of app-specific library dataclasses.
-        dispatch_search: Send the search command via the appropriate client method.
-        make_client: Construct an (unopened) client for the application.
-    """
-
-    adapt_missing: Callable[..., SearchCandidate]
-    adapt_cutoff: Callable[..., SearchCandidate]
-    adapt_upgrade: Callable[..., SearchCandidate]
-    fetch_upgrade_pool: Callable[..., Awaitable[list[Any]]]
-    dispatch_search: Callable[..., Awaitable[None]]
-    make_client: Callable[[Instance], ArrClient]
-
-
-ADAPTERS: dict[InstanceType, AppAdapter] = {
-    InstanceType.radarr: AppAdapter(
-        adapt_missing=radarr.adapt_missing,
-        adapt_cutoff=radarr.adapt_cutoff,
-        adapt_upgrade=radarr.adapt_upgrade,
-        fetch_upgrade_pool=radarr.fetch_upgrade_pool,
-        dispatch_search=radarr.dispatch_search,
-        make_client=radarr.make_client,
-    ),
-    InstanceType.sonarr: AppAdapter(
-        adapt_missing=sonarr.adapt_missing,
-        adapt_cutoff=sonarr.adapt_cutoff,
-        adapt_upgrade=sonarr.adapt_upgrade,
-        fetch_upgrade_pool=sonarr.fetch_upgrade_pool,
-        dispatch_search=sonarr.dispatch_search,
-        make_client=sonarr.make_client,
-    ),
-    InstanceType.lidarr: AppAdapter(
-        adapt_missing=lidarr.adapt_missing,
-        adapt_cutoff=lidarr.adapt_cutoff,
-        adapt_upgrade=lidarr.adapt_upgrade,
-        fetch_upgrade_pool=lidarr.fetch_upgrade_pool,
-        dispatch_search=lidarr.dispatch_search,
-        make_client=lidarr.make_client,
-    ),
-    InstanceType.readarr: AppAdapter(
-        adapt_missing=readarr.adapt_missing,
-        adapt_cutoff=readarr.adapt_cutoff,
-        adapt_upgrade=readarr.adapt_upgrade,
-        fetch_upgrade_pool=readarr.fetch_upgrade_pool,
-        dispatch_search=readarr.dispatch_search,
-        make_client=readarr.make_client,
-    ),
-    InstanceType.whisparr_v2: AppAdapter(
-        adapt_missing=whisparr_v2.adapt_missing,
-        adapt_cutoff=whisparr_v2.adapt_cutoff,
-        adapt_upgrade=whisparr_v2.adapt_upgrade,
-        fetch_upgrade_pool=whisparr_v2.fetch_upgrade_pool,
-        dispatch_search=whisparr_v2.dispatch_search,
-        make_client=whisparr_v2.make_client,
-    ),
-    InstanceType.whisparr_v3: AppAdapter(
-        adapt_missing=whisparr_v3.adapt_missing,
-        adapt_cutoff=whisparr_v3.adapt_cutoff,
-        adapt_upgrade=whisparr_v3.adapt_upgrade,
-        fetch_upgrade_pool=whisparr_v3.fetch_upgrade_pool,
-        dispatch_search=whisparr_v3.dispatch_search,
-        make_client=whisparr_v3.make_client,
-    ),
+ADAPTERS: dict[InstanceType, AppAdapterProto] = {
+    InstanceType.radarr: radarr.RadarrAdapter(),
+    InstanceType.sonarr: sonarr.SonarrAdapter(),
+    InstanceType.lidarr: lidarr.LidarrAdapter(),
+    InstanceType.readarr: readarr.ReadarrAdapter(),
+    InstanceType.whisparr_v2: whisparr_v2.WhisparrV2Adapter(),
+    InstanceType.whisparr_v3: whisparr_v3.WhisparrV3Adapter(),
 }
 
 
-def get_adapter(instance_type: InstanceType) -> AppAdapter:
+def get_adapter(instance_type: InstanceType) -> AppAdapterProto:
     """Look up the adapter for *instance_type*.
 
     Args:
         instance_type: The :class:`InstanceType` to look up.
 
     Returns:
-        The matching :class:`AppAdapter`.
+        The matching adapter as an :class:`AppAdapterProto`-conforming
+        class instance.
 
     Raises:
         ValueError: If *instance_type* is not registered.

--- a/src/houndarr/engine/adapters/_common.py
+++ b/src/houndarr/engine/adapters/_common.py
@@ -32,7 +32,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-from houndarr.engine.candidates import SearchCandidate
+from houndarr.engine.candidates import ItemType, SearchCandidate
 
 
 class _UpgradeFilterable(Protocol):
@@ -110,7 +110,7 @@ class ContextOverride:
 
 def build_missing_candidate(
     *,
-    item_type: str,
+    item_type: ItemType,
     item_id: int,
     label: str,
     unreleased_reason: str | None,
@@ -167,7 +167,7 @@ def build_missing_candidate(
 
 def build_cutoff_candidate(
     *,
-    item_type: str,
+    item_type: ItemType,
     item_id: int,
     label: str,
     unreleased_reason: str | None,

--- a/src/houndarr/engine/adapters/_common.py
+++ b/src/houndarr/engine/adapters/_common.py
@@ -1,0 +1,71 @@
+"""Shared adapter templates for the search engine pipeline.
+
+Adapters today copy 85-100% of the same upgrade-pool builder, missing
+candidate builder, and cutoff candidate builder per app.  This module
+collects the shared templates so each adapter shrinks to per-app data
+shaping plus a single call into here.
+
+Track C.7 - C.9 land the templates and migrate the matching adapters;
+C.10 then converts :class:`~houndarr.engine.adapters.AppAdapter` from a
+dataclass of callables into a Protocol so adapters can become classes
+that inherit the shared behaviour from a base instead of importing it
+piecemeal.
+
+The first inhabitant is :func:`fetch_movie_upgrade_pool`, used by the
+two movie-shaped clients (Radarr and Whisparr v3) whose library item
+exposes the three boolean flags every upgrade pass filters on.  Series,
+album, and book libraries iterate the parent aggregate first and so use
+their own per-adapter pool builders that this helper cannot subsume.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+
+class _UpgradeFilterable(Protocol):
+    """Library items the movie upgrade-pool filter understands.
+
+    Both Radarr's :class:`~houndarr.clients.radarr.LibraryMovie` and
+    Whisparr v3's :class:`~houndarr.clients.whisparr_v3.LibraryWhisparrV3Movie`
+    structurally conform; episode, album, and book library items do not
+    (their parent monitoring lives one level up so they take a different
+    upgrade path entirely).
+
+    The attributes are declared as ``@property`` so frozen dataclasses
+    structurally satisfy the bound (the same pattern the
+    :class:`~houndarr.engine.adapters.protocols.AppAdapterProto` uses
+    for the same reason).
+    """
+
+    @property
+    def monitored(self) -> bool: ...
+    @property
+    def has_file(self) -> bool: ...
+    @property
+    def cutoff_met(self) -> bool: ...
+
+
+async def fetch_movie_upgrade_pool[T: _UpgradeFilterable](
+    library_fetcher: Callable[[], Awaitable[list[T]]],
+) -> list[T]:
+    """Return upgrade-eligible items from a movie-shaped library.
+
+    Calls *library_fetcher* once and filters the result to items that
+    are monitored, already have a file, and have already met the
+    quality cutoff.  Identical to the inline filter every per-adapter
+    ``fetch_upgrade_pool`` used to carry; centralising it lets future
+    changes to the upgrade-eligibility rule land in one place.
+
+    Args:
+        library_fetcher: A zero-arg awaitable returning the full
+            library (typically ``client.get_library``).  Bound at the
+            call site so the helper does not need to know how the
+            client constructs the request.
+
+    Returns:
+        The filtered subset of the library, preserving fetch order.
+    """
+    library = await library_fetcher()
+    return [m for m in library if m.monitored and m.has_file and m.cutoff_met]

--- a/src/houndarr/engine/adapters/_common.py
+++ b/src/houndarr/engine/adapters/_common.py
@@ -11,17 +11,28 @@ dataclass of callables into a Protocol so adapters can become classes
 that inherit the shared behaviour from a base instead of importing it
 piecemeal.
 
-The first inhabitant is :func:`fetch_movie_upgrade_pool`, used by the
-two movie-shaped clients (Radarr and Whisparr v3) whose library item
-exposes the three boolean flags every upgrade pass filters on.  Series,
-album, and book libraries iterate the parent aggregate first and so use
-their own per-adapter pool builders that this helper cannot subsume.
+Inhabitants:
+
+- :func:`fetch_movie_upgrade_pool`: shared library-filter for the two
+  movie adapters (Radarr, Whisparr v3).
+- :class:`ContextOverride` + :func:`build_missing_candidate`: shared
+  missing-pass candidate constructor.  Two-mode adapters
+  (Sonarr / Whisparr v2 season-context, Lidarr artist-context, Readarr
+  author-context) pass a ``ContextOverride`` when their per-instance
+  search mode selects the parent-aggregate variant; single-mode
+  adapters (Radarr, Whisparr v3) leave it as ``None``.
+- :func:`build_cutoff_candidate`: shared cutoff-pass constructor.
+  Single-mode for every app (cutoff always uses item-level dispatch
+  even when missing-pass uses parent-context).
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Protocol
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from houndarr.engine.candidates import SearchCandidate
 
 
 class _UpgradeFilterable(Protocol):
@@ -69,3 +80,86 @@ async def fetch_movie_upgrade_pool[T: _UpgradeFilterable](
     """
     library = await library_fetcher()
     return [m for m in library if m.monitored and m.has_file and m.cutoff_met]
+
+
+@dataclass(frozen=True, slots=True)
+class ContextOverride:
+    """Parent-context dispatch override for the missing-pass candidate.
+
+    Four adapters (Sonarr, Whisparr v2, Lidarr, Readarr) optionally
+    promote a per-item search to a per-parent search when their
+    instance search-mode setting selects the parent-aggregate variant
+    (``season_context`` for Sonarr / Whisparr v2; ``artist_context``
+    for Lidarr; ``author_context`` for Readarr).  In context mode the
+    candidate uses a synthetic negative item ID, a parent-scoped log
+    label, a non-``None`` ``group_key`` for dispatch deduplication,
+    and a different ``search_payload`` shape that the per-adapter
+    ``dispatch_search`` reads.
+
+    Single-mode adapters (Radarr, Whisparr v3) never set this; they
+    always run per-item.  Cutoff-pass dispatch is always per-item even
+    when the missing pass uses parent-context, so this override does
+    not apply to :func:`build_cutoff_candidate`.
+    """
+
+    item_id: int
+    label: str
+    group_key: tuple[int, int]
+    search_payload: dict[str, Any]
+
+
+def build_missing_candidate(
+    *,
+    item_type: str,
+    item_id: int,
+    label: str,
+    unreleased_reason: str | None,
+    search_payload: dict[str, Any],
+    context: ContextOverride | None = None,
+) -> SearchCandidate:
+    """Construct a :class:`SearchCandidate` for the missing pass.
+
+    When *context* is supplied the candidate uses the override fields
+    (synthetic item_id, parent-scoped label, parent-context group_key,
+    parent-shaped search_payload); when *context* is ``None`` the
+    candidate uses the primary per-item fields.
+
+    The unreleased-reason and item_type are shared regardless of
+    dispatch mode; both pass through to the constructed candidate.
+
+    Args:
+        item_type: Per-adapter type string (``"movie"``, ``"episode"``,
+            ``"album"``, ``"book"``, ``"whisparr_episode"``,
+            ``"whisparr_v3_movie"``).
+        item_id: The DB-stable per-item id used in primary mode.
+            Ignored when *context* is supplied.
+        label: Human-readable per-item log label.  Ignored when
+            *context* is supplied.
+        unreleased_reason: ``None`` when eligible; a skip-reason
+            string when the candidate should be treated as unreleased.
+        search_payload: Per-item dispatch payload.  Ignored when
+            *context* is supplied.
+        context: Optional parent-context override.  When set, replaces
+            ``item_id`` / ``label`` / ``group_key`` / ``search_payload``
+            and the resulting candidate dispatches at the parent level.
+
+    Returns:
+        A fully populated :class:`SearchCandidate`.
+    """
+    if context is not None:
+        return SearchCandidate(
+            item_id=context.item_id,
+            item_type=item_type,
+            label=context.label,
+            unreleased_reason=unreleased_reason,
+            group_key=context.group_key,
+            search_payload=context.search_payload,
+        )
+    return SearchCandidate(
+        item_id=item_id,
+        item_type=item_type,
+        label=label,
+        unreleased_reason=unreleased_reason,
+        group_key=None,
+        search_payload=search_payload,
+    )

--- a/src/houndarr/engine/adapters/_common.py
+++ b/src/houndarr/engine/adapters/_common.py
@@ -163,3 +163,46 @@ def build_missing_candidate(
         group_key=None,
         search_payload=search_payload,
     )
+
+
+def build_cutoff_candidate(
+    *,
+    item_type: str,
+    item_id: int,
+    label: str,
+    unreleased_reason: str | None,
+    search_payload: dict[str, Any],
+) -> SearchCandidate:
+    """Construct a :class:`SearchCandidate` for the cutoff pass.
+
+    The cutoff pass is single-mode for every *arr regardless of how the
+    missing pass dispatches, so this helper takes no
+    :class:`ContextOverride`.  Sonarr / Whisparr v2 / Lidarr / Readarr
+    can run their missing pass under parent-context dispatch
+    (``season_context``, ``artist_context``, ``author_context``) but
+    their cutoff pass always dispatches per-item; Radarr and Whisparr
+    v3 are single-mode end to end and delegate ``adapt_cutoff`` to
+    ``adapt_missing`` directly.
+
+    Args:
+        item_type: Per-adapter type string (``"movie"``,
+            ``"episode"``, ``"album"``, ``"book"``,
+            ``"whisparr_episode"``, ``"whisparr_v3_movie"``).
+        item_id: The DB-stable per-item id.
+        label: Human-readable per-item log label.
+        unreleased_reason: ``None`` when eligible; a skip-reason
+            string when the candidate should be treated as unreleased.
+        search_payload: Per-item dispatch payload.
+
+    Returns:
+        A fully populated :class:`SearchCandidate` with ``group_key``
+        always ``None``.
+    """
+    return SearchCandidate(
+        item_id=item_id,
+        item_type=item_type,
+        label=label,
+        unreleased_reason=unreleased_reason,
+        group_key=None,
+        search_payload=search_payload,
+    )

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -12,6 +12,7 @@ import logging
 from houndarr.clients.lidarr import LibraryAlbum, LidarrClient, MissingAlbum
 from houndarr.engine.adapters._common import (
     ContextOverride,
+    build_cutoff_candidate,
     build_missing_candidate,
 )
 from houndarr.engine.candidates import (
@@ -118,16 +119,13 @@ def adapt_cutoff(item: MissingAlbum, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    unreleased_reason = _lidarr_unreleased_reason(
-        item.release_date, instance.post_release_grace_hrs
-    )
-
-    return SearchCandidate(
-        item_id=item.album_id,
+    return build_cutoff_candidate(
         item_type="album",
+        item_id=item.album_id,
         label=_album_label(item),
-        unreleased_reason=unreleased_reason,
-        group_key=None,
+        unreleased_reason=_lidarr_unreleased_reason(
+            item.release_date, instance.post_release_grace_hrs
+        ),
         search_payload={
             "command": "AlbumSearch",
             "album_id": item.album_id,

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -256,3 +256,21 @@ def make_client(instance: Instance) -> LidarrClient:
         A new (unopened) :class:`LidarrClient`.
     """
     return LidarrClient(url=instance.url, api_key=instance.api_key)
+
+
+class LidarrAdapter:
+    """Class-form Lidarr adapter for the :data:`ADAPTERS` registry.
+
+    Conforms to :class:`~houndarr.engine.adapters.protocols.AppAdapterProto`
+    structurally via the six staticmethod attributes below; the
+    module-level functions remain importable for direct unit-test use.
+    Track C.10 introduces this class form to replace the prior
+    ``AppAdapter`` dataclass-of-callables registry shape.
+    """
+
+    adapt_missing = staticmethod(adapt_missing)
+    adapt_cutoff = staticmethod(adapt_cutoff)
+    adapt_upgrade = staticmethod(adapt_upgrade)
+    fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
+    dispatch_search = staticmethod(dispatch_search)
+    make_client = staticmethod(make_client)

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 import logging
 
 from houndarr.clients.lidarr import LibraryAlbum, LidarrClient, MissingAlbum
+from houndarr.engine.adapters._common import (
+    ContextOverride,
+    build_missing_candidate,
+)
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -73,38 +77,32 @@ def adapt_missing(item: MissingAlbum, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    album_mode = instance.lidarr_search_mode == LidarrSearchMode.album
-
-    use_artist_context = not album_mode and item.artist_id > 0
-
-    if use_artist_context:
-        item_id = _artist_item_id(item.artist_id)
-        label = _artist_context_label(item)
-        group_key: tuple[int, int] | None = (item.artist_id, 0)
-        search_payload = {
-            "command": "ArtistSearch",
-            "artist_id": item.artist_id,
-        }
-    else:
-        item_id = item.album_id
-        label = _album_label(item)
-        group_key = None
-        search_payload = {
-            "command": "AlbumSearch",
-            "album_id": item.album_id,
-        }
-
     unreleased_reason = _lidarr_unreleased_reason(
         item.release_date, instance.post_release_grace_hrs
     )
 
-    return SearchCandidate(
-        item_id=item_id,
+    context: ContextOverride | None = None
+    if instance.lidarr_search_mode != LidarrSearchMode.album and item.artist_id > 0:
+        context = ContextOverride(
+            item_id=_artist_item_id(item.artist_id),
+            label=_artist_context_label(item),
+            group_key=(item.artist_id, 0),
+            search_payload={
+                "command": "ArtistSearch",
+                "artist_id": item.artist_id,
+            },
+        )
+
+    return build_missing_candidate(
         item_type="album",
-        label=label,
+        item_id=item.album_id,
+        label=_album_label(item),
         unreleased_reason=unreleased_reason,
-        group_key=group_key,
-        search_payload=search_payload,
+        search_payload={
+            "command": "AlbumSearch",
+            "album_id": item.album_id,
+        },
+        context=context,
     )
 
 

--- a/src/houndarr/engine/adapters/protocols.py
+++ b/src/houndarr/engine/adapters/protocols.py
@@ -1,0 +1,31 @@
+"""Structural Protocol mirroring the AppAdapter dataclass shape.
+
+Track B.18 declaration.  The :class:`AppAdapter` dataclass today
+holds six callables.  This Protocol captures the same shape so
+future Track C.10 can migrate the registry to Protocol-typed class
+instances without a call-site cascade.
+
+Runtime-checkable so tests can ``isinstance(adapter, AppAdapterProto)``
+as a conformance check when the registry is rewired.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol, runtime_checkable
+
+from houndarr.clients.base import ArrClient
+from houndarr.engine.candidates import SearchCandidate
+from houndarr.services.instances import Instance
+
+
+@runtime_checkable
+class AppAdapterProto(Protocol):
+    """Structural contract every adapter (module or class) must satisfy."""
+
+    adapt_missing: Callable[..., SearchCandidate]
+    adapt_cutoff: Callable[..., SearchCandidate]
+    adapt_upgrade: Callable[..., SearchCandidate]
+    fetch_upgrade_pool: Callable[..., Awaitable[list[Any]]]
+    dispatch_search: Callable[..., Awaitable[None]]
+    make_client: Callable[[Instance], ArrClient]

--- a/src/houndarr/engine/adapters/protocols.py
+++ b/src/houndarr/engine/adapters/protocols.py
@@ -7,6 +7,14 @@ instances without a call-site cascade.
 
 Runtime-checkable so tests can ``isinstance(adapter, AppAdapterProto)``
 as a conformance check when the registry is rewired.
+
+Each member is declared via ``@property`` so the Protocol advertises
+read-only attributes.  That matters because :class:`AppAdapter` is a
+frozen dataclass: its slots are read-only at runtime, and a
+bare-attribute Protocol would reject frozen instances as
+non-conforming.  Future class-based adapters can expose the same
+callables as plain attributes or as properties; either form
+satisfies this Protocol.
 """
 
 from __future__ import annotations
@@ -23,9 +31,26 @@ from houndarr.services.instances import Instance
 class AppAdapterProto(Protocol):
     """Structural contract every adapter (module or class) must satisfy."""
 
-    adapt_missing: Callable[..., SearchCandidate]
-    adapt_cutoff: Callable[..., SearchCandidate]
-    adapt_upgrade: Callable[..., SearchCandidate]
-    fetch_upgrade_pool: Callable[..., Awaitable[list[Any]]]
-    dispatch_search: Callable[..., Awaitable[None]]
-    make_client: Callable[[Instance], ArrClient]
+    @property
+    def adapt_missing(self) -> Callable[..., SearchCandidate]:
+        """Build a :class:`SearchCandidate` from a raw missing-pass item."""
+
+    @property
+    def adapt_cutoff(self) -> Callable[..., SearchCandidate]:
+        """Build a :class:`SearchCandidate` from a raw cutoff-unmet item."""
+
+    @property
+    def adapt_upgrade(self) -> Callable[..., SearchCandidate]:
+        """Build a :class:`SearchCandidate` from a raw upgrade-pool item."""
+
+    @property
+    def fetch_upgrade_pool(self) -> Callable[..., Awaitable[list[Any]]]:
+        """Fetch the per-cycle upgrade candidate list from the *arr app."""
+
+    @property
+    def dispatch_search(self) -> Callable[..., Awaitable[None]]:
+        """Send the *arr search command for one candidate."""
+
+    @property
+    def make_client(self) -> Callable[[Instance], ArrClient]:
+        """Return a fresh (unopened) :class:`ArrClient` for *instance*."""

--- a/src/houndarr/engine/adapters/radarr.py
+++ b/src/houndarr/engine/adapters/radarr.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from houndarr.clients.radarr import LibraryMovie, MissingMovie, RadarrClient
-from houndarr.engine.adapters._common import fetch_movie_upgrade_pool
+from houndarr.engine.adapters._common import (
+    build_missing_candidate,
+    fetch_movie_upgrade_pool,
+)
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -79,12 +82,11 @@ def adapt_missing(item: MissingMovie, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    return SearchCandidate(
-        item_id=item.movie_id,
+    return build_missing_candidate(
         item_type="movie",
+        item_id=item.movie_id,
         label=_movie_label(item),
         unreleased_reason=_radarr_unreleased_reason(item, instance.post_release_grace_hrs),
-        group_key=None,
         search_payload={
             "command": "MoviesSearch",
             "movie_id": item.movie_id,

--- a/src/houndarr/engine/adapters/radarr.py
+++ b/src/houndarr/engine/adapters/radarr.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from houndarr.clients.radarr import LibraryMovie, MissingMovie, RadarrClient
+from houndarr.engine.adapters._common import fetch_movie_upgrade_pool
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -142,7 +143,7 @@ def adapt_upgrade(item: LibraryMovie, instance: Instance) -> SearchCandidate:
 
 async def fetch_upgrade_pool(
     client: RadarrClient,
-    instance: Instance,
+    instance: Instance,  # noqa: ARG001
 ) -> list[LibraryMovie]:
     """Fetch and filter Radarr library for upgrade-eligible movies.
 
@@ -150,13 +151,15 @@ async def fetch_upgrade_pool(
 
     Args:
         client: An open :class:`RadarrClient` context.
-        instance: The configured Radarr instance.
+        instance: The configured Radarr instance.  Unused at present;
+            kept for AppAdapter signature parity with the series /
+            album / book adapters whose pool builders consult instance
+            policy.
 
     Returns:
         List of upgrade-eligible :class:`LibraryMovie` items.
     """
-    library = await client.get_library()
-    return [m for m in library if m.monitored and m.has_file and m.cutoff_met]
+    return await fetch_movie_upgrade_pool(client.get_library)
 
 
 async def dispatch_search(client: RadarrClient, candidate: SearchCandidate) -> None:

--- a/src/houndarr/engine/adapters/radarr.py
+++ b/src/houndarr/engine/adapters/radarr.py
@@ -184,3 +184,21 @@ def make_client(instance: Instance) -> RadarrClient:
         A new (unopened) :class:`RadarrClient`.
     """
     return RadarrClient(url=instance.url, api_key=instance.api_key)
+
+
+class RadarrAdapter:
+    """Class-form Radarr adapter for the :data:`ADAPTERS` registry.
+
+    Conforms to :class:`~houndarr.engine.adapters.protocols.AppAdapterProto`
+    structurally via the six staticmethod attributes below; the
+    module-level functions remain importable for direct unit-test use.
+    Track C.10 introduces this class form to replace the prior
+    ``AppAdapter`` dataclass-of-callables registry shape.
+    """
+
+    adapt_missing = staticmethod(adapt_missing)
+    adapt_cutoff = staticmethod(adapt_cutoff)
+    adapt_upgrade = staticmethod(adapt_upgrade)
+    fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
+    dispatch_search = staticmethod(dispatch_search)
+    make_client = staticmethod(make_client)

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -12,6 +12,7 @@ import logging
 from houndarr.clients.readarr import LibraryBook, MissingBook, ReadarrClient
 from houndarr.engine.adapters._common import (
     ContextOverride,
+    build_cutoff_candidate,
     build_missing_candidate,
 )
 from houndarr.engine.candidates import (
@@ -117,16 +118,13 @@ def adapt_cutoff(item: MissingBook, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    unreleased_reason = _readarr_unreleased_reason(
-        item.release_date, instance.post_release_grace_hrs
-    )
-
-    return SearchCandidate(
-        item_id=item.book_id,
+    return build_cutoff_candidate(
         item_type="book",
+        item_id=item.book_id,
         label=_book_label(item),
-        unreleased_reason=unreleased_reason,
-        group_key=None,
+        unreleased_reason=_readarr_unreleased_reason(
+            item.release_date, instance.post_release_grace_hrs
+        ),
         search_payload={
             "command": "BookSearch",
             "book_id": item.book_id,

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -255,3 +255,21 @@ def make_client(instance: Instance) -> ReadarrClient:
         A new (unopened) :class:`ReadarrClient`.
     """
     return ReadarrClient(url=instance.url, api_key=instance.api_key)
+
+
+class ReadarrAdapter:
+    """Class-form Readarr adapter for the :data:`ADAPTERS` registry.
+
+    Conforms to :class:`~houndarr.engine.adapters.protocols.AppAdapterProto`
+    structurally via the six staticmethod attributes below; the
+    module-level functions remain importable for direct unit-test use.
+    Track C.10 introduces this class form to replace the prior
+    ``AppAdapter`` dataclass-of-callables registry shape.
+    """
+
+    adapt_missing = staticmethod(adapt_missing)
+    adapt_cutoff = staticmethod(adapt_cutoff)
+    adapt_upgrade = staticmethod(adapt_upgrade)
+    fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
+    dispatch_search = staticmethod(dispatch_search)
+    make_client = staticmethod(make_client)

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 import logging
 
 from houndarr.clients.readarr import LibraryBook, MissingBook, ReadarrClient
+from houndarr.engine.adapters._common import (
+    ContextOverride,
+    build_missing_candidate,
+)
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -72,38 +76,32 @@ def adapt_missing(item: MissingBook, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    book_mode = instance.readarr_search_mode == ReadarrSearchMode.book
-
-    use_author_context = not book_mode and item.author_id > 0
-
-    if use_author_context:
-        item_id = _author_item_id(item.author_id)
-        label = _author_context_label(item)
-        group_key: tuple[int, int] | None = (item.author_id, 0)
-        search_payload = {
-            "command": "AuthorSearch",
-            "author_id": item.author_id,
-        }
-    else:
-        item_id = item.book_id
-        label = _book_label(item)
-        group_key = None
-        search_payload = {
-            "command": "BookSearch",
-            "book_id": item.book_id,
-        }
-
     unreleased_reason = _readarr_unreleased_reason(
         item.release_date, instance.post_release_grace_hrs
     )
 
-    return SearchCandidate(
-        item_id=item_id,
+    context: ContextOverride | None = None
+    if instance.readarr_search_mode != ReadarrSearchMode.book and item.author_id > 0:
+        context = ContextOverride(
+            item_id=_author_item_id(item.author_id),
+            label=_author_context_label(item),
+            group_key=(item.author_id, 0),
+            search_payload={
+                "command": "AuthorSearch",
+                "author_id": item.author_id,
+            },
+        )
+
+    return build_missing_candidate(
         item_type="book",
-        label=label,
+        item_id=item.book_id,
+        label=_book_label(item),
         unreleased_reason=unreleased_reason,
-        group_key=group_key,
-        search_payload=search_payload,
+        search_payload={
+            "command": "BookSearch",
+            "book_id": item.book_id,
+        },
+        context=context,
     )
 
 

--- a/src/houndarr/engine/adapters/sonarr.py
+++ b/src/houndarr/engine/adapters/sonarr.py
@@ -308,3 +308,21 @@ def make_client(instance: Instance) -> SonarrClient:
         A new (unopened) :class:`SonarrClient`.
     """
     return SonarrClient(url=instance.url, api_key=instance.api_key)
+
+
+class SonarrAdapter:
+    """Class-form Sonarr adapter for the :data:`ADAPTERS` registry.
+
+    Conforms to :class:`~houndarr.engine.adapters.protocols.AppAdapterProto`
+    structurally via the six staticmethod attributes below; the
+    module-level functions remain importable for direct unit-test use.
+    Track C.10 introduces this class form to replace the prior
+    ``AppAdapter`` dataclass-of-callables registry shape.
+    """
+
+    adapt_missing = staticmethod(adapt_missing)
+    adapt_cutoff = staticmethod(adapt_cutoff)
+    adapt_upgrade = staticmethod(adapt_upgrade)
+    fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
+    dispatch_search = staticmethod(dispatch_search)
+    make_client = staticmethod(make_client)

--- a/src/houndarr/engine/adapters/sonarr.py
+++ b/src/houndarr/engine/adapters/sonarr.py
@@ -13,6 +13,7 @@ from typing import Any
 from houndarr.clients.sonarr import LibraryEpisode, MissingEpisode, SonarrClient
 from houndarr.engine.adapters._common import (
     ContextOverride,
+    build_cutoff_candidate,
     build_missing_candidate,
 )
 from houndarr.engine.candidates import (
@@ -149,16 +150,13 @@ def adapt_cutoff(item: MissingEpisode, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    unreleased_reason = _sonarr_unreleased_reason(
-        item.air_date_utc, instance.post_release_grace_hrs
-    )
-
-    return SearchCandidate(
-        item_id=item.episode_id,
+    return build_cutoff_candidate(
         item_type="episode",
+        item_id=item.episode_id,
         label=_episode_label(item),
-        unreleased_reason=unreleased_reason,
-        group_key=None,
+        unreleased_reason=_sonarr_unreleased_reason(
+            item.air_date_utc, instance.post_release_grace_hrs
+        ),
         search_payload={
             "command": "EpisodeSearch",
             "episode_id": item.episode_id,

--- a/src/houndarr/engine/adapters/sonarr.py
+++ b/src/houndarr/engine/adapters/sonarr.py
@@ -11,6 +11,10 @@ import logging
 from typing import Any
 
 from houndarr.clients.sonarr import LibraryEpisode, MissingEpisode, SonarrClient
+from houndarr.engine.adapters._common import (
+    ContextOverride,
+    build_missing_candidate,
+)
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -97,40 +101,37 @@ def adapt_missing(item: MissingEpisode, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    episode_mode = instance.sonarr_search_mode == SonarrSearchMode.episode
-
-    use_season_context = not episode_mode and item.series_id is not None and item.season > 0
-
-    if use_season_context:
-        assert item.series_id is not None  # noqa: S101
-        item_id = _season_item_id(item.series_id, item.season)
-        label = _season_context_label(item)
-        group_key: tuple[int, int] | None = (item.series_id, item.season)
-        search_payload = {
-            "command": "SeasonSearch",
-            "series_id": item.series_id,
-            "season_number": item.season,
-        }
-    else:
-        item_id = item.episode_id
-        label = _episode_label(item)
-        group_key = None
-        search_payload = {
-            "command": "EpisodeSearch",
-            "episode_id": item.episode_id,
-        }
-
     unreleased_reason = _sonarr_unreleased_reason(
         item.air_date_utc, instance.post_release_grace_hrs
     )
 
-    return SearchCandidate(
-        item_id=item_id,
+    context: ContextOverride | None = None
+    if (
+        instance.sonarr_search_mode != SonarrSearchMode.episode
+        and item.series_id is not None
+        and item.season > 0
+    ):
+        context = ContextOverride(
+            item_id=_season_item_id(item.series_id, item.season),
+            label=_season_context_label(item),
+            group_key=(item.series_id, item.season),
+            search_payload={
+                "command": "SeasonSearch",
+                "series_id": item.series_id,
+                "season_number": item.season,
+            },
+        )
+
+    return build_missing_candidate(
         item_type="episode",
-        label=label,
+        item_id=item.episode_id,
+        label=_episode_label(item),
         unreleased_reason=unreleased_reason,
-        group_key=group_key,
-        search_payload=search_payload,
+        search_payload={
+            "command": "EpisodeSearch",
+            "episode_id": item.episode_id,
+        },
+        context=context,
     )
 
 

--- a/src/houndarr/engine/adapters/whisparr_v2.py
+++ b/src/houndarr/engine/adapters/whisparr_v2.py
@@ -20,6 +20,10 @@ from houndarr.clients.whisparr_v2 import (
     MissingWhisparrEpisode,
     WhisparrClient,
 )
+from houndarr.engine.adapters._common import (
+    ContextOverride,
+    build_missing_candidate,
+)
 from houndarr.engine.candidates import SearchCandidate
 from houndarr.services.instances import Instance, WhisparrSearchMode
 
@@ -93,29 +97,6 @@ def adapt_missing(item: MissingWhisparrEpisode, instance: Instance) -> SearchCan
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    episode_mode = instance.whisparr_search_mode == WhisparrSearchMode.episode
-
-    use_season_context = not episode_mode and item.series_id is not None and item.season_number > 0
-
-    if use_season_context:
-        assert item.series_id is not None  # noqa: S101
-        item_id = _season_item_id(item.series_id, item.season_number)
-        label = _season_context_label(item)
-        group_key: tuple[int, int] | None = (item.series_id, item.season_number)
-        search_payload = {
-            "command": "SeasonSearch",
-            "series_id": item.series_id,
-            "season_number": item.season_number,
-        }
-    else:
-        item_id = item.episode_id
-        label = _episode_label(item)
-        group_key = None
-        search_payload = {
-            "command": "EpisodeSearch",
-            "episode_id": item.episode_id,
-        }
-
     unreleased_reason = _whisparr_unreleased_reason(
         item.release_date, instance.post_release_grace_hrs
     )
@@ -128,13 +109,33 @@ def adapt_missing(item: MissingWhisparrEpisode, instance: Instance) -> SearchCan
     if item.series_id is None and unreleased_reason is None:
         unreleased_reason = "no series linked"
 
-    return SearchCandidate(
-        item_id=item_id,
+    context: ContextOverride | None = None
+    if (
+        instance.whisparr_search_mode != WhisparrSearchMode.episode
+        and item.series_id is not None
+        and item.season_number > 0
+    ):
+        context = ContextOverride(
+            item_id=_season_item_id(item.series_id, item.season_number),
+            label=_season_context_label(item),
+            group_key=(item.series_id, item.season_number),
+            search_payload={
+                "command": "SeasonSearch",
+                "series_id": item.series_id,
+                "season_number": item.season_number,
+            },
+        )
+
+    return build_missing_candidate(
         item_type="whisparr_episode",
-        label=label,
+        item_id=item.episode_id,
+        label=_episode_label(item),
         unreleased_reason=unreleased_reason,
-        group_key=group_key,
-        search_payload=search_payload,
+        search_payload={
+            "command": "EpisodeSearch",
+            "episode_id": item.episode_id,
+        },
+        context=context,
     )
 
 

--- a/src/houndarr/engine/adapters/whisparr_v2.py
+++ b/src/houndarr/engine/adapters/whisparr_v2.py
@@ -315,3 +315,21 @@ def make_client(instance: Instance) -> WhisparrClient:
         A new (unopened) :class:`WhisparrClient`.
     """
     return WhisparrClient(url=instance.url, api_key=instance.api_key)
+
+
+class WhisparrV2Adapter:
+    """Class-form Whisparr v2 adapter for the :data:`ADAPTERS` registry.
+
+    Conforms to :class:`~houndarr.engine.adapters.protocols.AppAdapterProto`
+    structurally via the six staticmethod attributes below; the
+    module-level functions remain importable for direct unit-test use.
+    Track C.10 introduces this class form to replace the prior
+    ``AppAdapter`` dataclass-of-callables registry shape.
+    """
+
+    adapt_missing = staticmethod(adapt_missing)
+    adapt_cutoff = staticmethod(adapt_cutoff)
+    adapt_upgrade = staticmethod(adapt_upgrade)
+    fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
+    dispatch_search = staticmethod(dispatch_search)
+    make_client = staticmethod(make_client)

--- a/src/houndarr/engine/adapters/whisparr_v2.py
+++ b/src/houndarr/engine/adapters/whisparr_v2.py
@@ -22,6 +22,7 @@ from houndarr.clients.whisparr_v2 import (
 )
 from houndarr.engine.adapters._common import (
     ContextOverride,
+    build_cutoff_candidate,
     build_missing_candidate,
 )
 from houndarr.engine.candidates import SearchCandidate
@@ -159,12 +160,11 @@ def adapt_cutoff(item: MissingWhisparrEpisode, instance: Instance) -> SearchCand
     if item.series_id is None and unreleased_reason is None:
         unreleased_reason = "no series linked"
 
-    return SearchCandidate(
-        item_id=item.episode_id,
+    return build_cutoff_candidate(
         item_type="whisparr_episode",
+        item_id=item.episode_id,
         label=_episode_label(item),
         unreleased_reason=unreleased_reason,
-        group_key=None,
         search_payload={
             "command": "EpisodeSearch",
             "episode_id": item.episode_id,

--- a/src/houndarr/engine/adapters/whisparr_v3.py
+++ b/src/houndarr/engine/adapters/whisparr_v3.py
@@ -18,6 +18,7 @@ from houndarr.clients.whisparr_v3 import (
     MissingWhisparrV3Movie,
     WhisparrV3Client,
 )
+from houndarr.engine.adapters._common import fetch_movie_upgrade_pool
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -147,7 +148,7 @@ def adapt_upgrade(item: LibraryWhisparrV3Movie, instance: Instance) -> SearchCan
 
 async def fetch_upgrade_pool(
     client: WhisparrV3Client,
-    instance: Instance,
+    instance: Instance,  # noqa: ARG001
 ) -> list[LibraryWhisparrV3Movie]:
     """Fetch and filter the Whisparr v3 library for upgrade-eligible movies/scenes.
 
@@ -155,13 +156,15 @@ async def fetch_upgrade_pool(
 
     Args:
         client: An open :class:`WhisparrV3Client` context.
-        instance: The configured Whisparr v3 instance.
+        instance: The configured Whisparr v3 instance.  Unused at
+            present; kept for AppAdapter signature parity with the
+            series / album / book adapters whose pool builders consult
+            instance policy.
 
     Returns:
         List of upgrade-eligible :class:`LibraryWhisparrV3Movie` items.
     """
-    library = await client.get_library()
-    return [m for m in library if m.monitored and m.has_file and m.cutoff_met]
+    return await fetch_movie_upgrade_pool(client.get_library)
 
 
 async def dispatch_search(client: WhisparrV3Client, candidate: SearchCandidate) -> None:

--- a/src/houndarr/engine/adapters/whisparr_v3.py
+++ b/src/houndarr/engine/adapters/whisparr_v3.py
@@ -189,3 +189,21 @@ def make_client(instance: Instance) -> WhisparrV3Client:
         A new (unopened) :class:`WhisparrV3Client`.
     """
     return WhisparrV3Client(url=instance.url, api_key=instance.api_key)
+
+
+class WhisparrV3Adapter:
+    """Class-form Whisparr v3 adapter for the :data:`ADAPTERS` registry.
+
+    Conforms to :class:`~houndarr.engine.adapters.protocols.AppAdapterProto`
+    structurally via the six staticmethod attributes below; the
+    module-level functions remain importable for direct unit-test use.
+    Track C.10 introduces this class form to replace the prior
+    ``AppAdapter`` dataclass-of-callables registry shape.
+    """
+
+    adapt_missing = staticmethod(adapt_missing)
+    adapt_cutoff = staticmethod(adapt_cutoff)
+    adapt_upgrade = staticmethod(adapt_upgrade)
+    fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
+    dispatch_search = staticmethod(dispatch_search)
+    make_client = staticmethod(make_client)

--- a/src/houndarr/engine/adapters/whisparr_v3.py
+++ b/src/houndarr/engine/adapters/whisparr_v3.py
@@ -18,7 +18,10 @@ from houndarr.clients.whisparr_v3 import (
     MissingWhisparrV3Movie,
     WhisparrV3Client,
 )
-from houndarr.engine.adapters._common import fetch_movie_upgrade_pool
+from houndarr.engine.adapters._common import (
+    build_missing_candidate,
+    fetch_movie_upgrade_pool,
+)
 from houndarr.engine.candidates import (
     SearchCandidate,
     _is_unreleased,
@@ -87,12 +90,11 @@ def adapt_missing(item: MissingWhisparrV3Movie, instance: Instance) -> SearchCan
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    return SearchCandidate(
-        item_id=item.movie_id,
+    return build_missing_candidate(
         item_type="whisparr_v3_movie",
+        item_id=item.movie_id,
         label=_movie_label(item),
         unreleased_reason=_unreleased_reason(item, instance.post_release_grace_hrs),
-        group_key=None,
         search_payload={
             "command": "MoviesSearch",
             "movie_id": item.movie_id,

--- a/src/houndarr/engine/config/__init__.py
+++ b/src/houndarr/engine/config/__init__.py
@@ -1,0 +1,7 @@
+"""Engine configuration value objects.
+
+Track B.22 introduces :mod:`~houndarr.engine.config.search_pass`.
+Additional per-subsystem configs may land here in later tracks.
+"""
+
+from __future__ import annotations

--- a/src/houndarr/engine/config/search_pass.py
+++ b/src/houndarr/engine/config/search_pass.py
@@ -1,0 +1,90 @@
+"""Frozen value object for one missing or cutoff search pass.
+
+Track B.22 declaration.  :func:`houndarr.engine.search_loop._run_search_pass`
+currently takes 13 keyword arguments that fall naturally into four
+groups:
+
+* pass identity: ``search_kind``;
+* adapter bindings: ``adapt_fn``, ``dispatch_fn``, ``fetch_fn``,
+  ``total_fn``;
+* behaviour knobs: ``batch_size``, ``hourly_cap``,
+  ``cooldown_days``, ``page_size``, ``scan_budget``;
+* cycle metadata: ``cycle_id``, ``cycle_trigger``, ``start_page``.
+
+:class:`SearchPassConfig` collapses all thirteen into a single frozen
+dataclass so the caller at
+:func:`~houndarr.engine.search_loop.run_instance_search` passes one
+value instead of keyword-unpacking every field.  The signature switch
+itself is deferred to Track D.21; this batch only lands the
+declaration + pinning tests so Track C pattern work and Track D
+repository work can reference the type safely.
+
+The dataclass is frozen + slots for the same reason every other
+value object in Houndarr is: keep construction cheap, reject
+accidental mutation across the per-cycle boundary, and let the type
+checker narrow safely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from houndarr.engine.candidates import SearchCandidate
+from houndarr.enums import CycleTrigger, SearchKind
+
+
+@dataclass(frozen=True, slots=True)
+class SearchPassConfig:
+    """Per-pass configuration for :func:`_run_search_pass`.
+
+    The fields mirror the current keyword-argument surface one-for-one
+    so Track D.21's migration is mechanical: every ``foo=bar`` kwarg
+    becomes ``config.foo`` at the call site.
+
+    Attributes:
+        search_kind: ``"missing"`` or ``"cutoff"``.
+        adapt_fn: Converts a raw *arr item into a
+            :class:`SearchCandidate`.  Typically bound to the
+            adapter's ``adapt_missing`` or ``adapt_cutoff``.
+        dispatch_fn: Sends the *arr search command for one candidate.
+            Typically ``adapter.dispatch_search``.
+        fetch_fn: Returns one page of wanted items.  Typically
+            ``client.get_missing`` or ``client.get_cutoff_unmet``.
+        batch_size: Maximum items to search in this pass.
+        hourly_cap: Hourly search cap for this pass kind
+            (``0`` disables the cap).
+        cooldown_days: Days since last search after which an item is
+            eligible again.
+        page_size: Items to request per page from *arr.
+        scan_budget: Upper bound on candidates evaluated before the
+            pass aborts (guards against scanning past the end of the
+            list when everything is on cooldown).
+        cycle_id: Shared identifier written to every ``search_log``
+            row produced by the pass.
+        cycle_trigger: ``"scheduled"``, ``"run_now"``, or ``"system"``.
+        start_page: 1-based first page to fetch.  Rotates across
+            cycles under chronological search order.
+        total_fn: Optional probe returning the total wanted-item count.
+            Used by random search order to pick a random start page.
+            ``None`` disables the random probe and falls back to
+            *start_page*.
+    """
+
+    search_kind: SearchKind | str
+    adapt_fn: Callable[..., SearchCandidate]
+    dispatch_fn: Callable[..., Awaitable[None]]
+    fetch_fn: Callable[..., Awaitable[list[Any]]]
+    batch_size: int
+    hourly_cap: int
+    cooldown_days: int
+    page_size: int
+    scan_budget: int
+    cycle_id: str
+    cycle_trigger: CycleTrigger | str
+    start_page: int = 1
+    total_fn: Callable[[], Awaitable[int]] | None = None
+
+
+__all__ = ["SearchPassConfig"]

--- a/src/houndarr/engine/retry.py
+++ b/src/houndarr/engine/retry.py
@@ -1,0 +1,130 @@
+"""Reconnect-state machine for the supervisor's per-instance loop.
+
+The supervisor's per-cycle outcome is governed by a small state machine:
+write a single ``error`` row on the first failed cycle in a streak,
+suppress further error rows until the streak ends, then write a
+single ``info`` recovery row on the first successful cycle that
+follows.  This file owns that logic so the supervisor's ``while True``
+loop body stays straight-line and the state-transition rules can be
+exercised directly.
+
+Track C.11 introduces this module.  The user explicitly rejected
+``tenacity`` and ``httpx-retries``: there is no new runtime dep here,
+just a small ``ReconnectState`` plus a single ``run_with_reconnect``
+helper.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from houndarr.enums import CycleTrigger, SearchAction
+from houndarr.services.instances import Instance
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ReconnectState:
+    """Per-instance state carried across supervisor loop iterations.
+
+    ``in_retry`` is true between the first failed cycle in a streak
+    and the first successful cycle that follows.  Mutated by
+    :func:`run_with_reconnect`.
+
+    The dataclass is deliberately not frozen and not slotted: the
+    helper mutates ``in_retry`` in place across many awaits and a
+    frozen instance would require returning a new object every call.
+    """
+
+    in_retry: bool = False
+
+
+async def run_with_reconnect(
+    state: ReconnectState,
+    *,
+    instance: Instance,
+    cycle: Callable[[], Awaitable[bool]],
+    cycle_trigger: CycleTrigger | str,
+    error_retry_secs: int,
+    success_sleep_secs: int,
+    write_log: Callable[..., Awaitable[None]],
+) -> int:
+    """Run *cycle* and apply per-instance reconnect-state transitions.
+
+    *cycle* is a zero-arg awaitable that runs one search cycle and
+    returns ``True`` iff the cycle failed with a connection error,
+    ``False`` otherwise.  This helper translates that outcome into
+    state-transition log rows and returns how long the caller should
+    sleep before invoking the next cycle.
+
+    State transitions:
+
+    - First failure in a streak: writes one ``error`` row with the
+        message ``Could not reach <url>``, sets ``state.in_retry``,
+        returns ``error_retry_secs``.
+    - Subsequent failures in the same streak: returns
+        ``error_retry_secs`` without a log write (the dashboard error
+        counter must not inflate with retry noise).
+    - First success after a streak: writes one ``info`` recovery row
+        with the message ``'<name>' (<url>) is reachable again``,
+        clears ``state.in_retry``, returns ``success_sleep_secs``.
+    - Steady-state success: returns ``success_sleep_secs`` without a
+        log write.
+
+    Args:
+        state: The per-instance reconnect state object the helper
+            mutates.  The caller is expected to keep one
+            :class:`ReconnectState` per instance loop and pass the
+            same instance every iteration.
+        instance: The current Instance snapshot (refreshed by the
+            caller each iteration so live setting changes apply).
+        cycle: A zero-arg awaitable that runs one search cycle and
+            returns ``True`` iff the cycle failed with a connection
+            error.
+        cycle_trigger: The trigger string written to ``search_log``
+            on state transitions.
+        error_retry_secs: Sleep duration after a failure (whether or
+            not a row is written this iteration).
+        success_sleep_secs: Sleep duration after a success.
+        write_log: The ``search_log`` writer callback.  Threading the
+            writer in keeps this module free of any direct dependency
+            on ``engine.search_loop`` and lets tests substitute a
+            spy.
+
+    Returns:
+        Number of seconds to sleep before the next cycle.
+    """
+    got_connect_error = await cycle()
+
+    if got_connect_error:
+        if not state.in_retry:
+            await write_log(
+                instance_id=instance.id,
+                item_id=None,
+                item_type=None,
+                action=SearchAction.error.value,
+                cycle_trigger=cycle_trigger,
+                message=f"Could not reach {instance.url}",
+            )
+        state.in_retry = True
+        return error_retry_secs
+
+    if state.in_retry:
+        logger.info(
+            "Reconnect: %r (%s) is reachable again",
+            instance.name,
+            instance.url,
+        )
+        await write_log(
+            instance_id=instance.id,
+            item_id=None,
+            item_type=None,
+            action=SearchAction.info.value,
+            cycle_trigger=cycle_trigger,
+            message=f"{instance.name!r} ({instance.url}) is reachable again",
+        )
+        state.in_retry = False
+    return success_sleep_secs

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -21,7 +21,8 @@ import httpx
 from pydantic import ValidationError
 
 from houndarr.database import get_db
-from houndarr.engine.adapters import AppAdapter, get_adapter
+from houndarr.engine.adapters import get_adapter
+from houndarr.engine.adapters.protocols import AppAdapterProto
 from houndarr.engine.candidates import SearchCandidate
 from houndarr.services.cooldown import (
     is_on_cooldown,
@@ -202,7 +203,7 @@ def _is_release_timing_reason(reason: str | None) -> bool:
 
 async def _run_search_pass(  # noqa: C901
     instance: Instance,
-    adapter: AppAdapter,
+    adapter: AppAdapterProto,
     *,
     adapt_fn: Callable[..., SearchCandidate],
     dispatch_fn: Callable[..., Awaitable[None]],
@@ -229,7 +230,8 @@ async def _run_search_pass(  # noqa: C901
 
     Args:
         instance: Fully-populated (decrypted) instance.
-        adapter: The :class:`AppAdapter` for this instance type.
+        adapter: The :class:`AppAdapterProto` implementation for this
+            instance type.
         adapt_fn: Converts a raw API item to a :class:`SearchCandidate`.
         dispatch_fn: Sends the search command via the appropriate client.
         fetch_fn: Bound method to fetch a page of items
@@ -530,7 +532,7 @@ async def _run_search_pass(  # noqa: C901
 
 async def _run_upgrade_pass(
     instance: Instance,
-    adapter: AppAdapter,
+    adapter: AppAdapterProto,
     master_key: bytes,
     *,
     cycle_id: str,
@@ -543,7 +545,8 @@ async def _run_upgrade_pass(
 
     Args:
         instance: Fully-populated (decrypted) instance.
-        adapter: The :class:`AppAdapter` for this instance type.
+        adapter: The :class:`AppAdapterProto` implementation for this
+            instance type.
         master_key: Fernet key for persisting offset updates.
         cycle_id: Shared cycle identifier for all log rows.
         cycle_trigger: How this cycle was initiated.

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 
 import httpx
 
+from houndarr.engine.retry import ReconnectState, run_with_reconnect
 from houndarr.engine.search_loop import CycleTrigger, _write_log, run_instance_search
 from houndarr.services.instances import Instance, get_instance, list_instances
 
@@ -197,10 +198,11 @@ class Supervisor:
         A one-time startup grace delay gives co-located *arr services time
         to become ready before the first cycle fires.  Connection errors are
         logged to ``search_log`` only on state transitions (first failure and
-        recovery) to avoid inflating the dashboard error counter with retry noise.
+        recovery) to avoid inflating the dashboard error counter with retry
+        noise; the state machine lives in
+        :func:`houndarr.engine.retry.run_with_reconnect`.
         """
         logger.debug("Supervisor: loop started for instance id=%d", instance_id)
-        _in_connect_retry = False
 
         logger.info(
             "Supervisor: waiting %d s startup grace for instance id=%d",
@@ -208,6 +210,8 @@ class Supervisor:
             instance_id,
         )
         await asyncio.sleep(_STARTUP_GRACE_SECS + startup_offset)
+
+        state = ReconnectState()
 
         try:
             while True:
@@ -226,41 +230,18 @@ class Supervisor:
                     )
                     return
 
-                got_connect_error = await self._run_search_cycle(
-                    instance, cycle_trigger="scheduled"
+                sleep_secs = await run_with_reconnect(
+                    state,
+                    instance=instance,
+                    cycle=partial(
+                        self._run_search_cycle, instance, cycle_trigger="scheduled"
+                    ),
+                    cycle_trigger="scheduled",
+                    error_retry_secs=_CONNECT_RETRY_SECS,
+                    success_sleep_secs=instance.sleep_interval_mins * 60,
+                    write_log=_write_log,
                 )
-
-                if got_connect_error:
-                    if not _in_connect_retry:
-                        # First failure: write one error row and enter retry state.
-                        await _write_log(
-                            instance_id=instance.id,
-                            item_id=None,
-                            item_type=None,
-                            action="error",
-                            cycle_trigger="scheduled",
-                            message=f"Could not reach {instance.url}",
-                        )
-                    _in_connect_retry = True
-                    await asyncio.sleep(_CONNECT_RETRY_SECS)
-                else:
-                    if _in_connect_retry:
-                        # Recovery: write one info row and leave retry state.
-                        logger.info(
-                            "Supervisor: %r (%s) is reachable again",
-                            instance.name,
-                            instance.url,
-                        )
-                        await _write_log(
-                            instance_id=instance.id,
-                            item_id=None,
-                            item_type=None,
-                            action="info",
-                            cycle_trigger="scheduled",
-                            message=f"{instance.name!r} ({instance.url}) is reachable again",
-                        )
-                        _in_connect_retry = False
-                    await asyncio.sleep(instance.sleep_interval_mins * 60)
+                await asyncio.sleep(sleep_secs)
 
         except asyncio.CancelledError:
             logger.debug("Supervisor: loop cancelled for instance id=%d", instance_id)

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -233,9 +233,7 @@ class Supervisor:
                 sleep_secs = await run_with_reconnect(
                     state,
                     instance=instance,
-                    cycle=partial(
-                        self._run_search_cycle, instance, cycle_trigger="scheduled"
-                    ),
+                    cycle=partial(self._run_search_cycle, instance, cycle_trigger="scheduled"),
                     cycle_trigger="scheduled",
                     error_retry_secs=_CONNECT_RETRY_SECS,
                     success_sleep_secs=instance.sleep_interval_mins * 60,

--- a/tests/test_engine/test_adapter_candidate_pinning.py
+++ b/tests/test_engine/test_adapter_candidate_pinning.py
@@ -1,0 +1,273 @@
+"""Pin the SearchCandidate byte-shape produced by every adapter.
+
+Track A.21 of the refactor plan.  Track C.7-C.9 will extract shared
+adapt_missing / adapt_cutoff / fetch_upgrade_pool templates in
+``engine/adapters/_common.py``.  These tests snapshot the exact
+SearchCandidate each of the six adapters returns today for an
+already-released item, so the template extraction cannot silently
+drift item_id, item_type, label shape, unreleased_reason, group_key,
+or search_payload.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.clients.lidarr import MissingAlbum
+from houndarr.clients.radarr import MissingMovie
+from houndarr.clients.readarr import MissingBook
+from houndarr.clients.sonarr import MissingEpisode
+from houndarr.clients.whisparr_v2 import MissingWhisparrEpisode
+from houndarr.clients.whisparr_v3 import MissingWhisparrV3Movie
+from houndarr.engine.adapters.lidarr import (
+    adapt_cutoff as lidarr_adapt_cutoff,
+)
+from houndarr.engine.adapters.lidarr import (
+    adapt_missing as lidarr_adapt_missing,
+)
+from houndarr.engine.adapters.radarr import (
+    adapt_cutoff as radarr_adapt_cutoff,
+)
+from houndarr.engine.adapters.radarr import (
+    adapt_missing as radarr_adapt_missing,
+)
+from houndarr.engine.adapters.readarr import (
+    adapt_cutoff as readarr_adapt_cutoff,
+)
+from houndarr.engine.adapters.readarr import (
+    adapt_missing as readarr_adapt_missing,
+)
+from houndarr.engine.adapters.sonarr import (
+    adapt_cutoff as sonarr_adapt_cutoff,
+)
+from houndarr.engine.adapters.sonarr import (
+    adapt_missing as sonarr_adapt_missing,
+)
+from houndarr.engine.adapters.whisparr_v2 import (
+    adapt_cutoff as whisparr_v2_adapt_cutoff,
+)
+from houndarr.engine.adapters.whisparr_v2 import (
+    adapt_missing as whisparr_v2_adapt_missing,
+)
+from houndarr.engine.adapters.whisparr_v3 import (
+    adapt_cutoff as whisparr_v3_adapt_cutoff,
+)
+from houndarr.engine.adapters.whisparr_v3 import (
+    adapt_missing as whisparr_v3_adapt_missing,
+)
+from houndarr.services.instances import InstanceType, SonarrSearchMode
+from tests.test_engine.conftest import make_instance
+
+pytestmark = pytest.mark.pinning
+
+
+_PAST_ISO = "2020-01-01T00:00:00Z"
+
+
+def _radarr_movie() -> MissingMovie:
+    return MissingMovie(
+        movie_id=101,
+        title="Classic Film",
+        year=2020,
+        status="released",
+        minimum_availability="released",
+        is_available=True,
+        in_cinemas=_PAST_ISO,
+        physical_release=_PAST_ISO,
+        release_date=_PAST_ISO,
+        digital_release=_PAST_ISO,
+    )
+
+
+def _sonarr_episode() -> MissingEpisode:
+    return MissingEpisode(
+        episode_id=55,
+        series_id=7,
+        series_title="My Show",
+        episode_title="Pilot",
+        season=1,
+        episode=1,
+        air_date_utc=_PAST_ISO,
+    )
+
+
+def _lidarr_album() -> MissingAlbum:
+    return MissingAlbum(
+        album_id=201,
+        artist_id=11,
+        artist_name="Test Artist",
+        title="First Album",
+        release_date=_PAST_ISO,
+    )
+
+
+def _readarr_book() -> MissingBook:
+    return MissingBook(
+        book_id=301,
+        author_id=31,
+        author_name="Test Author",
+        title="First Book",
+        release_date=_PAST_ISO,
+    )
+
+
+def _whisparr_v2_episode() -> MissingWhisparrEpisode:
+    return MissingWhisparrEpisode(
+        episode_id=401,
+        series_id=41,
+        series_title="Site",
+        episode_title="Scene",
+        season_number=1,
+        absolute_episode_number=None,
+        release_date=None,  # datetime | None
+    )
+
+
+def _whisparr_v3_movie() -> MissingWhisparrV3Movie:
+    return MissingWhisparrV3Movie(
+        movie_id=501,
+        title="V3 Movie",
+        year=2021,
+        status="released",
+        minimum_availability="released",
+        is_available=True,
+        in_cinemas=_PAST_ISO,
+        physical_release=_PAST_ISO,
+        release_date=_PAST_ISO,
+        digital_release=_PAST_ISO,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Radarr
+# ---------------------------------------------------------------------------
+
+
+class TestRadarrAdapter:
+    def test_adapt_missing_candidate_shape(self) -> None:
+        inst = make_instance(itype=InstanceType.radarr)
+        cand = radarr_adapt_missing(_radarr_movie(), inst)
+        assert cand.item_id == 101
+        assert cand.item_type == "movie"
+        assert cand.label == "Classic Film (2020)"
+        assert cand.unreleased_reason is None
+        assert cand.group_key is None
+        assert cand.search_payload == {"command": "MoviesSearch", "movie_id": 101}
+
+    def test_adapt_cutoff_matches_missing(self) -> None:
+        inst = make_instance(itype=InstanceType.radarr)
+        movie = _radarr_movie()
+        assert radarr_adapt_cutoff(movie, inst) == radarr_adapt_missing(movie, inst)
+
+
+# ---------------------------------------------------------------------------
+# Sonarr
+# ---------------------------------------------------------------------------
+
+
+class TestSonarrAdapter:
+    def test_adapt_missing_episode_mode(self) -> None:
+        inst = make_instance(itype=InstanceType.sonarr, sonarr_search_mode=SonarrSearchMode.episode)
+        cand = sonarr_adapt_missing(_sonarr_episode(), inst)
+        assert cand.item_id == 55
+        assert cand.item_type == "episode"
+        assert cand.group_key is None
+        assert cand.search_payload["command"] == "EpisodeSearch"
+        assert cand.search_payload["episode_id"] == 55
+
+    def test_adapt_missing_season_context_mode(self) -> None:
+        inst = make_instance(
+            itype=InstanceType.sonarr,
+            sonarr_search_mode=SonarrSearchMode.season_context,
+        )
+        cand = sonarr_adapt_missing(_sonarr_episode(), inst)
+        assert cand.group_key == (7, 1)
+        assert cand.search_payload["command"] == "SeasonSearch"
+        assert cand.search_payload["series_id"] == 7
+        assert cand.search_payload["season_number"] == 1
+
+    def test_adapt_cutoff_always_episode_mode(self) -> None:
+        inst = make_instance(
+            itype=InstanceType.sonarr,
+            sonarr_search_mode=SonarrSearchMode.season_context,
+        )
+        cand = sonarr_adapt_cutoff(_sonarr_episode(), inst)
+        assert cand.item_type == "episode"
+        assert cand.group_key is None
+        assert cand.search_payload["command"] == "EpisodeSearch"
+
+
+# ---------------------------------------------------------------------------
+# Lidarr
+# ---------------------------------------------------------------------------
+
+
+class TestLidarrAdapter:
+    def test_adapt_missing_album_shape(self) -> None:
+        inst = make_instance(itype=InstanceType.lidarr)
+        cand = lidarr_adapt_missing(_lidarr_album(), inst)
+        assert cand.item_id == 201
+        assert cand.item_type == "album"
+        assert cand.search_payload["command"] == "AlbumSearch"
+
+    def test_adapt_cutoff_album_type(self) -> None:
+        inst = make_instance(itype=InstanceType.lidarr)
+        cand = lidarr_adapt_cutoff(_lidarr_album(), inst)
+        assert cand.item_type == "album"
+
+
+# ---------------------------------------------------------------------------
+# Readarr
+# ---------------------------------------------------------------------------
+
+
+class TestReadarrAdapter:
+    def test_adapt_missing_book_shape(self) -> None:
+        inst = make_instance(itype=InstanceType.readarr)
+        cand = readarr_adapt_missing(_readarr_book(), inst)
+        assert cand.item_id == 301
+        assert cand.item_type == "book"
+        assert cand.search_payload["command"] == "BookSearch"
+
+    def test_adapt_cutoff_book_type(self) -> None:
+        inst = make_instance(itype=InstanceType.readarr)
+        cand = readarr_adapt_cutoff(_readarr_book(), inst)
+        assert cand.item_type == "book"
+
+
+# ---------------------------------------------------------------------------
+# Whisparr v2
+# ---------------------------------------------------------------------------
+
+
+class TestWhisparrV2Adapter:
+    def test_adapt_missing_episode_shape(self) -> None:
+        inst = make_instance(itype=InstanceType.whisparr_v2)
+        cand = whisparr_v2_adapt_missing(_whisparr_v2_episode(), inst)
+        assert cand.item_id == 401
+        assert cand.item_type == "whisparr_episode"
+        assert cand.search_payload["command"] == "EpisodeSearch"
+
+    def test_adapt_cutoff_episode_type(self) -> None:
+        inst = make_instance(itype=InstanceType.whisparr_v2)
+        cand = whisparr_v2_adapt_cutoff(_whisparr_v2_episode(), inst)
+        assert cand.item_type == "whisparr_episode"
+
+
+# ---------------------------------------------------------------------------
+# Whisparr v3
+# ---------------------------------------------------------------------------
+
+
+class TestWhisparrV3Adapter:
+    def test_adapt_missing_movie_shape(self) -> None:
+        inst = make_instance(itype=InstanceType.whisparr_v3)
+        cand = whisparr_v3_adapt_missing(_whisparr_v3_movie(), inst)
+        assert cand.item_id == 501
+        assert cand.item_type == "whisparr_v3_movie"
+        assert cand.search_payload["command"] == "MoviesSearch"
+
+    def test_adapt_cutoff_matches_missing(self) -> None:
+        inst = make_instance(itype=InstanceType.whisparr_v3)
+        movie = _whisparr_v3_movie()
+        assert whisparr_v3_adapt_cutoff(movie, inst).item_type == "whisparr_v3_movie"

--- a/tests/test_engine/test_adapter_protocols.py
+++ b/tests/test_engine/test_adapter_protocols.py
@@ -1,0 +1,29 @@
+"""Conformance tests for engine.adapters.protocols.AppAdapterProto."""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.engine.adapters import ADAPTERS
+from houndarr.engine.adapters.protocols import AppAdapterProto
+from houndarr.services.instances import InstanceType
+
+
+class TestAppAdapterProto:
+    @pytest.mark.parametrize(
+        "instance_type",
+        [
+            InstanceType.radarr,
+            InstanceType.sonarr,
+            InstanceType.lidarr,
+            InstanceType.readarr,
+            InstanceType.whisparr_v2,
+            InstanceType.whisparr_v3,
+        ],
+    )
+    def test_every_registered_adapter_satisfies_proto(self, instance_type: InstanceType) -> None:
+        adapter = ADAPTERS[instance_type]
+        assert isinstance(adapter, AppAdapterProto)
+
+    def test_plain_object_does_not_satisfy(self) -> None:
+        assert not isinstance(object(), AppAdapterProto)

--- a/tests/test_engine/test_search_pass_config_pinning.py
+++ b/tests/test_engine/test_search_pass_config_pinning.py
@@ -1,0 +1,168 @@
+"""Pin the :class:`SearchPassConfig` dataclass from Track B.22.
+
+This module is declaration-only today; the consumer switch in
+:func:`~houndarr.engine.search_loop._run_search_pass` lands in
+Track D.21.  These tests lock the fields, defaults, and invariants
+the consumer will rely on.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Awaitable
+from typing import Any
+
+import pytest
+
+from houndarr.engine.candidates import SearchCandidate
+from houndarr.engine.config.search_pass import SearchPassConfig
+from houndarr.enums import CycleTrigger, ItemType, SearchKind
+
+pytestmark = pytest.mark.pinning
+
+
+def _adapt(item: Any, instance: Any) -> SearchCandidate:
+    return SearchCandidate(
+        item_id=0,
+        item_type=ItemType.episode,
+        label="",
+        unreleased_reason=None,
+        group_key=None,
+        search_payload={},
+    )
+
+
+async def _dispatch(client: Any, candidate: Any) -> None:
+    return None
+
+
+async def _fetch(**kwargs: Any) -> list[Any]:
+    return []
+
+
+async def _total() -> int:
+    return 0
+
+
+class TestSearchPassConfigDeclaration:
+    """Pin the dataclass shape so Track D.21's consumer switch is mechanical."""
+
+    def test_is_frozen(self) -> None:
+        """``frozen=True`` prevents in-place mutation at the pass boundary."""
+        config = SearchPassConfig(
+            search_kind=SearchKind.missing,
+            adapt_fn=_adapt,
+            dispatch_fn=_dispatch,
+            fetch_fn=_fetch,
+            batch_size=5,
+            hourly_cap=10,
+            cooldown_days=7,
+            page_size=20,
+            scan_budget=40,
+            cycle_id="cid",
+            cycle_trigger=CycleTrigger.scheduled,
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            config.batch_size = 99  # type: ignore[misc]
+
+    def test_slots_means_no_instance_dict(self) -> None:
+        """``slots=True`` strips ``__dict__`` so memory footprint stays tight.
+
+        frozen=True already rejects in-place mutation; slots=True adds
+        the memory-footprint discipline every Houndarr value object
+        shares.  The absence of ``__dict__`` is the clearest marker.
+        """
+        config = SearchPassConfig(
+            search_kind=SearchKind.cutoff,
+            adapt_fn=_adapt,
+            dispatch_fn=_dispatch,
+            fetch_fn=_fetch,
+            batch_size=5,
+            hourly_cap=0,
+            cooldown_days=21,
+            page_size=10,
+            scan_budget=12,
+            cycle_id="cid-2",
+            cycle_trigger=CycleTrigger.run_now,
+        )
+        assert not hasattr(config, "__dict__")
+
+    def test_start_page_default_is_one(self) -> None:
+        """The default start page matches the 1-based convention in search_log."""
+        config = SearchPassConfig(
+            search_kind=SearchKind.missing,
+            adapt_fn=_adapt,
+            dispatch_fn=_dispatch,
+            fetch_fn=_fetch,
+            batch_size=1,
+            hourly_cap=0,
+            cooldown_days=0,
+            page_size=1,
+            scan_budget=1,
+            cycle_id="c",
+            cycle_trigger=CycleTrigger.scheduled,
+        )
+        assert config.start_page == 1
+
+    def test_total_fn_default_is_none(self) -> None:
+        """Omitting ``total_fn`` disables the random probe fallback."""
+        config = SearchPassConfig(
+            search_kind=SearchKind.cutoff,
+            adapt_fn=_adapt,
+            dispatch_fn=_dispatch,
+            fetch_fn=_fetch,
+            batch_size=1,
+            hourly_cap=0,
+            cooldown_days=0,
+            page_size=1,
+            scan_budget=1,
+            cycle_id="c",
+            cycle_trigger=CycleTrigger.system,
+        )
+        assert config.total_fn is None
+
+    def test_field_order_matches_current_kwargs(self) -> None:
+        """Field order is the same as ``_run_search_pass``'s kwarg order.
+
+        Track D.21 will consume ``config.<field>`` at every call site,
+        so locking the order here guards against an accidental swap
+        that would change default-value semantics.
+        """
+        assert [f.name for f in dataclasses.fields(SearchPassConfig)] == [
+            "search_kind",
+            "adapt_fn",
+            "dispatch_fn",
+            "fetch_fn",
+            "batch_size",
+            "hourly_cap",
+            "cooldown_days",
+            "page_size",
+            "scan_budget",
+            "cycle_id",
+            "cycle_trigger",
+            "start_page",
+            "total_fn",
+        ]
+
+    def test_optional_total_fn_accepts_bound_coroutine(self) -> None:
+        """``total_fn`` stores the caller's bound coroutine untouched."""
+        config = SearchPassConfig(
+            search_kind=SearchKind.missing,
+            adapt_fn=_adapt,
+            dispatch_fn=_dispatch,
+            fetch_fn=_fetch,
+            batch_size=2,
+            hourly_cap=10,
+            cooldown_days=7,
+            page_size=5,
+            scan_budget=10,
+            cycle_id="c",
+            cycle_trigger=CycleTrigger.scheduled,
+            total_fn=_total,
+        )
+        assert config.total_fn is _total
+
+
+# Pure type-compat exercise: ensure Awaitable-returning callables type-check.
+def _type_check_example(config: SearchPassConfig) -> Awaitable[None]:
+    return config.dispatch_fn(object(), object())


### PR DESCRIPTION
## Summary

Lands Track C of the engine refactor.  Introduces `AppAdapterProto` (a `runtime_checkable` structural Protocol), collapses the per-app `/wanted/{kind}` page reads onto a shared template on `ArrClient`, extracts the missing / cutoff / upgrade candidate constructors into `engine/adapters/_common.py`, converts the adapter registry from a frozen dataclass-of-callables to per-app classes that structurally satisfy the Protocol, and splits the supervisor's inline reconnect state machine into `engine/retry.py`.

Closes #456

## Changes

- Add `src/houndarr/engine/adapters/protocols.py` with `AppAdapterProto`.  Each member is declared via `@property` so the previous frozen `AppAdapter` dataclass and the new class-form adapters both satisfy the structural contract.
- Add `src/houndarr/engine/adapters/_common.py` with `fetch_movie_upgrade_pool`, `build_missing_candidate` (+ `ContextOverride`), and `build_cutoff_candidate`.  Centralises the upgrade-pool filter, the missing-pass primary-vs-context branch, and the cutoff-pass single-mode constructor.  Both helpers type `item_type` as the existing `ItemType` Literal so any string drift surfaces at the helper boundary.
- Migrate Sonarr, Radarr, Lidarr, Readarr, and Whisparr v2 onto a shared `_fetch_wanted_page` / `_fetch_wanted_total` template on `ArrClient`.  Per-app behaviour collapses to four class-level hooks (`_WANTED_BASE_PATH`, `_WANTED_SORT_KEY`, `_WANTED_INCLUDE_PARAM`, `_WANTED_ENVELOPE`).  `_fetch_wanted_total` owns the typed-error wrap so per-app `get_wanted_total` shrinks to a one-liner.
- Add an `include_param` knob mirroring `include_sort` so the size-1 wanted-total probe stays embed-free on the four embed-using clients (Sonarr, Lidarr, Readarr, Whisparr v2); Radarr is unaffected.
- Document Whisparr v3's outlier rationale on the module and class docstrings.  No upstream `/wanted` endpoint exists, the four `_WANTED_*` hooks stay at base defaults, an accidental call to `_fetch_wanted_page` raises `NotImplementedError` by design, and the cached `/api/v3/movie` payload backs `get_missing` / `get_cutoff_unmet` / `get_wanted_total`.
- Convert `ADAPTERS` from `dict[InstanceType, AppAdapter]` (frozen dataclass of callables) to `dict[InstanceType, AppAdapterProto]` populated by per-app `RadarrAdapter` / `SonarrAdapter` / etc. instances.  Each class exposes the six callables as `staticmethod` attributes wrapping the existing module-level functions, so direct unit-test imports keep working.  `AppAdapter` survives as an alias for `AppAdapterProto` so historical type hints and `MagicMock(spec=AppAdapter)` resolve to the structural surface.
- Widen `_run_search_pass` and `_run_upgrade_pass` adapter hints from `AppAdapter` to `AppAdapterProto`; the engine reads only the structural contract.
- Add `engine/retry.py` with `ReconnectState` (a one-field mutable dataclass) and `run_with_reconnect` (state machine + `search_log` writes + sleep-duration calculation).  Supervisor's `_instance_loop` shrinks to: refresh instance, check enabled, call `run_with_reconnect`, sleep.  The cycle is threaded as a zero-arg awaitable via `functools.partial` and the search-log writer is threaded as a callback so `engine/retry` does not import from `engine/search_loop`.
- Add `SearchPassConfig` declaration in the engine module so future cross-pass changes have one shape to update.
- Pin the adapter `SearchCandidate` byte-shape (12 cases) under `tests/test_engine/test_adapter_candidate_pinning.py` to lock the wire output before further template edits.

## Testing

- `just check` clean: ruff, ruff format, mypy strict, bandit all pass.
- `pytest -n auto -m "not integration"` runs 1310 tests in 13.47 s green locally.

## Type of Change

- [x] Refactoring (`refactor:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #456`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`refactor/adapter-proto-class-form`)
- [x] Tests added/updated for all changes (adapter byte-shape pinning at 12 cases)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (Whisparr v3 outlier rationale on module + class docstrings; AGENTS.md updates ride a later docs PR)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: Same wire surface, same product behaviour; structural seam at the adapter boundary so the registry can evolve without touching call sites.
