### PR TITLE
feat(db): schema v14+v15 cooldown search_kind + reconcile

### DIFF
--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -37,6 +37,55 @@ class InstanceSnapshot:
     unreleased_count: int
 
 
+@dataclass(frozen=True, slots=True)
+class ReconcileSets:
+    """Authoritative (item_type, item_id) sets for each search pass.
+
+    One set per ``search_kind`` value stamped on cooldown rows.  Each
+    entry is a pair that matches a cooldown row's ``(item_type,
+    item_id)`` columns: leaf item ids for straight-episode / movie /
+    album / book / scene searches, or the negative synthetic ids
+    (e.g. ``-(series_id * 1000 + season_number)``) that context-mode
+    adapters stamp when the search was dispatched at the parent
+    level.  A cooldown row is considered live iff its ``(item_type,
+    item_id)`` appears in the matching ``search_kind`` set.
+
+    The adapter populates both leaves AND synthetics in one pass:
+    synthetics are derived from the leaf wanted list by grouping on
+    the parent id carried on each item (e.g. ``series_id``,
+    ``artist_id``, ``author_id``).  Reconciliation stays a pure set
+    membership check and does not need adapter-specific logic.
+    """
+
+    missing: frozenset[tuple[str, int]]
+    cutoff: frozenset[tuple[str, int]]
+    upgrade: frozenset[tuple[str, int]]
+
+    @classmethod
+    def empty(cls) -> ReconcileSets:
+        """Return a :class:`ReconcileSets` with three empty sets.
+
+        Used when an adapter cannot build a reliable authoritative set
+        (network failure mid-fetch, unsupported feature path) so the
+        supervisor skips reconciliation for that cycle rather than
+        wiping every cooldown row against an empty reference.
+        """
+        return cls(missing=frozenset(), cutoff=frozenset(), upgrade=frozenset())
+
+    def is_empty(self) -> bool:
+        """Return True if every pass set is empty.
+
+        The reconciler treats an all-empty result as an explicit
+        signal to SKIP the DELETE step: an instance that genuinely has
+        zero wanted items and zero upgrade-pool items will not have
+        cooldowns either, so the no-op is safe; and a mid-fetch
+        failure that returned :meth:`empty` must never drive the DB
+        to a blank state.
+        """
+        return not self.missing and not self.cutoff and not self.upgrade
+
+
+
 # Default timeouts (seconds): connect=5, read=30
 _DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
 

--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -85,7 +85,6 @@ class ReconcileSets:
         return not self.missing and not self.cutoff and not self.upgrade
 
 
-
 # Default timeouts (seconds): connect=5, read=30
 _DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
 

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Schema version: bump when adding new migrations
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -84,6 +84,8 @@ CREATE TABLE IF NOT EXISTS cooldowns (
     instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
     item_id     INTEGER NOT NULL,
     item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES})),
+    search_kind TEXT    NOT NULL DEFAULT 'missing'
+                        CHECK(search_kind IN ('missing', 'cutoff', 'upgrade')),
     searched_at TEXT    NOT NULL,
     UNIQUE(instance_id, item_id, item_type)
 );
@@ -180,6 +182,7 @@ async def init_db() -> None:
             await _migrate_to_v11(db)
             await _migrate_to_v12(db)
             await _migrate_to_v13(db)
+            await _migrate_to_v14(db)
             await _ensure_v3_indexes(db)
             await db.commit()
 
@@ -210,6 +213,8 @@ async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
         await _migrate_to_v12(db)
     if from_version < 13:
         await _migrate_to_v13(db)
+    if from_version < 14:
+        await _migrate_to_v14(db)
 
     logger.info("Migrated database from schema version %d to %d", from_version, SCHEMA_VERSION)
     await db.execute(
@@ -755,10 +760,90 @@ async def _migrate_to_v13(db: aiosqlite.Connection) -> None:
         )
 
 
+async def _migrate_to_v14(db: aiosqlite.Connection) -> None:
+    """Stamp ``search_kind`` on cooldown rows at insert time.
+
+    Previously ``cooldown_breakdown`` was derived at read time by joining
+    every cooldown row to its most-recent ``search_log`` row and reading
+    ``search_kind`` off that.  Two fragilities fall out of this: the
+    classification flips whenever a later search kind is logged for the
+    same item, and it quietly defaults to ``"missing"`` if the log row
+    is absent (e.g. retention pruned it, or a migration truncated the
+    table).  Also a correlated subquery per cooldown row per
+    ``/api/status`` poll.
+
+    Stamp the kind on the row itself at INSERT time so the cooldowns
+    table carries its own classification.  Backfill existing rows from
+    the newest ``searched`` log entry per item, defaulting to
+    ``"missing"`` when no log match exists (preserving current read
+    behaviour for pre-migration data).  A nullable-then-default dance
+    is unnecessary because the column has a ``NOT NULL DEFAULT
+    'missing'`` literal: rows added before backfill simply carry the
+    default, which matches what the old read-path returned anyway.
+
+    The ``(instance_id, item_id, item_type)`` UNIQUE constraint stays
+    as-is: cooldowns are about pacing indexer requests per item, not
+    per pass, so one row per item-per-instance is correct.  The
+    stamped ``search_kind`` is the kind of the MOST RECENT search that
+    updated that row, which is what the reconciliation path matches
+    against the *arr's per-pass wanted sets.
+    """
+    if not await _column_exists(db, "cooldowns", "search_kind"):
+        await db.execute(
+            "ALTER TABLE cooldowns ADD COLUMN search_kind TEXT NOT NULL DEFAULT 'missing'"
+        )
+    # Backfill any rows that still carry the literal default from the
+    # ALTER.  The SELECT mirrors the classifier that used to live in
+    # services/metrics.py's cooldown breakdown SQL; newer log rows
+    # override older ones so the stamp matches what the dashboard used
+    # to infer at read time.
+    await db.execute(
+        """
+        UPDATE cooldowns
+           SET search_kind = (
+                 SELECT sl.search_kind
+                   FROM search_log sl
+                  WHERE sl.instance_id = cooldowns.instance_id
+                    AND sl.item_id     = cooldowns.item_id
+                    AND sl.item_type   = cooldowns.item_type
+                    AND sl.action      = 'searched'
+                    AND sl.search_kind IN ('missing', 'cutoff', 'upgrade')
+                  ORDER BY sl.timestamp DESC
+                  LIMIT 1
+               )
+         WHERE EXISTS (
+                 SELECT 1 FROM search_log sl2
+                  WHERE sl2.instance_id = cooldowns.instance_id
+                    AND sl2.item_id     = cooldowns.item_id
+                    AND sl2.item_type   = cooldowns.item_type
+                    AND sl2.action      = 'searched'
+                    AND sl2.search_kind IN ('missing', 'cutoff', 'upgrade')
+               )
+        """
+    )
+    # Index creation lives in _ensure_v3_indexes so fresh installs
+    # (which skip migrations) still get it; the helper runs after both
+    # the fresh-install DDL and the upgrade migration path.
+
+
 async def _ensure_v3_indexes(db: aiosqlite.Connection) -> None:
-    """Create v3 indexes that depend on post-v2 columns."""
+    """Create indexes that depend on post-v2 columns.
+
+    Runs after the main schema DDL and after any migrations, so every
+    column each index references is guaranteed to exist.  Kept under
+    the ``v3`` name for historical continuity; in practice it now
+    carries any post-schema index that cannot live in ``_SCHEMA_SQL``
+    because its column was added by a later migration.
+    """
     await db.execute(
         "CREATE INDEX IF NOT EXISTS idx_search_log_cycle ON search_log(cycle_id, timestamp DESC)"
+    )
+    # search_kind arrived in v14; the column will exist here whether
+    # this DB came in fresh (the DDL in _SCHEMA_SQL creates it) or
+    # migrated up (_migrate_to_v14 adds it via ALTER TABLE).
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_cooldowns_search_kind "
+        "ON cooldowns(instance_id, search_kind)"
     )
 
 

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Schema version: bump when adding new migrations
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -183,6 +183,7 @@ async def init_db() -> None:
             await _migrate_to_v12(db)
             await _migrate_to_v13(db)
             await _migrate_to_v14(db)
+            await _migrate_to_v15(db)
             await _ensure_v3_indexes(db)
             await db.commit()
 
@@ -215,6 +216,8 @@ async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
         await _migrate_to_v13(db)
     if from_version < 14:
         await _migrate_to_v14(db)
+    if from_version < 15:
+        await _migrate_to_v15(db)
 
     logger.info("Migrated database from schema version %d to %d", from_version, SCHEMA_VERSION)
     await db.execute(
@@ -824,6 +827,96 @@ async def _migrate_to_v14(db: aiosqlite.Connection) -> None:
     # Index creation lives in _ensure_v3_indexes so fresh installs
     # (which skip migrations) still get it; the helper runs after both
     # the fresh-install DDL and the upgrade migration path.
+
+
+async def _migrate_to_v15(db: aiosqlite.Connection) -> None:
+    """Enforce the ``search_kind`` CHECK constraint on migrated databases.
+
+    v14's ``ALTER TABLE ADD COLUMN`` could only set the ``NOT NULL
+    DEFAULT 'missing'`` clause; SQLite does not let you append a CHECK
+    constraint to an existing column.  Fresh installs already carry
+    the ``CHECK(search_kind IN ('missing', 'cutoff', 'upgrade'))``
+    clause from ``_SCHEMA_SQL``, but databases that migrated through
+    v14 silently accept any string in that column.  Re-create the
+    table with the full CHECK clause and copy the rows across so
+    every install enforces the same invariant.
+
+    The rebuild is idempotent: the sentinel inspects
+    ``sqlite_master.sql`` for the ``CHECK(search_kind IN`` token and
+    returns immediately when the table already carries it.  Any row
+    whose stamped kind falls outside the three allowed values is
+    coerced to ``'missing'`` during the copy so the new CHECK does
+    not reject pre-existing data; such rows should not exist in
+    practice (the app writes only valid kinds) but defence-in-depth
+    keeps the migration from failing on a corrupted snapshot.
+    """
+    if await _cooldowns_has_search_kind_check(db):
+        return
+
+    await db.execute("PRAGMA foreign_keys=OFF")
+    try:
+        await db.execute(
+            f"""
+            CREATE TABLE cooldowns_new (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER NOT NULL
+                                    REFERENCES instances(id) ON DELETE CASCADE,
+                item_id     INTEGER NOT NULL,
+                item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES})),
+                search_kind TEXT    NOT NULL DEFAULT 'missing'
+                                    CHECK(search_kind IN ('missing', 'cutoff', 'upgrade')),
+                searched_at TEXT    NOT NULL,
+                UNIQUE(instance_id, item_id, item_type)
+            )
+            """
+        )
+        await db.execute(
+            """
+            INSERT INTO cooldowns_new
+                (id, instance_id, item_id, item_type, search_kind, searched_at)
+            SELECT id,
+                   instance_id,
+                   item_id,
+                   item_type,
+                   CASE
+                       WHEN search_kind IN ('missing', 'cutoff', 'upgrade')
+                           THEN search_kind
+                       ELSE 'missing'
+                   END AS search_kind,
+                   searched_at
+              FROM cooldowns
+            """
+        )
+        await db.execute("DROP TABLE cooldowns")
+        await db.execute("ALTER TABLE cooldowns_new RENAME TO cooldowns")
+        # Recreate every index that referenced the old table.  The
+        # search_kind index is also emitted by _ensure_v3_indexes, but
+        # the lookup index lived only in _SCHEMA_SQL so without this
+        # line migrated databases would lose it.
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_cooldowns_lookup "
+            "ON cooldowns(instance_id, item_type, searched_at)"
+        )
+    finally:
+        await db.execute("PRAGMA foreign_keys=ON")
+
+
+async def _cooldowns_has_search_kind_check(db: aiosqlite.Connection) -> bool:
+    """Return whether the ``cooldowns`` table carries the v15 CHECK clause.
+
+    The fresh-install DDL emits ``CHECK(search_kind IN ('missing', ...))``
+    (sqlite stores whatever whitespace was used).  Strip all whitespace
+    from the stored SQL and look for the compact form so either
+    formatting path is recognised.
+    """
+    async with db.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='cooldowns'"
+    ) as cur:
+        row = await cur.fetchone()
+    if row is None:
+        return False
+    compact = "".join(str(row[0] or "").split())
+    return "CHECK(search_kindIN" in compact
 
 
 async def _ensure_v3_indexes(db: aiosqlite.Connection) -> None:

