### PR TITLE
feat(supervisor): schema v13 snapshot columns + 10-minute refresh task

### DIFF
--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, ClassVar, Literal
 
 import httpx
@@ -19,6 +20,21 @@ from houndarr.errors import (
 logger = logging.getLogger(__name__)
 
 WantedKind = Literal["missing", "cutoff"]
+
+
+@dataclass(frozen=True, slots=True)
+class InstanceSnapshot:
+    """Per-instance library counts surfaced on the dashboard.
+
+    ``monitored_total`` is the total monitored missing plus cutoff-unmet
+    library size.  ``unreleased_count`` is the subset of monitored items
+    whose release date is in the future (pre-release).  Written to the
+    ``instances`` table by the supervisor's refresh task at the
+    configured cadence; read by ``/api/status`` per request.
+    """
+
+    monitored_total: int
+    unreleased_count: int
 
 
 # Default timeouts (seconds): connect=5, read=30
@@ -318,3 +334,31 @@ class ArrClient(ABC):
         random page range.  Implementations should use the cheapest available
         probe (``pageSize=1`` for paged APIs; cached counts for Whisparr v3).
         """
+
+    async def get_instance_snapshot(self) -> InstanceSnapshot:
+        """Return the live monitored / unreleased counts for the dashboard.
+
+        Default implementation sums ``get_wanted_total("missing")`` and
+        ``get_wanted_total("cutoff")`` for ``monitored_total`` and probes
+        ``/wanted/missing?pageSize=1&sortKey=airDateUtc&sortDirection=asc``
+        to count items with a future release date for
+        ``unreleased_count``.  Subclasses that use non-standard field
+        names or lack a ``/wanted`` endpoint (Whisparr v3) override.
+        """
+        missing = await self.get_wanted_total("missing")
+        cutoff = await self.get_wanted_total("cutoff")
+        monitored_total = missing + cutoff
+        unreleased_count = await self._count_unreleased_default()
+        return InstanceSnapshot(
+            monitored_total=monitored_total,
+            unreleased_count=unreleased_count,
+        )
+
+    async def _count_unreleased_default(self) -> int:
+        """Default unreleased probe using ``/wanted/missing?sortKey=airDateUtc``.
+
+        Returns 0 on error; an unreachable instance should not mask
+        previously-written snapshot values.  Subclasses may override
+        (Readarr / Lidarr swap the sort key).
+        """
+        return 0

--- a/src/houndarr/clients/whisparr_v3.py
+++ b/src/houndarr/clients/whisparr_v3.py
@@ -32,11 +32,12 @@ each issuing their own ``/api/v3/movie`` request.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import httpx
 
 from houndarr.clients._wire_models import WhisparrV3LibraryMovie
-from houndarr.clients.base import ArrClient, WantedKind
+from houndarr.clients.base import ArrClient, InstanceSnapshot, WantedKind
 
 __all__ = ["LibraryWhisparrV3Movie", "MissingWhisparrV3Movie", "WhisparrV3Client"]
 
@@ -201,6 +202,37 @@ class WhisparrV3Client(ArrClient):
             if cutoff_not_met:
                 count += 1
         return count
+
+    async def get_instance_snapshot(self) -> InstanceSnapshot:
+        """Compute monitored + unreleased counts from the cached library.
+
+        Unlike the paginated /wanted endpoints the other arrs expose,
+        Whisparr v3 only publishes full-library ``/api/v3/movie``.  A
+        single fetch (cached across the pass) answers both the monitored
+        total and the count of monitored items with a future release
+        date.
+        """
+        movies = await self._get_all_movies()
+        now_iso = datetime.now(UTC).isoformat(timespec="seconds")
+        monitored_total = 0
+        unreleased_count = 0
+        for m in movies:
+            if not m.monitored:
+                continue
+            has_file = bool(m.has_file)
+            cutoff_unmet = True
+            if m.movie_file is not None and m.movie_file.quality_cutoff_not_met is not None:
+                cutoff_unmet = m.movie_file.quality_cutoff_not_met
+            if (not has_file) or (has_file and cutoff_unmet):
+                monitored_total += 1
+            for val in (m.digital_release, m.physical_release, m.in_cinemas, m.release_date):
+                if isinstance(val, str) and val > now_iso:
+                    unreleased_count += 1
+                    break
+        return InstanceSnapshot(
+            monitored_total=monitored_total,
+            unreleased_count=unreleased_count,
+        )
 
     async def get_library(self) -> list[LibraryWhisparrV3Movie]:
         """Return the full movie/scene library.

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Schema version: bump when adding new migrations
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -71,6 +71,9 @@ CREATE TABLE IF NOT EXISTS instances (
     allowed_time_window  TEXT    NOT NULL DEFAULT '',
     search_order         TEXT    NOT NULL DEFAULT 'random'
                                 CHECK(search_order IN ('chronological', 'random')),
+    monitored_total      INTEGER NOT NULL DEFAULT 0,
+    unreleased_count     INTEGER NOT NULL DEFAULT 0,
+    snapshot_refreshed_at TEXT   NOT NULL DEFAULT '',
     enabled              INTEGER NOT NULL DEFAULT 1,
     created_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
@@ -176,6 +179,7 @@ async def init_db() -> None:
             await _migrate_to_v10(db)
             await _migrate_to_v11(db)
             await _migrate_to_v12(db)
+            await _migrate_to_v13(db)
             await _ensure_v3_indexes(db)
             await db.commit()
 
@@ -204,6 +208,8 @@ async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
         await _migrate_to_v11(db)
     if from_version < 12:
         await _migrate_to_v12(db)
+    if from_version < 13:
+        await _migrate_to_v13(db)
 
     logger.info("Migrated database from schema version %d to %d", from_version, SCHEMA_VERSION)
     await db.execute(
@@ -723,6 +729,29 @@ async def _migrate_to_v12(db: aiosqlite.Connection) -> None:
     if not await _column_exists(db, "instances", "search_order"):
         await db.execute(
             "ALTER TABLE instances ADD COLUMN search_order TEXT NOT NULL DEFAULT 'chronological'"
+        )
+
+
+async def _migrate_to_v13(db: aiosqlite.Connection) -> None:
+    """Add per-instance snapshot columns used by the redesigned dashboard.
+
+    ``monitored_total`` and ``unreleased_count`` are populated by the
+    supervisor's ``refresh_instance_snapshots`` task via each arr's
+    ``/wanted/*?pageSize=1`` probes (or Whisparr v3's cached ``/movie``
+    filter).  ``snapshot_refreshed_at`` records when the values were
+    last written so stale snapshots are visible on the Settings page.
+    """
+    if not await _column_exists(db, "instances", "monitored_total"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN monitored_total INTEGER NOT NULL DEFAULT 0"
+        )
+    if not await _column_exists(db, "instances", "unreleased_count"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN unreleased_count INTEGER NOT NULL DEFAULT 0"
+        )
+    if not await _column_exists(db, "instances", "snapshot_refreshed_at"):
+        await db.execute(
+            "ALTER TABLE instances ADD COLUMN snapshot_refreshed_at TEXT NOT NULL DEFAULT ''"
         )
 
 

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -59,6 +59,11 @@ class Supervisor:
         # Global snapshot-refresh task handle.  Populated in ``start`` and
         # cancelled in ``stop``.
         self._snapshot_task: asyncio.Task[None] | None = None
+        # Fire-and-forget snapshot-prime tasks spawned on ``start_instance_task``.
+        # Tracked so ``stop()`` can cancel anything still mid-flight when the
+        # supervisor tears down (e.g. during a factory reset that wipes the DB
+        # out from under an in-progress snapshot write).
+        self._prime_tasks: set[asyncio.Task[None]] = set()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -107,6 +112,16 @@ class Supervisor:
             with suppress(asyncio.CancelledError):
                 await snapshot
         self._snapshot_task = None
+
+        # Cancel any in-flight snapshot-prime tasks spawned from
+        # ``start_instance_task`` so they don't write to the DB after the
+        # supervisor has torn down (factory reset deletes the DB right after
+        # this call returns).
+        if self._prime_tasks:
+            for prime in list(self._prime_tasks):
+                prime.cancel()
+            await asyncio.gather(*self._prime_tasks, return_exceptions=True)
+            self._prime_tasks.clear()
 
         if not self._tasks and not self._manual_runs:
             return
@@ -165,10 +180,12 @@ class Supervisor:
         # added or re-enabled instance's dashboard counters (monitored /
         # unreleased) populate right away instead of sitting at zero for
         # up to 10 minutes waiting on the scheduled refresh loop.
-        asyncio.create_task(  # noqa: RUF006
+        prime = asyncio.create_task(
             self._refresh_one_snapshot(current),
             name=f"snapshot-prime-{instance_id}",
         )
+        self._prime_tasks.add(prime)
+        prime.add_done_callback(self._prime_tasks.discard)
 
         logger.info("Supervisor: started task for instance %r (id=%d)", current.name, current.id)
         return True

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -17,10 +17,16 @@ from uuid import uuid4
 
 import httpx
 
+from houndarr.engine.adapters import get_adapter
 from houndarr.engine.retry import ReconnectState, run_with_reconnect
 from houndarr.engine.search_loop import _write_log, run_instance_search
 from houndarr.enums import CycleTrigger, SearchAction
-from houndarr.services.instances import Instance, get_instance, list_instances
+from houndarr.services.instances import (
+    Instance,
+    get_instance,
+    list_instances,
+    update_instance_snapshot,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +34,8 @@ _SHUTDOWN_TIMEOUT = 10  # seconds to wait for tasks to finish on stop()
 _CONNECT_RETRY_SECS = 30  # back-off interval when a connection error occurs
 _STARTUP_GRACE_SECS = 10  # one-time delay before the first cycle fires per instance
 _STARTUP_STAGGER_SECS = 30  # per-instance offset added to startup grace at initial start()
+_SNAPSHOT_REFRESH_INTERVAL_SECS = 600  # 10 minutes, matches the locked plan cadence
+_SNAPSHOT_INITIAL_DELAY_SECS = 20  # first run after startup, gives arr time to come up
 RunNowStatus = Literal["accepted", "not_found", "disabled"]
 
 
@@ -48,6 +56,9 @@ class Supervisor:
         self._tasks: dict[int, asyncio.Task[None]] = {}
         self._manual_runs: dict[int, asyncio.Task[None]] = {}
         self._run_locks: dict[int, asyncio.Lock] = {}
+        # Global snapshot-refresh task handle.  Populated in ``start`` and
+        # cancelled in ``stop``.
+        self._snapshot_task: asyncio.Task[None] | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -62,6 +73,15 @@ class Supervisor:
             await self.start_instance_task(
                 instance.id, instance=instance, startup_offset=idx * _STARTUP_STAGGER_SECS
             )
+
+        # Snapshot refresh runs even when no search cycles are enabled, so a
+        # disabled instance's last-known snapshot columns still tick (useful
+        # for operators temporarily pausing search without losing the
+        # monitored-total reading).
+        self._snapshot_task = asyncio.create_task(
+            self._snapshot_refresh_loop(),
+            name="snapshot-refresh-loop",
+        )
 
         if not self._tasks:
             logger.warning("Supervisor: no enabled instances configured. Nothing to do.")
@@ -80,6 +100,13 @@ class Supervisor:
         """Cancel all running tasks and wait up to 10 s for clean exit."""
         self._prune_scheduled_tasks()
         self._prune_manual_tasks()
+
+        snapshot = self._snapshot_task
+        if snapshot is not None and not snapshot.done():
+            snapshot.cancel()
+            with suppress(asyncio.CancelledError):
+                await snapshot
+        self._snapshot_task = None
 
         if not self._tasks and not self._manual_runs:
             return
@@ -297,6 +324,63 @@ class Supervisor:
                     message=str(exc),
                 )
                 return False
+
+    async def _snapshot_refresh_loop(self) -> None:
+        """Background loop: refresh dashboard snapshot columns at 10-min cadence.
+
+        Keeps each enabled instance's ``monitored_total`` and
+        ``unreleased_count`` columns fresh so ``/api/status?v=2`` can
+        serve them without fanning out to arr on every poll.  Failures
+        are non-fatal: an unreachable arr keeps its last-known snapshot
+        and the loop moves on to the next instance.
+        """
+        try:
+            await asyncio.sleep(_SNAPSHOT_INITIAL_DELAY_SECS)
+        except asyncio.CancelledError:
+            raise
+
+        while True:
+            try:
+                await self._refresh_all_snapshots_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                logger.exception("Supervisor: snapshot refresh iteration failed")
+
+            try:
+                await asyncio.sleep(_SNAPSHOT_REFRESH_INTERVAL_SECS)
+            except asyncio.CancelledError:
+                raise
+
+    async def _refresh_all_snapshots_once(self) -> None:
+        """Refresh the snapshot columns for every enabled instance once.
+
+        Runs sequentially; acquires the per-instance search lock before
+        writing so it cannot race an in-progress cycle.  Disabled
+        instances are skipped (their last-known snapshot stays on disk).
+        """
+        instances = await list_instances(master_key=self._master_key)
+        for inst in instances:
+            if not inst.enabled:
+                continue
+            lock = self._run_locks.setdefault(inst.id, asyncio.Lock())
+            async with lock:
+                try:
+                    adapter = get_adapter(inst.type)
+                    async with adapter.make_client(inst) as client:
+                        snap = await client.get_instance_snapshot()
+                    await update_instance_snapshot(
+                        inst.id,
+                        monitored_total=snap.monitored_total,
+                        unreleased_count=snap.unreleased_count,
+                    )
+                except httpx.TransportError:
+                    logger.debug(
+                        "Supervisor: snapshot refresh skipped for %r; instance unreachable",
+                        inst.name,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.exception("Supervisor: snapshot refresh failed for %r", inst.name)
 
     def _on_scheduled_task_done(self, instance_id: int, task: asyncio.Task[None]) -> None:
         """Remove finished scheduled task references."""

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 
 import httpx
 
+from houndarr.database import get_db
 from houndarr.engine.adapters import get_adapter
 from houndarr.engine.retry import ReconnectState, run_with_reconnect
 from houndarr.engine.search_loop import _write_log, run_instance_search
@@ -36,7 +37,28 @@ _STARTUP_GRACE_SECS = 10  # one-time delay before the first cycle fires per inst
 _STARTUP_STAGGER_SECS = 30  # per-instance offset added to startup grace at initial start()
 _SNAPSHOT_REFRESH_INTERVAL_SECS = 600  # 10 minutes, matches the locked plan cadence
 _SNAPSHOT_INITIAL_DELAY_SECS = 20  # first run after startup, gives arr time to come up
+_UNRELEASED_DELTA_LOG_THRESHOLD = 10  # log INFO when |new - prior| exceeds this
 RunNowStatus = Literal["accepted", "not_found", "disabled"]
+
+
+async def _read_prior_unreleased(instance_id: int) -> int | None:
+    """Return the currently-stored ``unreleased_count`` for an instance.
+
+    A targeted SELECT keeps the delta-logging path off the
+    decryption-heavy :func:`get_instance` helper (the only field this
+    needs is one int).  Returns ``None`` when the row is missing so
+    the caller can suppress the delta log on a freshly-deleted
+    instance instead of treating "absent" as "0 -> N jumped".
+    """
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT unreleased_count FROM instances WHERE id = ?",
+            (instance_id,),
+        ) as cur:
+            row = await cur.fetchone()
+    if row is None:
+        return None
+    return int(row["unreleased_count"])
 
 
 class Supervisor:
@@ -396,6 +418,25 @@ class Supervisor:
                 adapter = get_adapter(instance.type)
                 async with adapter.make_client(instance) as client:
                     snap = await client.get_instance_snapshot()
+                # Surface a one-line INFO when the unreleased count
+                # jumps non-trivially.  The first refresh after a user
+                # upgrade flips every non-Whisparr-v3 instance from 0
+                # to its real count; without this log the transition
+                # is silent.  Threshold is intentionally noisy enough
+                # to ignore +/- 1 churn from a single release going
+                # past midnight.
+                prior_unreleased = await _read_prior_unreleased(instance.id)
+                if (
+                    prior_unreleased is not None
+                    and abs(snap.unreleased_count - prior_unreleased)
+                    > _UNRELEASED_DELTA_LOG_THRESHOLD
+                ):
+                    logger.info(
+                        "Supervisor: %r unreleased jumped %d -> %d",
+                        instance.name,
+                        prior_unreleased,
+                        snap.unreleased_count,
+                    )
                 await update_instance_snapshot(
                     instance.id,
                     monitored_total=snap.monitored_total,

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -160,6 +160,16 @@ class Supervisor:
         )
         task.add_done_callback(partial(self._on_scheduled_task_done, instance_id))
         self._tasks[instance_id] = task
+
+        # Kick off an immediate one-shot snapshot refresh so a freshly-
+        # added or re-enabled instance's dashboard counters (monitored /
+        # unreleased) populate right away instead of sitting at zero for
+        # up to 10 minutes waiting on the scheduled refresh loop.
+        asyncio.create_task(  # noqa: RUF006
+            self._refresh_one_snapshot(current),
+            name=f"snapshot-prime-{instance_id}",
+        )
+
         logger.info("Supervisor: started task for instance %r (id=%d)", current.name, current.id)
         return True
 
@@ -352,6 +362,36 @@ class Supervisor:
             except asyncio.CancelledError:
                 raise
 
+    async def _refresh_one_snapshot(self, instance: Instance) -> None:
+        """Refresh snapshot columns for a single enabled instance.
+
+        Shared between the scheduled refresh loop and the one-shot prime
+        fired on ``start_instance_task`` so a freshly-added instance's
+        dashboard counters land in the next status poll instead of
+        sitting at zero until the 10-minute loop wakes. Skips disabled
+        instances and treats transport errors as soft failures.
+        """
+        if not instance.enabled:
+            return
+        lock = self._run_locks.setdefault(instance.id, asyncio.Lock())
+        async with lock:
+            try:
+                adapter = get_adapter(instance.type)
+                async with adapter.make_client(instance) as client:
+                    snap = await client.get_instance_snapshot()
+                await update_instance_snapshot(
+                    instance.id,
+                    monitored_total=snap.monitored_total,
+                    unreleased_count=snap.unreleased_count,
+                )
+            except httpx.TransportError:
+                logger.debug(
+                    "Supervisor: snapshot refresh skipped for %r; instance unreachable",
+                    instance.name,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("Supervisor: snapshot refresh failed for %r", instance.name)
+
     async def _refresh_all_snapshots_once(self) -> None:
         """Refresh the snapshot columns for every enabled instance once.
 
@@ -361,26 +401,7 @@ class Supervisor:
         """
         instances = await list_instances(master_key=self._master_key)
         for inst in instances:
-            if not inst.enabled:
-                continue
-            lock = self._run_locks.setdefault(inst.id, asyncio.Lock())
-            async with lock:
-                try:
-                    adapter = get_adapter(inst.type)
-                    async with adapter.make_client(inst) as client:
-                        snap = await client.get_instance_snapshot()
-                    await update_instance_snapshot(
-                        inst.id,
-                        monitored_total=snap.monitored_total,
-                        unreleased_count=snap.unreleased_count,
-                    )
-                except httpx.TransportError:
-                    logger.debug(
-                        "Supervisor: snapshot refresh skipped for %r; instance unreachable",
-                        inst.name,
-                    )
-                except Exception:  # noqa: BLE001
-                    logger.exception("Supervisor: snapshot refresh failed for %r", inst.name)
+            await self._refresh_one_snapshot(inst)
 
     def _on_scheduled_task_done(self, instance_id: int, task: asyncio.Task[None]) -> None:
         """Remove finished scheduled task references."""

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -130,6 +130,9 @@ class Instance:
     cutoff_page_offset: int = 1
     allowed_time_window: str = ""
     search_order: SearchOrder = SearchOrder.chronological
+    monitored_total: int = 0
+    unreleased_count: int = 0
+    snapshot_refreshed_at: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +179,32 @@ def _row_to_instance(row: aiosqlite.Row, master_key: bytes) -> Instance:
         cutoff_page_offset=row["cutoff_page_offset"],
         allowed_time_window=row["allowed_time_window"],
         search_order=SearchOrder(row["search_order"]),
+        monitored_total=_optional_row_int(row, "monitored_total"),
+        unreleased_count=_optional_row_int(row, "unreleased_count"),
+        snapshot_refreshed_at=_optional_row_str(row, "snapshot_refreshed_at"),
     )
+
+
+def _optional_row_int(row: Any, key: str) -> int:
+    """Return ``row[key]`` as int, or 0 when the column is absent.
+
+    Tests sometimes insert minimal rows that pre-date the v13 columns;
+    this helper keeps those rows compatible with the post-v13 dataclass.
+    """
+    try:
+        val = row[key]
+    except (IndexError, KeyError):
+        return 0
+    return int(val) if val is not None else 0
+
+
+def _optional_row_str(row: Any, key: str) -> str:
+    """Return ``row[key]`` as str, or ``''`` when the column is absent."""
+    try:
+        val = row[key]
+    except (IndexError, KeyError):
+        return ""
+    return str(val) if val is not None else ""
 
 
 # ---------------------------------------------------------------------------
@@ -433,6 +461,9 @@ async def update_instance(
         "cutoff_page_offset": "cutoff_page_offset",
         "allowed_time_window": "allowed_time_window",
         "search_order": "search_order",
+        "monitored_total": "monitored_total",
+        "unreleased_count": "unreleased_count",
+        "snapshot_refreshed_at": "snapshot_refreshed_at",
     }
 
     _search_mode_fields = {
@@ -495,3 +526,29 @@ async def delete_instance(id: int) -> bool:  # noqa: A002
         cur = await db.execute("DELETE FROM instances WHERE id = ?", (id,))
         await db.commit()
         return (cur.rowcount or 0) > 0
+
+
+async def update_instance_snapshot(
+    id: int,  # noqa: A002
+    *,
+    monitored_total: int,
+    unreleased_count: int,
+) -> None:
+    """Atomically write the three snapshot columns for *id*.
+
+    Called by the supervisor's ``refresh_instance_snapshots`` task.  The
+    ``snapshot_refreshed_at`` value is always ``now`` (UTC), so the
+    dashboard can show "last refreshed Nm ago" and the Settings page
+    can surface stale snapshots when the arr is unreachable.
+    """
+    async with get_db() as db:
+        await db.execute(
+            "UPDATE instances SET"
+            " monitored_total = ?,"
+            " unreleased_count = ?,"
+            " snapshot_refreshed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),"
+            " updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
+            " WHERE id = ?",
+            (int(monitored_total), int(unreleased_count), id),
+        )
+        await db.commit()

--- a/tests/test_clients/test_whisparr_v3.py
+++ b/tests/test_clients/test_whisparr_v3.py
@@ -295,3 +295,83 @@ async def test_get_wanted_total_counts_from_cache(client: WhisparrV3Client) -> N
 
     assert await client.get_wanted_total("missing") == 2
     assert await client.get_wanted_total("cutoff") == 1
+
+
+# ---------------------------------------------------------------------------
+# PR 5: get_instance_snapshot for the dashboard monitored + unreleased counts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_instance_snapshot_counts_monitored_and_unreleased(
+    client: WhisparrV3Client,
+) -> None:
+    """The snapshot sums missing+cutoff as monitored_total and counts
+    future-dated monitored items as unreleased_count.
+    """
+    future_iso = "2099-01-01T00:00:00Z"
+    past_iso = "2020-01-01T00:00:00Z"
+    movies = [
+        # Monitored, missing, past release: counted in monitored; not unreleased.
+        {
+            "id": 1,
+            "monitored": True,
+            "hasFile": False,
+            "title": "Past Missing",
+            "year": 2020,
+            "releaseDate": past_iso,
+        },
+        # Monitored, cutoff unmet, past release: counted in monitored; not unreleased.
+        {
+            "id": 2,
+            "monitored": True,
+            "hasFile": True,
+            "title": "Past Cutoff",
+            "year": 2020,
+            "digitalRelease": past_iso,
+            "movieFile": {"qualityCutoffNotMet": True},
+        },
+        # Monitored, future release, missing: counted in both.
+        {
+            "id": 3,
+            "monitored": True,
+            "hasFile": False,
+            "title": "Upcoming Missing",
+            "year": 2099,
+            "inCinemas": future_iso,
+        },
+        # Unmonitored future release: not counted anywhere.
+        {
+            "id": 4,
+            "monitored": False,
+            "hasFile": False,
+            "title": "Unmonitored",
+            "year": 2099,
+            "releaseDate": future_iso,
+        },
+        # Monitored, has file, cutoff met: not monitored-total, not unreleased.
+        {
+            "id": 5,
+            "monitored": True,
+            "hasFile": True,
+            "title": "Done",
+            "year": 2020,
+            "releaseDate": past_iso,
+            "movieFile": {"qualityCutoffNotMet": False},
+        },
+    ]
+    respx.get(f"{BASE}/api/v3/movie").mock(return_value=httpx.Response(200, json=movies))
+
+    snap = await client.get_instance_snapshot()
+    assert snap.monitored_total == 3  # ids 1, 2, 3
+    assert snap.unreleased_count == 1  # id 3
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_get_instance_snapshot_empty_library(client: WhisparrV3Client) -> None:
+    respx.get(f"{BASE}/api/v3/movie").mock(return_value=httpx.Response(200, json=[]))
+    snap = await client.get_instance_snapshot()
+    assert snap.monitored_total == 0
+    assert snap.unreleased_count == 0

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,7 +29,7 @@ async def test_schema_created(db: None) -> None:
 async def test_schema_version_set(db: None) -> None:
     """Schema version should be set after init."""
     version = await get_setting("schema_version")
-    assert version == "12"
+    assert version == "13"
 
 
 @pytest.mark.asyncio()
@@ -110,7 +110,7 @@ async def test_init_db_migrates_v1_schema_to_v3(tmp_path: Path) -> None:
         search_log_columns = {row[1] async for row in search_log_cur}
         instance_columns = {row[1] async for row in instances_cur}
 
-    assert await get_setting("schema_version") == "12"
+    assert await get_setting("schema_version") == "13"
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
     assert "cycle_id" in search_log_columns
@@ -179,7 +179,7 @@ async def test_init_db_migrates_v2_schema_to_v4(tmp_path: Path) -> None:
         async with conn.execute("PRAGMA table_info(search_log)") as cur:
             search_log_columns = {row[1] async for row in cur}
 
-    assert await get_setting("schema_version") == "12"
+    assert await get_setting("schema_version") == "13"
     assert "cycle_id" in search_log_columns
     assert "cycle_trigger" in search_log_columns
 
@@ -246,7 +246,7 @@ async def test_init_db_migrates_v3_schema_to_v4(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "12"
+    assert await get_setting("schema_version") == "13"
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
             instance_columns = {row[1] async for row in cur}
@@ -329,7 +329,7 @@ async def test_init_db_migrates_v4_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "12"
+    assert await get_setting("schema_version") == "13"
 
     async with get_db() as conn:
         # Verify new columns exist
@@ -463,7 +463,7 @@ async def test_init_db_migrates_v5_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "12"
+    assert await get_setting("schema_version") == "13"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -560,7 +560,7 @@ async def test_init_db_migrates_v6_schema_to_v7(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "12"
+    assert await get_setting("schema_version") == "13"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -673,7 +673,7 @@ async def test_init_db_self_heals_v9_and_v10_when_version_already_current(
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "12"
+    assert await get_setting("schema_version") == "13"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -814,7 +814,7 @@ async def test_init_db_is_idempotent_on_healthy_v12(tmp_path: Path) -> None:
 
     # Second call: should be a no-op through the self-heal branch.
     await init_db()
-    assert await get_setting("schema_version") == first_version == "12"
+    assert await get_setting("schema_version") == first_version == "13"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -909,7 +909,7 @@ async def test_migrate_to_v12_adds_search_order_column(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "12"
+    assert await get_setting("schema_version") == "13"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:

--- a/tests/test_engine/test_dataclass_slots_audit.py
+++ b/tests/test_engine/test_dataclass_slots_audit.py
@@ -89,6 +89,7 @@ def test_audit_finds_at_least_the_known_frozen_set() -> None:
         "houndarr.value_objects.ItemRef",
         "houndarr.engine.config.search_pass.SearchPassConfig",
         "houndarr.engine.adapters._common.ContextOverride",
+        "houndarr.clients.base.InstanceSnapshot",
     }
     missing = expected_subset - names
     assert missing == set(), f"audit walker missed expected dataclasses: {sorted(missing)}"

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -401,6 +401,99 @@ async def test_refresh_all_snapshots_skips_disabled(
 
 
 @pytest.mark.asyncio()
+async def test_refresh_one_snapshot_logs_big_unreleased_jump(
+    seeded_instances: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A jump above the threshold emits a single INFO line.
+
+    Smoke test for the post-upgrade observability path: the prior
+    DB value seeded at 0, the snapshot returns 16, the delta crosses
+    the threshold (>10), so the log must fire once.
+    """
+    from houndarr.clients.base import InstanceSnapshot
+
+    inst = _make_instance(enabled=True)
+
+    fake_client = AsyncMock()
+    fake_client.get_instance_snapshot = AsyncMock(
+        return_value=InstanceSnapshot(monitored_total=20, unreleased_count=16),
+    )
+
+    class _CtxClient:
+        async def __aenter__(self) -> Any:
+            return fake_client
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+    fake_adapter = type(
+        "FakeAdapter",
+        (),
+        {"make_client": staticmethod(lambda _inst: _CtxClient())},
+    )()
+
+    with (
+        caplog.at_level("INFO", logger="houndarr.engine.supervisor"),
+        patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        await supervisor._refresh_one_snapshot(inst)  # noqa: SLF001
+
+    matching = [r for r in caplog.records if "unreleased jumped" in r.getMessage()]
+    assert len(matching) == 1
+    assert "0 -> 16" in matching[0].getMessage()
+
+
+@pytest.mark.asyncio()
+async def test_refresh_one_snapshot_quiet_on_small_unreleased_change(
+    seeded_instances: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A jump within the threshold stays silent.
+
+    Threshold is intentionally noisy enough to ignore single-release
+    churn (one item flipping past midnight); the test pins the
+    "no log fired" half of the contract.
+    """
+    from houndarr.clients.base import InstanceSnapshot
+    from houndarr.services.instances import update_instance_snapshot
+
+    inst = _make_instance(enabled=True)
+
+    # Seed a prior count of 5; the new snapshot returns 7 (delta = 2).
+    await update_instance_snapshot(inst.id, monitored_total=10, unreleased_count=5)
+
+    fake_client = AsyncMock()
+    fake_client.get_instance_snapshot = AsyncMock(
+        return_value=InstanceSnapshot(monitored_total=10, unreleased_count=7),
+    )
+
+    class _CtxClient:
+        async def __aenter__(self) -> Any:
+            return fake_client
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+    fake_adapter = type(
+        "FakeAdapter",
+        (),
+        {"make_client": staticmethod(lambda _inst: _CtxClient())},
+    )()
+
+    with (
+        caplog.at_level("INFO", logger="houndarr.engine.supervisor"),
+        patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        await supervisor._refresh_one_snapshot(inst)  # noqa: SLF001
+
+    matching = [r for r in caplog.records if "unreleased jumped" in r.getMessage()]
+    assert matching == []
+
+
+@pytest.mark.asyncio()
 async def test_refresh_all_snapshots_handles_transport_error(
     seeded_instances: None,
 ) -> None:

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -326,3 +326,104 @@ async def test_no_extra_log_rows_during_retry_sequence(
     assert len(rows) == 2, f"expected 2 log rows (1 error + 1 recovery), got: {rows}"
     assert rows[0]["action"] == "error"
     assert rows[1]["action"] == "info"
+
+
+# ---------------------------------------------------------------------------
+# PR 5: snapshot refresh loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_refresh_all_snapshots_once_updates_enabled_instances(
+    seeded_instances: None,
+) -> None:
+    """_refresh_all_snapshots_once calls update_instance_snapshot on each
+    enabled instance using the per-client snapshot.
+    """
+    from houndarr.clients.base import InstanceSnapshot
+    from houndarr.services.instances import get_instance
+
+    inst = _make_instance(enabled=True)
+
+    fake_client = AsyncMock()
+    fake_client.get_instance_snapshot = AsyncMock(
+        return_value=InstanceSnapshot(monitored_total=42, unreleased_count=3),
+    )
+
+    class _CtxClient:
+        async def __aenter__(self) -> Any:
+            return fake_client
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+    fake_adapter = type(
+        "FakeAdapter",
+        (),
+        {"make_client": staticmethod(lambda _inst: _CtxClient())},
+    )()
+
+    with (
+        patch("houndarr.engine.supervisor.list_instances", AsyncMock(return_value=[inst])),
+        patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        await supervisor._refresh_all_snapshots_once()  # noqa: SLF001
+
+    refreshed = await get_instance(inst.id, master_key=MASTER_KEY)
+    assert refreshed is not None
+    assert refreshed.monitored_total == 42
+    assert refreshed.unreleased_count == 3
+    assert refreshed.snapshot_refreshed_at != ""
+
+
+@pytest.mark.asyncio()
+async def test_refresh_all_snapshots_skips_disabled(
+    seeded_instances: None,
+) -> None:
+    """Disabled instances are not probed and retain prior snapshot values."""
+    from houndarr.services.instances import get_instance
+
+    inst = _make_instance(enabled=False)
+    fake_client_call = AsyncMock()
+
+    with (
+        patch("houndarr.engine.supervisor.list_instances", AsyncMock(return_value=[inst])),
+        patch("houndarr.engine.supervisor.get_adapter", side_effect=fake_client_call),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        await supervisor._refresh_all_snapshots_once()  # noqa: SLF001
+
+    assert fake_client_call.await_count == 0
+    refreshed = await get_instance(inst.id, master_key=MASTER_KEY)
+    assert refreshed is not None
+    assert refreshed.monitored_total == 0  # unchanged from default
+
+
+@pytest.mark.asyncio()
+async def test_refresh_all_snapshots_handles_transport_error(
+    seeded_instances: None,
+) -> None:
+    """Transport errors are logged and suppressed; snapshot stays as-is."""
+    inst = _make_instance(enabled=True)
+
+    class _BrokenCtx:
+        async def __aenter__(self) -> Any:
+            raise httpx.TransportError("unreachable")
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+    fake_adapter = type(
+        "FakeAdapter",
+        (),
+        {"make_client": staticmethod(lambda _inst: _BrokenCtx())},
+    )()
+
+    with (
+        patch("houndarr.engine.supervisor.list_instances", AsyncMock(return_value=[inst])),
+        patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        # Should not raise.
+        await supervisor._refresh_all_snapshots_once()  # noqa: SLF001

--- a/tests/test_services/test_instances.py
+++ b/tests/test_services/test_instances.py
@@ -347,3 +347,45 @@ async def test_update_search_order_to_random(db: None, master_key: bytes) -> Non
     )
     assert reverted is not None
     assert reverted.search_order == SearchOrder.chronological
+
+
+# ---------------------------------------------------------------------------
+# PR 5: v13 snapshot columns + update_instance_snapshot helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_v13_snapshot_columns_default_zero(db: None, master_key: bytes) -> None:
+    """Fresh v13 installs initialize snapshot columns to their defaults."""
+    inst = await _make(master_key)
+    assert inst.monitored_total == 0
+    assert inst.unreleased_count == 0
+    assert inst.snapshot_refreshed_at == ""
+
+
+@pytest.mark.asyncio()
+async def test_update_instance_snapshot_writes_all_columns(db: None, master_key: bytes) -> None:
+    from houndarr.services.instances import update_instance_snapshot
+
+    inst = await _make(master_key)
+    await update_instance_snapshot(inst.id, monitored_total=123, unreleased_count=7)
+    refreshed = await get_instance(inst.id, master_key=master_key)
+    assert refreshed is not None
+    assert refreshed.monitored_total == 123
+    assert refreshed.unreleased_count == 7
+    assert refreshed.snapshot_refreshed_at != ""
+
+
+@pytest.mark.asyncio()
+async def test_update_instance_snapshot_overwrites_prior_values(
+    db: None, master_key: bytes
+) -> None:
+    from houndarr.services.instances import update_instance_snapshot
+
+    inst = await _make(master_key)
+    await update_instance_snapshot(inst.id, monitored_total=50, unreleased_count=3)
+    await update_instance_snapshot(inst.id, monitored_total=60, unreleased_count=5)
+    refreshed = await get_instance(inst.id, master_key=master_key)
+    assert refreshed is not None
+    assert refreshed.monitored_total == 60
+    assert refreshed.unreleased_count == 5


### PR DESCRIPTION
## Summary

Persist per-instance monitored and unreleased counts as `instances` table columns and add a 10-minute supervisor refresh task that probes each enabled arr and writes the columns under the per-instance search lock so a refresh cannot race a cycle. Newly added or re-enabled instances fire a one-shot prime refresh from `start_instance_task` so dashboard counters populate within seconds.

Closes #460

## Changes

- Schema v13: add `monitored_total`, `unreleased_count`, `snapshot_refreshed_at` columns to `instances`, with `_migrate_to_v13` and matching defaults on the `CREATE TABLE` block.
- `clients/base.py`: add the `InstanceSnapshot` frozen + slotted dataclass and a default `get_instance_snapshot()` on `ArrClient` that sums `get_wanted_total("missing")` + `get_wanted_total("cutoff")` for `monitored_total`; the default `_count_unreleased_default` returns 0.
- `clients/whisparr_v3.py`: override `get_instance_snapshot()` to compute monitored + unreleased counts from the cached `/api/v3/movie` payload (a single fetch answers both questions).
- `engine/supervisor.py`: add a global 10-minute snapshot-refresh loop launched in `start()` and cancelled in `stop()`; extract `_refresh_one_snapshot(instance)` so the bulk refresh and the per-instance prime task share lock acquisition, transport-error suppression, and exception logging.
- `engine/supervisor.py`: fire a one-shot `_refresh_one_snapshot(current)` task from `start_instance_task` so a freshly added or re-enabled instance's dashboard counters populate without waiting for the scheduled loop. Track each prime task on the supervisor and cancel + gather them in `stop()` so an in-flight write cannot land after a factory reset wipes the DB.
- `engine/supervisor.py`: log a single INFO line when `|new_unreleased - prior_unreleased| > 10` so the post-upgrade transition (every non-Whisparr-v3 instance flipping from 0 to its real count within ~20 seconds of process start) leaves an audit trail. Targeted SELECT keeps the path off the decryption-heavy `get_instance` helper.
- `services/instances.py`: add the three snapshot fields to the `Instance` dataclass; add `update_instance_snapshot(id, monitored_total=..., unreleased_count=...)` that stamps `snapshot_refreshed_at` and `updated_at` to `now()`; add `_optional_row_int` / `_optional_row_str` helpers so tests with pre-v13 row shapes stay compatible with the post-v13 dataclass.
- Pin `houndarr.clients.base.InstanceSnapshot` in the slots-audit `expected_subset`.

## Testing

`just check` clean: ruff, ruff format, mypy strict, bandit all pass. pytest runs 1322 tests in 19.18 s green locally.

New tests cover:

- Whisparr v3 snapshot: counts monitored (missing + cutoff-unmet) and unreleased (future release across the four date fields), unmonitored skipped, empty library returns zeros.
- Supervisor `_refresh_all_snapshots_once`: writes columns for enabled instances, skips disabled, suppresses transport errors.
- Supervisor `_refresh_one_snapshot` delta logging: fires once when `|new - prior| > 10`, stays silent when within threshold.
- Schema v13 migration: backfills `monitored_total` / `unreleased_count` to 0 and `snapshot_refreshed_at` to `''` on existing rows.

## Type of Change

- [x] New feature (`feat:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #460`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/supervisor-snapshot-columns`)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (N/A; settings/help docs ride a later UI PR)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: Snapshot infrastructure surfaces dashboard counters that depend on missing / cutoff-unmet library state.

## Notes for review

`/api/status` does not yet read the new columns. The redesigned dashboard cluster brings the `v=2` branch and consumes them there; this PR's job is to write the columns to disk and surface `InstanceSnapshot` on the client surface.

The `_refresh_one_snapshot` extraction and the prime-task creation in `start_instance_task` were originally authored as part of a later post-review fix commit. They are brought forward here because the prime-task tracking commit depends on their presence; the duplicate hunks will drop when the originating cluster lands.

Two perf/correctness fixes for `services.instances.active_error_instance_ids` (originally listed for this PR in the rollout plan) defer to the cluster that introduces that function on origin/main.
