### PR TITLE
refactor(bootstrap): extract bootstrap_non_web and bootstrap_settings

### DIFF
--- a/docs/refactor/track-i-env-audit.md
+++ b/docs/refactor/track-i-env-audit.md
@@ -1,0 +1,131 @@
+# Track I.1: `os.getenv` / `os.environ` usage audit
+
+Scope: every `.py` file under `src/`, excluding the two modules the
+refactor plan carves out as the environment-variable boundary
+(`src/houndarr/config.py` and `src/houndarr/__main__.py`).  The goal is
+to confirm that no downstream module reaches around the
+`AppSettings` / CLI boundary to read process env directly, and to list
+anything that does so a consumer-migration batch (I.2) can pick it up.
+
+## Method
+
+```
+grep -rn --include='*.py' -E 'os\.getenv|os\.environ|environ\[|environ\.get' src/
+```
+
+A broader `\bgetenv\b|\benviron\b` sweep across `src/`, `tests/`, and
+`scripts/` was used to cross-check that no unusual idiom (for example
+`from os import environ`) slipped past the first pattern.
+
+## Finding
+
+Zero hits in `src/` outside the two allowed files.  Every
+environment-variable access inside the application source tree lives
+inside `config.py` (reads) or `__main__.py` (writes).  The carved-out
+boundary is intact; no consumer migration is required for I.2.
+
+## In-scope reference: the boundary files
+
+Listed so future audits can spot drift quickly.
+
+### `src/houndarr/config.py` (reads; 10 call sites, 11 environment variables)
+
+| Line | Env var                        | `AppSettings` field   |
+| ---- | ------------------------------ | --------------------- |
+| 113  | (generic, used by `_parse_bool_env`) | n/a             |
+| 154  | `HOUNDARR_DATA_DIR`            | `data_dir`            |
+| 155  | `HOUNDARR_HOST`                | `host`                |
+| 156  | `HOUNDARR_PORT`                | `port`                |
+| 157  | `HOUNDARR_DEV` (via `_parse_bool_env`) | `dev`         |
+| 158  | `HOUNDARR_LOG_LEVEL`           | `log_level`           |
+| 159  | `HOUNDARR_SECURE_COOKIES` (via `_parse_bool_env`) | `secure_cookies` |
+| 160  | `HOUNDARR_COOKIE_SAMESITE`     | `cookie_samesite`     |
+| 161  | `HOUNDARR_TRUSTED_PROXIES`     | `trusted_proxies`     |
+| 162  | `HOUNDARR_AUTH_MODE`           | `auth_mode`           |
+| 163  | `HOUNDARR_AUTH_PROXY_HEADER`   | `auth_proxy_header`   |
+| 165  | `HOUNDARR_UPDATE_CHECK_REPO`   | `update_check_repo`   |
+
+Recommended resolution: keep.  This is the one location allowed to
+read process env; every field is documented on `AppSettings` and is the
+canonical way for the rest of the app to consume the value.
+
+### `src/houndarr/__main__.py` (writes; 8 call sites)
+
+| Line | Env var                       |
+| ---- | ----------------------------- |
+| 174  | `HOUNDARR_DATA_DIR`           |
+| 175  | `HOUNDARR_DEV`                |
+| 176  | `HOUNDARR_LOG_LEVEL`          |
+| 177  | `HOUNDARR_SECURE_COOKIES`     |
+| 178  | `HOUNDARR_COOKIE_SAMESITE`    |
+| 179  | `HOUNDARR_TRUSTED_PROXIES`    |
+| 180  | `HOUNDARR_AUTH_MODE`          |
+| 181  | `HOUNDARR_AUTH_PROXY_HEADER`  |
+
+The writes propagate resolved CLI values to the process environment so
+that uvicorn's reload child process (which re-imports modules fresh and
+loses the `config._runtime_settings` module global) still resolves the
+right values via `get_settings()`'s env-var fallback.
+
+Note the three omissions from the write pass: `HOUNDARR_HOST` and
+`HOUNDARR_PORT` (uvicorn's reload child receives these as arguments to
+`uvicorn.run()`, not via `get_settings()`), and
+`HOUNDARR_UPDATE_CHECK_REPO` (no CLI flag exists; the variable is
+env-only by design so forks can redirect the update check without a
+code change).
+
+Recommended resolution: keep.  Any tightening here belongs to I.2's
+`bootstrap_settings(**overrides)` collapse rather than to I.1.
+
+## Out of scope: references outside `src/`
+
+Recorded here only so nothing gets lost; none of these are consumer
+migrations for Track I.
+
+### `tests/e2e_browser/conftest.py` (5 reads)
+
+| Line | Env var           | Purpose                                       |
+| ---- | ----------------- | --------------------------------------------- |
+| 21   | `HOUNDARR_URL`    | Playwright base URL override                  |
+| 22   | `MOCK_SONARR_URL` | Mock Sonarr URL override                      |
+| 23   | `MOCK_RADARR_URL` | Mock Radarr URL override                      |
+| 24   | `HOUNDARR_E2E_USER` | Admin username for the browser flows        |
+| 25   | `HOUNDARR_E2E_PASS` | Admin password for the browser flows        |
+
+Recommended resolution: keep as documented exception.  These are
+test-rig knobs used by the Playwright fixtures to point at whichever
+mock stack the tester is running; they have no production surface and
+no place on `AppSettings`.
+
+### `scripts/marketing/seed_demo_data.py` (1 write)
+
+| Line | Env var             |
+| ---- | ------------------- |
+| 74   | `HOUNDARR_DATA_DIR` |
+
+Recommended resolution: defer to Track H.  Batch H.2
+(`refactor(scripts): migrate scripts/marketing/seed_demo_data.py to use
+bootstrap_non_web`) covers this script directly.  After H.2 the write
+stays if the script still needs to set `HOUNDARR_DATA_DIR` for a
+reload-capable sub-import path; otherwise it is replaced by a direct
+`bootstrap_non_web(data_dir=...)` call.
+
+### `scripts/marketing/serve_demo.py` (1 write)
+
+| Line | Env var             |
+| ---- | ------------------- |
+| 52   | `HOUNDARR_DATA_DIR` |
+
+Recommended resolution: defer to Track H.  Batch H.3
+(`refactor(scripts): migrate scripts/marketing/serve_demo.py to use
+bootstrap + document supervisor no-op patch`) covers this one.  Same
+treatment as the seed script.
+
+## Consequences for I.2
+
+Because `src/` has no consumers to switch, the I.2 batch
+(`refactor(config): collapse _runtime_settings override into
+bootstrap_settings(**overrides)`) is strictly internal to `config.py`.
+It does not need to chase down callers.  The CLI remains the single
+writer (via env vars) and `get_settings()` / future
+`bootstrap_settings(**overrides)` remain the single reader.