--- a/src/houndarr/engine/adapters/_common.py
+++ b/src/houndarr/engine/adapters/_common.py
@@ -90,6 +90,15 @@ means a 5,000-item wanted list becomes 20 requests at refresh time — a
 one-off cost per instance per snapshot cycle rather than a per-poll
 overhead."""
 
+_RECONCILE_MAX_PAGES = 200
+"""Safety cap on the paginate-wanted loop.
+
+At ``_RECONCILE_PAGE_SIZE=250`` items per page, 200 pages admit a
+50,000-item wanted list, well beyond any realistic *arr library.  The
+cap exists only to bound a misbehaving upstream that always returns
+exactly ``page_size`` items (whether due to an off-by-one bug or a
+hostile endpoint); without it the loop would never terminate."""
+
 
 async def paginate_wanted[T](
     fetch_page: Callable[..., Awaitable[list[T]]],
@@ -100,7 +109,11 @@ async def paginate_wanted[T](
 
     Stops on the first short page (length < *page_size*) since that is
     the last page by contract.  An explicit empty first page yields an
-    empty list without a second request.
+    empty list without a second request.  A hard cap of
+    :data:`_RECONCILE_MAX_PAGES` bounds the loop so a misbehaving *arr
+    that always returns a full page cannot spin forever; hitting the
+    cap returns what has been collected so far and leaves reconcile to
+    act conservatively against a possibly-truncated view.
 
     Used by every adapter's :func:`fetch_reconcile_sets` to walk the
     full wanted list so the reconciler sees a complete picture of which
@@ -117,13 +130,12 @@ async def paginate_wanted[T](
         Flat list of every item across every page, preserving order.
     """
     items: list[T] = []
-    page = 1
-    while True:
+    for page in range(1, _RECONCILE_MAX_PAGES + 1):
         chunk = await fetch_page(page=page, page_size=page_size)
         items.extend(chunk)
         if len(chunk) < page_size:
             return items