--- a/docs/refactor/track-i-env-audit.md
+++ b/docs/refactor/track-i-env-audit.md
@@ -28,11 +28,17 @@ boundary is intact; no consumer migration is required for I.2.
 
 Listed so future audits can spot drift quickly.
 
-### `src/houndarr/config.py` (reads; 10 call sites, 11 environment variables)
+### `src/houndarr/config.py` (reads; 10 direct call sites, 11 environment variables)
+
+The table lists one row per environment variable plus one row for the
+`_parse_bool_env` helper body itself (line 113).  The two rows marked
+*via `_parse_bool_env`* are not additional `os.environ` call sites;
+their values are resolved through the shared helper at line 113, which
+is why the direct-call-site count (10) is one below the row count (12).
 
 | Line | Env var                        | `AppSettings` field   |
 | ---- | ------------------------------ | --------------------- |
-| 113  | (generic, used by `_parse_bool_env`) | n/a             |
+| 113  | (helper body; `_parse_bool_env`) | n/a                 |
 | 154  | `HOUNDARR_DATA_DIR`            | `data_dir`            |
 | 155  | `HOUNDARR_HOST`                | `host`                |
 | 156  | `HOUNDARR_PORT`                | `port`                |

--- a/src/houndarr/__main__.py
+++ b/src/houndarr/__main__.py
@@ -127,7 +127,8 @@ def cli(
 
     import uvicorn
 
-    from houndarr.config import AppSettings, _parse_samesite
+    from houndarr.bootstrap import bootstrap_non_web
+    from houndarr.config import _parse_samesite
 
     # Configure the root logger so that application loggers (houndarr.*)
     # respect --log-level.  Without this, only uvicorn's own loggers are
@@ -138,7 +139,11 @@ def cli(
         format="%(levelname)s:     %(message)s",
     )
 
-    settings = AppSettings(
+    # Shared non-web bootstrap: pin AppSettings with CLI overrides, ensure
+    # the data dir, load the Fernet master key, and run init_db. The
+    # FastAPI lifespan re-runs the same idempotent primitives once uvicorn
+    # spawns (or reloads) the ASGI child, so running them here is safe.
+    settings, _db_path, _master_key = bootstrap_non_web(
         data_dir=data_dir,
         host=host,
         port=port,
@@ -163,15 +168,11 @@ def cli(
     else:
         logging.info("Auth mode: builtin")
 
-    # Store settings so the app factory can pick them up.
-    import houndarr.config as _cfg
-
-    _cfg._runtime_settings = settings  # noqa: SLF001
-
-    # Propagate resolved CLI values to env vars so that uvicorn's reload
-    # child process (which reimports modules fresh, losing _runtime_settings)
-    # gets the correct values from get_settings()'s env-var fallback.
-    os.environ["HOUNDARR_DATA_DIR"] = data_dir
+    # Propagate the remaining resolved CLI values to env vars so that
+    # uvicorn's reload child process (which reimports modules fresh,
+    # losing _runtime_settings) gets the correct values from
+    # get_settings()'s env-var fallback. bootstrap_non_web already
+    # exports HOUNDARR_DATA_DIR.
     os.environ["HOUNDARR_DEV"] = "1" if dev else ""
     os.environ["HOUNDARR_LOG_LEVEL"] = log_level.lower()
     os.environ["HOUNDARR_SECURE_COOKIES"] = "1" if secure_cookies else ""

--- a/src/houndarr/bootstrap.py
+++ b/src/houndarr/bootstrap.py
@@ -81,6 +81,21 @@ def bootstrap_non_web(
         Three-tuple ``(settings, db_path, master_key)``. ``db_path`` is
         the resolved SQLite path (same object as ``settings.db_path``)
         and ``master_key`` is the 32-byte URL-safe base64 Fernet key.
+
+    Notes:
+        Must be called from a sync context. The body invokes
+        :func:`asyncio.run` to execute :func:`~houndarr.database.init_db`,
+        so calling this from inside an already-running event loop raises
+        ``RuntimeError: asyncio.run() cannot be called from a running
+        event loop``.
+
+        Every call clears ``_runtime_settings`` before resolving the new
+        one and, when ``overrides`` are supplied, pins a fresh
+        :class:`AppSettings` into the singleton. Back-to-back calls with
+        different overrides therefore leave the singleton pinned to the
+        last call; callers holding an :class:`AppSettings` reference
+        returned by an earlier call keep their own object but disagree
+        with the process-wide singleton.
     """
     # Drop any prior pin so tests and repeated script invocations cannot
     # leak stale settings from a previous run (seed_demo_data + serve_demo

--- a/src/houndarr/bootstrap.py
+++ b/src/houndarr/bootstrap.py
@@ -28,8 +28,7 @@ import os
 from pathlib import Path
 from typing import Literal, TypedDict, Unpack
 
-from houndarr import config as _cfg
-from houndarr.config import AppSettings, get_settings
+from houndarr.config import AppSettings, bootstrap_settings
 from houndarr.crypto import ensure_master_key
 from houndarr.database import init_db, set_db_path
 
@@ -52,7 +51,6 @@ class AppSettingsOverrides(TypedDict, total=False):
     trusted_proxies: str
     auth_mode: str
     auth_proxy_header: str
-    update_check_repo: str
 
 
 def bootstrap_non_web(
@@ -70,7 +68,7 @@ def bootstrap_non_web(
         **overrides: Additional :class:`AppSettings` field values (``host``,
             ``port``, ``dev``, ``log_level``, ``secure_cookies``,
             ``cookie_samesite``, ``trusted_proxies``, ``auth_mode``,
-            ``auth_proxy_header``, ``update_check_repo``). When any
+            ``auth_proxy_header``). When any
             override is supplied, :class:`AppSettings` is constructed
             directly and pinned into the runtime singleton so the whole
             process agrees on the overridden values. When no overrides
@@ -89,25 +87,30 @@ def bootstrap_non_web(
         ``RuntimeError: asyncio.run() cannot be called from a running
         event loop``.
 
-        Every call clears ``_runtime_settings`` before resolving the new
-        one and, when ``overrides`` are supplied, pins a fresh
-        :class:`AppSettings` into the singleton. Back-to-back calls with
-        different overrides therefore leave the singleton pinned to the
-        last call; callers holding an :class:`AppSettings` reference
-        returned by an earlier call keep their own object but disagree
-        with the process-wide singleton.
+        Both branches funnel through :func:`~houndarr.config.bootstrap_settings`,
+        which clears any prior pin first and then either pins a fresh
+        :class:`AppSettings` (override branch) or returns env-resolved
+        settings without pinning (no-override branch). Back-to-back
+        calls with different overrides therefore leave the singleton
+        pinned to the last call; callers holding an :class:`AppSettings`
+        reference returned by an earlier call keep their own object but
+        disagree with the process-wide singleton.
     """
-    # Drop any prior pin so tests and repeated script invocations cannot
-    # leak stale settings from a previous run (seed_demo_data + serve_demo
-    # ship-rebuild the singleton deliberately; the CLI re-pins below).
-    _cfg._runtime_settings = None  # noqa: SLF001
+    # Export data_dir to the environment first so the no-override branch's
+    # env-resolved fallback (and any uvicorn reload child that reimports
+    # houndarr fresh, losing the singleton pin) sees the right path.
     os.environ["HOUNDARR_DATA_DIR"] = data_dir
 
+    # bootstrap_settings owns the pin lifecycle: with overrides it builds
+    # AppSettings(data_dir=..., **overrides) and pins it; without overrides
+    # it clears the pin and returns env-resolved (data_dir comes from the
+    # env export above). seed_demo_data + serve_demo deliberately go
+    # through the no-override branch so later get_settings() calls keep
+    # honouring any HOUNDARR_* changes the script makes after bootstrap.
     if overrides:
-        settings = AppSettings(data_dir=data_dir, **overrides)
-        _cfg._runtime_settings = settings  # noqa: SLF001
+        settings = bootstrap_settings(data_dir=data_dir, **overrides)
     else:
-        settings = get_settings()
+        settings = bootstrap_settings()
 
     Path(settings.data_dir).mkdir(parents=True, exist_ok=True)
 

--- a/src/houndarr/bootstrap.py
+++ b/src/houndarr/bootstrap.py
@@ -1,0 +1,104 @@
+"""Shared non-web bootstrap composition for every Houndarr entry point.
+
+Four steps every entry point needs before doing real work:
+
+1. Pin an :class:`~houndarr.config.AppSettings` (CLI overrides win; otherwise
+   the env-derived defaults from :func:`~houndarr.config.get_settings`).
+2. Ensure the data directory exists on disk.
+3. Load or generate the Fernet master key at
+   ``<data_dir>/houndarr.masterkey`` via
+   :func:`~houndarr.crypto.ensure_master_key`.
+4. Point the SQLite helper at ``<data_dir>/houndarr.db`` and run
+   :func:`~houndarr.database.init_db` to advance the schema to the current
+   version.
+
+Before this module existed, three separate call sites (the ``python -m
+houndarr`` CLI, ``scripts/marketing/seed_demo_data.py``, and
+``scripts/marketing/serve_demo.py``) each copy-pasted the sequence. The
+FastAPI lifespan in :mod:`houndarr.app` keeps its own equivalent steps
+so ``create_app`` callers in tests still boot without hitting a
+pre-uvicorn bootstrap; both paths call the same idempotent primitives
+so running the four steps twice is safe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Literal, TypedDict, Unpack
+
+from houndarr import config as _cfg
+from houndarr.config import AppSettings, get_settings
+from houndarr.crypto import ensure_master_key
+from houndarr.database import init_db, set_db_path
+
+
+class AppSettingsOverrides(TypedDict, total=False):
+    """Optional overrides accepted by :func:`bootstrap_non_web`.
+
+    Keys mirror the non-``data_dir`` fields of
+    :class:`~houndarr.config.AppSettings`. Every key is optional: callers
+    pass only the fields they need (typically the CLI handler forwards
+    every flag; scripts pass nothing and let env vars + defaults win).
+    """
+
+    host: str
+    port: int
+    dev: bool
+    log_level: str
+    secure_cookies: bool
+    cookie_samesite: Literal["lax", "strict"]
+    trusted_proxies: str
+    auth_mode: str
+    auth_proxy_header: str
+    update_check_repo: str
+
+
+def bootstrap_non_web(
+    data_dir: str,
+    **overrides: Unpack[AppSettingsOverrides],
+) -> tuple[AppSettings, Path, bytes]:
+    """Compose settings, Fernet master key, and DB init for a non-web boot.
+
+    Args:
+        data_dir: Filesystem path to the Houndarr data directory. Pinned
+            to the returned :class:`AppSettings` ``data_dir`` field and
+            exported as ``HOUNDARR_DATA_DIR`` so uvicorn reload children,
+            later ``get_settings()`` fallbacks, and subprocesses all see
+            the same value.
+        **overrides: Additional :class:`AppSettings` field values (``host``,
+            ``port``, ``dev``, ``log_level``, ``secure_cookies``,
+            ``cookie_samesite``, ``trusted_proxies``, ``auth_mode``,
+            ``auth_proxy_header``, ``update_check_repo``). When any
+            override is supplied, :class:`AppSettings` is constructed
+            directly and pinned into the runtime singleton so the whole
+            process agrees on the overridden values. When no overrides
+            are supplied, :func:`get_settings` is used so env vars and
+            the dataclass defaults still take effect.
+
+    Returns:
+        Three-tuple ``(settings, db_path, master_key)``. ``db_path`` is
+        the resolved SQLite path (same object as ``settings.db_path``)
+        and ``master_key`` is the 32-byte URL-safe base64 Fernet key.
+    """
+    # Drop any prior pin so tests and repeated script invocations cannot
+    # leak stale settings from a previous run (seed_demo_data + serve_demo
+    # ship-rebuild the singleton deliberately; the CLI re-pins below).
+    _cfg._runtime_settings = None  # noqa: SLF001
+    os.environ["HOUNDARR_DATA_DIR"] = data_dir
+
+    if overrides:
+        settings = AppSettings(data_dir=data_dir, **overrides)
+        _cfg._runtime_settings = settings  # noqa: SLF001
+    else:
+        settings = get_settings()
+
+    Path(settings.data_dir).mkdir(parents=True, exist_ok=True)
+
+    master_key = ensure_master_key(settings.data_dir)
+
+    set_db_path(str(settings.db_path))
+    asyncio.run(init_db())
+
+    return settings, settings.db_path, master_key

--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -1,4 +1,39 @@
-"""Application configuration and runtime settings."""
+"""Application configuration and runtime settings.
+
+Houndarr keeps two config surfaces and this module owns one of them.
+
+Ops config lives on :class:`AppSettings` and is resolved from environment
+variables at boot.  The CLI in :mod:`houndarr.__main__` propagates its
+flags into ``HOUNDARR_*`` env vars before :func:`bootstrap_settings` pins
+an :class:`AppSettings`, so uvicorn reload children that re-import the
+module pick up the same values via :func:`get_settings`.  Once pinned,
+every field is fixed for the life of the process: the operator changes
+it by editing ``docker-compose.yml`` (or the systemd unit env) and
+restarting the container.  ``HOUNDARR_AUTH_MODE`` is the canonical
+example.  Switching from ``builtin`` to ``proxy`` rewires the auth
+middleware, which only happens at app construction time;
+``HOUNDARR_DATA_DIR``, ``HOUNDARR_TRUSTED_PROXIES``, and
+``HOUNDARR_SECURE_COOKIES`` behave the same way for the same reason.
+
+User config lives in SQLite and is editable at runtime through the web
+UI without any restart.  The key-value ``settings`` table holds
+singletons read and written through
+:mod:`houndarr.repositories.settings`; canonical examples are the
+authenticated ``username`` and bcrypt ``password_hash`` (changed from
+the admin account UI), the boolean ``update_check_enabled`` flag
+(Settings > Maintenance), and the ``schema_version`` migration cursor.
+The ``instances`` table holds per-instance policy (``batch_size``,
+``sleep_interval_mins``, ``hourly_cap``, ``cooldown_days``, the per-app
+search-mode columns) read through
+:mod:`houndarr.repositories.instances`; the engine picks up new values
+on the next supervisor cycle, so the operator can retune the search rate
+from ``/settings/instances/<id>`` and see it take effect within minutes.
+
+The two surfaces never overlap.  Anything that needs a process boot to
+take effect (network bind, cookie attributes, auth wiring, log level)
+lives here as an :class:`AppSettings` field.  Anything an operator
+should be able to retune without redeploying lives in the database.
+"""
 
 from __future__ import annotations
 

--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -8,7 +8,7 @@ import os
 from dataclasses import dataclass, field
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from pathlib import Path
-from typing import Literal
+from typing import Literal, TypedDict, Unpack
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +133,70 @@ def get_settings() -> AppSettings:
         auth_mode=os.environ.get("HOUNDARR_AUTH_MODE", "builtin").lower(),
         auth_proxy_header=os.environ.get("HOUNDARR_AUTH_PROXY_HEADER", ""),
     )
+
+
+class BootstrapOverrides(TypedDict, total=False):
+    """Optional :class:`AppSettings` field overrides accepted by ``bootstrap_settings``.
+
+    Every key is optional. Supplied keys are forwarded directly to the
+    :class:`AppSettings` constructor; unsupplied keys take whatever default
+    the dataclass declares (the env-var fallback in :func:`get_settings`
+    is only consulted on the no-override branch, never on the explicit
+    override path).
+    """
+
+    data_dir: str
+    host: str
+    port: int
+    dev: bool
+    log_level: str
+    secure_cookies: bool
+    cookie_samesite: SameSitePolicy
+    trusted_proxies: str
+    auth_mode: str
+    auth_proxy_header: str
+
+
+def bootstrap_settings(**overrides: Unpack[BootstrapOverrides]) -> AppSettings:
+    """Resolve, pin, and return the runtime ``AppSettings`` honouring overrides.
+
+    This is the single entry point for installing :class:`AppSettings` into
+    the module-level singleton. CLI boot, scripts, and tests all funnel
+    through it instead of reaching into ``_runtime_settings`` directly,
+    so the pin lifecycle is observable in one place.
+
+    With at least one override supplied, an :class:`AppSettings` is
+    constructed from the kwargs and pinned. Subsequent
+    :func:`get_settings` calls return the same instance until the next
+    ``bootstrap_settings`` call (or process restart). Any prior pin is
+    replaced; any env var for an *unsupplied* key is ignored (the kwarg
+    path matches the pre-refactor ``AppSettings(data_dir=..., **overrides)``
+    shape, where missing fields take the dataclass default rather than the
+    env value).
+
+    With no overrides supplied, any prior pin is cleared and the result of
+    :func:`get_settings` (env-var resolved) is returned *without* pinning.
+    Callers that subsequently change env vars therefore still see those
+    changes through :func:`get_settings`.
+
+    Args:
+        **overrides: Optional :class:`AppSettings` field values.
+
+    Returns:
+        The :class:`AppSettings` now visible to subsequent
+        :func:`get_settings` calls. With overrides this is the freshly
+        pinned instance; without overrides this is an unpinned
+        env-resolved instance.
+    """
+    global _runtime_settings  # noqa: PLW0603
+
+    if not overrides:
+        _runtime_settings = None
+        return get_settings()
+
+    settings = AppSettings(**overrides)
+    _runtime_settings = settings
+    return settings
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,8 @@ import pytest_asyncio
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
-from houndarr import config as _cfg
 from houndarr.auth import CSRF_COOKIE_NAME
-from houndarr.config import AppSettings
+from houndarr.config import AppSettings, bootstrap_settings
 from houndarr.database import init_db, set_db_path
 
 # ---------------------------------------------------------------------------
@@ -72,8 +71,7 @@ async def db(tmp_data_dir: str) -> AsyncGenerator[None, None]:
 @pytest.fixture()
 def test_settings(tmp_data_dir: str) -> AppSettings:
     """Return AppSettings pointing at tmp data dir."""
-    settings = AppSettings(data_dir=tmp_data_dir)
-    _cfg._runtime_settings = settings  # noqa: SLF001
+    settings = bootstrap_settings(data_dir=tmp_data_dir)
     # Reset auth module singletons so each test starts with a clean state.
     # - _serializer: re-initialized with the new test DB's session_secret.
     # - _login_attempts: cleared so rate-limit counters don't bleed between tests.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -149,21 +149,17 @@ def test_client_ip_honours_xff_for_cidr_trusted_proxy(
     """_client_ip honours X-Forwarded-For when direct IP is in a trusted subnet."""
     from unittest.mock import MagicMock
 
-    import houndarr.config as _cfg
     from houndarr.auth import _client_ip  # noqa: SLF001
-    from houndarr.config import AppSettings
+    from houndarr.config import bootstrap_settings
 
-    original = _cfg._runtime_settings  # noqa: SLF001
     try:
-        _cfg._runtime_settings = AppSettings(  # noqa: SLF001
-            data_dir=tmp_data_dir, trusted_proxies="172.18.0.0/16"
-        )
+        bootstrap_settings(data_dir=tmp_data_dir, trusted_proxies="172.18.0.0/16")
         request = MagicMock()
         request.client.host = "172.18.0.5"
         request.headers.get.return_value = "203.0.113.50, 172.18.0.5"
         assert _client_ip(request) == "203.0.113.50"
     finally:
-        _cfg._runtime_settings = original  # noqa: SLF001
+        bootstrap_settings()
 
 
 def test_client_ip_ignores_xff_when_not_in_trusted_subnet(
@@ -172,21 +168,17 @@ def test_client_ip_ignores_xff_when_not_in_trusted_subnet(
     """_client_ip ignores X-Forwarded-For when direct IP is NOT in trusted subnet."""
     from unittest.mock import MagicMock
 
-    import houndarr.config as _cfg
     from houndarr.auth import _client_ip  # noqa: SLF001
-    from houndarr.config import AppSettings
+    from houndarr.config import bootstrap_settings
 
-    original = _cfg._runtime_settings  # noqa: SLF001
     try:
-        _cfg._runtime_settings = AppSettings(  # noqa: SLF001
-            data_dir=tmp_data_dir, trusted_proxies="172.18.0.0/16"
-        )
+        bootstrap_settings(data_dir=tmp_data_dir, trusted_proxies="172.18.0.0/16")
         request = MagicMock()
         request.client.host = "10.0.0.5"
         request.headers.get.return_value = "203.0.113.50"
         assert _client_ip(request) == "10.0.0.5"
     finally:
-        _cfg._runtime_settings = original  # noqa: SLF001
+        bootstrap_settings()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap/test_bootstrap_non_web.py
+++ b/tests/test_bootstrap/test_bootstrap_non_web.py
@@ -16,7 +16,7 @@ import pytest
 
 from houndarr import config as _cfg
 from houndarr.bootstrap import bootstrap_non_web
-from houndarr.config import AppSettings
+from houndarr.config import AppSettings, bootstrap_settings
 
 pytestmark = pytest.mark.pinning
 
@@ -31,7 +31,8 @@ def _reset_config_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
     isolation for the env-fallback branch.
     """
     monkeypatch.delenv("HOUNDARR_DATA_DIR", raising=False)
-    _cfg._runtime_settings = None  # noqa: SLF001
+    # bootstrap_settings() with no overrides clears the pin (see config.py).
+    bootstrap_settings()
 
 
 class TestReturnShape:
@@ -184,7 +185,7 @@ class TestRuntimeSettingsPinning:
 
     def test_prior_pin_is_cleared_before_resolving(self, tmp_path: Path) -> None:
         # A stale pin from a previous run must not leak into the new one.
-        _cfg._runtime_settings = AppSettings(data_dir="/stale", port=1234)  # noqa: SLF001
+        bootstrap_settings(data_dir="/stale", port=1234)
         settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
         assert settings.data_dir == str(tmp_path)
         assert settings.port != 1234

--- a/tests/test_bootstrap/test_bootstrap_non_web.py
+++ b/tests/test_bootstrap/test_bootstrap_non_web.py
@@ -10,6 +10,7 @@ init_db, and the Fernet master-key persistence contract.
 from __future__ import annotations
 
 import base64
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -22,16 +23,28 @@ pytestmark = pytest.mark.pinning
 
 
 @pytest.fixture(autouse=True)
-def _reset_config_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Each test starts with a clean singleton and no HOUNDARR_DATA_DIR env.
+def _reset_config_singleton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    """Clear the pinned singleton + HOUNDARR_DATA_DIR before and after each test.
 
     The config module caches resolved settings in ``_runtime_settings``;
     without this reset, test ordering would determine which path inside
-    :func:`bootstrap_non_web` runs. The env delete mirrors the same
-    isolation for the env-fallback branch.
+    :func:`bootstrap_non_web` runs. ``test_update_check_repo_override``
+    in particular leaves the pin set to a non-default ``update_check_repo``
+    that would otherwise leak into downstream test files (the
+    ``test_services/test_update_check.py`` mocks would miss the leaked
+    repo URL and respx would raise ``AllMockedAssertionError``). The
+    teardown ``bootstrap_settings()`` mirrors the ``_isolate_pin``
+    pattern in ``tests/test_config.py``: clear before to defend against
+    upstream pollution, clear after to defend downstream tests against
+    ours. The env delete provides the same isolation for the
+    env-fallback branch.
     """
     monkeypatch.delenv("HOUNDARR_DATA_DIR", raising=False)
     # bootstrap_settings() with no overrides clears the pin (see config.py).
+    bootstrap_settings()
+    yield
     bootstrap_settings()
 
 

--- a/tests/test_bootstrap/test_bootstrap_non_web.py
+++ b/tests/test_bootstrap/test_bootstrap_non_web.py
@@ -1,0 +1,236 @@
+"""Pinning tests for ``houndarr.bootstrap.bootstrap_non_web``.
+
+Locks the four-step composition extracted from the three pre-existing
+call sites (the CLI pre-uvicorn phase, ``seed_demo_data.py``, and
+``serve_demo.py``). Every branch and boundary is covered so later
+callers can depend on: tuple shape, singleton pinning rules, idempotent
+init_db, and the Fernet master-key persistence contract.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from houndarr import config as _cfg
+from houndarr.bootstrap import bootstrap_non_web
+from houndarr.config import AppSettings
+
+pytestmark = pytest.mark.pinning
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts with a clean singleton and no HOUNDARR_DATA_DIR env.
+
+    The config module caches resolved settings in ``_runtime_settings``;
+    without this reset, test ordering would determine which path inside
+    :func:`bootstrap_non_web` runs. The env delete mirrors the same
+    isolation for the env-fallback branch.
+    """
+    monkeypatch.delenv("HOUNDARR_DATA_DIR", raising=False)
+    _cfg._runtime_settings = None  # noqa: SLF001
+
+
+class TestReturnShape:
+    """Pin the three-tuple shape the plan fixes as the public contract."""
+
+    def test_returns_three_tuple(self, tmp_path: Path) -> None:
+        result = bootstrap_non_web(data_dir=str(tmp_path))
+        assert len(result) == 3
+
+    def test_first_is_app_settings(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert isinstance(settings, AppSettings)
+
+    def test_second_is_path(self, tmp_path: Path) -> None:
+        _settings, db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert isinstance(db_path, Path)
+
+    def test_third_is_bytes(self, tmp_path: Path) -> None:
+        _settings, _db_path, key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert isinstance(key, bytes)
+
+
+class TestSettingsContents:
+    """The returned :class:`AppSettings` reflects the requested data_dir."""
+
+    def test_data_dir_matches_argument(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert settings.data_dir == str(tmp_path)
+
+    def test_db_path_derived_from_data_dir(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert settings.db_path == tmp_path / "houndarr.db"
+
+    def test_master_key_path_derived_from_data_dir(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert settings.master_key_path == tmp_path / "houndarr.masterkey"
+
+    def test_returned_db_path_matches_settings(self, tmp_path: Path) -> None:
+        settings, db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert db_path == settings.db_path
+
+
+class TestDbInit:
+    """Pin the idempotent init_db contract and on-disk side effects."""
+
+    def test_db_file_exists_after_init(self, tmp_path: Path) -> None:
+        _settings, db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert db_path.exists()
+
+    def test_idempotent_second_call_succeeds(self, tmp_path: Path) -> None:
+        bootstrap_non_web(data_dir=str(tmp_path))
+        # A second call against the same data dir must not raise: init_db
+        # is idempotent and ensure_master_key returns the existing key.
+        settings, db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert settings.data_dir == str(tmp_path)
+        assert db_path.exists()
+
+    def test_schema_version_is_pinned(self, tmp_path: Path) -> None:
+        import asyncio
+
+        from houndarr.database import get_db
+
+        bootstrap_non_web(data_dir=str(tmp_path))
+
+        async def _read_version() -> str | None:
+            async with get_db() as db:
+                async with db.execute(
+                    "SELECT value FROM settings WHERE key = 'schema_version'"
+                ) as cur:
+                    row = await cur.fetchone()
+            return None if row is None else str(row["value"])
+
+        version = asyncio.run(_read_version())
+        assert version is not None
+        assert int(version) >= 13
+
+
+class TestMasterKey:
+    """Pin the Fernet master-key invariants."""
+
+    def test_master_key_file_created(self, tmp_path: Path) -> None:
+        _settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert (tmp_path / "houndarr.masterkey").exists()
+
+    def test_master_key_is_fernet_shaped(self, tmp_path: Path) -> None:
+        _settings, _db_path, key = bootstrap_non_web(data_dir=str(tmp_path))
+        # Fernet keys decode from URL-safe base64 to exactly 32 bytes.
+        assert len(base64.urlsafe_b64decode(key)) == 32
+
+    def test_master_key_persists_across_calls(self, tmp_path: Path) -> None:
+        _s1, _d1, key1 = bootstrap_non_web(data_dir=str(tmp_path))
+        _s2, _d2, key2 = bootstrap_non_web(data_dir=str(tmp_path))
+        assert key1 == key2
+
+
+class TestDataDirCreation:
+    """Nested data dirs must be created eagerly before crypto + DB run."""
+
+    def test_nested_data_dir_is_created(self, tmp_path: Path) -> None:
+        nested = tmp_path / "deeply" / "nested" / "dir"
+        assert not nested.exists()
+        bootstrap_non_web(data_dir=str(nested))
+        assert nested.is_dir()
+        assert (nested / "houndarr.db").exists()
+        assert (nested / "houndarr.masterkey").exists()
+
+    def test_pre_existing_data_dir_is_fine(self, tmp_path: Path) -> None:
+        # mkdir(exist_ok=True) must not raise when the dir already exists.
+        existing = tmp_path / "already"
+        existing.mkdir()
+        settings, db_path, _key = bootstrap_non_web(data_dir=str(existing))
+        assert settings.data_dir == str(existing)
+        assert db_path.exists()
+
+
+class TestEnvPropagation:
+    """HOUNDARR_DATA_DIR must land in the process env for reload children."""
+
+    def test_env_is_set_to_data_dir(self, tmp_path: Path) -> None:
+        import os
+
+        bootstrap_non_web(data_dir=str(tmp_path))
+        assert os.environ["HOUNDARR_DATA_DIR"] == str(tmp_path)
+
+    def test_env_is_overwritten_on_subsequent_call(self, tmp_path: Path) -> None:
+        import os
+
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        bootstrap_non_web(data_dir=str(first))
+        assert os.environ["HOUNDARR_DATA_DIR"] == str(first)
+        bootstrap_non_web(data_dir=str(second))
+        assert os.environ["HOUNDARR_DATA_DIR"] == str(second)
+
+
+class TestRuntimeSettingsPinning:
+    """The ``_runtime_settings`` singleton is only pinned when overrides win."""
+
+    def test_no_overrides_leaves_singleton_unpinned(self, tmp_path: Path) -> None:
+        # With no overrides, callers fall back to env-var resolution via
+        # get_settings() on every call. Pinning would trap the derived
+        # object and break later env changes, so we explicitly do not.
+        bootstrap_non_web(data_dir=str(tmp_path))
+        assert _cfg._runtime_settings is None  # noqa: SLF001
+
+    def test_overrides_pin_the_singleton(self, tmp_path: Path) -> None:
+        bootstrap_non_web(data_dir=str(tmp_path), port=9999)
+        assert _cfg._runtime_settings is not None  # noqa: SLF001
+        assert _cfg._runtime_settings.port == 9999  # noqa: SLF001
+
+    def test_prior_pin_is_cleared_before_resolving(self, tmp_path: Path) -> None:
+        # A stale pin from a previous run must not leak into the new one.
+        _cfg._runtime_settings = AppSettings(data_dir="/stale", port=1234)  # noqa: SLF001
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path))
+        assert settings.data_dir == str(tmp_path)
+        assert settings.port != 1234
+
+
+class TestOverrides:
+    """Every documented override key flows through to AppSettings."""
+
+    def test_host_override(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path), host="127.0.0.1")
+        assert settings.host == "127.0.0.1"
+
+    def test_port_override(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path), port=9000)
+        assert settings.port == 9000
+
+    def test_dev_override(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path), dev=True)
+        assert settings.dev is True
+
+    def test_log_level_override(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path), log_level="debug")
+        assert settings.log_level == "debug"
+
+    def test_secure_cookies_override(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(data_dir=str(tmp_path), secure_cookies=True)
+        assert settings.secure_cookies is True
+
+    def test_cookie_samesite_override(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(
+            data_dir=str(tmp_path), cookie_samesite="strict"
+        )
+        assert settings.cookie_samesite == "strict"
+
+    def test_trusted_proxies_override(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(
+            data_dir=str(tmp_path), trusted_proxies="10.0.0.1,172.18.0.0/16"
+        )
+        assert settings.trusted_proxies == "10.0.0.1,172.18.0.0/16"
+
+    def test_auth_mode_override(self, tmp_path: Path) -> None:
+        settings, _db_path, _key = bootstrap_non_web(
+            data_dir=str(tmp_path),
+            auth_mode="proxy",
+            auth_proxy_header="Remote-User",
+            trusted_proxies="10.0.0.1",
+        )
+        assert settings.auth_mode == "proxy"
+        assert settings.auth_proxy_header == "Remote-User"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+
 import pytest
 
-from houndarr.config import AppSettings
+from houndarr.config import AppSettings, bootstrap_settings, get_settings
 
 # ---------------------------------------------------------------------------
 # validate_auth_config - builtin mode (default, always valid)
@@ -161,3 +163,89 @@ def test_validate_invalid_auth_mode() -> None:
     assert len(errors) == 1
     assert "builtin" in errors[0]
     assert "proxy" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_settings: override precedence + singleton lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _isolate_pin() -> Generator[None, None, None]:
+    """Clear the runtime-settings pin before and after each test in this section.
+
+    bootstrap_settings pins a module-level singleton; without isolation
+    these tests would leak state into each other (and into unrelated
+    tests sharing the worker process under pytest-xdist).
+    """
+    bootstrap_settings()
+    yield
+    bootstrap_settings()
+
+
+def test_bootstrap_settings_with_overrides_pins_into_get_settings(
+    _isolate_pin: None,
+) -> None:
+    """An override survives via get_settings until the next bootstrap_settings call."""
+    bootstrap_settings(data_dir="/tmp/test", port=9000)
+    assert get_settings().port == 9000
+
+
+def test_bootstrap_settings_override_wins_over_env_var(
+    _isolate_pin: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit overrides take precedence over HOUNDARR_* env vars."""
+    monkeypatch.setenv("HOUNDARR_PORT", "8000")
+    bootstrap_settings(data_dir="/tmp/test", port=9000)
+    assert get_settings().port == 9000
+
+
+def test_bootstrap_settings_unsupplied_keys_take_dataclass_defaults(
+    _isolate_pin: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsupplied override keys take the dataclass default, not the env var.
+
+    The override path matches the pre-refactor ``AppSettings(**overrides)``
+    construction shape: env vars are only consulted on the no-override
+    fallback through get_settings.
+    """
+    monkeypatch.setenv("HOUNDARR_PORT", "7777")
+    bootstrap_settings(data_dir="/tmp/test")
+    assert get_settings().port == 8877
+
+
+def test_bootstrap_settings_no_overrides_clears_prior_pin(_isolate_pin: None) -> None:
+    """Calling bootstrap_settings() with no kwargs drops the pinned override."""
+    bootstrap_settings(data_dir="/tmp/test", port=9000)
+    bootstrap_settings()
+    # Singleton is unpinned; get_settings re-resolves from env / defaults.
+    assert get_settings().port == 8877
+
+
+def test_bootstrap_settings_no_overrides_returns_env_resolved(
+    _isolate_pin: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The no-overrides return value reflects current env vars."""
+    monkeypatch.setenv("HOUNDARR_PORT", "7777")
+    settings = bootstrap_settings()
+    assert settings.port == 7777
+
+
+def test_bootstrap_settings_back_to_back_overrides_replace(_isolate_pin: None) -> None:
+    """Each call replaces the prior pin; earlier overrides do not bleed through."""
+    bootstrap_settings(data_dir="/tmp/a", port=9000)
+    bootstrap_settings(data_dir="/tmp/b", host="127.0.0.1")
+    pinned = get_settings()
+    assert pinned.data_dir == "/tmp/b"
+    assert pinned.host == "127.0.0.1"
+    # port from the first call must not survive into the second pin.
+    assert pinned.port == 8877
+
+
+def test_bootstrap_settings_returns_pinned_instance(_isolate_pin: None) -> None:
+    """The returned AppSettings is the same object get_settings hands back."""
+    pinned = bootstrap_settings(data_dir="/tmp/test", port=9000)
+    assert get_settings() is pinned

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -20,13 +20,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 import houndarr.auth as _auth_mod
-import houndarr.config as _cfg
 from houndarr.auth import (
     CSRF_COOKIE_NAME,
     _is_proxy_auth_mode,
     _validate_proxy_auth,
 )
-from houndarr.config import AppSettings
+from houndarr.config import AppSettings, bootstrap_settings
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -46,13 +45,12 @@ _AUTH_USER = "alice"
 @pytest.fixture()
 def proxy_settings(tmp_data_dir: str) -> AppSettings:
     """Configure proxy auth mode with a trusted IP."""
-    settings = AppSettings(
+    settings = bootstrap_settings(
         data_dir=tmp_data_dir,
         auth_mode="proxy",
         auth_proxy_header=_AUTH_HEADER,
         trusted_proxies=_TRUSTED_IP,
     )
-    _cfg._runtime_settings = settings  # noqa: SLF001
     _auth_mod._serializer = None  # noqa: SLF001
     _auth_mod._login_attempts.clear()  # noqa: SLF001
     return settings


### PR DESCRIPTION
## Summary

Extract the non-web boot sequence into `houndarr.bootstrap.bootstrap_non_web` and concentrate the runtime-settings pin into `houndarr.config.bootstrap_settings`. The CLI now delegates pre-uvicorn composition to the shared primitive; tests migrate from direct `_runtime_settings` assignment to `bootstrap_settings`.

Closes #466

## Changes

- `src/houndarr/bootstrap.py`: new module exposing `bootstrap_non_web(data_dir, **overrides)`. Pins `AppSettings` (with optional overrides), ensures the data dir, loads the Fernet master key, and runs `init_db`. Returns `(AppSettings, Path, bytes)`. Overrides are typed via `AppSettingsOverrides` (`TypedDict`, `total=False`) so misspelled keys fail at type-check time.
- `src/houndarr/config.py`: add `BootstrapOverrides` `TypedDict` and `bootstrap_settings(**overrides)`. With overrides, builds and pins a fresh `AppSettings`. With no overrides, clears any prior pin and returns env-resolved settings without pinning so callers can still mutate `HOUNDARR_*` env vars after bootstrap. Module docstring spells out the ops-vs-user config boundary (env-pinned at boot vs SQLite-editable at runtime).
- `src/houndarr/__main__.py`: pre-uvicorn pin + master-key load + `init_db` collapse to a single `bootstrap_non_web(...)` call.
- `tests/conftest.py`, `tests/test_auth.py`, `tests/test_proxy_auth.py`: migrate fixtures and helpers from `_cfg._runtime_settings = AppSettings(...)` to `bootstrap_settings(...)`.
- `tests/test_bootstrap/`: new package. `test_bootstrap_non_web.py` pins the `bootstrap_non_web` contract (return-tuple shape, idempotent `init_db`, master-key persistence, env propagation, every documented override flowing through). The setup/teardown fixture clears the pin on both sides to prevent leaks under `pytest-xdist`.
- `tests/test_config.py`: seven targeted cases pinning `bootstrap_settings` precedence (overrides win over env, missing keys take dataclass defaults, no-overrides clears the pin, returned instance is what `get_settings` hands back).
- `docs/refactor/track-i-env-audit.md`: every `os.getenv` call site outside `config.py` and `__main__.py`, with the in-scope vs out-of-scope split documented and reconciled row counts.

## Testing

All gates green locally.

## Type of Change

- [x] Refactoring (`refactor:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