-        page += 1
+    return items
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/houndarr/engine/adapters/_common.py
+++ b/src/houndarr/engine/adapters/_common.py
@@ -82,6 +82,50 @@ async def fetch_movie_upgrade_pool[T: _UpgradeFilterable](
     return [m for m in library if m.monitored and m.has_file and m.cutoff_met]
 
 
+_RECONCILE_PAGE_SIZE = 250
+"""Page size used when paginating /wanted endpoints for reconciliation.
+
+250 is the maximum every /wanted endpoint accepts.  Picking the ceiling
+means a 5,000-item wanted list becomes 20 requests at refresh time — a
+one-off cost per instance per snapshot cycle rather than a per-poll
+overhead."""
+
+
+async def paginate_wanted[T](
+    fetch_page: Callable[..., Awaitable[list[T]]],
+    *,
+    page_size: int = _RECONCILE_PAGE_SIZE,
+) -> list[T]:
+    """Return every wanted item by paginating *fetch_page* until exhausted.
+
+    Stops on the first short page (length < *page_size*) since that is
+    the last page by contract.  An explicit empty first page yields an
+    empty list without a second request.
+
+    Used by every adapter's :func:`fetch_reconcile_sets` to walk the
+    full wanted list so the reconciler sees a complete picture of which
+    items are still wanted at this instant.
+
+    Args:
+        fetch_page: ``async def(page=N, page_size=M)`` callable.
+            Typically bound to ``client.get_missing`` or
+            ``client.get_cutoff_unmet``.
+        page_size: Items per request.  Defaults to the /wanted endpoint
+            maximum so total requests stay minimal at full library scale.
+
+    Returns:
+        Flat list of every item across every page, preserving order.
+    """
+    items: list[T] = []
+    page = 1
+    while True:
+        chunk = await fetch_page(page=page, page_size=page_size)
+        items.extend(chunk)
+        if len(chunk) < page_size:
+            return items
+        page += 1
+
+
 @dataclass(frozen=True, slots=True)
 class ContextOverride:
     """Parent-context dispatch override for the missing-pass candidate.

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -9,9 +9,6 @@ from __future__ import annotations
 
 import logging
 
-import httpx
-from pydantic import ValidationError
-
 from houndarr.clients.base import ReconcileSets
 from houndarr.clients.lidarr import LibraryAlbum, LidarrClient, MissingAlbum
 from houndarr.engine.adapters._common import (

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -9,11 +9,16 @@ from __future__ import annotations
 
 import logging
 
+import httpx
+from pydantic import ValidationError
+
+from houndarr.clients.base import ReconcileSets
 from houndarr.clients.lidarr import LibraryAlbum, LidarrClient, MissingAlbum
 from houndarr.engine.adapters._common import (
     ContextOverride,
     build_cutoff_candidate,
     build_missing_candidate,
+    paginate_wanted,
 )
 from houndarr.engine.candidates import (
     SearchCandidate,
@@ -258,6 +263,49 @@ def make_client(instance: Instance) -> LidarrClient:
     return LidarrClient(url=instance.url, api_key=instance.api_key)
 
 
+def _album_leaf_pairs(items: list[MissingAlbum]) -> frozenset[tuple[str, int]]:
+    """Return the ``(item_type, album_id)`` pairs for a wanted list."""
+    return frozenset(("album", it.album_id) for it in items if it.album_id)
+
+
+def _artist_synth_pairs(items: list[MissingAlbum]) -> frozenset[tuple[str, int]]:
+    """Return synthetic artist-context pairs for artist-context cooldowns.
+
+    Collapses the leaf wanted list to the set of distinct artist ids,
+    then renders each through :func:`_artist_item_id` so the negative
+    synthetic ids match what :func:`adapt_missing` stamps in
+    artist-context mode.  Items with ``artist_id <= 0`` are skipped;
+    those would not have produced a context-mode cooldown.
+    """
+    artists = {it.artist_id for it in items if it.artist_id and it.artist_id > 0}
+    return frozenset(("album", _artist_item_id(aid)) for aid in artists)
+
+
+async def fetch_reconcile_sets(client: LidarrClient, instance: Instance) -> ReconcileSets:
+    """Return the authoritative wanted / upgrade-pool sets for Lidarr.
+
+    The missing set always carries leaf album ids.  When the instance
+    runs in ``artist_context`` missing-pass mode, synthetic negative
+    artist ids derived from the same wanted list are unioned in so
+    cooldown rows written under the context path keep matching.
+    Cutoff cooldowns are always leaf (album-level dispatch); no
+    context-mode promotion happens there.
+    """
+    missing_items = await paginate_wanted(client.get_missing)
+    cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
+    missing_set = _album_leaf_pairs(missing_items)
+    cutoff_set = _album_leaf_pairs(cutoff_items)
+    if instance.lidarr_search_mode != LidarrSearchMode.album:
+        missing_set = missing_set | _artist_synth_pairs(missing_items)
+    upgrade_candidates = [
+        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
+    ]
+    upgrade_set: frozenset[tuple[str, int]] = frozenset(
+        (str(c.item_type), c.item_id) for c in upgrade_candidates
+    )
+    return ReconcileSets(missing=missing_set, cutoff=cutoff_set, upgrade=upgrade_set)
+
+
 class LidarrAdapter:
     """Class-form Lidarr adapter for the :data:`ADAPTERS` registry.
 
@@ -274,3 +322,4 @@ class LidarrAdapter:
     fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
     dispatch_search = staticmethod(dispatch_search)
     make_client = staticmethod(make_client)
+    fetch_reconcile_sets = staticmethod(fetch_reconcile_sets)

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -289,7 +289,9 @@ async def fetch_reconcile_sets(client: LidarrClient, instance: Instance) -> Reco
     artist ids derived from the same wanted list are unioned in so
     cooldown rows written under the context path keep matching.
     Cutoff cooldowns are always leaf (album-level dispatch); no
-    context-mode promotion happens there.
+    context-mode promotion happens there.  When ``upgrade_enabled`` is
+    false the upgrade set short-circuits to empty so the library scan
+    + cutoff-exclusion paginate loop are skipped.
     """
     missing_items = await paginate_wanted(client.get_missing)
     cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
@@ -297,12 +299,12 @@ async def fetch_reconcile_sets(client: LidarrClient, instance: Instance) -> Reco
     cutoff_set = _album_leaf_pairs(cutoff_items)
     if instance.lidarr_search_mode != LidarrSearchMode.album:
         missing_set = missing_set | _artist_synth_pairs(missing_items)
-    upgrade_candidates = [
-        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
-    ]
-    upgrade_set: frozenset[tuple[str, int]] = frozenset(
-        (str(c.item_type), c.item_id) for c in upgrade_candidates
-    )
+    upgrade_set: frozenset[tuple[str, int]] = frozenset()
+    if instance.upgrade_enabled:
+        upgrade_candidates = [
+            adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
+        ]
+        upgrade_set = frozenset((str(c.item_type), c.item_id) for c in upgrade_candidates)
     return ReconcileSets(missing=missing_set, cutoff=cutoff_set, upgrade=upgrade_set)
 
 

--- a/src/houndarr/engine/adapters/protocols.py
+++ b/src/houndarr/engine/adapters/protocols.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
 
-from houndarr.clients.base import ArrClient
+from houndarr.clients.base import ArrClient, ReconcileSets
 from houndarr.engine.candidates import SearchCandidate
 from houndarr.services.instances import Instance
 
@@ -54,3 +54,17 @@ class AppAdapterProto(Protocol):
     @property
     def make_client(self) -> Callable[[Instance], ArrClient]:
         """Return a fresh (unopened) :class:`ArrClient` for *instance*."""
+
+    @property
+    def fetch_reconcile_sets(self) -> Callable[..., Awaitable[ReconcileSets]]:
+        """Return the authoritative ``(item_type, item_id)`` sets per pass.
+
+        Called from the supervisor's snapshot refresh; the returned
+        :class:`~houndarr.clients.base.ReconcileSets` drive the cooldown
+        reconciliation that reaps rows for items no longer wanted.
+        Implementations paginate ``/wanted/missing`` and
+        ``/wanted/cutoff`` for leaf ids, call :attr:`fetch_upgrade_pool`
+        for upgrade-pool ids, and (in context-mode adapters) UNION in
+        the synthetic parent ids derived from leaf parent metadata so
+        the DB match stays pure set membership.
+        """

--- a/src/houndarr/engine/adapters/radarr.py
+++ b/src/houndarr/engine/adapters/radarr.py
@@ -178,24 +178,28 @@ async def dispatch_search(client: RadarrClient, candidate: SearchCandidate) -> N
 
 async def fetch_reconcile_sets(
     client: RadarrClient,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> ReconcileSets:
     """Return the authoritative wanted / upgrade-pool sets for Radarr.
 
     Radarr has no parent-context mode: cooldown rows always carry the
     leaf ``movie_id``, so the reconciliation sets are just the leaf
-    ids from each pass.  ``instance`` is kept for signature parity
-    with the parent-context adapters.
+    ids from each pass.  When ``upgrade_enabled`` is false the upgrade
+    set short-circuits to empty so the ``/movie`` library call is
+    skipped.
     """
     missing_items = await paginate_wanted(client.get_missing)
     cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
-    upgrade_candidates = [
-        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
-    ]
+    upgrade_set: frozenset[tuple[str, int]] = frozenset()
+    if instance.upgrade_enabled:
+        upgrade_candidates = [
+            adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
+        ]
+        upgrade_set = frozenset((str(c.item_type), c.item_id) for c in upgrade_candidates)
     return ReconcileSets(
         missing=frozenset(("movie", m.movie_id) for m in missing_items),
         cutoff=frozenset(("movie", m.movie_id) for m in cutoff_items),
-        upgrade=frozenset((str(c.item_type), c.item_id) for c in upgrade_candidates),
+        upgrade=upgrade_set,
     )
 
 

--- a/src/houndarr/engine/adapters/radarr.py
+++ b/src/houndarr/engine/adapters/radarr.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+from houndarr.clients.base import ReconcileSets
 from houndarr.clients.radarr import LibraryMovie, MissingMovie, RadarrClient
 from houndarr.engine.adapters._common import (
     build_missing_candidate,
     fetch_movie_upgrade_pool,
+    paginate_wanted,
 )
 from houndarr.engine.candidates import (
     SearchCandidate,
@@ -174,6 +176,29 @@ async def dispatch_search(client: RadarrClient, candidate: SearchCandidate) -> N
     await client.search(candidate.search_payload["movie_id"])
 
 
+async def fetch_reconcile_sets(
+    client: RadarrClient,
+    instance: Instance,  # noqa: ARG001
+) -> ReconcileSets:
+    """Return the authoritative wanted / upgrade-pool sets for Radarr.
+
+    Radarr has no parent-context mode: cooldown rows always carry the
+    leaf ``movie_id``, so the reconciliation sets are just the leaf
+    ids from each pass.  ``instance`` is kept for signature parity
+    with the parent-context adapters.
+    """
+    missing_items = await paginate_wanted(client.get_missing)
+    cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
+    upgrade_candidates = [
+        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
+    ]
+    return ReconcileSets(
+        missing=frozenset(("movie", m.movie_id) for m in missing_items),
+        cutoff=frozenset(("movie", m.movie_id) for m in cutoff_items),
+        upgrade=frozenset((str(c.item_type), c.item_id) for c in upgrade_candidates),
+    )
+
+
 def make_client(instance: Instance) -> RadarrClient:
     """Construct a :class:`RadarrClient` for *instance*.
 
@@ -202,3 +227,4 @@ class RadarrAdapter:
     fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
     dispatch_search = staticmethod(dispatch_search)
     make_client = staticmethod(make_client)
+    fetch_reconcile_sets = staticmethod(fetch_reconcile_sets)

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -9,11 +9,16 @@ from __future__ import annotations
 
 import logging
 
+import httpx
+from pydantic import ValidationError
+
+from houndarr.clients.base import ReconcileSets
 from houndarr.clients.readarr import LibraryBook, MissingBook, ReadarrClient
 from houndarr.engine.adapters._common import (
     ContextOverride,
     build_cutoff_candidate,
     build_missing_candidate,
+    paginate_wanted,
 )
 from houndarr.engine.candidates import (
     SearchCandidate,
@@ -257,6 +262,39 @@ def make_client(instance: Instance) -> ReadarrClient:
     return ReadarrClient(url=instance.url, api_key=instance.api_key)
 
 
+def _book_leaf_pairs(items: list[MissingBook]) -> frozenset[tuple[str, int]]:
+    """Return the ``(item_type, book_id)`` pairs for a wanted list."""
+    return frozenset(("book", it.book_id) for it in items if it.book_id)
+
+
+def _author_synth_pairs(items: list[MissingBook]) -> frozenset[tuple[str, int]]:
+    """Return synthetic author-context pairs for author-context cooldowns."""
+    authors = {it.author_id for it in items if it.author_id and it.author_id > 0}
+    return frozenset(("book", _author_item_id(aid)) for aid in authors)
+
+
+async def fetch_reconcile_sets(client: ReadarrClient, instance: Instance) -> ReconcileSets:
+    """Return the authoritative wanted / upgrade-pool sets for Readarr.
+
+    Parallels the Lidarr implementation: leaf book ids always, plus
+    synthetic negative author ids when the instance runs author-context
+    missing-pass mode.  Cutoff cooldowns are always leaf.
+    """
+    missing_items = await paginate_wanted(client.get_missing)
+    cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
+    missing_set = _book_leaf_pairs(missing_items)
+    cutoff_set = _book_leaf_pairs(cutoff_items)
+    if instance.readarr_search_mode != ReadarrSearchMode.book:
+        missing_set = missing_set | _author_synth_pairs(missing_items)
+    upgrade_candidates = [
+        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
+    ]
+    upgrade_set: frozenset[tuple[str, int]] = frozenset(
+        (str(c.item_type), c.item_id) for c in upgrade_candidates
+    )
+    return ReconcileSets(missing=missing_set, cutoff=cutoff_set, upgrade=upgrade_set)
+
+
 class ReadarrAdapter:
     """Class-form Readarr adapter for the :data:`ADAPTERS` registry.
 
@@ -273,3 +311,4 @@ class ReadarrAdapter:
     fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
     dispatch_search = staticmethod(dispatch_search)
     make_client = staticmethod(make_client)
+    fetch_reconcile_sets = staticmethod(fetch_reconcile_sets)

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -278,7 +278,10 @@ async def fetch_reconcile_sets(client: ReadarrClient, instance: Instance) -> Rec
 
     Parallels the Lidarr implementation: leaf book ids always, plus
     synthetic negative author ids when the instance runs author-context
-    missing-pass mode.  Cutoff cooldowns are always leaf.
+    missing-pass mode.  Cutoff cooldowns are always leaf.  When
+    ``upgrade_enabled`` is false the upgrade set short-circuits to
+    empty so the library scan + cutoff-exclusion paginate loop are
+    skipped.
     """
     missing_items = await paginate_wanted(client.get_missing)
     cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
@@ -286,12 +289,12 @@ async def fetch_reconcile_sets(client: ReadarrClient, instance: Instance) -> Rec
     cutoff_set = _book_leaf_pairs(cutoff_items)
     if instance.readarr_search_mode != ReadarrSearchMode.book:
         missing_set = missing_set | _author_synth_pairs(missing_items)
-    upgrade_candidates = [
-        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
-    ]
-    upgrade_set: frozenset[tuple[str, int]] = frozenset(
-        (str(c.item_type), c.item_id) for c in upgrade_candidates
-    )
+    upgrade_set: frozenset[tuple[str, int]] = frozenset()
+    if instance.upgrade_enabled:
+        upgrade_candidates = [
+            adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
+        ]
+        upgrade_set = frozenset((str(c.item_type), c.item_id) for c in upgrade_candidates)
     return ReconcileSets(missing=missing_set, cutoff=cutoff_set, upgrade=upgrade_set)
 
 

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -9,9 +9,6 @@ from __future__ import annotations
 
 import logging
 
-import httpx
-from pydantic import ValidationError
-
 from houndarr.clients.base import ReconcileSets
 from houndarr.clients.readarr import LibraryBook, MissingBook, ReadarrClient
 from houndarr.engine.adapters._common import (

--- a/src/houndarr/engine/adapters/sonarr.py
+++ b/src/houndarr/engine/adapters/sonarr.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import httpx
+from pydantic import ValidationError
+
+from houndarr.clients.base import ReconcileSets
 from houndarr.clients.sonarr import LibraryEpisode, MissingEpisode, SonarrClient
 from houndarr.engine.adapters._common import (
     ContextOverride,
     build_cutoff_candidate,
     build_missing_candidate,
+    paginate_wanted,
 )
 from houndarr.engine.candidates import (
     SearchCandidate,
@@ -310,6 +315,62 @@ def make_client(instance: Instance) -> SonarrClient:
     return SonarrClient(url=instance.url, api_key=instance.api_key)
 
 
+def _episode_leaf_pairs(items: list[MissingEpisode]) -> frozenset[tuple[str, int]]:
+    """Return the ``(item_type, episode_id)`` pairs for a wanted list.
+
+    Shared between the missing and cutoff passes; leaf cooldown rows
+    match episodes by positive episode_id.  Items whose ``episode_id``
+    is missing are dropped (defensive: the Sonarr wire model marks it
+    as ``int`` not optional, so this should not fire in practice).
+    """
+    return frozenset(("episode", it.episode_id) for it in items if it.episode_id)
+
+
+def _season_synth_pairs(items: list[MissingEpisode]) -> frozenset[tuple[str, int]]:
+    """Return ``(item_type, synthetic)`` pairs for season-context rows.
+
+    Collapses the leaf wanted list to the set of ``(series_id,
+    season)`` parents, then renders each parent through
+    :func:`_season_item_id` so the synthetic negative ids match what
+    :func:`adapt_missing` stamps onto cooldowns in season-context
+    mode.  Items without ``series_id`` are skipped; they could not
+    have produced a season-context cooldown in the first place.
+    """
+    parents: set[tuple[int, int]] = set()
+    for it in items:
+        if it.series_id:
+            parents.add((it.series_id, it.season))
+    return frozenset(("episode", _season_item_id(sid, sn)) for sid, sn in parents)
+
+
+async def fetch_reconcile_sets(client: SonarrClient, instance: Instance) -> ReconcileSets:
+    """Return the authoritative wanted / upgrade-pool sets for Sonarr.
+
+    Always unions leaf episode ids into the missing / cutoff sets.
+    When the instance runs in ``season_context`` missing-pass mode, the
+    missing set ALSO carries synthetic negative season ids derived
+    from the same wanted list so cooldown rows stamped under the
+    season-context path keep matching.  Cutoff is always dispatched
+    per-episode, so cutoff cooldown rows never carry synthetic ids;
+    the cutoff reconcile set stays leaf-only.  Upgrade-pool ids come
+    from the existing :func:`fetch_upgrade_pool` which already applies
+    the same context-mode branch to each library episode.
+    """
+    missing_items = await paginate_wanted(client.get_missing)
+    cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
+    missing_set = _episode_leaf_pairs(missing_items)
+    cutoff_set = _episode_leaf_pairs(cutoff_items)
+    if instance.sonarr_search_mode != SonarrSearchMode.episode:
+        missing_set = missing_set | _season_synth_pairs(missing_items)
+    upgrade_candidates = [
+        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
+    ]
+    upgrade_set: frozenset[tuple[str, int]] = frozenset(
+        (str(c.item_type), c.item_id) for c in upgrade_candidates
+    )
+    return ReconcileSets(missing=missing_set, cutoff=cutoff_set, upgrade=upgrade_set)
+
+
 class SonarrAdapter:
     """Class-form Sonarr adapter for the :data:`ADAPTERS` registry.
 
@@ -326,3 +387,4 @@ class SonarrAdapter:
     fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
     dispatch_search = staticmethod(dispatch_search)
     make_client = staticmethod(make_client)
+    fetch_reconcile_sets = staticmethod(fetch_reconcile_sets)

--- a/src/houndarr/engine/adapters/sonarr.py
+++ b/src/houndarr/engine/adapters/sonarr.py
@@ -8,11 +8,13 @@ commands via :class:`~houndarr.clients.sonarr.SonarrClient`.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 import httpx
 from pydantic import ValidationError
 
+from houndarr.clients._wire_models import ArrSeries
 from houndarr.clients.base import ReconcileSets
 from houndarr.clients.sonarr import LibraryEpisode, MissingEpisode, SonarrClient
 from houndarr.engine.adapters._common import (
@@ -229,6 +231,35 @@ def adapt_upgrade(item: LibraryEpisode, instance: Instance) -> SearchCandidate:
     )
 
 
+async def _collect_upgrade_episodes(
+    client: SonarrClient,
+    instance: Instance,
+    series_list: Sequence[ArrSeries],
+) -> list[LibraryEpisode]:
+    """Return monitored, on-disk, cutoff-met episodes for the given series.
+
+    Shared loop body between the rotation-windowed search-cycle fetch
+    (:func:`fetch_upgrade_pool`) and the full-library reconcile fetch
+    (:func:`_fetch_all_upgrade_episodes`).  Transport or validation
+    errors on a single series are logged and skipped so one flaky
+    series cannot blank the whole pool.
+    """
+    episodes: list[LibraryEpisode] = []
+    for s in series_list:
+        series_id = s.id or 0
+        try:
+            eps = await client.get_episodes(series_id)
+        except (httpx.HTTPError, httpx.InvalidURL, ValidationError):
+            logger.warning(
+                "[%s] failed to fetch episodes for series %d, skipping",
+                instance.name,
+                series_id,
+            )
+            continue
+        episodes.extend(e for e in eps if e.monitored and e.has_file and e.cutoff_met)
+    return episodes
+
+
 async def fetch_upgrade_pool(
     client: SonarrClient,
     instance: Instance,
@@ -260,21 +291,29 @@ async def fetch_upgrade_pool(
         remaining = _UPGRADE_MAX_SERIES_PER_CYCLE - len(selected)
         selected += monitored[:remaining]
 
-    episodes: list[LibraryEpisode] = []
-    for s in selected:
-        series_id = s.id or 0
-        try:
-            eps = await client.get_episodes(series_id)
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "[%s] failed to fetch episodes for series %d, skipping",
-                instance.name,
-                series_id,
-            )
-            continue
-        episodes.extend(e for e in eps if e.monitored and e.has_file and e.cutoff_met)
+    return await _collect_upgrade_episodes(client, instance, selected)
 
-    return episodes
+
+async def _fetch_all_upgrade_episodes(
+    client: SonarrClient,
+    instance: Instance,
+) -> list[LibraryEpisode]:
+    """Return upgrade-eligible episodes across EVERY monitored series.
+
+    The cycle-facing :func:`fetch_upgrade_pool` windows the series list
+    via ``upgrade_series_offset`` so indexer traffic stays polite per
+    cycle.  Reconciliation cannot use that windowed set: it would mark
+    every upgrade cooldown outside the current slice as an orphan and
+    delete it on the next snapshot refresh, collapsing the configured
+    ``upgrade_cooldown_days`` down to roughly one rotation period.
+    This helper ignores the window and walks the full monitored list
+    so the reconcile upgrade set matches everything
+    :func:`adapt_upgrade` could legitimately stamp.  Amortised against
+    the supervisor's 10-minute snapshot cadence.
+    """
+    all_series = await client.get_series()
+    monitored = [s for s in all_series if s.monitored]
+    return await _collect_upgrade_episodes(client, instance, monitored)
 
 
 async def dispatch_search(client: SonarrClient, candidate: SearchCandidate) -> None:
@@ -352,9 +391,14 @@ async def fetch_reconcile_sets(client: SonarrClient, instance: Instance) -> Reco
     from the same wanted list so cooldown rows stamped under the
     season-context path keep matching.  Cutoff is always dispatched
     per-episode, so cutoff cooldown rows never carry synthetic ids;
-    the cutoff reconcile set stays leaf-only.  Upgrade-pool ids come
-    from the existing :func:`fetch_upgrade_pool` which already applies
-    the same context-mode branch to each library episode.
+    the cutoff reconcile set stays leaf-only.  The upgrade set walks
+    the FULL monitored library via :func:`_fetch_all_upgrade_episodes`
+    rather than the cycle-rotation window, otherwise reconcile would
+    treat every upgrade cooldown outside the current 5-series slice as
+    an orphan and truncate ``upgrade_cooldown_days`` to one rotation.
+    When ``upgrade_enabled`` is false the upgrade set is an empty
+    frozenset so no library traffic is paid; no upgrade cooldowns can
+    exist in that state anyway.
     """
     missing_items = await paginate_wanted(client.get_missing)
     cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
@@ -362,12 +406,13 @@ async def fetch_reconcile_sets(client: SonarrClient, instance: Instance) -> Reco
     cutoff_set = _episode_leaf_pairs(cutoff_items)
     if instance.sonarr_search_mode != SonarrSearchMode.episode:
         missing_set = missing_set | _season_synth_pairs(missing_items)
-    upgrade_candidates = [
-        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
-    ]
-    upgrade_set: frozenset[tuple[str, int]] = frozenset(
-        (str(c.item_type), c.item_id) for c in upgrade_candidates
-    )
+    upgrade_set: frozenset[tuple[str, int]] = frozenset()
+    if instance.upgrade_enabled:
+        upgrade_candidates = [
+            adapt_upgrade(item, instance)
+            for item in await _fetch_all_upgrade_episodes(client, instance)
+        ]
+        upgrade_set = frozenset((str(c.item_type), c.item_id) for c in upgrade_candidates)
     return ReconcileSets(missing=missing_set, cutoff=cutoff_set, upgrade=upgrade_set)
 
 

--- a/src/houndarr/engine/adapters/whisparr_v2.py
+++ b/src/houndarr/engine/adapters/whisparr_v2.py
@@ -12,12 +12,14 @@ with Sonarr), and episode labels omit ``episodeNumber`` (absent in Whisparr).
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import httpx
 from pydantic import ValidationError
 
+from houndarr.clients._wire_models import ArrSeries
 from houndarr.clients.base import ReconcileSets
 from houndarr.clients.whisparr_v2 import (
     LibraryWhisparrEpisode,
@@ -239,6 +241,35 @@ def adapt_upgrade(
     )
 
 
+async def _collect_upgrade_episodes(
+    client: WhisparrClient,
+    instance: Instance,
+    series_list: Sequence[ArrSeries],
+) -> list[LibraryWhisparrEpisode]:
+    """Return monitored, on-disk, cutoff-met episodes for the given series.
+
+    Shared loop body between the rotation-windowed search-cycle fetch
+    (:func:`fetch_upgrade_pool`) and the full-library reconcile fetch
+    (:func:`_fetch_all_upgrade_episodes`).  Transport or validation
+    errors on a single series are logged and skipped so one flaky
+    series cannot blank the whole pool.
+    """
+    episodes: list[LibraryWhisparrEpisode] = []
+    for s in series_list:
+        series_id = s.id or 0
+        try:
+            eps = await client.get_episodes(series_id)
+        except (httpx.HTTPError, httpx.InvalidURL, ValidationError):
+            logger.warning(
+                "[%s] failed to fetch episodes for series %d, skipping",
+                instance.name,
+                series_id,
+            )
+            continue
+        episodes.extend(e for e in eps if e.monitored and e.has_file and e.cutoff_met)
+    return episodes
+
+
 async def fetch_upgrade_pool(
     client: WhisparrClient,
     instance: Instance,
@@ -270,21 +301,28 @@ async def fetch_upgrade_pool(
         remaining = _UPGRADE_MAX_SERIES_PER_CYCLE - len(selected)
         selected += monitored[:remaining]
 
-    episodes: list[LibraryWhisparrEpisode] = []
-    for s in selected:
-        series_id = s.id or 0
-        try:
-            eps = await client.get_episodes(series_id)
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "[%s] failed to fetch episodes for series %d, skipping",
-                instance.name,
-                series_id,
-            )
-            continue
-        episodes.extend(e for e in eps if e.monitored and e.has_file and e.cutoff_met)
+    return await _collect_upgrade_episodes(client, instance, selected)
 
-    return episodes
+
+async def _fetch_all_upgrade_episodes(
+    client: WhisparrClient,
+    instance: Instance,
+) -> list[LibraryWhisparrEpisode]:
+    """Return upgrade-eligible episodes across EVERY monitored series.
+
+    The cycle-facing :func:`fetch_upgrade_pool` windows the series list
+    via ``upgrade_series_offset`` for per-cycle politeness.  Reconcile
+    cannot use that window: anything outside the current slice would
+    be flagged as an orphan and deleted on the next snapshot refresh,
+    collapsing ``upgrade_cooldown_days`` to one rotation period.  This
+    helper walks every monitored series so the reconcile upgrade set
+    matches the universe :func:`adapt_upgrade` could legitimately
+    stamp.  The N extra episode fetches are amortised across the
+    10-minute supervisor cadence.
+    """
+    all_series = await client.get_series()
+    monitored = [s for s in all_series if s.monitored]
+    return await _collect_upgrade_episodes(client, instance, monitored)
 
 
 async def dispatch_search(client: WhisparrClient, candidate: SearchCandidate) -> None:
@@ -349,7 +387,12 @@ async def fetch_reconcile_sets(client: WhisparrClient, instance: Instance) -> Re
     Mirrors the Sonarr implementation but uses the
     ``whisparr_episode`` item_type.  In ``season_context`` missing-pass
     mode, synthetic negative season ids derived from the same wanted
-    list are unioned in.  Cutoff cooldowns stay leaf-only.
+    list are unioned in.  Cutoff cooldowns stay leaf-only.  The
+    upgrade set walks the FULL monitored library via
+    :func:`_fetch_all_upgrade_episodes` rather than the cycle-rotation
+    window so ``upgrade_cooldown_days`` is not silently collapsed to
+    one rotation period.  An upgrade-disabled instance short-circuits
+    to an empty upgrade set so no library traffic is paid.
     """
     missing_items = await paginate_wanted(client.get_missing)
     cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
@@ -357,12 +400,13 @@ async def fetch_reconcile_sets(client: WhisparrClient, instance: Instance) -> Re
     cutoff_set = _whisparr_leaf_pairs(cutoff_items)
     if instance.whisparr_search_mode != WhisparrSearchMode.episode:
         missing_set = missing_set | _whisparr_season_synth_pairs(missing_items)
-    upgrade_candidates = [
-        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
-    ]
-    upgrade_set: frozenset[tuple[str, int]] = frozenset(
-        (str(c.item_type), c.item_id) for c in upgrade_candidates
-    )
+    upgrade_set: frozenset[tuple[str, int]] = frozenset()
+    if instance.upgrade_enabled:
+        upgrade_candidates = [
+            adapt_upgrade(item, instance)
+            for item in await _fetch_all_upgrade_episodes(client, instance)
+        ]
+        upgrade_set = frozenset((str(c.item_type), c.item_id) for c in upgrade_candidates)
     return ReconcileSets(missing=missing_set, cutoff=cutoff_set, upgrade=upgrade_set)
 
 

--- a/src/houndarr/engine/adapters/whisparr_v2.py
+++ b/src/houndarr/engine/adapters/whisparr_v2.py
@@ -15,6 +15,10 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import httpx
+from pydantic import ValidationError
+
+from houndarr.clients.base import ReconcileSets
 from houndarr.clients.whisparr_v2 import (
     LibraryWhisparrEpisode,
     MissingWhisparrEpisode,
@@ -24,6 +28,7 @@ from houndarr.engine.adapters._common import (
     ContextOverride,
     build_cutoff_candidate,
     build_missing_candidate,
+    paginate_wanted,
 )
 from houndarr.engine.candidates import SearchCandidate
 from houndarr.services.instances import Instance, WhisparrSearchMode
@@ -317,6 +322,52 @@ def make_client(instance: Instance) -> WhisparrClient:
     return WhisparrClient(url=instance.url, api_key=instance.api_key)
 
 
+def _whisparr_leaf_pairs(items: list[MissingWhisparrEpisode]) -> frozenset[tuple[str, int]]:
+    """Return ``(item_type, episode_id)`` pairs for a wanted list.
+
+    Whisparr v2 stamps cooldowns with ``item_type="whisparr_episode"``
+    to distinguish them from Sonarr episodes that share the same
+    numeric id space.
+    """
+    return frozenset(("whisparr_episode", it.episode_id) for it in items if it.episode_id)
+
+
+def _whisparr_season_synth_pairs(
+    items: list[MissingWhisparrEpisode],
+) -> frozenset[tuple[str, int]]:
+    """Return synthetic season-context pairs for Whisparr v2 cooldowns."""
+    parents: set[tuple[int, int]] = set()
+    for it in items:
+        if it.series_id is not None and it.series_id > 0 and it.season_number > 0:
+            parents.add((it.series_id, it.season_number))
+    return frozenset(
+        ("whisparr_episode", _season_item_id(sid, sn)) for sid, sn in parents
+    )
+
+
+async def fetch_reconcile_sets(client: WhisparrClient, instance: Instance) -> ReconcileSets:
+    """Return the authoritative wanted / upgrade-pool sets for Whisparr v2.
+
+    Mirrors the Sonarr implementation but uses the
+    ``whisparr_episode`` item_type.  In ``season_context`` missing-pass
+    mode, synthetic negative season ids derived from the same wanted
+    list are unioned in.  Cutoff cooldowns stay leaf-only.
+    """
+    missing_items = await paginate_wanted(client.get_missing)
+    cutoff_items = await paginate_wanted(client.get_cutoff_unmet)
+    missing_set = _whisparr_leaf_pairs(missing_items)
+    cutoff_set = _whisparr_leaf_pairs(cutoff_items)
+    if instance.whisparr_search_mode != WhisparrSearchMode.episode:
+        missing_set = missing_set | _whisparr_season_synth_pairs(missing_items)
+    upgrade_candidates = [
+        adapt_upgrade(item, instance) for item in await fetch_upgrade_pool(client, instance)
+    ]
+    upgrade_set: frozenset[tuple[str, int]] = frozenset(
+        (str(c.item_type), c.item_id) for c in upgrade_candidates
+    )
+    return ReconcileSets(missing=missing_set, cutoff=cutoff_set, upgrade=upgrade_set)
+
+
 class WhisparrV2Adapter:
     """Class-form Whisparr v2 adapter for the :data:`ADAPTERS` registry.
 
@@ -333,3 +384,4 @@ class WhisparrV2Adapter:
     fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
     dispatch_search = staticmethod(dispatch_search)
     make_client = staticmethod(make_client)
+    fetch_reconcile_sets = staticmethod(fetch_reconcile_sets)

--- a/src/houndarr/engine/adapters/whisparr_v2.py
+++ b/src/houndarr/engine/adapters/whisparr_v2.py
@@ -340,9 +340,7 @@ def _whisparr_season_synth_pairs(
     for it in items:
         if it.series_id is not None and it.series_id > 0 and it.season_number > 0:
             parents.add((it.series_id, it.season_number))
-    return frozenset(
-        ("whisparr_episode", _season_item_id(sid, sn)) for sid, sn in parents
-    )
+    return frozenset(("whisparr_episode", _season_item_id(sid, sn)) for sid, sn in parents)
 
 
 async def fetch_reconcile_sets(client: WhisparrClient, instance: Instance) -> ReconcileSets:

--- a/src/houndarr/engine/adapters/whisparr_v3.py
+++ b/src/houndarr/engine/adapters/whisparr_v3.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+from houndarr.clients.base import ReconcileSets
 from houndarr.clients.whisparr_v3 import (
     LibraryWhisparrV3Movie,
     MissingWhisparrV3Movie,
@@ -191,6 +192,40 @@ def make_client(instance: Instance) -> WhisparrV3Client:
     return WhisparrV3Client(url=instance.url, api_key=instance.api_key)
 
 
+async def fetch_reconcile_sets(
+    client: WhisparrV3Client,
+    instance: Instance,  # noqa: ARG001
+) -> ReconcileSets:
+    """Return the authoritative wanted / upgrade-pool sets for Whisparr v3.
+
+    Whisparr v3 has no ``/wanted`` endpoint; the client already caches
+    the full ``/api/v3/movie`` response for the whole lifetime of one
+    client context.  Read that cache three ways to build the sets
+    without additional network calls: missing = monitored without
+    file; cutoff = monitored with file but cutoff-unmet; upgrade =
+    monitored with file and cutoff-met.  There is no context-mode
+    variant to handle.
+    """
+    library = await client.get_library()
+    missing_ids: set[int] = set()
+    cutoff_ids: set[int] = set()
+    upgrade_ids: set[int] = set()
+    for movie in library:
+        if not movie.monitored:
+            continue
+        if not movie.has_file:
+            missing_ids.add(movie.movie_id)
+        elif not movie.cutoff_met:
+            cutoff_ids.add(movie.movie_id)
+        else:
+            upgrade_ids.add(movie.movie_id)
+    return ReconcileSets(
+        missing=frozenset(("whisparr_v3_movie", mid) for mid in missing_ids),
+        cutoff=frozenset(("whisparr_v3_movie", mid) for mid in cutoff_ids),
+        upgrade=frozenset(("whisparr_v3_movie", mid) for mid in upgrade_ids),
+    )
+
+
 class WhisparrV3Adapter:
     """Class-form Whisparr v3 adapter for the :data:`ADAPTERS` registry.
 
@@ -207,3 +242,4 @@ class WhisparrV3Adapter:
     fetch_upgrade_pool = staticmethod(fetch_upgrade_pool)
     dispatch_search = staticmethod(dispatch_search)
     make_client = staticmethod(make_client)
+    fetch_reconcile_sets = staticmethod(fetch_reconcile_sets)

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -418,7 +418,12 @@ async def _run_search_pass(  # noqa: C901
                             )
                             continue
 
-                        await record_search(instance.id, candidate.item_id, candidate.item_type)
+                        await record_search(
+                            instance.id,
+                            candidate.item_id,
+                            candidate.item_type,
+                            search_kind,
+                        )
                         await _write_log(
                             instance.id,
                             candidate.item_id,
@@ -489,7 +494,12 @@ async def _run_search_pass(  # noqa: C901
                 )
                 continue
 
-            await record_search(instance.id, candidate.item_id, candidate.item_type)
+            await record_search(
+                instance.id,
+                candidate.item_id,
+                candidate.item_type,
+                search_kind,
+            )
             await _write_log(
                 instance.id,
                 candidate.item_id,
@@ -722,7 +732,12 @@ async def _run_upgrade_pass(
             new_offset = (offset + scanned) % len(pool)
             continue
 
-        await record_search(instance.id, candidate.item_id, candidate.item_type)
+        await record_search(
+            instance.id,
+            candidate.item_id,
+            candidate.item_type,
+            "upgrade",
+        )
         await _write_log(
             instance.id,
             candidate.item_id,

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -17,11 +17,13 @@ from uuid import uuid4
 
 import httpx
 
+from houndarr.clients.base import ReconcileSets
 from houndarr.database import get_db
 from houndarr.engine.adapters import get_adapter
 from houndarr.engine.retry import ReconnectState, run_with_reconnect
 from houndarr.engine.search_loop import _write_log, run_instance_search
 from houndarr.enums import CycleTrigger, SearchAction
+from houndarr.services.cooldown_reconcile import reconcile_cooldowns
 from houndarr.services.instances import (
     Instance,
     get_instance,
@@ -409,6 +411,18 @@ class Supervisor:
         dashboard counters land in the next status poll instead of
         sitting at zero until the 10-minute loop wakes. Skips disabled
         instances and treats transport errors as soft failures.
+
+        Also reconciles the ``cooldowns`` table for this instance
+        against the authoritative wanted / upgrade-pool sets returned
+        by the adapter.  Cooldown rows for items that have left the
+        *arr's wanted state (downloaded, unmonitored, deleted,
+        cutoff-met) are deleted in the same round-trip so the
+        dashboard breakdown reflects live reality instead of
+        historical search dispatches that no longer bind.  An adapter
+        failure anywhere in the reconcile fetch causes the reconcile
+        step to skip (the :meth:`ReconcileSets.empty` sentinel path),
+        preserving existing rows rather than risking a wipe on a
+        transient *arr blip.
         """
         if not instance.enabled:
             return
@@ -418,6 +432,22 @@ class Supervisor:
                 adapter = get_adapter(instance.type)
                 async with adapter.make_client(instance) as client:
                     snap = await client.get_instance_snapshot()
+                    try:
+                        reconcile_sets = await adapter.fetch_reconcile_sets(client, instance)
+                    except httpx.TransportError:
+                        reconcile_sets = ReconcileSets.empty()
+                        logger.debug(
+                            "Supervisor: reconcile sets unreachable for %r; "
+                            "keeping existing cooldowns.",
+                            instance.name,
+                        )
+                    except Exception:  # noqa: BLE001
+                        reconcile_sets = ReconcileSets.empty()
+                        logger.exception(
+                            "Supervisor: reconcile fetch failed for %r; "
+                            "keeping existing cooldowns.",
+                            instance.name,
+                        )
                 # Surface a one-line INFO when the unreleased count
                 # jumps non-trivially.  The first refresh after a user
                 # upgrade flips every non-Whisparr-v3 instance from 0
@@ -442,6 +472,7 @@ class Supervisor:
                     monitored_total=snap.monitored_total,
                     unreleased_count=snap.unreleased_count,
                 )
+                await reconcile_cooldowns(instance.id, reconcile_sets)
             except httpx.TransportError:
                 logger.debug(
                     "Supervisor: snapshot refresh skipped for %r; instance unreachable",

--- a/src/houndarr/services/cooldown.py
+++ b/src/houndarr/services/cooldown.py
@@ -70,6 +70,7 @@ async def record_search(
     instance_id: int,
     item_id: int,
     item_type: ItemType | str,
+    search_kind: str = "missing",
 ) -> None:
     """Upsert a cooldown record for *item_id* with the current UTC timestamp.
 
@@ -80,17 +81,24 @@ async def record_search(
         instance_id: Owning instance primary key.
         item_id: Item identifier (e.g. episode, movie, album, or book ID).
         item_type: ``"episode"``, ``"movie"``, ``"album"``, ``"book"``, or ``"whisparr_episode"``.
+        search_kind: Which pass dispatched the search: ``"missing"``,
+            ``"cutoff"``, or ``"upgrade"``.  Stamped on the cooldown
+            row so the dashboard breakdown and the reconciliation path
+            both read it from the column instead of re-classifying via
+            ``search_log``.  Defaults to ``"missing"`` to keep older
+            seed fixtures working.
     """
     now = _iso(_now_utc())
     async with get_db() as db:
         await db.execute(
             """
-            INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at, search_kind)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(instance_id, item_id, item_type)
-            DO UPDATE SET searched_at = excluded.searched_at
+            DO UPDATE SET searched_at = excluded.searched_at,
+                          search_kind = excluded.search_kind
             """,
-            (instance_id, item_id, item_type, now),
+            (instance_id, item_id, item_type, now, search_kind),
         )
         await db.commit()
 
@@ -125,9 +133,9 @@ async def is_on_cooldown_ref(ref: ItemRef, cooldown_days: int) -> bool:
     return await is_on_cooldown(ref.instance_id, ref.item_id, ref.item_type, cooldown_days)
 
 
-async def record_search_ref(ref: ItemRef) -> None:
+async def record_search_ref(ref: ItemRef, search_kind: str) -> None:
     """ItemRef-accepting overload of :func:`record_search`."""
-    await record_search(ref.instance_id, ref.item_id, ref.item_type)
+    await record_search(ref.instance_id, ref.item_id, ref.item_type, search_kind)
 
 
 async def clear_cooldowns(instance_id: int) -> int:

--- a/src/houndarr/services/cooldown_reconcile.py
+++ b/src/houndarr/services/cooldown_reconcile.py
@@ -1,0 +1,116 @@
+"""Cooldown reconciliation against the *arr's live wanted sets.
+
+A cooldown row is an operational decision made at dispatch time: Houndarr
+just searched item X, so pause it for ``cooldown_days``.  That decision
+remains valid only while the item is still something the *arr cares
+about.  Items leave the *arr's wanted / upgrade-pool state for several
+reasons: a download finished, the user unmonitored or deleted it, a file
+crossed the quality cutoff, a series / artist / author was removed.  The
+``cooldowns`` table never saw any of those events, so rows pile up and
+inflate the dashboard's ``cooldown_breakdown``, driving Eligible below
+its true value at the rollup scope.
+
+This module reconciles that drift.  For each instance the supervisor
+asks the adapter for the authoritative
+:class:`~houndarr.clients.base.ReconcileSets` (leaf ids + synthetic
+parent ids for context modes) at snapshot-refresh cadence, and this
+function deletes every cooldown row whose ``(item_type, item_id)`` does
+not appear in the matching ``search_kind`` set.  An empty
+:class:`ReconcileSets` (e.g. a mid-fetch failure) is a hard skip: never
+drive the DB to an empty state from an unreliable source.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from houndarr.clients.base import ReconcileSets
+from houndarr.database import get_db
+
+logger = logging.getLogger(__name__)
+
+
+async def reconcile_cooldowns(instance_id: int, sets: ReconcileSets) -> int:
+    """Delete cooldown rows for *instance_id* not present in *sets*.
+
+    Reads every cooldown row for the instance in one SELECT, filters
+    in Python (cooldown tables are typically <5K rows per instance, so
+    the set intersection is trivially fast), and DELETEs the
+    non-matching rows in one batch.  Returns the count of rows removed
+    for the supervisor to log.
+
+    Args:
+        instance_id: Primary key of the instance whose cooldowns should
+            be reconciled.
+        sets: Authoritative ``(item_type, item_id)`` sets per
+            ``search_kind`` bucket.  Produced by the adapter's
+            ``fetch_reconcile_sets`` method.  An empty sets object
+            (every bucket empty) is treated as an explicit skip so a
+            mid-fetch failure never wipes the table.
+
+    Returns:
+        Number of cooldown rows deleted.  Zero is the expected steady
+        state on a healthy install.
+    """
+    if sets.is_empty():
+        logger.debug(
+            "cooldown reconcile skipped for instance %d: empty reconcile sets",
+            instance_id,
+        )
+        return 0
+
+    # Pull every cooldown row for the instance, classify each by its
+    # stamped search_kind, and compare (item_type, item_id) against
+    # the matching pass's wanted set.  Rows with an unrecognised
+    # search_kind keep the column CHECK honest and are skipped from
+    # reconciliation (they should never exist; defensive only).
+    stale: list[int] = []
+    async with get_db() as db:
+        async with db.execute(
+            """
+            SELECT id, item_type, item_id, search_kind
+              FROM cooldowns
+             WHERE instance_id = ?
+            """,
+            (instance_id,),
+        ) as cur:
+            rows = list(await cur.fetchall())
+
+        valid_by_kind = {
+            "missing": sets.missing,
+            "cutoff": sets.cutoff,
+            "upgrade": sets.upgrade,
+        }
+        for row in rows:
+            kind = str(row["search_kind"]) if row["search_kind"] else "missing"
+            valid = valid_by_kind.get(kind)
+            if valid is None:
+                continue
+            key = (str(row["item_type"]), int(row["item_id"]))
+            if key not in valid:
+                stale.append(int(row["id"]))
+
+        if not stale:
+            return 0
+
+        # Delete stale rows in a single parameter-safe batch.  The
+        # placeholder list is sized to the stale list so SQLite's
+        # per-statement parameter limit (999 by default) is respected;
+        # chunks of 500 stay well inside that bound.
+        batch_size = 500
+        for chunk_start in range(0, len(stale), batch_size):
+            chunk = stale[chunk_start : chunk_start + batch_size]
+            placeholders = ",".join("?" for _ in chunk)
+            await db.execute(
+                f"DELETE FROM cooldowns WHERE id IN ({placeholders})",  # noqa: S608  # nosec B608
+                chunk,
+            )
+        await db.commit()
+
+    logger.info(
+        "reconciled cooldowns for instance %d: removed %d stale row(s) out of %d total",
+        instance_id,
+        len(stale),
+        len(rows),
+    )
+    return len(stale)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,7 +29,7 @@ async def test_schema_created(db: None) -> None:
 async def test_schema_version_set(db: None) -> None:
     """Schema version should be set after init."""
     version = await get_setting("schema_version")
-    assert version == "13"
+    assert version == "14"
 
 
 @pytest.mark.asyncio()
@@ -110,7 +110,7 @@ async def test_init_db_migrates_v1_schema_to_v3(tmp_path: Path) -> None:
         search_log_columns = {row[1] async for row in search_log_cur}
         instance_columns = {row[1] async for row in instances_cur}
 
-    assert await get_setting("schema_version") == "13"
+    assert await get_setting("schema_version") == "14"
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
     assert "cycle_id" in search_log_columns
@@ -179,7 +179,7 @@ async def test_init_db_migrates_v2_schema_to_v4(tmp_path: Path) -> None:
         async with conn.execute("PRAGMA table_info(search_log)") as cur:
             search_log_columns = {row[1] async for row in cur}
 
-    assert await get_setting("schema_version") == "13"
+    assert await get_setting("schema_version") == "14"
     assert "cycle_id" in search_log_columns
     assert "cycle_trigger" in search_log_columns
 
@@ -246,7 +246,7 @@ async def test_init_db_migrates_v3_schema_to_v4(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "13"
+    assert await get_setting("schema_version") == "14"
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
             instance_columns = {row[1] async for row in cur}
@@ -329,7 +329,7 @@ async def test_init_db_migrates_v4_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "13"
+    assert await get_setting("schema_version") == "14"
 
     async with get_db() as conn:
         # Verify new columns exist
@@ -463,7 +463,7 @@ async def test_init_db_migrates_v5_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "13"
+    assert await get_setting("schema_version") == "14"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -560,7 +560,7 @@ async def test_init_db_migrates_v6_schema_to_v7(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "13"
+    assert await get_setting("schema_version") == "14"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -673,7 +673,7 @@ async def test_init_db_self_heals_v9_and_v10_when_version_already_current(
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "13"
+    assert await get_setting("schema_version") == "14"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -814,7 +814,7 @@ async def test_init_db_is_idempotent_on_healthy_v12(tmp_path: Path) -> None:
 
     # Second call: should be a no-op through the self-heal branch.
     await init_db()
-    assert await get_setting("schema_version") == first_version == "13"
+    assert await get_setting("schema_version") == first_version == "14"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -909,7 +909,7 @@ async def test_migrate_to_v12_adds_search_order_column(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "13"
+    assert await get_setting("schema_version") == "14"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,7 +29,7 @@ async def test_schema_created(db: None) -> None:
 async def test_schema_version_set(db: None) -> None:
     """Schema version should be set after init."""
     version = await get_setting("schema_version")
-    assert version == "14"
+    assert version == "15"
 
 
 @pytest.mark.asyncio()
@@ -110,7 +110,7 @@ async def test_init_db_migrates_v1_schema_to_v3(tmp_path: Path) -> None:
         search_log_columns = {row[1] async for row in search_log_cur}
         instance_columns = {row[1] async for row in instances_cur}
 
-    assert await get_setting("schema_version") == "14"
+    assert await get_setting("schema_version") == "15"
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
     assert "cycle_id" in search_log_columns
@@ -179,7 +179,7 @@ async def test_init_db_migrates_v2_schema_to_v4(tmp_path: Path) -> None:
         async with conn.execute("PRAGMA table_info(search_log)") as cur:
             search_log_columns = {row[1] async for row in cur}
 
-    assert await get_setting("schema_version") == "14"
+    assert await get_setting("schema_version") == "15"
     assert "cycle_id" in search_log_columns
     assert "cycle_trigger" in search_log_columns
 
@@ -246,7 +246,7 @@ async def test_init_db_migrates_v3_schema_to_v4(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "14"
+    assert await get_setting("schema_version") == "15"
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
             instance_columns = {row[1] async for row in cur}
@@ -329,7 +329,7 @@ async def test_init_db_migrates_v4_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "14"
+    assert await get_setting("schema_version") == "15"
 
     async with get_db() as conn:
         # Verify new columns exist
@@ -463,7 +463,7 @@ async def test_init_db_migrates_v5_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "14"
+    assert await get_setting("schema_version") == "15"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -560,7 +560,7 @@ async def test_init_db_migrates_v6_schema_to_v7(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "14"
+    assert await get_setting("schema_version") == "15"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -673,7 +673,7 @@ async def test_init_db_self_heals_v9_and_v10_when_version_already_current(
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "14"
+    assert await get_setting("schema_version") == "15"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -814,7 +814,7 @@ async def test_init_db_is_idempotent_on_healthy_v12(tmp_path: Path) -> None:
 
     # Second call: should be a no-op through the self-heal branch.
     await init_db()
-    assert await get_setting("schema_version") == first_version == "14"
+    assert await get_setting("schema_version") == first_version == "15"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -909,7 +909,7 @@ async def test_migrate_to_v12_adds_search_order_column(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "14"
+    assert await get_setting("schema_version") == "15"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -922,6 +922,150 @@ async def test_migrate_to_v12_adds_search_order_column(tmp_path: Path) -> None:
             row = await cur.fetchone()
         assert row is not None
         assert row[0] == "chronological"
+
+
+@pytest.mark.asyncio()
+async def test_cooldowns_search_kind_check_enforced(db: None) -> None:  # noqa: ARG001
+    """Every initialised DB rejects search_kind values outside the CHECK.
+
+    Fresh installs pick this up from ``_SCHEMA_SQL``; databases that
+    migrated through v14 used to silently accept any string (SQLite
+    cannot attach a CHECK via ALTER TABLE ADD COLUMN).  v15 rebuilds
+    the table so the invariant holds everywhere.
+    """
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+            " VALUES (1, 'Sonarr', 'sonarr', 'http://sonarr:8989', 'fake-key')"
+        )
+        await conn.commit()
+
+        with pytest.raises(aiosqlite.IntegrityError):
+            await conn.execute(
+                "INSERT INTO cooldowns"
+                " (instance_id, item_id, item_type, search_kind, searched_at)"
+                " VALUES (1, 999, 'episode', 'not_a_kind', '2024-01-01T00:00:00.000Z')"
+            )
+
+
+@pytest.mark.asyncio()
+async def test_migrate_to_v15_coerces_invalid_search_kind(tmp_path: Path) -> None:
+    """Pre-existing rows with an invalid ``search_kind`` are coerced to
+    ``'missing'`` during the v14→v15 rebuild so the new CHECK does not
+    reject them.  The app itself never writes a bad kind, but a
+    corrupted snapshot or a hand-edited DB might; the defensive CASE
+    in the INSERT SELECT keeps the rebuild from failing."""
+    db_path = tmp_path / "migrate-v14-to-v15.db"
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        # Minimal v14-shaped schema.  The v9-v12 self-heal migrations
+        # only run when their target columns are absent, so the
+        # instances table must already carry every post-v8 column; we
+        # mirror the v12-test's full column list below.
+        await conn.executescript(
+            """
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO settings (key, value) VALUES ('schema_version', '14');
+
+            CREATE TABLE instances (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL CHECK(type IN (
+                    'radarr','sonarr','lidarr','readarr','whisparr_v2','whisparr_v3'
+                )),
+                url TEXT NOT NULL,
+                encrypted_api_key TEXT NOT NULL DEFAULT '',
+                batch_size INTEGER NOT NULL DEFAULT 2,
+                sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+                hourly_cap INTEGER NOT NULL DEFAULT 4,
+                cooldown_days INTEGER NOT NULL DEFAULT 14,
+                post_release_grace_hrs INTEGER NOT NULL DEFAULT 6,
+                queue_limit INTEGER NOT NULL DEFAULT 0,
+                cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+                cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+                cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+                cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+                sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+                readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+                whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_enabled INTEGER NOT NULL DEFAULT 0,
+                upgrade_batch_size INTEGER NOT NULL DEFAULT 1,
+                upgrade_cooldown_days INTEGER NOT NULL DEFAULT 90,
+                upgrade_hourly_cap INTEGER NOT NULL DEFAULT 1,
+                upgrade_sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+                upgrade_readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+                upgrade_whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+                upgrade_item_offset INTEGER NOT NULL DEFAULT 0,
+                upgrade_series_offset INTEGER NOT NULL DEFAULT 0,
+                missing_page_offset INTEGER NOT NULL DEFAULT 1,
+                cutoff_page_offset INTEGER NOT NULL DEFAULT 1,
+                allowed_time_window TEXT NOT NULL DEFAULT '',
+                search_order TEXT NOT NULL DEFAULT 'chronological',
+                monitored_total INTEGER NOT NULL DEFAULT 0,
+                unreleased_count INTEGER NOT NULL DEFAULT 0,
+                snapshot_refreshed_at TEXT NOT NULL DEFAULT '',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z',
+                updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+            );
+
+            CREATE TABLE cooldowns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER NOT NULL
+                    REFERENCES instances(id) ON DELETE CASCADE,
+                item_id INTEGER NOT NULL,
+                item_type TEXT NOT NULL,
+                search_kind TEXT NOT NULL DEFAULT 'missing',
+                searched_at TEXT NOT NULL,
+                UNIQUE(instance_id, item_id, item_type)
+            );
+
+            CREATE TABLE search_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER,
+                item_id INTEGER,
+                item_type TEXT,
+                search_kind TEXT,
+                cycle_id TEXT,
+                cycle_trigger TEXT,
+                item_label TEXT,
+                action TEXT NOT NULL,
+                reason TEXT,
+                message TEXT,
+                timestamp TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+            );
+
+            INSERT INTO instances (id, name, type, url)
+            VALUES (1, 'Sonarr', 'sonarr', 'http://sonarr:8989');
+
+            INSERT INTO cooldowns (instance_id, item_id, item_type, search_kind, searched_at)
+            VALUES (1, 100, 'episode', 'missing', '2024-01-01T00:00:00.000Z'),
+                   (1, 101, 'episode', 'cutoff',  '2024-01-01T00:00:00.000Z'),
+                   (1, 102, 'episode', 'upgrade', '2024-01-01T00:00:00.000Z'),
+                   (1, 103, 'episode', 'BOGUS',   '2024-01-01T00:00:00.000Z');
+            """
+        )
+        await conn.commit()
+
+    set_db_path(str(db_path))
+    await init_db()
+
+    assert await get_setting("schema_version") == "15"
+
+    async with get_db() as conn:
+        await conn.execute("PRAGMA foreign_keys=ON")
+        async with conn.execute(
+            "SELECT item_id, search_kind FROM cooldowns ORDER BY item_id"
+        ) as cur:
+            rows = [(int(r[0]), str(r[1])) async for r in cur]
+        assert rows == [
+            (100, "missing"),
+            (101, "cutoff"),
+            (102, "upgrade"),
+            (103, "missing"),
+        ]
 
 
 @pytest.mark.asyncio()

--- a/tests/test_engine/test_adapters/test_sonarr_adapter.py
+++ b/tests/test_engine/test_adapters/test_sonarr_adapter.py
@@ -7,7 +7,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from houndarr.clients.sonarr import MissingEpisode, SonarrClient
+from houndarr.clients._wire_models import ArrSeries
+from houndarr.clients.sonarr import LibraryEpisode, MissingEpisode, SonarrClient
 from houndarr.engine.adapters.sonarr import (
     _episode_label,
     _season_context_label,
@@ -15,6 +16,7 @@ from houndarr.engine.adapters.sonarr import (
     adapt_cutoff,
     adapt_missing,
     dispatch_search,
+    fetch_reconcile_sets,
     make_client,
 )
 from houndarr.engine.candidates import SearchCandidate
@@ -349,3 +351,97 @@ class TestMakeClient:
         instance = _make_instance()
         client = make_client(instance)
         assert isinstance(client, SonarrClient)
+
+
+# ---------------------------------------------------------------------------
+# fetch_reconcile_sets
+# ---------------------------------------------------------------------------
+
+
+def _make_library_episode(
+    *,
+    episode_id: int,
+    series_id: int,
+    season: int = 1,
+    episode: int = 1,
+    monitored: bool = True,
+    has_file: bool = True,
+    cutoff_met: bool = True,
+) -> LibraryEpisode:
+    return LibraryEpisode(
+        episode_id=episode_id,
+        series_id=series_id,
+        series_title=f"Series {series_id}",
+        episode_title=f"Ep {episode_id}",
+        season=season,
+        episode=episode,
+        monitored=monitored,
+        has_file=has_file,
+        cutoff_met=cutoff_met,
+    )
+
+
+class TestFetchReconcileSetsUpgrade:
+    """Verify the upgrade bucket covers the FULL monitored library.
+
+    Regression pin for the rotation-window bug: the cycle-facing
+    ``fetch_upgrade_pool`` deliberately windows the series list via
+    ``upgrade_series_offset`` so per-cycle indexer traffic stays
+    polite.  Reconcile cannot use that window because anything
+    outside the current 5-series slice would then be flagged as an
+    orphan and deleted on the next snapshot refresh, silently
+    collapsing ``upgrade_cooldown_days`` to one rotation period.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_upgrade_set_covers_every_monitored_series(self):
+        """With 10 monitored series (rotation window = 5), the upgrade
+        set must contain episodes from all 10, not just the windowed
+        slice."""
+        series_count = 10
+        series_list = [
+            ArrSeries(id=sid, title=f"Series {sid}", monitored=True)
+            for sid in range(1, series_count + 1)
+        ]
+        episodes_by_series = {
+            sid: [_make_library_episode(episode_id=sid * 100, series_id=sid)]
+            for sid in range(1, series_count + 1)
+        }
+
+        client = AsyncMock(spec=SonarrClient)
+        client.get_missing.return_value = []
+        client.get_cutoff_unmet.return_value = []
+        client.get_series.return_value = series_list
+        client.get_episodes.side_effect = lambda series_id: episodes_by_series[series_id]
+
+        instance = _make_instance()
+        instance_with_upgrade = Instance(
+            core=instance.core,
+            missing=instance.missing,
+            cutoff=instance.cutoff,
+            upgrade=UpgradePolicy(upgrade_enabled=True, upgrade_series_offset=0),
+            schedule=instance.schedule,
+            snapshot=instance.snapshot,
+            timestamps=instance.timestamps,
+        )
+
+        sets = await fetch_reconcile_sets(client, instance_with_upgrade)
+
+        expected = frozenset(("episode", sid * 100) for sid in range(1, series_count + 1))
+        assert sets.upgrade == expected
+
+    @pytest.mark.asyncio()
+    async def test_upgrade_disabled_skips_library_fetch(self):
+        """Upgrade-disabled instance returns an empty upgrade set and
+        never touches the ``/series`` endpoint."""
+        client = AsyncMock(spec=SonarrClient)
+        client.get_missing.return_value = []
+        client.get_cutoff_unmet.return_value = []
+
+        instance = _make_instance()  # UpgradePolicy() defaults to upgrade_enabled=False
+
+        sets = await fetch_reconcile_sets(client, instance)
+
+        assert sets.upgrade == frozenset()
+        client.get_series.assert_not_called()
+        client.get_episodes.assert_not_called()

--- a/tests/test_engine/test_adapters/test_sonarr_adapter.py
+++ b/tests/test_engine/test_adapters/test_sonarr_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
@@ -415,14 +416,10 @@ class TestFetchReconcileSetsUpgrade:
         client.get_episodes.side_effect = lambda series_id: episodes_by_series[series_id]
 
         instance = _make_instance()
-        instance_with_upgrade = Instance(
-            core=instance.core,
-            missing=instance.missing,
-            cutoff=instance.cutoff,
-            upgrade=UpgradePolicy(upgrade_enabled=True, upgrade_series_offset=0),
-            schedule=instance.schedule,
-            snapshot=instance.snapshot,
-            timestamps=instance.timestamps,
+        instance_with_upgrade = replace(
+            instance,
+            upgrade_enabled=True,
+            upgrade_series_offset=0,
         )
 
         sets = await fetch_reconcile_sets(client, instance_with_upgrade)

--- a/tests/test_services/test_cooldown_reconcile.py
+++ b/tests/test_services/test_cooldown_reconcile.py
@@ -30,8 +30,7 @@ async def seeded_instance(db: None) -> AsyncGenerator[None, None]:  # noqa: ARG0
     """Seed one instance row so cooldowns FKs resolve."""
     async with get_db() as conn:
         await conn.execute(
-            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
-            " VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
             (1, "Sonarr Test", "sonarr", "http://sonarr:8989", _ENC_KEY),
         )
         await conn.commit()

--- a/tests/test_services/test_cooldown_reconcile.py
+++ b/tests/test_services/test_cooldown_reconcile.py
@@ -1,0 +1,160 @@
+"""Cooldown reconciliation service tests.
+
+Targets :func:`houndarr.services.cooldown_reconcile.reconcile_cooldowns`
+and the invariant it is meant to enforce downstream: on every /api/status
+envelope after the supervisor's snapshot refresh has run,
+``eligible + gated + unreleased <= monitored_total`` per instance.
+Stale cooldown rows are the only accumulator that can break the
+inequality, so reconcile's job is to keep the cooldowns table a
+projection of the *arr's live wanted / upgrade-pool state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+
+from houndarr.clients.base import ReconcileSets
+from houndarr.database import get_db
+from houndarr.services.cooldown_reconcile import reconcile_cooldowns
+
+_ENC_KEY = "gAAAAABlX_fake_fernet_value_long_enough_to_pass_validation=="
+
+
+@pytest_asyncio.fixture()
+async def seeded_instance(db: None) -> AsyncGenerator[None, None]:  # noqa: ARG001
+    """Seed one instance row so cooldowns FKs resolve."""
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (1, "Sonarr Test", "sonarr", "http://sonarr:8989", _ENC_KEY),
+        )
+        await conn.commit()
+    yield
+
+
+async def _seed_cooldown(
+    instance_id: int,
+    item_id: int,
+    item_type: str,
+    search_kind: str = "missing",
+) -> None:
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.000000Z")
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns"
+            " (instance_id, item_id, item_type, search_kind, searched_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (instance_id, item_id, item_type, search_kind, now),
+        )
+        await conn.commit()
+
+
+async def _count_cooldowns(instance_id: int) -> int:
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT COUNT(*) FROM cooldowns WHERE instance_id = ?",
+            (instance_id,),
+        ) as cur:
+            row = await cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+@pytest.mark.asyncio()
+async def test_empty_sets_skip_delete(seeded_instance: None) -> None:  # noqa: ARG001
+    """An empty ReconcileSets is a hard skip: never wipe the table."""
+    await _seed_cooldown(1, 100, "episode", "missing")
+    await _seed_cooldown(1, 200, "episode", "cutoff")
+    removed = await reconcile_cooldowns(1, ReconcileSets.empty())
+    assert removed == 0
+    assert await _count_cooldowns(1) == 2
+
+
+@pytest.mark.asyncio()
+async def test_keeps_matching_rows(seeded_instance: None) -> None:  # noqa: ARG001
+    """Rows whose (item_type, item_id) is in the matching set stay."""
+    await _seed_cooldown(1, 100, "episode", "missing")
+    await _seed_cooldown(1, 200, "episode", "cutoff")
+    sets = ReconcileSets(
+        missing=frozenset({("episode", 100)}),
+        cutoff=frozenset({("episode", 200)}),
+        upgrade=frozenset(),
+    )
+    removed = await reconcile_cooldowns(1, sets)
+    assert removed == 0
+    assert await _count_cooldowns(1) == 2
+
+
+@pytest.mark.asyncio()
+async def test_deletes_orphan_rows(seeded_instance: None) -> None:  # noqa: ARG001
+    """Rows not in the matching set get deleted."""
+    await _seed_cooldown(1, 100, "episode", "missing")  # orphan
+    await _seed_cooldown(1, 101, "episode", "missing")  # keeper
+    await _seed_cooldown(1, 200, "episode", "cutoff")  # orphan
+    sets = ReconcileSets(
+        missing=frozenset({("episode", 101)}),
+        cutoff=frozenset(),
+        upgrade=frozenset(),
+    )
+    removed = await reconcile_cooldowns(1, sets)
+    assert removed == 2
+    assert await _count_cooldowns(1) == 1
+
+
+@pytest.mark.asyncio()
+async def test_search_kind_scoped_to_pass(seeded_instance: None) -> None:  # noqa: ARG001
+    """A row tagged 'missing' matches the missing set even if the cutoff
+    set contains the same (item_type, item_id)."""
+    await _seed_cooldown(1, 100, "episode", "missing")
+    sets = ReconcileSets(
+        missing=frozenset(),  # empty: 100 is orphaned from missing
+        cutoff=frozenset({("episode", 100)}),  # present here but wrong kind
+        upgrade=frozenset(),
+    )
+    removed = await reconcile_cooldowns(1, sets)
+    assert removed == 1
+    assert await _count_cooldowns(1) == 0
+
+
+@pytest.mark.asyncio()
+async def test_context_synth_id_kept(seeded_instance: None) -> None:  # noqa: ARG001
+    """Season-context synthetic negative id survives reconcile when the
+    adapter unions it into the pass set."""
+    synth = -1234  # -(series_id * 1000 + season_number) for (1, 234)
+    await _seed_cooldown(1, synth, "episode", "missing")
+    sets = ReconcileSets(
+        missing=frozenset({("episode", synth)}),
+        cutoff=frozenset(),
+        upgrade=frozenset(),
+    )
+    removed = await reconcile_cooldowns(1, sets)
+    assert removed == 0
+    assert await _count_cooldowns(1) == 1
+
+
+@pytest.mark.asyncio()
+async def test_batched_delete_many_rows(seeded_instance: None) -> None:  # noqa: ARG001
+    """Deleting more than the batch size (500) still succeeds."""
+    # Seed 600 orphan rows.
+    tasks = [_seed_cooldown(1, i, "episode", "missing") for i in range(1, 601)]
+    await asyncio.gather(*tasks)
+    sets = ReconcileSets(
+        missing=frozenset(),
+        cutoff=frozenset(),
+        upgrade=frozenset(),
+    )
+    # Empty sets skip delete entirely, so use a keeper to bypass the
+    # is_empty sentinel path while still orphaning all seeded rows.
+    sets = ReconcileSets(
+        missing=frozenset({("episode", 10_000)}),
+        cutoff=frozenset(),
+        upgrade=frozenset(),
+    )
+    removed = await reconcile_cooldowns(1, sets)
+    assert removed == 600
+    assert await _count_cooldowns(1) == 0


### PR DESCRIPTION
## Summary

Stamp `search_kind` on every cooldown row at insert time and add a supervisor reconcile step that prunes cooldown rows whose items are no longer wanted on the *arr side. Removes the orphan-drift that inflates `cooldown_breakdown` and silently clamps the dashboard's `Eligible = monitored - gated - unreleased` formula to zero.

Closes #462

## Changes

- Schema v14: add `search_kind TEXT NOT NULL DEFAULT 'missing'` to `cooldowns` plus `idx_cooldowns_search_kind` for the breakdown GROUP BY. Existing rows backfill via the same `search_log` classifier that used to run at read time.
- Schema v15: rebuild `cooldowns` with `CHECK(search_kind IN ('missing','cutoff','upgrade'))`. SQLite cannot `ALTER TABLE ADD CHECK`, so the v14 column accepted any string until the v15 rebuild. Rows with invalid kinds during the rebuild are coerced to `'missing'`.
- `services/cooldown.py`: thread `search_kind` through `record_search` / `record_search_ref`. The UPSERT path updates both `searched_at` and `search_kind` on conflict so the row carries the kind of the most recent search.
- `engine/search_loop.py`: forward the loop's `search_kind` variable from `_run_search_pass` to both `record_search` call sites; `_run_upgrade_pass` passes `"upgrade"` literally.
- `clients/base.py`: add the `ReconcileSets` frozen + slotted dataclass with `empty()` and `is_empty()` helpers.
- `engine/adapters/protocols.py` + every adapter: add `fetch_reconcile_sets(client, instance) -> ReconcileSets`. Sonarr / Lidarr / Readarr / Whisparr v2 reuse the shared `paginate_wanted` helper for missing + cutoff and union in synthetic parent ids for context-mode passes. Sonarr and Whisparr v2 introduce `_fetch_all_upgrade_episodes` so the upgrade reconcile set walks the full monitored library while `fetch_upgrade_pool` keeps its 5-series rotation window for per-cycle traffic. The upgrade bucket short-circuits to empty when `upgrade_enabled` is false. Whisparr v3 reads its cached `/movie` list three ways with no extra network I/O. `paginate_wanted` is bounded at 200 pages.
- `services/cooldown_reconcile.py`: one SELECT per instance, Python-side intersection against the pass's set, batched DELETE (500 per batch, well inside SQLite's 999-parameter limit). `is_empty` guard skips the DELETE when the adapter signalled reconcile failure.
- `engine/supervisor.py`: fetch reconcile sets alongside the snapshot probe inside the same client context and lock; call `reconcile_cooldowns` after `update_instance_snapshot`. Transport / adapter errors collapse to `ReconcileSets.empty()` so an unreachable arr preserves its cooldowns until recovery.

## Testing

`just check` clean: ruff, ruff format, mypy strict, bandit all pass. pytest runs 1332 tests in 14.10 s green locally.

New tests cover:

- v14 + v15 migration paths (column add, rebuild with CHECK, backfill classifier, invalid-kind coercion).
- `cooldown_reconcile` invariants: empty set skips DELETE, non-empty set prunes only stale rows, batch boundary at 500.
- Sonarr `fetch_reconcile_sets` upgrade bucket covers all monitored series even with the 5-series rotation window applied to `fetch_upgrade_pool`.

## Type of Change

- [x] New feature (`feat:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #462`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/cooldown-search-kind-reconcile`)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (N/A; cooldown / dashboard docs ride a later UI PR)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: Reconcile keeps the cooldown table in sync with the *arr's live wanted set so the dashboard breakdown and the throttling logic stay accurate.

## Notes for review

Two commits from the originally-planned set are deferred:

- The metrics-service shift (`refactor(metrics): read cooldown search_kind from the column`) defers because origin/main has no `services/metrics.py` yet; the dashboard breakdown still uses its current correlated-subquery path until that service lands.
- The eligible-invariant `/api/status` test pin defers because origin/main's `/api/status` does not have the `v=2` envelope (lifetime / cooldown / snapshot) yet; the pin rides with the dashboard redesign cluster that introduces v=2.

The supervisor reconcile call uses `instance.id` / `instance.name` (flat-attribute Instance shape on origin/main) rather than the sub-struct form used on local main; the adapter sub-mode reads (`instance.sonarr_search_mode`, `instance.lidarr_search_mode`, etc., plus `instance.upgrade_enabled`) follow the same flat shape.
