### PR TITLE
refactor(repositories): namespace + per-table SQL extraction

### DIFF
--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -17,8 +17,9 @@ from houndarr import __version__
 from houndarr.auth import AuthMiddleware
 from houndarr.config import DEFAULT_LOG_RETENTION_DAYS, get_settings
 from houndarr.crypto import ensure_master_key
-from houndarr.database import init_db, purge_old_logs, set_db_path
+from houndarr.database import init_db, set_db_path
 from houndarr.engine.supervisor import Supervisor
+from houndarr.repositories.search_log import purge_old_logs
 from houndarr.services.instances import list_instances
 
 logger = logging.getLogger(__name__)

--- a/src/houndarr/auth.py
+++ b/src/houndarr/auth.py
@@ -19,7 +19,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
 from houndarr.config import get_settings
-from houndarr.database import get_setting, set_setting
+from houndarr.repositories.settings import get_setting, set_setting
 
 logger = logging.getLogger(__name__)
 

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -947,28 +947,46 @@ async def _column_exists(db: aiosqlite.Connection, table_name: str, column_name:
     return any(row[1] == column_name for row in rows)
 
 
-# ---------------------------------------------------------------------------
-# Settings helpers
-# ---------------------------------------------------------------------------
-
-
 async def get_setting(key: str, default: str | None = None) -> str | None:
-    """Fetch a single setting value by key."""
-    async with get_db() as db:
-        async with db.execute("SELECT value FROM settings WHERE key = ?", (key,)) as cur:
-            row = await cur.fetchone()
-            return str(row["value"]) if row else default
+    """Fetch a single setting value by key.
+
+    Thin delegator over
+    :func:`houndarr.repositories.settings.get_setting`; kept here so
+    callers that still import from :mod:`houndarr.database` keep
+    working while the D batches migrate them one file at a time.  The
+    ``default=`` fallback is preserved because route-layer callers
+    rely on it; the repository contract has no default (see
+    :class:`houndarr.protocols.SettingsRepository`).
+
+    Args:
+        key: Setting key to look up.
+        default: Value to return when *key* has no row (the legacy
+            contract).  Defaults to ``None``.
+
+    Returns:
+        The stored string value, or *default* when the row is absent.
+    """
+    from houndarr.repositories.settings import get_setting as _repo_get_setting
+
+    value = await _repo_get_setting(key)
+    return value if value is not None else default
 
 
 async def set_setting(key: str, value: str) -> None:
-    """Upsert a setting."""
-    async with get_db() as db:
-        await db.execute(
-            "INSERT INTO settings (key, value) VALUES (?, ?)"
-            " ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            (key, value),
-        )
-        await db.commit()
+    """Upsert a setting.
+
+    Thin delegator over
+    :func:`houndarr.repositories.settings.set_setting`.  Same rationale
+    as :func:`get_setting`: callers still importing from this module
+    see the previous signature; the SQL itself lives in the repository.
+
+    Args:
+        key: Setting key.
+        value: Raw string value to store.
+    """
+    from houndarr.repositories.settings import set_setting as _repo_set_setting
+
+    await _repo_set_setting(key, value)
 
 
 # ---------------------------------------------------------------------------

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -987,33 +987,3 @@ async def set_setting(key: str, value: str) -> None:
     from houndarr.repositories.settings import set_setting as _repo_set_setting
 
     await _repo_set_setting(key, value)
-
-
-# ---------------------------------------------------------------------------
-# Log retention
-# ---------------------------------------------------------------------------
-
-
-async def purge_old_logs(retention_days: int) -> int:
-    """Delete ``search_log`` rows older than *retention_days* days.
-
-    Called at startup (and optionally on a schedule) to prevent unbounded
-    log growth on long-running instances.
-
-    Args:
-        retention_days: Rows with a ``timestamp`` older than this many days
-            are deleted.  Pass ``0`` or a negative value to disable purging.
-
-    Returns:
-        Number of rows deleted (0 if retention is disabled or nothing to purge).
-    """
-    if retention_days <= 0:
-        return 0
-
-    async with get_db() as db:
-        cur = await db.execute(
-            "DELETE FROM search_log WHERE timestamp < datetime('now', ? || ' days')",
-            (f"-{retention_days}",),
-        )
-        await db.commit()
-        return cur.rowcount or 0

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -80,39 +80,32 @@ async def _write_log(
     reason: str | None = None,
     message: str | None = None,
 ) -> None:
-    """Insert a single row into ``search_log``."""
-    async with get_db() as db:
-        await db.execute(
-            """
-            INSERT INTO search_log
-                (
-                    instance_id,
-                    item_id,
-                    item_type,
-                    search_kind,
-                    cycle_id,
-                    cycle_trigger,
-                    item_label,
-                    action,
-                    reason,
-                    message
-                )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                instance_id,
-                item_id,
-                item_type,
-                search_kind,
-                cycle_id,
-                cycle_trigger,
-                item_label,
-                action,
-                reason,
-                message,
-            ),
-        )
-        await db.commit()
+    """Insert a single row into ``search_log``.
+
+    Thin delegator over
+    :func:`houndarr.repositories.search_log.insert_log_row`.  The
+    engine keeps this module-local symbol so the many hot-path call
+    sites (queue gate, window gate, dispatch, cycle prologue / epilogue,
+    upgrade pool fetch) all continue to import from one place; D.27
+    will sweep remaining ``_write_log`` call sites to the repository
+    directly.  The :class:`~houndarr.enums.SearchKind` /
+    :class:`~houndarr.enums.CycleTrigger` unions collapse to their
+    underlying str here so the repository sees a plain column value.
+    """
+    from houndarr.repositories.search_log import insert_log_row
+
+    await insert_log_row(
+        instance_id=instance_id,
+        item_id=item_id,
+        item_type=item_type,
+        action=action,
+        search_kind=str(search_kind) if search_kind is not None else None,
+        cycle_id=cycle_id,
+        cycle_trigger=str(cycle_trigger) if cycle_trigger is not None else None,
+        item_label=item_label,
+        reason=reason,
+        message=message,
+    )
 
 
 def _clamp(value: int, minimum: int, maximum: int) -> int:

--- a/src/houndarr/protocols.py
+++ b/src/houndarr/protocols.py
@@ -56,11 +56,14 @@ class InstanceRepository(Protocol):
     """Instance CRUD boundary backing the ``instances`` table.
 
     Track D.3 lands the read half under ``repositories/instances.py``;
-    D.4 lands the write half with concrete payload dataclasses.  The
-    read methods take the Fernet ``master_key`` so the repository can
-    decrypt ``encrypted_api_key`` before returning an :class:`Instance`;
-    the service layer in ``services/instances.py`` becomes a facade
-    over this boundary.
+    Track D.4 lands the write half, including the concrete
+    :class:`~houndarr.repositories.instances.InstanceInsert` and
+    :class:`~houndarr.repositories.instances.InstanceUpdate` payload
+    dataclasses the Protocol references below.  The read methods take
+    the Fernet ``master_key`` so the repository can decrypt
+    ``encrypted_api_key`` before returning an :class:`Instance`; the
+    service layer in ``services/instances.py`` becomes a facade over
+    this boundary.
     """
 
     def list_instances(self, *, master_key: bytes) -> Awaitable[list[Instance]]:
@@ -69,24 +72,46 @@ class InstanceRepository(Protocol):
     def get_instance(self, instance_id: int, *, master_key: bytes) -> Awaitable[Instance | None]:
         """Return the instance identified by *instance_id*, or ``None``."""
 
-    def insert_instance(self, payload: Any) -> Awaitable[int]:
+    def insert_instance(
+        self,
+        payload: Any,
+        *,
+        master_key: bytes,
+    ) -> Awaitable[int]:
         """Insert a new instance row and return the assigned primary key.
 
-        *payload* is intentionally typed as :class:`Any` here; Track
-        D.4 will replace it with the concrete ``InstanceInsert``
-        dataclass declared alongside the repository.
+        *payload* is structurally typed as :class:`Any` so consumers
+        do not import the concrete repository module just to satisfy
+        the Protocol; the concrete implementation takes an
+        :class:`~houndarr.repositories.instances.InstanceInsert`.
         """
 
-    def update_instance(self, instance_id: int, payload: Any) -> Awaitable[None]:
+    def update_instance(
+        self,
+        instance_id: int,
+        payload: Any,
+        *,
+        master_key: bytes,
+    ) -> Awaitable[None]:
         """Partially update the instance identified by *instance_id*.
 
-        *payload* is placeholder-typed for the same reason as
-        :meth:`insert_instance`; Track D.4 replaces it with the
-        concrete ``InstanceUpdate`` dataclass.
+        *payload* is structurally typed as :class:`Any` for the same
+        reason as :meth:`insert_instance`; the concrete implementation
+        takes an :class:`~houndarr.repositories.instances.InstanceUpdate`
+        and no-ops when every field is ``None``.
         """
 
-    def delete_instance(self, instance_id: int) -> Awaitable[None]:
-        """Delete the instance row and any FK-cascaded rows."""
+    def delete_instance(self, instance_id: int) -> Awaitable[bool]:
+        """Delete the instance row; return ``True`` iff a row was removed."""
+
+    def update_instance_snapshot(
+        self,
+        instance_id: int,
+        *,
+        monitored_total: int,
+        unreleased_count: int,
+    ) -> Awaitable[None]:
+        """Refresh the three v13 snapshot columns for *instance_id*."""
 
 
 @runtime_checkable

--- a/src/houndarr/protocols.py
+++ b/src/houndarr/protocols.py
@@ -55,16 +55,18 @@ class SettingsRepository(Protocol):
 class InstanceRepository(Protocol):
     """Instance CRUD boundary backing the ``instances`` table.
 
-    Track D.3 + D.4 will land a concrete module under
-    ``repositories/instances.py`` whose function shapes match this
-    Protocol; the service layer in ``services/instances.py`` then
-    becomes a facade over the repository.
+    Track D.3 lands the read half under ``repositories/instances.py``;
+    D.4 lands the write half with concrete payload dataclasses.  The
+    read methods take the Fernet ``master_key`` so the repository can
+    decrypt ``encrypted_api_key`` before returning an :class:`Instance`;
+    the service layer in ``services/instances.py`` becomes a facade
+    over this boundary.
     """
 
-    def list_instances(self) -> Awaitable[list[Instance]]:
-        """Return every instance ordered by id."""
+    def list_instances(self, *, master_key: bytes) -> Awaitable[list[Instance]]:
+        """Return every instance ordered by id ascending."""
 
-    def get_instance(self, instance_id: int) -> Awaitable[Instance | None]:
+    def get_instance(self, instance_id: int, *, master_key: bytes) -> Awaitable[Instance | None]:
         """Return the instance identified by *instance_id*, or ``None``."""
 
     def insert_instance(self, payload: Any) -> Awaitable[int]:

--- a/src/houndarr/repositories/__init__.py
+++ b/src/houndarr/repositories/__init__.py
@@ -1,0 +1,29 @@
+"""Repository layer: module-per-aggregate SQL boundary.
+
+Track D.1 introduces this namespace.  Concrete modules land
+incrementally over the remaining D batches and implement the
+Protocols already declared in :mod:`houndarr.protocols`:
+
+- ``settings.py`` (D.2): key-value reads and writes, replacing the
+  ``get_setting`` / ``set_setting`` helpers inside ``database.py``.
+- ``instances.py`` (D.3 reads, D.4 writes): ``instances`` table CRUD
+  with ``InstanceInsert`` + ``InstanceUpdate`` payload dataclasses.
+- ``cooldowns.py`` (D.5): ``cooldowns`` table SQL.  The LRU skip-log
+  sentinel stays in :mod:`houndarr.services.cooldown` and is not
+  part of this boundary.
+- ``search_log.py`` (D.6): insert, filtered page fetch, recent
+  searches counter, and per-instance delete for the ``search_log``
+  table; the engine's ``_write_log`` helper becomes a thin call into
+  ``insert_log_row``.
+
+Per locked user decision #4, every module in this package is
+function-based (no classes) and scoped to a single aggregate.
+Callers depend on the structural :mod:`houndarr.protocols` shape,
+not on the concrete repository import, which keeps the boundary
+test-swappable without subclass gymnastics.
+
+The migration helpers ``_migrate_to_v2`` through ``_migrate_to_v13``
+stay off-limits in :mod:`houndarr.database`; repository functions
+only wrap ``get_db()`` queries and never alter schema, PRAGMAs, or
+the WAL lifecycle.
+"""

--- a/src/houndarr/repositories/cooldowns.py
+++ b/src/houndarr/repositories/cooldowns.py
@@ -1,0 +1,152 @@
+"""Cooldowns aggregate: SQL boundary for the ``cooldowns`` table.
+
+Three functions cover the full surface:
+
+- :func:`exists_active_cooldown`: the SELECT that decides whether
+  an item is still inside its cooldown window.
+- :func:`upsert_cooldown`: the ``INSERT ... ON CONFLICT ... DO
+  UPDATE`` that records a freshly-searched item.
+- :func:`delete_cooldowns_for_instance`: the admin "reset cooldowns"
+  cascade for a single instance.
+
+The in-memory LRU sentinel (``should_log_skip`` and
+``_reset_skip_log_cache``) stays in the service module: it guards
+log writes, not the cooldowns table.  The repository is
+function-based with no class.
+
+Timestamps are serialised in the SQLite-native ISO-8601 format
+(``strftime('%Y-%m-%dT%H:%M:%S.%f') + 'Z'``) so ``searched_at``
+values compare lexicographically against both existing rows and
+fresh writes.  The format string is duplicated here intentionally:
+the ``search_log`` table uses a slightly different format
+(``%f`` is milliseconds there) and mixing the two is a debugging
+footgun when the column names are the same shape.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from houndarr.database import get_db
+from houndarr.value_objects import ItemRef
+
+
+def _now_utc() -> datetime:
+    """Return the current UTC moment.
+
+    Wrapped in a helper so tests can ``monkeypatch`` time without
+    touching every SQL call site.  Used by both :func:`exists_active_cooldown`
+    (cutoff computation) and :func:`upsert_cooldown` (timestamp write).
+    """
+    return datetime.now(UTC)
+
+
+def _iso(dt: datetime) -> str:
+    """Format a datetime in the cooldowns column's storage format.
+
+    The output is lexicographically comparable against existing
+    ``searched_at`` values stored in the same format.
+
+    Args:
+        dt: Datetime to render.  The caller is responsible for
+            passing a UTC value; no timezone conversion is applied.
+    """
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+async def exists_active_cooldown(ref: ItemRef, cooldown_days: int) -> bool:
+    """Return ``True`` when *ref* is still inside its cooldown window.
+
+    Short-circuits to ``False`` without touching the database when
+    *cooldown_days* is zero or negative: disabling cooldowns is a
+    common config, so the cheap path stays cheap.  Otherwise the
+    cutoff is ``now - cooldown_days`` rendered with :func:`_iso`,
+    and a row is active iff its ``searched_at`` sits strictly after
+    the cutoff.
+
+    Args:
+        ref: The (instance, item_id, item_type) triple to check.
+        cooldown_days: Length of the cooldown window in days.  Pass
+            a non-positive value to disable.
+    """
+    if cooldown_days <= 0:
+        return False
+
+    cutoff = _iso(_now_utc() - timedelta(days=cooldown_days))
+    async with get_db() as db:
+        async with db.execute(
+            """
+            SELECT 1 FROM cooldowns
+            WHERE instance_id = ?
+              AND item_id     = ?
+              AND item_type   = ?
+              AND searched_at > ?
+            LIMIT 1
+            """,
+            (ref.instance_id, ref.item_id, ref.item_type.value, cutoff),
+        ) as cur:
+            row = await cur.fetchone()
+    return row is not None
+
+
+async def upsert_cooldown(ref: ItemRef, search_kind: str) -> None:
+    """Record *ref* as just-searched, upserting any existing row.
+
+    Uses ``INSERT ... ON CONFLICT(instance_id, item_id, item_type) DO
+    UPDATE SET searched_at = excluded.searched_at, search_kind =
+    excluded.search_kind`` so repeated searches slide both the
+    timestamp AND the classification forward.  One row per
+    (instance_id, item_id, item_type) carries the kind of the most
+    recent search that wrote it; the reconciliation path reads that
+    column directly instead of re-deriving it from search_log.
+
+    Args:
+        ref: The (instance, item_id, item_type) triple that was just
+            searched.  ``item_type`` serialises through
+            :attr:`~enum.StrEnum.value`.
+        search_kind: Which pass dispatched the search: ``"missing"``,
+            ``"cutoff"``, or ``"upgrade"``.  Required, non-default on
+            purpose: callers always know which pass they are in, and
+            a default would silently miscategorise cutoff / upgrade
+            searches as missing.  The DB CHECK constraint enforces
+            the allowed values; passing anything else raises at
+            write time.
+    """
+    now = _iso(_now_utc())
+    async with get_db() as db:
+        await db.execute(
+            """
+            INSERT INTO cooldowns (instance_id, item_id, item_type, search_kind, searched_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(instance_id, item_id, item_type)
+            DO UPDATE SET
+                searched_at = excluded.searched_at,
+                search_kind = excluded.search_kind
+            """,
+            (ref.instance_id, ref.item_id, ref.item_type.value, search_kind, now),
+        )
+        await db.commit()
+
+
+async def delete_cooldowns_for_instance(instance_id: int) -> int:
+    """Delete every cooldown row for *instance_id*.
+
+    Used by the admin "reset cooldowns" action.  FK-cascaded deletes
+    from the instance row are handled at the schema level; this
+    function is for the explicit per-instance reset that leaves the
+    instance row itself intact.
+
+    Args:
+        instance_id: Owning instance primary key.
+
+    Returns:
+        Number of rows removed.  ``0`` is valid (the instance never
+        had any cooldown records).
+    """
+    async with get_db() as db:
+        cur = await db.execute(
+            "DELETE FROM cooldowns WHERE instance_id = ?",
+            (instance_id,),
+        )
+        await db.commit()
+        return cur.rowcount or 0

--- a/src/houndarr/repositories/instances.py
+++ b/src/houndarr/repositories/instances.py
@@ -1,0 +1,178 @@
+"""Instances aggregate: SQL boundary for the ``instances`` table.
+
+Track D.3 lands the read path: ``list_instances`` and
+``get_instance`` plus the row mapper and the two fault-tolerant
+column readers that keep tests with pre-v13 minimal rows compatible
+with the current :class:`houndarr.services.instances.Instance`
+dataclass.  Writes follow in D.4 (``insert_instance`` /
+``update_instance`` / ``delete_instance`` with payload dataclasses).
+
+The :class:`houndarr.services.instances.Instance` dataclass, the
+search-mode :class:`enum.StrEnum` classes, and the value-mapping
+invariants all stay in the service module through D.3; D.13 - D.20
+reshape ``Instance`` into sub-struct facades and the row mapper will
+follow that migration.  Until then the repository imports the
+dataclass and enums from the service and the service's reads
+delegate here via local imports to avoid an import-time cycle.
+
+API keys are encrypted at rest: every row passes through
+:func:`houndarr.crypto.decrypt` inside :func:`_row_to_instance`
+before the :class:`Instance` leaves this boundary.  Callers that do
+not have a master key cannot use this module; there is no
+"raw row" public reader because no caller currently wants one.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+from houndarr.crypto import decrypt
+from houndarr.database import get_db
+from houndarr.services.instances import (
+    Instance,
+    InstanceType,
+    LidarrSearchMode,
+    ReadarrSearchMode,
+    SearchOrder,
+    SonarrSearchMode,
+    WhisparrSearchMode,
+)
+
+
+def _optional_row_int(row: aiosqlite.Row, key: str) -> int:
+    """Return ``row[key]`` coerced to int, or ``0`` when the column is absent.
+
+    Some tests seed the ``instances`` table with the pre-v13 column
+    set (no ``monitored_total`` / ``unreleased_count`` /
+    ``snapshot_refreshed_at``); this helper keeps those rows readable
+    against the current dataclass without a migration.
+
+    Args:
+        row: aiosqlite row, typically from a ``SELECT *`` against
+            the ``instances`` table.
+        key: Column name to read.
+
+    Returns:
+        The column's value as an int, or ``0`` when the column or
+        value is absent (``None``).
+    """
+    try:
+        val = row[key]
+    except (IndexError, KeyError):
+        return 0
+    return int(val) if val is not None else 0
+
+
+def _optional_row_str(row: aiosqlite.Row, key: str) -> str:
+    """Return ``row[key]`` coerced to str, or ``''`` when the column is absent.
+
+    Args:
+        row: aiosqlite row, typically from a ``SELECT *`` against
+            the ``instances`` table.
+        key: Column name to read.
+
+    Returns:
+        The column's value as a string, or ``''`` when the column
+        or value is absent (``None``).
+    """
+    try:
+        val = row[key]
+    except (IndexError, KeyError):
+        return ""
+    return str(val) if val is not None else ""
+
+
+def _row_to_instance(row: aiosqlite.Row, master_key: bytes) -> Instance:
+    """Map an aiosqlite row to a decrypted :class:`Instance`.
+
+    Decrypts ``encrypted_api_key`` with *master_key* and coerces each
+    ``*_search_mode`` / ``search_order`` column through the matching
+    :class:`enum.StrEnum`.  ``monitored_total`` / ``unreleased_count``
+    / ``snapshot_refreshed_at`` route through the tolerant optional
+    helpers so older test fixtures keep deserialising.
+
+    Args:
+        row: ``SELECT *`` row from the ``instances`` table.
+        master_key: Fernet key used to decrypt ``encrypted_api_key``.
+
+    Returns:
+        A fully-populated :class:`Instance` with a plaintext
+        ``api_key``.
+    """
+    return Instance(
+        id=row["id"],
+        name=row["name"],
+        type=InstanceType(row["type"]),
+        url=row["url"],
+        api_key=decrypt(row["encrypted_api_key"], master_key),
+        enabled=bool(row["enabled"]),
+        batch_size=row["batch_size"],
+        sleep_interval_mins=row["sleep_interval_mins"],
+        hourly_cap=row["hourly_cap"],
+        cooldown_days=row["cooldown_days"],
+        post_release_grace_hrs=row["post_release_grace_hrs"],
+        queue_limit=row["queue_limit"],
+        cutoff_enabled=bool(row["cutoff_enabled"]),
+        cutoff_batch_size=row["cutoff_batch_size"],
+        cutoff_cooldown_days=row["cutoff_cooldown_days"],
+        cutoff_hourly_cap=row["cutoff_hourly_cap"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        sonarr_search_mode=SonarrSearchMode(row["sonarr_search_mode"]),
+        lidarr_search_mode=LidarrSearchMode(row["lidarr_search_mode"]),
+        readarr_search_mode=ReadarrSearchMode(row["readarr_search_mode"]),
+        whisparr_search_mode=WhisparrSearchMode(row["whisparr_search_mode"]),
+        upgrade_enabled=bool(row["upgrade_enabled"]),
+        upgrade_batch_size=row["upgrade_batch_size"],
+        upgrade_cooldown_days=row["upgrade_cooldown_days"],
+        upgrade_hourly_cap=row["upgrade_hourly_cap"],
+        upgrade_sonarr_search_mode=SonarrSearchMode(row["upgrade_sonarr_search_mode"]),
+        upgrade_lidarr_search_mode=LidarrSearchMode(row["upgrade_lidarr_search_mode"]),
+        upgrade_readarr_search_mode=ReadarrSearchMode(row["upgrade_readarr_search_mode"]),
+        upgrade_whisparr_search_mode=WhisparrSearchMode(row["upgrade_whisparr_search_mode"]),
+        upgrade_item_offset=row["upgrade_item_offset"],
+        upgrade_series_offset=row["upgrade_series_offset"],
+        missing_page_offset=row["missing_page_offset"],
+        cutoff_page_offset=row["cutoff_page_offset"],
+        allowed_time_window=row["allowed_time_window"],
+        search_order=SearchOrder(row["search_order"]),
+        monitored_total=_optional_row_int(row, "monitored_total"),
+        unreleased_count=_optional_row_int(row, "unreleased_count"),
+        snapshot_refreshed_at=_optional_row_str(row, "snapshot_refreshed_at"),
+    )
+
+
+async def get_instance(instance_id: int, *, master_key: bytes) -> Instance | None:
+    """Fetch one instance row by primary key.
+
+    Args:
+        instance_id: Primary key of the row to read.
+        master_key: Fernet key used to decrypt the stored API key.
+
+    Returns:
+        Decrypted :class:`Instance`, or ``None`` when no row exists
+        for *instance_id*.
+    """
+    async with get_db() as db:
+        async with db.execute("SELECT * FROM instances WHERE id = ?", (instance_id,)) as cur:
+            row = await cur.fetchone()
+    if row is None:
+        return None
+    return _row_to_instance(row, master_key)
+
+
+async def list_instances(*, master_key: bytes) -> list[Instance]:
+    """Return every instance row in stable id order.
+
+    Args:
+        master_key: Fernet key used to decrypt each stored API key.
+
+    Returns:
+        List of decrypted :class:`Instance` objects (may be empty);
+        sort order is ``id ASC`` so the UI's row ordering matches
+        insertion order.
+    """
+    async with get_db() as db:
+        async with db.execute("SELECT * FROM instances ORDER BY id ASC") as cur:
+            rows = await cur.fetchall()
+    return [_row_to_instance(r, master_key) for r in rows]

--- a/src/houndarr/repositories/instances.py
+++ b/src/houndarr/repositories/instances.py
@@ -1,32 +1,63 @@
 """Instances aggregate: SQL boundary for the ``instances`` table.
 
-Track D.3 lands the read path: ``list_instances`` and
-``get_instance`` plus the row mapper and the two fault-tolerant
-column readers that keep tests with pre-v13 minimal rows compatible
-with the current :class:`houndarr.services.instances.Instance`
-dataclass.  Writes follow in D.4 (``insert_instance`` /
-``update_instance`` / ``delete_instance`` with payload dataclasses).
+Track D.3 landed the read path (``list_instances`` / ``get_instance``
+plus the row mapper and the fault-tolerant column readers that keep
+tests with pre-v13 minimal rows compatible with the current
+:class:`houndarr.services.instances.Instance` dataclass).  Track D.4
+lands the write path: :class:`InstanceInsert` and
+:class:`InstanceUpdate` payload dataclasses, ``insert_instance``,
+``update_instance``, ``delete_instance``, and
+``update_instance_snapshot``.
 
-The :class:`houndarr.services.instances.Instance` dataclass, the
-search-mode :class:`enum.StrEnum` classes, and the value-mapping
-invariants all stay in the service module through D.3; D.13 - D.20
-reshape ``Instance`` into sub-struct facades and the row mapper will
-follow that migration.  Until then the repository imports the
-dataclass and enums from the service and the service's reads
-delegate here via local imports to avoid an import-time cycle.
+The :class:`~houndarr.services.instances.Instance` domain dataclass,
+the search-mode :class:`enum.StrEnum` classes, and the value-mapping
+invariants all stay in the service module through Track D's early
+batches; D.13 - D.20 reshape ``Instance`` into sub-struct facades and
+the row mapper will follow that migration.  Until then this
+repository imports the dataclass and enums from the service and the
+service's writes delegate here via local imports to avoid an
+import-time cycle.
 
-API keys are encrypted at rest: every row passes through
-:func:`houndarr.crypto.decrypt` inside :func:`_row_to_instance`
-before the :class:`Instance` leaves this boundary.  Callers that do
-not have a master key cannot use this module; there is no
-"raw row" public reader because no caller currently wants one.
+API keys are encrypted at rest: every write accepts plaintext, and
+the repository runs :func:`houndarr.crypto.encrypt` before touching
+SQL.  Every read decrypts via :func:`_row_to_instance`.  Payload
+dataclasses therefore carry plaintext in their ``api_key`` field;
+the encrypted blob never escapes this module.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, fields
+from enum import StrEnum
+from typing import Any
+
 import aiosqlite
 
-from houndarr.crypto import decrypt
+from houndarr.config import (
+    DEFAULT_ALLOWED_TIME_WINDOW,
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_COOLDOWN_DAYS,
+    DEFAULT_CUTOFF_BATCH_SIZE,
+    DEFAULT_CUTOFF_COOLDOWN_DAYS,
+    DEFAULT_CUTOFF_HOURLY_CAP,
+    DEFAULT_HOURLY_CAP,
+    DEFAULT_LIDARR_SEARCH_MODE,
+    DEFAULT_POST_RELEASE_GRACE_HOURS,
+    DEFAULT_QUEUE_LIMIT,
+    DEFAULT_READARR_SEARCH_MODE,
+    DEFAULT_SEARCH_ORDER,
+    DEFAULT_SLEEP_INTERVAL_MINUTES,
+    DEFAULT_SONARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_BATCH_SIZE,
+    DEFAULT_UPGRADE_COOLDOWN_DAYS,
+    DEFAULT_UPGRADE_HOURLY_CAP,
+    DEFAULT_UPGRADE_LIDARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_READARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_SONARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
+    DEFAULT_WHISPARR_SEARCH_MODE,
+)
+from houndarr.crypto import decrypt, encrypt
 from houndarr.database import get_db
 from houndarr.services.instances import (
     Instance,
@@ -176,3 +207,334 @@ async def list_instances(*, master_key: bytes) -> list[Instance]:
         async with db.execute("SELECT * FROM instances ORDER BY id ASC") as cur:
             rows = await cur.fetchall()
     return [_row_to_instance(r, master_key) for r in rows]
+
+
+@dataclass(frozen=True, slots=True)
+class InstanceInsert:
+    """Payload for :func:`insert_instance`.
+
+    Mirrors the columns written by the concrete SQL.  ``api_key`` is
+    the plaintext value; :func:`insert_instance` encrypts it before
+    the row lands.  Every field carries a default that matches the
+    ``instances`` table DDL, so the three identifying fields
+    (``name`` / ``type`` / ``url``) plus ``api_key`` are the only
+    mandatory inputs for the common UI-driven create path.
+    ``created_at`` and ``updated_at`` are not exposed here because
+    SQLite fills them from the ``DEFAULT strftime(...)`` column spec.
+    """
+
+    name: str
+    type: InstanceType
+    url: str
+    api_key: str
+    enabled: bool = True
+    batch_size: int = DEFAULT_BATCH_SIZE
+    sleep_interval_mins: int = DEFAULT_SLEEP_INTERVAL_MINUTES
+    hourly_cap: int = DEFAULT_HOURLY_CAP
+    cooldown_days: int = DEFAULT_COOLDOWN_DAYS
+    post_release_grace_hrs: int = DEFAULT_POST_RELEASE_GRACE_HOURS
+    queue_limit: int = DEFAULT_QUEUE_LIMIT
+    cutoff_enabled: bool = False
+    cutoff_batch_size: int = DEFAULT_CUTOFF_BATCH_SIZE
+    cutoff_cooldown_days: int = DEFAULT_CUTOFF_COOLDOWN_DAYS
+    cutoff_hourly_cap: int = DEFAULT_CUTOFF_HOURLY_CAP
+    sonarr_search_mode: SonarrSearchMode = SonarrSearchMode(DEFAULT_SONARR_SEARCH_MODE)
+    lidarr_search_mode: LidarrSearchMode = LidarrSearchMode(DEFAULT_LIDARR_SEARCH_MODE)
+    readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode(DEFAULT_READARR_SEARCH_MODE)
+    whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode(DEFAULT_WHISPARR_SEARCH_MODE)
+    upgrade_enabled: bool = False
+    upgrade_batch_size: int = DEFAULT_UPGRADE_BATCH_SIZE
+    upgrade_cooldown_days: int = DEFAULT_UPGRADE_COOLDOWN_DAYS
+    upgrade_hourly_cap: int = DEFAULT_UPGRADE_HOURLY_CAP
+    upgrade_sonarr_search_mode: SonarrSearchMode = SonarrSearchMode(
+        DEFAULT_UPGRADE_SONARR_SEARCH_MODE
+    )
+    upgrade_lidarr_search_mode: LidarrSearchMode = LidarrSearchMode(
+        DEFAULT_UPGRADE_LIDARR_SEARCH_MODE
+    )
+    upgrade_readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode(
+        DEFAULT_UPGRADE_READARR_SEARCH_MODE
+    )
+    upgrade_whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode(
+        DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE
+    )
+    allowed_time_window: str = DEFAULT_ALLOWED_TIME_WINDOW
+    search_order: SearchOrder = SearchOrder(DEFAULT_SEARCH_ORDER)
+
+
+@dataclass(frozen=True, slots=True)
+class InstanceUpdate:
+    """Payload for :func:`update_instance`.
+
+    Every field is optional with ``None`` as the "do not touch"
+    sentinel.  This is safe because every updatable column is
+    non-nullable at the schema level, so no field's domain includes
+    ``None`` legitimately.  ``api_key``, when supplied, is plaintext;
+    :func:`update_instance` re-encrypts it.  The three snapshot
+    columns and the four pagination-offset columns are included so
+    the update surface matches the table schema exactly, even though
+    the routine caller path uses :func:`update_instance_snapshot`
+    and :func:`update_instance` for offsets respectively.
+    """
+
+    name: str | None = None
+    type: InstanceType | None = None
+    url: str | None = None
+    api_key: str | None = None
+    enabled: bool | None = None
+    batch_size: int | None = None
+    sleep_interval_mins: int | None = None
+    hourly_cap: int | None = None
+    cooldown_days: int | None = None
+    post_release_grace_hrs: int | None = None
+    queue_limit: int | None = None
+    cutoff_enabled: bool | None = None
+    cutoff_batch_size: int | None = None
+    cutoff_cooldown_days: int | None = None
+    cutoff_hourly_cap: int | None = None
+    sonarr_search_mode: SonarrSearchMode | None = None
+    lidarr_search_mode: LidarrSearchMode | None = None
+    readarr_search_mode: ReadarrSearchMode | None = None
+    whisparr_search_mode: WhisparrSearchMode | None = None
+    upgrade_enabled: bool | None = None
+    upgrade_batch_size: int | None = None
+    upgrade_cooldown_days: int | None = None
+    upgrade_hourly_cap: int | None = None
+    upgrade_sonarr_search_mode: SonarrSearchMode | None = None
+    upgrade_lidarr_search_mode: LidarrSearchMode | None = None
+    upgrade_readarr_search_mode: ReadarrSearchMode | None = None
+    upgrade_whisparr_search_mode: WhisparrSearchMode | None = None
+    upgrade_item_offset: int | None = None
+    upgrade_series_offset: int | None = None
+    missing_page_offset: int | None = None
+    cutoff_page_offset: int | None = None
+    allowed_time_window: str | None = None
+    search_order: SearchOrder | None = None
+    monitored_total: int | None = None
+    unreleased_count: int | None = None
+    snapshot_refreshed_at: str | None = None
+
+
+# Columns whose value maps through ``StrEnum.value`` on the write path.
+# Declared once so _sql_value_for stays table-driven instead of a
+# long if / elif ladder that drifts as columns are added.
+_ENUM_UPDATE_FIELDS: frozenset[str] = frozenset(
+    {
+        "type",
+        "sonarr_search_mode",
+        "lidarr_search_mode",
+        "readarr_search_mode",
+        "whisparr_search_mode",
+        "upgrade_sonarr_search_mode",
+        "upgrade_lidarr_search_mode",
+        "upgrade_readarr_search_mode",
+        "upgrade_whisparr_search_mode",
+        "search_order",
+    }
+)
+
+# Columns stored as INTEGER that the dataclass exposes as bool.
+_BOOL_UPDATE_FIELDS: frozenset[str] = frozenset(
+    {
+        "enabled",
+        "cutoff_enabled",
+        "upgrade_enabled",
+    }
+)
+
+# Columns whose write-side database column name differs from the
+# dataclass field name.  Only ``api_key`` differs today; the rest
+# map 1:1.
+_FIELD_TO_COLUMN: dict[str, str] = {"api_key": "encrypted_api_key"}
+
+
+def _sql_column_for(field_name: str) -> str:
+    """Return the SQL column name for a payload field."""
+    return _FIELD_TO_COLUMN.get(field_name, field_name)
+
+
+def _sql_value_for(field_name: str, value: Any, master_key: bytes) -> Any:
+    """Coerce a payload value to the form SQLite wants.
+
+    Handles the three divergences between the Pythonic payload field
+    type and the SQLite column type:
+
+    - ``api_key`` is encrypted before storage.
+    - ``StrEnum`` values flatten to their underlying string.
+    - ``bool`` becomes ``int`` (SQLite stores 0 / 1 for BOOLEAN
+      columns declared as INTEGER).
+    """
+    if field_name == "api_key":
+        return encrypt(str(value), master_key)
+    if field_name in _ENUM_UPDATE_FIELDS and isinstance(value, StrEnum):
+        return value.value
+    if field_name in _BOOL_UPDATE_FIELDS:
+        return int(bool(value))
+    return value
+
+
+async def insert_instance(payload: InstanceInsert, *, master_key: bytes) -> int:
+    """Insert a new instance row and return the assigned primary key.
+
+    Args:
+        payload: Fully-populated :class:`InstanceInsert` describing
+            the new row.  ``api_key`` is plaintext; this function
+            encrypts it with *master_key* before the INSERT.
+        master_key: Fernet key used to encrypt ``api_key``.
+
+    Returns:
+        The ``id`` SQLite assigned to the new row.
+    """
+    encrypted = encrypt(payload.api_key, master_key)
+    async with get_db() as db:
+        cur = await db.execute(
+            """
+            INSERT INTO instances (
+                name, type, url, encrypted_api_key,
+                enabled, batch_size, sleep_interval_mins,
+                hourly_cap, cooldown_days, post_release_grace_hrs, queue_limit,
+                cutoff_enabled, cutoff_batch_size, cutoff_cooldown_days, cutoff_hourly_cap,
+                sonarr_search_mode, lidarr_search_mode, readarr_search_mode,
+                whisparr_search_mode,
+                upgrade_enabled, upgrade_batch_size, upgrade_cooldown_days,
+                upgrade_hourly_cap,
+                upgrade_sonarr_search_mode, upgrade_lidarr_search_mode,
+                upgrade_readarr_search_mode, upgrade_whisparr_search_mode,
+                allowed_time_window, search_order
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            (
+                payload.name,
+                payload.type.value,
+                payload.url,
+                encrypted,
+                int(payload.enabled),
+                payload.batch_size,
+                payload.sleep_interval_mins,
+                payload.hourly_cap,
+                payload.cooldown_days,
+                payload.post_release_grace_hrs,
+                payload.queue_limit,
+                int(payload.cutoff_enabled),
+                payload.cutoff_batch_size,
+                payload.cutoff_cooldown_days,
+                payload.cutoff_hourly_cap,
+                payload.sonarr_search_mode.value,
+                payload.lidarr_search_mode.value,
+                payload.readarr_search_mode.value,
+                payload.whisparr_search_mode.value,
+                int(payload.upgrade_enabled),
+                payload.upgrade_batch_size,
+                payload.upgrade_cooldown_days,
+                payload.upgrade_hourly_cap,
+                payload.upgrade_sonarr_search_mode.value,
+                payload.upgrade_lidarr_search_mode.value,
+                payload.upgrade_readarr_search_mode.value,
+                payload.upgrade_whisparr_search_mode.value,
+                payload.allowed_time_window,
+                payload.search_order.value,
+            ),
+        )
+        await db.commit()
+        row_id = cur.lastrowid
+        assert row_id is not None  # noqa: S101
+        return row_id
+
+
+async def update_instance(
+    instance_id: int,
+    payload: InstanceUpdate,
+    *,
+    master_key: bytes,
+) -> None:
+    """Partially update the instance row for *instance_id*.
+
+    Every non-``None`` field in *payload* becomes a ``column = ?``
+    assignment.  The SQL also bumps ``updated_at`` to ``now``
+    whenever at least one field is supplied, mirroring the pre-D.4
+    behaviour.  When every payload field is ``None`` this function is
+    a no-op (no SQL is executed), so callers can pass a blank
+    :class:`InstanceUpdate` cheaply.
+
+    Args:
+        instance_id: Primary key of the row to update.
+        payload: :class:`InstanceUpdate` describing the partial
+            update.  ``api_key``, when set, is plaintext.
+        master_key: Fernet key used to re-encrypt ``api_key`` when
+            it is part of the update.
+    """
+    assignments: list[str] = []
+    values: list[Any] = []
+
+    for field in fields(payload):
+        value = getattr(payload, field.name)
+        if value is None:
+            continue
+        assignments.append(f"{_sql_column_for(field.name)} = ?")
+        values.append(_sql_value_for(field.name, value, master_key))
+
+    if not assignments:
+        return
+
+    assignments.append("updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')")
+    values.append(instance_id)
+    sql = f"UPDATE instances SET {', '.join(assignments)} WHERE id = ?"  # noqa: S608  # nosec B608
+    async with get_db() as db:
+        await db.execute(sql, values)
+        await db.commit()
+
+
+async def delete_instance(instance_id: int) -> bool:
+    """Delete the instance row for *instance_id*.
+
+    Cooldown rows cascade via the FK declaration; ``search_log`` rows
+    set their ``instance_id`` to NULL per ``ON DELETE SET NULL``.
+
+    Args:
+        instance_id: Primary key of the row to delete.
+
+    Returns:
+        ``True`` when a row was removed, ``False`` when no row
+        matched the id.
+    """
+    async with get_db() as db:
+        cur = await db.execute("DELETE FROM instances WHERE id = ?", (instance_id,))
+        await db.commit()
+        return (cur.rowcount or 0) > 0
+
+
+async def update_instance_snapshot(
+    instance_id: int,
+    *,
+    monitored_total: int,
+    unreleased_count: int,
+) -> None:
+    """Write the three snapshot columns for *instance_id*.
+
+    Kept as a dedicated function rather than routed through
+    :func:`update_instance` because the supervisor refreshes
+    snapshots on a hot path and writing the literal ``strftime``
+    for ``snapshot_refreshed_at`` is clearer as a one-shot SQL
+    statement than as a payload transformation.  ``updated_at`` is
+    refreshed alongside so downstream ``last_modified`` displays
+    stay coherent.
+
+    Args:
+        instance_id: Primary key of the row to update.
+        monitored_total: New value for ``monitored_total``.
+        unreleased_count: New value for ``unreleased_count``.
+    """
+    async with get_db() as db:
+        await db.execute(
+            "UPDATE instances SET"
+            " monitored_total = ?,"
+            " unreleased_count = ?,"
+            " snapshot_refreshed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),"
+            " updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
+            " WHERE id = ?",
+            (int(monitored_total), int(unreleased_count), instance_id),
+        )
+        await db.commit()

--- a/src/houndarr/repositories/search_log.py
+++ b/src/houndarr/repositories/search_log.py
@@ -254,3 +254,34 @@ async def delete_logs_for_instance(instance_id: int) -> int:
         )
         await db.commit()
         return cur.rowcount or 0
+
+
+async def purge_old_logs(retention_days: int) -> int:
+    """Delete ``search_log`` rows older than *retention_days* days.
+
+    Called by the app lifespan at startup and by
+    ``_periodic_log_retention`` on a 24-hour cadence to prevent
+    unbounded log growth on long-running instances.  Living in the
+    repository layer (alongside every other ``search_log`` SQL writer)
+    keeps the table's SQL entirely owned here.
+
+    Args:
+        retention_days: Rows with a ``timestamp`` older than this many
+            days are deleted.  Pass ``0`` or a negative value to
+            disable purging; the function then returns ``0`` without
+            issuing any SQL.
+
+    Returns:
+        Number of rows deleted (``0`` when retention is disabled or
+        nothing matched the cut-off).
+    """
+    if retention_days <= 0:
+        return 0
+
+    async with get_db() as db:
+        cur = await db.execute(
+            "DELETE FROM search_log WHERE timestamp < datetime('now', ? || ' days')",
+            (f"-{retention_days}",),
+        )
+        await db.commit()
+        return cur.rowcount or 0

--- a/src/houndarr/repositories/search_log.py
+++ b/src/houndarr/repositories/search_log.py
@@ -1,0 +1,256 @@
+"""Search-log aggregate: SQL boundary for the ``search_log`` table.
+
+Track D.6 lands the insert path and a minimal fetch surface matching
+the :class:`houndarr.protocols.SearchLogRepository` Protocol.  The
+engine's ``_write_log`` helper in :mod:`houndarr.engine.search_loop`
+delegates to :func:`insert_log_row`; the golden-log characterisation
+test in ``tests/test_engine/test_golden_search_log.py`` pins the
+column ordering and NULL-vs-value handling so the byte-equal
+invariant survives the migration.
+
+Track D.9 extracts a log-query service that will consume
+:func:`fetch_log_rows` for the ``/api/logs`` route; until then the
+route keeps its own dynamic SQL.  D.27 sweeps the remaining engine
+call sites for ``_write_log`` (the specialised ``fetch_recent_searches``
+and ``fetch_latest_missing_reason`` lookups currently living in
+:mod:`houndarr.engine.search_loop`) through the repository.
+
+Timestamps: the ``search_log.timestamp`` column is a ``DEFAULT
+strftime(...)`` at the schema level, so inserts leave it untouched
+and SQLite assigns the value atomically at commit time.  This
+repository does not accept or return a timestamp on the insert path:
+every other call site that needs a row's timestamp reads it back
+via :func:`fetch_log_rows`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from houndarr.database import get_db
+
+# Columns the fetch query is allowed to filter on.  Declared once so the
+# dynamic WHERE builder in :func:`fetch_log_rows` stays table-driven and
+# only accepts parameter names that map directly to real columns; the
+# allowlist closes the SQL-injection surface that a free-form kwargs map
+# would otherwise open.
+_FETCH_FILTER_COLUMNS: frozenset[str] = frozenset(
+    {"instance_id", "action", "search_kind", "cycle_id"}
+)
+
+
+async def insert_log_row(
+    *,
+    instance_id: int | None,
+    item_id: int | None,
+    item_type: str | None,
+    action: str,
+    search_kind: str | None = None,
+    cycle_id: str | None = None,
+    cycle_trigger: str | None = None,
+    item_label: str | None = None,
+    reason: str | None = None,
+    message: str | None = None,
+) -> None:
+    """Insert a single row into ``search_log``.
+
+    The column list is fixed and matches the v13 schema exactly.
+    ``timestamp`` is not a parameter: the column has a ``DEFAULT
+    strftime(...)`` spec that SQLite resolves on commit, which keeps
+    the write path side-effect-free w.r.t. the clock.
+
+    Args:
+        instance_id: Owning instance primary key, or ``None`` for
+            system-scope rows (cycle-level info / error messages that
+            are not tied to a specific instance).
+        item_id: Item primary key as reported by the *arr, or ``None``
+            for cycle-scope rows.
+        item_type: One of the :class:`~houndarr.enums.ItemType` string
+            values, or ``None``.  The column has a CHECK constraint
+            that rejects unknown values, so callers that pass arbitrary
+            strings here will see a constraint violation at commit.
+        action: One of the :class:`~houndarr.enums.SearchAction` string
+            values (``"searched"`` / ``"skipped"`` / ``"error"`` /
+            ``"info"``).  Column has a CHECK constraint.
+        search_kind: ``"missing"`` / ``"cutoff"`` / ``"upgrade"``, or
+            ``None`` for cycle-scope rows.
+        cycle_id: Shared identifier joining all rows from one cycle,
+            or ``None`` for out-of-cycle writes.
+        cycle_trigger: ``"scheduled"`` / ``"run_now"`` / ``"system"``,
+            or ``None``.
+        item_label: Human-readable label for the item, or ``None``.
+        reason: Structured skip reason for ``action='skipped'`` rows.
+        message: Free-form detail for ``action='error'`` / ``'info'``
+            rows.
+    """
+    async with get_db() as db:
+        await db.execute(
+            """
+            INSERT INTO search_log
+                (
+                    instance_id,
+                    item_id,
+                    item_type,
+                    search_kind,
+                    cycle_id,
+                    cycle_trigger,
+                    item_label,
+                    action,
+                    reason,
+                    message
+                )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                instance_id,
+                item_id,
+                item_type,
+                search_kind,
+                cycle_id,
+                cycle_trigger,
+                item_label,
+                action,
+                reason,
+                message,
+            ),
+        )
+        await db.commit()
+
+
+async def fetch_log_rows(
+    *,
+    instance_id: int | None = None,
+    action: str | None = None,
+    search_kind: str | None = None,
+    cycle_id: str | None = None,
+    limit: int = 100,
+    after_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return a filtered page of ``search_log`` rows.
+
+    Each filter defaults to ``None`` (no restriction).  ``after_id``
+    acts as a descending cursor: pass the ``id`` of the last row from
+    a previous page to fetch the next chunk.  Rows sort by
+    ``timestamp DESC, id DESC`` so the newest row is always first,
+    which matches the UI's reverse-chronological listing.
+
+    The cycle-aggregate subqueries used by the ``/api/logs`` route
+    live in the route module for now; this repository returns the
+    raw column values.  D.9 will introduce a log-query service that
+    layers the aggregates on top of this primitive.
+
+    Args:
+        instance_id: Filter to rows owned by this instance id.
+        action: Filter to rows with this action string.
+        search_kind: Filter to rows with this search-kind string.
+        cycle_id: Filter to rows with this cycle identifier.
+        limit: Maximum number of rows to return.  Caller-enforced
+            positive integer; there is no server-side cap.
+        after_id: Return rows with ``id < after_id`` (for forward
+            pagination through a reverse-chronological page).
+
+    Returns:
+        List of dict rows; each dict has the column names as keys.
+    """
+    candidate_filters: dict[str, Any] = {
+        "instance_id": instance_id,
+        "action": action,
+        "search_kind": search_kind,
+        "cycle_id": cycle_id,
+    }
+    conditions: list[str] = []
+    values: list[Any] = []
+    for column, value in candidate_filters.items():
+        if value is None:
+            continue
+        if column not in _FETCH_FILTER_COLUMNS:
+            continue
+        conditions.append(f"{column} = ?")
+        values.append(value)
+
+    if after_id is not None:
+        conditions.append("id < ?")
+        values.append(after_id)
+
+    where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    values.append(int(limit))
+
+    sql = f"SELECT * FROM search_log {where_clause} ORDER BY timestamp DESC, id DESC LIMIT ?"  # noqa: S608  # nosec B608
+    async with get_db() as db:
+        async with db.execute(sql, values) as cur:
+            rows = await cur.fetchall()
+    return [dict(row) for row in rows]
+
+
+async def fetch_recent_searches(
+    instance_id: int,
+    *,
+    search_kind: str,
+    within_seconds: int,
+) -> int:
+    """Count ``action='searched'`` rows in the trailing window.
+
+    Used by the engine's hourly-cap gate: every pass counts how many
+    search commands have landed for the same (instance, kind) pair in
+    the trailing ``within_seconds`` and stops early once the cap is
+    reached.  The query is parameterised so callers can reuse the
+    boundary for short-window throttles too; the current engine path
+    passes ``3600``.
+
+    Args:
+        instance_id: Owning instance primary key.
+        search_kind: ``"missing"`` / ``"cutoff"`` / ``"upgrade"``.
+        within_seconds: Trailing window length in seconds.  Non-positive
+            values return ``0`` without touching the database.
+
+    Returns:
+        Number of ``searched`` rows for the (instance, search_kind)
+        pair inside the window.
+    """
+    if within_seconds <= 0:
+        return 0
+
+    cutoff = datetime.now(UTC) - timedelta(seconds=within_seconds)
+    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+    async with get_db() as db:
+        async with db.execute(
+            """
+            SELECT COUNT(*)
+            FROM search_log
+            WHERE instance_id = ?
+              AND action = 'searched'
+              AND search_kind = ?
+              AND timestamp > ?
+            """,
+            (instance_id, search_kind, cutoff_iso),
+        ) as cur:
+            row = await cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+async def delete_logs_for_instance(instance_id: int) -> int:
+    """Delete every ``search_log`` row for *instance_id*.
+
+    The table's ``instance_id`` FK uses ``ON DELETE SET NULL`` so
+    deleting the owning instance row leaves the log rows intact with
+    ``instance_id = NULL``.  This function is the explicit per-instance
+    purge: intended for a future admin "clear history" flow.  No
+    current caller exercises it; the method is implemented to match
+    the :class:`~houndarr.protocols.SearchLogRepository` Protocol
+    surface.
+
+    Args:
+        instance_id: Owning instance primary key.
+
+    Returns:
+        Number of rows deleted.
+    """
+    async with get_db() as db:
+        cur = await db.execute(
+            "DELETE FROM search_log WHERE instance_id = ?",
+            (instance_id,),
+        )
+        await db.commit()
+        return cur.rowcount or 0

--- a/src/houndarr/repositories/settings.py
+++ b/src/houndarr/repositories/settings.py
@@ -1,0 +1,83 @@
+"""Key-value settings aggregate: SQL boundary for the ``settings`` table.
+
+Track D.2 introduces this module.  The previous incarnation lived as
+two helpers (``get_setting`` / ``set_setting``) inside
+:mod:`houndarr.database`; this repository owns the SQL now and the
+database-module wrappers delegate here so callers migrate one file
+at a time.  ``delete_setting`` is added to match the full
+:class:`houndarr.protocols.SettingsRepository` contract; the previous
+code path had no delete at all because removing a setting was never
+required by any caller, but the contract calls for the symmetry.
+
+Function shape matches the Protocol (no ``default`` argument on
+``get_setting``).  Callers that need a default fall back at their own
+call site: ``(await get_setting(key)) or "default"`` for the truthy
+case, or ``(await get_setting(key)) if value is not None else default``
+for the strict ``None``-only fallback.  The legacy
+:func:`houndarr.database.get_setting` wrapper preserves the explicit
+``default=`` kwarg for the route call sites that still import from
+there; later D batches thin those callers out.
+"""
+
+from __future__ import annotations
+
+from houndarr.database import get_db
+
+
+async def get_setting(key: str) -> str | None:
+    """Fetch a single setting value by key.
+
+    Args:
+        key: Setting key to look up in the ``settings`` table.
+
+    Returns:
+        The stored value as a string, or ``None`` if no row exists for
+        *key*.  Callers that want a default on a missing row must
+        handle the ``None`` branch at the call site; the repository
+        contract deliberately omits the default to keep the SQL
+        boundary minimal.
+    """
+    async with get_db() as db:
+        async with db.execute("SELECT value FROM settings WHERE key = ?", (key,)) as cur:
+            row = await cur.fetchone()
+            return str(row["value"]) if row else None
+
+
+async def set_setting(key: str, value: str) -> None:
+    """Upsert a single setting row.
+
+    Executes ``INSERT ... ON CONFLICT(key) DO UPDATE SET value =
+    excluded.value`` so the row is either created or rewritten.  The
+    caller is responsible for any value serialisation (JSON, epoch
+    seconds, etc.); the column is ``TEXT`` and stores the string
+    verbatim.
+
+    Args:
+        key: Setting key.
+        value: Raw string value to store.  Empty strings are stored
+            as empty strings (distinct from a missing row, which
+            yields ``None`` from :func:`get_setting`).
+    """
+    async with get_db() as db:
+        await db.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)"
+            " ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+        await db.commit()
+
+
+async def delete_setting(key: str) -> None:
+    """Delete a setting row if it exists.
+
+    Silently succeeds when the key is absent: the intent is idempotent
+    removal.  No caller relies on the number of rows affected today,
+    so the function returns ``None`` rather than a count; add a
+    ``rowcount``-returning variant if a future caller needs it.
+
+    Args:
+        key: Setting key to remove.
+    """
+    async with get_db() as db:
+        await db.execute("DELETE FROM settings WHERE key = ?", (key,))
+        await db.commit()

--- a/src/houndarr/services/cooldown.py
+++ b/src/houndarr/services/cooldown.py
@@ -1,31 +1,85 @@
-"""Cooldown service: per-item search tracking and per-instance hourly cap.
+"""Cooldown service: per-item search tracking and skip-log throttling.
 
-The ``cooldowns`` table stores the last time each (instance, item) pair was
-searched.  This module provides the four operations the search engine needs:
+The ``cooldowns`` table SQL lives in
+:mod:`houndarr.repositories.cooldowns`; this module is the
+service-layer facade over that boundary and retains exclusive
+ownership of the in-memory LRU throttle (:func:`should_log_skip`)
+that gates duplicate cooldown-reason skip rows in ``search_log``.
+The throttle is single-process state, not SQL, so it does not
+belong in a repository.
 
-* :func:`is_on_cooldown` - should we skip this item?
-* :func:`record_search` - mark an item as just-searched (upsert).
-* :func:`count_searches_last_hour` - how many searches has this instance done
-  in the past 60 minutes?
-* :func:`clear_cooldowns` - admin reset for a single instance.
+Public surface:
+
+* :func:`is_on_cooldown_ref` and :func:`record_search_ref` are thin
+  delegators over the repository.  They are the canonical API; new
+  engine code should build an :class:`~houndarr.value_objects.ItemRef`
+  and call them.
+* :func:`is_on_cooldown` and :func:`record_search` are positional
+  compat shims kept for test seeds and any caller that still uses
+  the positional triple directly.
+* :func:`clear_cooldowns` delegates the admin reset to the repository.
+* :func:`should_log_skip` owns the LRU sentinel.
 """
 
 from __future__ import annotations
 
+import asyncio
+from collections import OrderedDict
 from datetime import UTC, datetime, timedelta
 
-from houndarr.database import get_db
 from houndarr.engine.candidates import ItemType
 from houndarr.value_objects import ItemRef
 
+# Skip-log throttle sentinel (single-process LRU with TTL)
 
-def _now_utc() -> datetime:
-    return datetime.now(UTC)
+SkipLogKey = tuple[int, int, str, str]
+
+_SKIP_LOG_CACHE: OrderedDict[SkipLogKey, datetime] = OrderedDict()
+_SKIP_LOG_MAX_ENTRIES = 1024
+_SKIP_LOG_TTL = timedelta(hours=24)
+_SKIP_LOG_LOCK = asyncio.Lock()
 
 
-def _iso(dt: datetime) -> str:
-    """Format a datetime as the ISO-8601 string stored in SQLite."""
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+async def is_on_cooldown_ref(ref: ItemRef, cooldown_days: int) -> bool:
+    """Return ``True`` if *ref* was searched within *cooldown_days* days.
+
+    Thin delegator over
+    :func:`houndarr.repositories.cooldowns.exists_active_cooldown`;
+    the SQL lives in the repository and this module stays in place
+    as the stable import path for engine callers.
+
+    Args:
+        ref: The item to check.
+        cooldown_days: Number of days before the same item can be
+            re-searched.  Pass ``0`` (or any non-positive value) to
+            disable cooldowns entirely; the underlying repository
+            call short-circuits without touching the database.
+
+    Returns:
+        ``True`` if a cooldown record exists and has not yet expired.
+    """
+    from houndarr.repositories.cooldowns import exists_active_cooldown
+
+    return await exists_active_cooldown(ref, cooldown_days)
+
+
+async def record_search_ref(ref: ItemRef, search_kind: str) -> None:
+    """Upsert a cooldown record for *ref* with the current UTC timestamp.
+
+    Thin delegator over
+    :func:`houndarr.repositories.cooldowns.upsert_cooldown`.
+
+    Args:
+        ref: The item to record as just-searched.
+        search_kind: Which pass dispatched the search: ``"missing"``,
+            ``"cutoff"``, or ``"upgrade"``.  Forwarded verbatim so the
+            cooldown row carries the classification for later dashboard
+            breakdown reads and for the reconciliation path that
+            intersects cooldowns against each pass's wanted set.
+    """
+    from houndarr.repositories.cooldowns import upsert_cooldown
+
+    await upsert_cooldown(ref, search_kind)
 
 
 async def is_on_cooldown(
@@ -34,36 +88,31 @@ async def is_on_cooldown(
     item_type: ItemType | str,
     cooldown_days: int,
 ) -> bool:
-    """Return ``True`` if *item_id* was searched within *cooldown_days* days.
+    """Positional compat wrapper over :func:`is_on_cooldown_ref`.
+
+    Retained so test fixtures and seed helpers that predate the
+    :class:`ItemRef` migration can keep calling the three-positional-arg
+    form.  New engine code should build an :class:`ItemRef` and call
+    :func:`is_on_cooldown_ref` directly.
 
     Args:
         instance_id: Owning instance primary key.
-        item_id: Item identifier (e.g. episode, movie, album, or book ID).
-        item_type: ``"episode"``, ``"movie"``, ``"album"``, ``"book"``, or ``"whisparr_episode"``.
-        cooldown_days: Number of days before the same item can be re-searched.
-            Pass ``0`` to disable cooldowns entirely.
+        item_id: Item identifier (e.g. episode, movie, album, or book
+            ID).
+        item_type: ``"episode"``, ``"movie"``, ``"album"``, ``"book"``,
+            ``"whisparr_v2_episode"``, or ``"whisparr_v3_movie"``.  Plain
+            ``str`` values are coerced to :class:`ItemType` for the
+            ItemRef construction.
+        cooldown_days: Number of days before the same item can be
+            re-searched.
 
     Returns:
         ``True`` if a cooldown record exists and has not yet expired.
     """
-    if cooldown_days <= 0:
-        return False
-
-    cutoff = _iso(_now_utc() - timedelta(days=cooldown_days))
-    async with get_db() as db:
-        async with db.execute(
-            """
-            SELECT 1 FROM cooldowns
-            WHERE instance_id = ?
-              AND item_id     = ?
-              AND item_type   = ?
-              AND searched_at > ?
-            LIMIT 1
-            """,
-            (instance_id, item_id, item_type, cutoff),
-        ) as cur:
-            row = await cur.fetchone()
-    return row is not None
+    return await is_on_cooldown_ref(
+        ItemRef(instance_id, item_id, ItemType(item_type)),
+        cooldown_days,
+    )
 
 
 async def record_search(
@@ -72,48 +121,44 @@ async def record_search(
     item_type: ItemType | str,
     search_kind: str = "missing",
 ) -> None:
-    """Upsert a cooldown record for *item_id* with the current UTC timestamp.
+    """Positional compat wrapper over :func:`record_search_ref`.
 
-    If a record already exists for ``(instance_id, item_id, item_type)`` it is
-    updated in place; otherwise a new row is inserted.
+    Retained for the same reason as :func:`is_on_cooldown`.  New engine
+    code should build an :class:`ItemRef` and call
+    :func:`record_search_ref` directly.
 
     Args:
         instance_id: Owning instance primary key.
-        item_id: Item identifier (e.g. episode, movie, album, or book ID).
-        item_type: ``"episode"``, ``"movie"``, ``"album"``, ``"book"``, or ``"whisparr_episode"``.
-        search_kind: Which pass dispatched the search: ``"missing"``,
-            ``"cutoff"``, or ``"upgrade"``.  Stamped on the cooldown
-            row so the dashboard breakdown and the reconciliation path
-            both read it from the column instead of re-classifying via
-            ``search_log``.  Defaults to ``"missing"`` to keep older
-            seed fixtures working.
+        item_id: Item identifier (e.g. episode, movie, album, or book
+            ID).
+        item_type: ``"episode"``, ``"movie"``, ``"album"``, ``"book"``,
+            ``"whisparr_v2_episode"``, or ``"whisparr_v3_movie"``.  Plain
+            ``str`` values are coerced to :class:`ItemType` for the
+            ItemRef construction.
+        search_kind: Defaults to ``"missing"`` to preserve the old
+            positional signature for seed fixtures and tests that
+            predate the classified-cooldown migration.  Pass
+            ``"cutoff"`` or ``"upgrade"`` explicitly when seeding
+            those cases.
     """
-    now = _iso(_now_utc())
-    async with get_db() as db:
-        await db.execute(
-            """
-            INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at, search_kind)
-            VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT(instance_id, item_id, item_type)
-            DO UPDATE SET searched_at = excluded.searched_at,
-                          search_kind = excluded.search_kind
-            """,
-            (instance_id, item_id, item_type, now, search_kind),
-        )
-        await db.commit()
+    await record_search_ref(
+        ItemRef(instance_id, item_id, ItemType(item_type)),
+        search_kind,
+    )
 
 
 async def count_searches_last_hour(instance_id: int) -> int:
-    """Return the number of searches recorded for *instance_id* in the last hour.
+    """Return how many cooldown rows *instance_id* has from the past 60 minutes.
 
-    Used by the search engine to enforce ``hourly_cap``.
-
-    Args:
-        instance_id: Owning instance primary key.
-
-    Returns:
-        Integer count (0 if none).
+    Counts ``cooldowns`` rows whose ``searched_at`` falls inside the
+    rolling one-hour window.  Used by the engine's per-instance hourly
+    cap.  Lives here as inline SQL alongside the
+    :func:`record_search` / :func:`is_on_cooldown` positional shims;
+    the cooldowns reads it shares with them keep the inline helpers
+    grouped on one module so the engine has a single import path.
     """
+    from houndarr.database import get_db
+
     cutoff = _iso(_now_utc() - timedelta(hours=1))
     async with get_db() as db:
         async with db.execute(
@@ -128,19 +173,20 @@ async def count_searches_last_hour(instance_id: int) -> int:
     return int(row[0]) if row else 0
 
 
-async def is_on_cooldown_ref(ref: ItemRef, cooldown_days: int) -> bool:
-    """ItemRef-accepting overload of :func:`is_on_cooldown`."""
-    return await is_on_cooldown(ref.instance_id, ref.item_id, ref.item_type, cooldown_days)
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
 
 
-async def record_search_ref(ref: ItemRef, search_kind: str) -> None:
-    """ItemRef-accepting overload of :func:`record_search`."""
-    await record_search(ref.instance_id, ref.item_id, ref.item_type, search_kind)
+def _iso(dt: datetime) -> str:
+    """ISO-8601 with millisecond precision and trailing Z, matching SQL writes."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
 
 
 async def clear_cooldowns(instance_id: int) -> int:
     """Delete all cooldown records for *instance_id*.
 
+    Thin delegator over
+    :func:`houndarr.repositories.cooldowns.delete_cooldowns_for_instance`.
     Intended for the admin "reset cooldowns" action.
 
     Args:
@@ -149,10 +195,109 @@ async def clear_cooldowns(instance_id: int) -> int:
     Returns:
         Number of rows deleted.
     """
-    async with get_db() as db:
-        cur = await db.execute(
-            "DELETE FROM cooldowns WHERE instance_id = ?",
-            (instance_id,),
-        )
-        await db.commit()
-        return cur.rowcount or 0
+    from houndarr.repositories.cooldowns import delete_cooldowns_for_instance
+
+    return await delete_cooldowns_for_instance(instance_id)
+
+
+async def should_log_skip(key: SkipLogKey) -> bool:
+    """Gate duplicate skip-log writes for cooldown-reason skips.
+
+    Engine passes write a ``search_log`` row every time an item is skipped
+    for the same reason on every cycle.  On a healthy install that produces
+    hundreds of identical rows per item per cooldown window.  This sentinel
+    caps writes to at most one per key per 24 h.
+
+    The check-and-write is serialized under an :class:`asyncio.Lock` so two
+    concurrent passes racing on the same item cannot both bypass the cache.
+    The cache is bounded at ``_SKIP_LOG_MAX_ENTRIES`` entries with LRU
+    eviction, and TTL is enforced on read.
+
+    Args:
+        key: ``(instance_id, item_id, search_kind, reason_bucket)``.
+            ``reason_bucket`` is a coarse category string, e.g.
+            ``"cooldown"``, ``"cutoff_cd"``, ``"upgrade_cd"``.
+
+    Returns:
+        ``True`` if the caller should write the skip row (cache miss or
+        expired entry).  ``False`` if a row for the same key was recorded
+        within the last 24 h.
+    """
+    now = datetime.now(UTC)
+    async with _SKIP_LOG_LOCK:
+        entry = _SKIP_LOG_CACHE.get(key)
+        if entry is not None and now - entry < _SKIP_LOG_TTL:
+            _SKIP_LOG_CACHE.move_to_end(key)
+            return False
+        _SKIP_LOG_CACHE[key] = now
+        _SKIP_LOG_CACHE.move_to_end(key)
+        while len(_SKIP_LOG_CACHE) > _SKIP_LOG_MAX_ENTRIES:
+            _SKIP_LOG_CACHE.popitem(last=False)
+        return True
+
+
+def _reset_skip_log_cache() -> None:
+    """Clear the sentinel cache.  Test-only helper."""
+    _SKIP_LOG_CACHE.clear()
+
+
+# Info-row throttle (separate cache + caller-supplied TTL)
+
+InfoLogKey = tuple[int, str]
+"""``(instance_id, reason_key)``.  The ``reason_key`` is a short
+stable slug identifying which recurring info-row this entry gates
+(e.g. ``"upgrade_pool_empty"``).  Keys are intentionally coarse: one
+per-instance-per-condition, not per-cycle."""
+
+_INFO_LOG_CACHE: OrderedDict[InfoLogKey, datetime] = OrderedDict()
+_INFO_LOG_MAX_ENTRIES = 256
+_INFO_LOG_LOCK = asyncio.Lock()
+
+
+async def should_log_info(key: InfoLogKey, ttl_seconds: int) -> bool:
+    """Gate recurring cycle-level info rows behind a caller-supplied TTL.
+
+    Sibling to :func:`should_log_skip` for info-row scenarios where a
+    condition persists across many cycles and would otherwise write an
+    identical row per cycle.  The upgrade-pass-empty case on an
+    instance with no upgrade-eligible items produces one row per
+    cycle; at a five-minute interval that is 288 rows per day per
+    instance of pure noise.  Wrapping the write behind
+    ``should_log_info((instance_id, "upgrade_pool_empty"), 6*3600)``
+    caps it at one row per six-hour window per instance.
+
+    The check-and-write is serialized under a dedicated lock so two
+    concurrent passes cannot both bypass the cache.  Cache is bounded
+    at 256 entries with LRU eviction; the keyspace is small (roughly
+    one entry per instance per distinct info-row category) so the
+    cap almost never fires in practice.
+
+    Args:
+        key: ``(instance_id, reason_key)``.  ``reason_key`` is a
+            stable short slug describing the info-row kind.
+        ttl_seconds: How long to suppress duplicate rows for the same
+            key, in seconds.  Caller owns the cadence; this function
+            does not pick one.
+
+    Returns:
+        ``True`` if the caller should write the info row (cache miss
+        or expired entry).  ``False`` if a row for the same key was
+        recorded within the TTL window.
+    """
+    now = datetime.now(UTC)
+    ttl = timedelta(seconds=ttl_seconds)
+    async with _INFO_LOG_LOCK:
+        entry = _INFO_LOG_CACHE.get(key)
+        if entry is not None and now - entry < ttl:
+            _INFO_LOG_CACHE.move_to_end(key)
+            return False
+        _INFO_LOG_CACHE[key] = now
+        _INFO_LOG_CACHE.move_to_end(key)
+        while len(_INFO_LOG_CACHE) > _INFO_LOG_MAX_ENTRIES:
+            _INFO_LOG_CACHE.popitem(last=False)
+        return True
+
+
+def _reset_info_log_cache() -> None:
+    """Clear the info-log sentinel cache.  Test-only helper."""
+    _INFO_LOG_CACHE.clear()

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -7,6 +7,7 @@ caller-supplied Fernet *master_key*; every read decrypts transparently.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import fields as dataclass_fields
 from enum import StrEnum
 from typing import Any
 
@@ -34,7 +35,6 @@ from houndarr.config import (
     DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     DEFAULT_WHISPARR_SEARCH_MODE,
 )
-from houndarr.crypto import encrypt
 from houndarr.database import get_db
 
 
@@ -218,62 +218,41 @@ async def create_instance(
     Returns:
         The newly created :class:`Instance` with its database-assigned *id*.
     """
-    encrypted = encrypt(api_key, master_key)
-    async with get_db() as db:
-        cur = await db.execute(
-            """
-            INSERT INTO instances (
-                name, type, url, encrypted_api_key,
-                enabled, batch_size, sleep_interval_mins,
-                hourly_cap, cooldown_days, post_release_grace_hrs, queue_limit,
-                cutoff_enabled, cutoff_batch_size, cutoff_cooldown_days, cutoff_hourly_cap,
-                sonarr_search_mode, lidarr_search_mode, readarr_search_mode,
-                whisparr_search_mode,
-                upgrade_enabled, upgrade_batch_size, upgrade_cooldown_days,
-                upgrade_hourly_cap,
-                upgrade_sonarr_search_mode, upgrade_lidarr_search_mode,
-                upgrade_readarr_search_mode, upgrade_whisparr_search_mode,
-                allowed_time_window, search_order
-            ) VALUES (
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-            )
-            """,
-            (
-                name,
-                type.value,
-                url,
-                encrypted,
-                int(enabled),
-                batch_size,
-                sleep_interval_mins,
-                hourly_cap,
-                cooldown_days,
-                post_release_grace_hrs,
-                queue_limit,
-                int(cutoff_enabled),
-                cutoff_batch_size,
-                cutoff_cooldown_days,
-                cutoff_hourly_cap,
-                sonarr_search_mode.value,
-                lidarr_search_mode.value,
-                readarr_search_mode.value,
-                whisparr_search_mode.value,
-                int(upgrade_enabled),
-                upgrade_batch_size,
-                upgrade_cooldown_days,
-                upgrade_hourly_cap,
-                upgrade_sonarr_search_mode.value,
-                upgrade_lidarr_search_mode.value,
-                upgrade_readarr_search_mode.value,
-                upgrade_whisparr_search_mode.value,
-                allowed_time_window,
-                search_order.value,
-            ),
-        )
-        await db.commit()
-        row_id = cur.lastrowid
-        assert row_id is not None  # noqa: S101
+    from houndarr.repositories.instances import InstanceInsert
+    from houndarr.repositories.instances import insert_instance as _repo_insert_instance
+
+    payload = InstanceInsert(
+        name=name,
+        type=type,
+        url=url,
+        api_key=api_key,
+        enabled=enabled,
+        batch_size=batch_size,
+        sleep_interval_mins=sleep_interval_mins,
+        hourly_cap=hourly_cap,
+        cooldown_days=cooldown_days,
+        post_release_grace_hrs=post_release_grace_hrs,
+        queue_limit=queue_limit,
+        cutoff_enabled=cutoff_enabled,
+        cutoff_batch_size=cutoff_batch_size,
+        cutoff_cooldown_days=cutoff_cooldown_days,
+        cutoff_hourly_cap=cutoff_hourly_cap,
+        sonarr_search_mode=sonarr_search_mode,
+        lidarr_search_mode=lidarr_search_mode,
+        readarr_search_mode=readarr_search_mode,
+        whisparr_search_mode=whisparr_search_mode,
+        upgrade_enabled=upgrade_enabled,
+        upgrade_batch_size=upgrade_batch_size,
+        upgrade_cooldown_days=upgrade_cooldown_days,
+        upgrade_hourly_cap=upgrade_hourly_cap,
+        upgrade_sonarr_search_mode=upgrade_sonarr_search_mode,
+        upgrade_lidarr_search_mode=upgrade_lidarr_search_mode,
+        upgrade_readarr_search_mode=upgrade_readarr_search_mode,
+        upgrade_whisparr_search_mode=upgrade_whisparr_search_mode,
+        allowed_time_window=allowed_time_window,
+        search_order=search_order,
+    )
+    row_id = await _repo_insert_instance(payload, master_key=master_key)
 
     instance = await get_instance(row_id, master_key=master_key)
     assert instance is not None  # just inserted, cannot be None  # noqa: S101
@@ -327,121 +306,46 @@ async def update_instance(
 ) -> Instance | None:
     """Partially update an instance and return the refreshed :class:`Instance`.
 
-    Accepts any subset of the mutable columns.  If ``api_key`` is included it
-    is re-encrypted before being persisted.  Unrecognised field names are
-    silently ignored to avoid SQL injection.
+    Thin delegator over
+    :func:`houndarr.repositories.instances.update_instance`.  Accepts
+    any subset of the mutable columns as kwargs to preserve the
+    pre-D.4 call sites; unrecognised field names are silently ignored
+    for safety and the remainder are packed into an
+    :class:`~houndarr.repositories.instances.InstanceUpdate` payload.
+    Payloads with no non-``None`` fields cause the repository to
+    no-op, at which point this function still re-fetches and returns
+    the current :class:`Instance` so the pre-refactor
+    empty-update-returns-state contract stays intact.
 
     Args:
         id: Primary key of the instance to update.
-        master_key: Fernet key (needed for re-encryption and for the return value).
-        **fields: Column-value pairs to update.  Accepted keys:
-            ``name``, ``type``, ``url``, ``api_key``, ``enabled``,
-            ``batch_size``, ``sleep_interval_mins``, ``hourly_cap``,
-            ``cooldown_days``, ``post_release_grace_hrs``, ``queue_limit``,
-            ``cutoff_enabled``, ``cutoff_batch_size``,
-            ``cutoff_cooldown_days``, ``cutoff_hourly_cap``,
-            ``sonarr_search_mode``, ``lidarr_search_mode``,
-            ``readarr_search_mode``, ``whisparr_search_mode``,
-            ``upgrade_enabled``, ``upgrade_batch_size``,
-            ``upgrade_cooldown_days``, ``upgrade_hourly_cap``,
-            ``upgrade_sonarr_search_mode``, ``upgrade_lidarr_search_mode``,
-            ``upgrade_readarr_search_mode``, ``upgrade_whisparr_search_mode``,
-            ``upgrade_item_offset``, ``upgrade_series_offset``,
-            ``missing_page_offset``, ``cutoff_page_offset``,
-            ``allowed_time_window``, ``search_order``.
+        master_key: Fernet key used to re-encrypt ``api_key`` when
+            that field is part of the update, and to decrypt on the
+            return-value round trip.
+        **fields: Column-value pairs to update.  See
+            :class:`~houndarr.repositories.instances.InstanceUpdate`
+            for the accepted keys; values that do not appear there
+            are silently dropped.
 
     Returns:
         Updated :class:`Instance`, or ``None`` if *id* does not exist.
     """
-    # Map public field names → DB column names
-    allowed_cols: dict[str, str] = {
-        "name": "name",
-        "type": "type",
-        "url": "url",
-        "api_key": "encrypted_api_key",
-        "enabled": "enabled",
-        "batch_size": "batch_size",
-        "sleep_interval_mins": "sleep_interval_mins",
-        "hourly_cap": "hourly_cap",
-        "cooldown_days": "cooldown_days",
-        "post_release_grace_hrs": "post_release_grace_hrs",
-        "queue_limit": "queue_limit",
-        "cutoff_enabled": "cutoff_enabled",
-        "cutoff_batch_size": "cutoff_batch_size",
-        "cutoff_cooldown_days": "cutoff_cooldown_days",
-        "cutoff_hourly_cap": "cutoff_hourly_cap",
-        "sonarr_search_mode": "sonarr_search_mode",
-        "lidarr_search_mode": "lidarr_search_mode",
-        "readarr_search_mode": "readarr_search_mode",
-        "whisparr_search_mode": "whisparr_search_mode",
-        "upgrade_enabled": "upgrade_enabled",
-        "upgrade_batch_size": "upgrade_batch_size",
-        "upgrade_cooldown_days": "upgrade_cooldown_days",
-        "upgrade_hourly_cap": "upgrade_hourly_cap",
-        "upgrade_sonarr_search_mode": "upgrade_sonarr_search_mode",
-        "upgrade_lidarr_search_mode": "upgrade_lidarr_search_mode",
-        "upgrade_readarr_search_mode": "upgrade_readarr_search_mode",
-        "upgrade_whisparr_search_mode": "upgrade_whisparr_search_mode",
-        "upgrade_item_offset": "upgrade_item_offset",
-        "upgrade_series_offset": "upgrade_series_offset",
-        "missing_page_offset": "missing_page_offset",
-        "cutoff_page_offset": "cutoff_page_offset",
-        "allowed_time_window": "allowed_time_window",
-        "search_order": "search_order",
-        "monitored_total": "monitored_total",
-        "unreleased_count": "unreleased_count",
-        "snapshot_refreshed_at": "snapshot_refreshed_at",
-    }
+    from houndarr.repositories.instances import InstanceUpdate
+    from houndarr.repositories.instances import update_instance as _repo_update_instance
 
-    _search_mode_fields = {
-        "sonarr_search_mode",
-        "lidarr_search_mode",
-        "readarr_search_mode",
-        "whisparr_search_mode",
-        "upgrade_sonarr_search_mode",
-        "upgrade_lidarr_search_mode",
-        "upgrade_readarr_search_mode",
-        "upgrade_whisparr_search_mode",
-        "search_order",
-    }
+    allowed_field_names = {f.name for f in dataclass_fields(InstanceUpdate)}
+    payload_kwargs = {name: value for name, value in fields.items() if name in allowed_field_names}
+    payload = InstanceUpdate(**payload_kwargs)
 
-    assignments: list[str] = []
-    values: list[Any] = []
-
-    for field_name, value in fields.items():
-        col = allowed_cols.get(field_name)
-        if col is None:
-            continue
-        # Coerce types for SQLite
-        if field_name == "api_key":
-            value = encrypt(str(value), master_key)
-        elif (field_name == "type" and isinstance(value, InstanceType)) or (
-            field_name in _search_mode_fields and isinstance(value, StrEnum)
-        ):
-            value = value.value
-        elif field_name in ("enabled", "cutoff_enabled", "upgrade_enabled"):
-            value = int(bool(value))
-        assignments.append(f"{col} = ?")
-        values.append(value)
-
-    if not assignments:
-        # Nothing to do; return current state
-        return await get_instance(id, master_key=master_key)
-
-    # Always refresh updated_at
-    assignments.append("updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')")
-    values.append(id)
-
-    sql = f"UPDATE instances SET {', '.join(assignments)} WHERE id = ?"  # noqa: S608  # nosec B608
-    async with get_db() as db:
-        await db.execute(sql, values)
-        await db.commit()
-
+    await _repo_update_instance(id, payload, master_key=master_key)
     return await get_instance(id, master_key=master_key)
 
 
 async def delete_instance(id: int) -> bool:  # noqa: A002
     """Delete an instance row (cascade removes cooldowns).
+
+    Thin delegator over
+    :func:`houndarr.repositories.instances.delete_instance`.
 
     Args:
         id: Primary key of the instance to delete.
@@ -449,10 +353,9 @@ async def delete_instance(id: int) -> bool:  # noqa: A002
     Returns:
         ``True`` if a row was deleted, ``False`` if *id* did not exist.
     """
-    async with get_db() as db:
-        cur = await db.execute("DELETE FROM instances WHERE id = ?", (id,))
-        await db.commit()
-        return (cur.rowcount or 0) > 0
+    from houndarr.repositories.instances import delete_instance as _repo_delete_instance
+
+    return await _repo_delete_instance(id)
 
 
 async def update_instance_snapshot(
@@ -463,19 +366,16 @@ async def update_instance_snapshot(
 ) -> None:
     """Atomically write the three snapshot columns for *id*.
 
-    Called by the supervisor's ``refresh_instance_snapshots`` task.  The
-    ``snapshot_refreshed_at`` value is always ``now`` (UTC), so the
-    dashboard can show "last refreshed Nm ago" and the Settings page
-    can surface stale snapshots when the arr is unreachable.
+    Thin delegator over
+    :func:`houndarr.repositories.instances.update_instance_snapshot`.
+    Called by the supervisor's ``refresh_instance_snapshots`` task.
     """
-    async with get_db() as db:
-        await db.execute(
-            "UPDATE instances SET"
-            " monitored_total = ?,"
-            " unreleased_count = ?,"
-            " snapshot_refreshed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),"
-            " updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
-            " WHERE id = ?",
-            (int(monitored_total), int(unreleased_count), id),
-        )
-        await db.commit()
+    from houndarr.repositories.instances import (
+        update_instance_snapshot as _repo_update_instance_snapshot,
+    )
+
+    await _repo_update_instance_snapshot(
+        id,
+        monitored_total=monitored_total,
+        unreleased_count=unreleased_count,
+    )

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
-import aiosqlite
-
 from houndarr.config import (
     DEFAULT_ALLOWED_TIME_WINDOW,
     DEFAULT_BATCH_SIZE,
@@ -36,7 +34,7 @@ from houndarr.config import (
     DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     DEFAULT_WHISPARR_SEARCH_MODE,
 )
-from houndarr.crypto import decrypt, encrypt
+from houndarr.crypto import encrypt
 from houndarr.database import get_db
 
 
@@ -133,83 +131,6 @@ class Instance:
     monitored_total: int = 0
     unreleased_count: int = 0
     snapshot_refreshed_at: str = ""
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _row_to_instance(row: aiosqlite.Row, master_key: bytes) -> Instance:
-    """Convert an aiosqlite Row to an :class:`Instance`, decrypting the key."""
-    return Instance(
-        id=row["id"],
-        name=row["name"],
-        type=InstanceType(row["type"]),
-        url=row["url"],
-        api_key=decrypt(row["encrypted_api_key"], master_key),
-        enabled=bool(row["enabled"]),
-        batch_size=row["batch_size"],
-        sleep_interval_mins=row["sleep_interval_mins"],
-        hourly_cap=row["hourly_cap"],
-        cooldown_days=row["cooldown_days"],
-        post_release_grace_hrs=row["post_release_grace_hrs"],
-        queue_limit=row["queue_limit"],
-        cutoff_enabled=bool(row["cutoff_enabled"]),
-        cutoff_batch_size=row["cutoff_batch_size"],
-        cutoff_cooldown_days=row["cutoff_cooldown_days"],
-        cutoff_hourly_cap=row["cutoff_hourly_cap"],
-        created_at=row["created_at"],
-        updated_at=row["updated_at"],
-        sonarr_search_mode=SonarrSearchMode(row["sonarr_search_mode"]),
-        lidarr_search_mode=LidarrSearchMode(row["lidarr_search_mode"]),
-        readarr_search_mode=ReadarrSearchMode(row["readarr_search_mode"]),
-        whisparr_search_mode=WhisparrSearchMode(row["whisparr_search_mode"]),
-        upgrade_enabled=bool(row["upgrade_enabled"]),
-        upgrade_batch_size=row["upgrade_batch_size"],
-        upgrade_cooldown_days=row["upgrade_cooldown_days"],
-        upgrade_hourly_cap=row["upgrade_hourly_cap"],
-        upgrade_sonarr_search_mode=SonarrSearchMode(row["upgrade_sonarr_search_mode"]),
-        upgrade_lidarr_search_mode=LidarrSearchMode(row["upgrade_lidarr_search_mode"]),
-        upgrade_readarr_search_mode=ReadarrSearchMode(row["upgrade_readarr_search_mode"]),
-        upgrade_whisparr_search_mode=WhisparrSearchMode(row["upgrade_whisparr_search_mode"]),
-        upgrade_item_offset=row["upgrade_item_offset"],
-        upgrade_series_offset=row["upgrade_series_offset"],
-        missing_page_offset=row["missing_page_offset"],
-        cutoff_page_offset=row["cutoff_page_offset"],
-        allowed_time_window=row["allowed_time_window"],
-        search_order=SearchOrder(row["search_order"]),
-        monitored_total=_optional_row_int(row, "monitored_total"),
-        unreleased_count=_optional_row_int(row, "unreleased_count"),
-        snapshot_refreshed_at=_optional_row_str(row, "snapshot_refreshed_at"),
-    )
-
-
-def _optional_row_int(row: Any, key: str) -> int:
-    """Return ``row[key]`` as int, or 0 when the column is absent.
-
-    Tests sometimes insert minimal rows that pre-date the v13 columns;
-    this helper keeps those rows compatible with the post-v13 dataclass.
-    """
-    try:
-        val = row[key]
-    except (IndexError, KeyError):
-        return 0
-    return int(val) if val is not None else 0
-
-
-def _optional_row_str(row: Any, key: str) -> str:
-    """Return ``row[key]`` as str, or ``''`` when the column is absent."""
-    try:
-        val = row[key]
-    except (IndexError, KeyError):
-        return ""
-    return str(val) if val is not None else ""
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
 
 
 async def create_instance(
@@ -362,6 +283,13 @@ async def create_instance(
 async def get_instance(id: int, *, master_key: bytes) -> Instance | None:  # noqa: A002
     """Fetch a single instance by *id*, or ``None`` if not found.
 
+    Thin delegator over
+    :func:`houndarr.repositories.instances.get_instance`.  The service
+    keeps the historical ``id`` parameter name (shadowing a builtin,
+    hence the ``# noqa: A002``) so existing callers do not move; the
+    repository uses the unshadowed ``instance_id`` keyword matching
+    the Protocol in :mod:`houndarr.protocols`.
+
     Args:
         id: Primary key of the instance row.
         master_key: Fernet key used to decrypt the stored API key.
@@ -369,16 +297,16 @@ async def get_instance(id: int, *, master_key: bytes) -> Instance | None:  # noq
     Returns:
         Decrypted :class:`Instance`, or ``None``.
     """
-    async with get_db() as db:
-        async with db.execute("SELECT * FROM instances WHERE id = ?", (id,)) as cur:
-            row = await cur.fetchone()
-    if row is None:
-        return None
-    return _row_to_instance(row, master_key)
+    from houndarr.repositories.instances import get_instance as _repo_get_instance
+
+    return await _repo_get_instance(id, master_key=master_key)
 
 
 async def list_instances(*, master_key: bytes) -> list[Instance]:
-    """Return all instances ordered by creation time (oldest first).
+    """Return all instances ordered by ``id`` ascending.
+
+    Thin delegator over
+    :func:`houndarr.repositories.instances.list_instances`.
 
     Args:
         master_key: Fernet key used to decrypt each stored API key.
@@ -386,10 +314,9 @@ async def list_instances(*, master_key: bytes) -> list[Instance]:
     Returns:
         List of decrypted :class:`Instance` objects (may be empty).
     """
-    async with get_db() as db:
-        async with db.execute("SELECT * FROM instances ORDER BY id ASC") as cur:
-            rows = await cur.fetchall()
-    return [_row_to_instance(r, master_key) for r in rows]
+    from houndarr.repositories.instances import list_instances as _repo_list_instances
+
+    return await _repo_list_instances(master_key=master_key)
 
 
 async def update_instance(

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -35,7 +35,6 @@ from houndarr.config import (
     DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
     DEFAULT_WHISPARR_SEARCH_MODE,
 )
-from houndarr.database import get_db
 
 
 class InstanceType(StrEnum):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,7 +7,9 @@ from pathlib import Path
 import aiosqlite
 import pytest
 
-from houndarr.database import get_db, get_setting, init_db, purge_old_logs, set_db_path, set_setting
+from houndarr.database import get_db, init_db, set_db_path
+from houndarr.repositories.search_log import purge_old_logs
+from houndarr.repositories.settings import get_setting, set_setting
 
 
 @pytest.mark.asyncio()
@@ -1077,10 +1079,10 @@ async def test_set_and_get_setting(db: None) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_get_setting_default(db: None) -> None:
-    """get_setting returns default when key not found."""
-    value = await get_setting("nonexistent_key", default="fallback")
-    assert value == "fallback"
+async def test_get_setting_missing_key_returns_none(db: None) -> None:
+    """get_setting returns None when key not found; callers compose any fallback."""
+    value = await get_setting("nonexistent_key")
+    assert value is None
 
 
 @pytest.mark.asyncio()

--- a/tests/test_database_edge_cases.py
+++ b/tests/test_database_edge_cases.py
@@ -6,7 +6,9 @@ import asyncio
 
 import pytest
 
-from houndarr.database import get_db, get_setting, purge_old_logs, set_setting
+from houndarr.database import get_db
+from houndarr.repositories.search_log import purge_old_logs
+from houndarr.repositories.settings import get_setting, set_setting
 
 # ---------------------------------------------------------------------------
 # purge_old_logs
@@ -102,17 +104,14 @@ async def test_purge_old_logs_returns_count(db: None) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_get_setting_missing_key_returns_default(db: None) -> None:
-    """A missing key returns the provided default."""
-    result = await get_setting("nonexistent", default="fallback")
-    assert result == "fallback"
+async def test_get_setting_missing_key_returns_none(db: None) -> None:
+    """A missing key returns ``None``; callers compose any fallback themselves.
 
-
-@pytest.mark.asyncio()
-async def test_get_setting_missing_key_no_default_returns_none(db: None) -> None:
-    """A missing key with no default returns None."""
-    result = await get_setting("nonexistent")
-    assert result is None
+    The repository contract is ``str | None``; route callers use the
+    ``(await get_setting(key)) == "1"`` / ``or <fallback>`` idiom
+    when they need a default value.
+    """
+    assert await get_setting("nonexistent") is None
 
 
 @pytest.mark.asyncio()

--- a/tests/test_engine/test_cooldown_edge_cases.py
+++ b/tests/test_engine/test_cooldown_edge_cases.py
@@ -15,8 +15,8 @@ from houndarr.engine.adapters.sonarr import _season_item_id
 from houndarr.engine.adapters.whisparr_v2 import (
     _season_item_id as whisparr_season_item_id,
 )
+from houndarr.repositories.cooldowns import _iso
 from houndarr.services.cooldown import (
-    _iso,
     clear_cooldowns,
     count_searches_last_hour,
     is_on_cooldown,

--- a/tests/test_repositories/test_cooldowns.py
+++ b/tests/test_repositories/test_cooldowns.py
@@ -1,0 +1,207 @@
+"""Pinning tests for the cooldowns-repository SQL boundary.
+
+Locks the contract of ``exists_active_cooldown``,
+``upsert_cooldown``, and ``delete_cooldowns_for_instance`` plus the
+service-layer delegators that keep
+:mod:`houndarr.services.cooldown` as the stable import path for the
+engine hot loop.  Each case below covers one boundary the delegation
+has to preserve: empty table, fresh insert, upsert replace,
+cooldown-days short-circuit, window-edge filter, per-instance delete
+scope, and symmetric delegation with the service wrappers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+
+from houndarr.database import get_db
+from houndarr.engine.candidates import ItemType
+from houndarr.repositories import cooldowns as repo
+from houndarr.value_objects import ItemRef
+
+
+@pytest_asyncio.fixture()
+async def seeded_instances(db: None) -> AsyncGenerator[None, None]:
+    """Insert two stub instance rows so FK constraints are satisfied."""
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url) VALUES (?, ?, ?, ?)",
+            [
+                (1, "Sonarr Test", "sonarr", "http://sonarr:8989"),
+                (2, "Radarr Test", "radarr", "http://radarr:7878"),
+            ],
+        )
+        await conn.commit()
+    yield
+
+
+async def _count_cooldowns(instance_id: int) -> int:
+    """Count cooldown rows for *instance_id* directly against SQL."""
+    async with (
+        get_db() as conn,
+        conn.execute(
+            "SELECT COUNT(*) FROM cooldowns WHERE instance_id = ?",
+            (instance_id,),
+        ) as cur,
+    ):
+        row = await cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_exists_active_cooldown_false_on_empty_table(seeded_instances: None) -> None:
+    """Empty cooldowns table returns False, no row present."""
+    ref = ItemRef(1, 42, ItemType.episode)
+    assert await repo.exists_active_cooldown(ref, cooldown_days=7) is False
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_exists_active_cooldown_short_circuits_on_disabled_cooldown(
+    seeded_instances: None,
+) -> None:
+    """cooldown_days <= 0 returns False without touching the database."""
+    ref = ItemRef(1, 42, ItemType.episode)
+    # Even with an active record present, zero days disables the check.
+    await repo.upsert_cooldown(ref, "missing")
+    assert await repo.exists_active_cooldown(ref, cooldown_days=0) is False
+    assert await repo.exists_active_cooldown(ref, cooldown_days=-3) is False
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_exists_active_cooldown_true_after_upsert(seeded_instances: None) -> None:
+    """A just-upserted cooldown reads as active within the configured window."""
+    ref = ItemRef(1, 42, ItemType.episode)
+    await repo.upsert_cooldown(ref, "missing")
+    assert await repo.exists_active_cooldown(ref, cooldown_days=7) is True
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_exists_active_cooldown_expired_row_returns_false(
+    seeded_instances: None,
+) -> None:
+    """A cooldown older than the window is no longer active."""
+    ref = ItemRef(1, 42, ItemType.episode)
+    # Seed a stale timestamp directly (10 days ago).
+    stale_time = (datetime.now(UTC) - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
+            " VALUES (?, ?, ?, ?)",
+            (ref.instance_id, ref.item_id, ref.item_type.value, stale_time),
+        )
+        await conn.commit()
+
+    assert await repo.exists_active_cooldown(ref, cooldown_days=7) is False
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_upsert_cooldown_inserts_first_time(seeded_instances: None) -> None:
+    """First upsert creates a row; count goes from 0 to 1."""
+    ref = ItemRef(1, 42, ItemType.episode)
+    assert await _count_cooldowns(1) == 0
+    await repo.upsert_cooldown(ref, "missing")
+    assert await _count_cooldowns(1) == 1
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_upsert_cooldown_replaces_on_repeat(seeded_instances: None) -> None:
+    """Repeated upsert keeps the row count at 1 (in-place UPDATE)."""
+    ref = ItemRef(1, 42, ItemType.episode)
+    await repo.upsert_cooldown(ref, "missing")
+    await repo.upsert_cooldown(ref, "missing")
+    await repo.upsert_cooldown(ref, "missing")
+    assert await _count_cooldowns(1) == 1
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_upsert_cooldown_distinct_items_coexist(seeded_instances: None) -> None:
+    """Different (item_id, item_type) triples share an instance without conflict."""
+    await repo.upsert_cooldown(ItemRef(1, 42, ItemType.episode), "missing")
+    await repo.upsert_cooldown(ItemRef(1, 43, ItemType.episode), "missing")
+    await repo.upsert_cooldown(ItemRef(1, 42, ItemType.movie), "missing")
+    assert await _count_cooldowns(1) == 3
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_cooldowns_for_instance_returns_row_count(
+    seeded_instances: None,
+) -> None:
+    """delete_cooldowns_for_instance returns the number of rows removed."""
+    await repo.upsert_cooldown(ItemRef(1, 1, ItemType.episode), "missing")
+    await repo.upsert_cooldown(ItemRef(1, 2, ItemType.episode), "missing")
+    await repo.upsert_cooldown(ItemRef(1, 3, ItemType.episode), "missing")
+
+    deleted = await repo.delete_cooldowns_for_instance(1)
+    assert deleted == 3
+    assert await _count_cooldowns(1) == 0
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_cooldowns_for_instance_returns_zero_when_empty(
+    seeded_instances: None,
+) -> None:
+    """delete_cooldowns_for_instance returns 0 when no rows match."""
+    deleted = await repo.delete_cooldowns_for_instance(1)
+    assert deleted == 0
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_cooldowns_is_scoped_to_one_instance(seeded_instances: None) -> None:
+    """Deleting cooldowns for instance A leaves instance B untouched."""
+    await repo.upsert_cooldown(ItemRef(1, 1, ItemType.episode), "missing")
+    await repo.upsert_cooldown(ItemRef(2, 1, ItemType.movie), "missing")
+
+    await repo.delete_cooldowns_for_instance(1)
+    assert await _count_cooldowns(1) == 0
+    assert await _count_cooldowns(2) == 1
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_is_on_cooldown_ref_delegates(seeded_instances: None) -> None:
+    """services.cooldown.is_on_cooldown_ref returns the same bool as the repo."""
+    from houndarr.services.cooldown import is_on_cooldown_ref as svc_check
+
+    ref = ItemRef(1, 42, ItemType.episode)
+    await repo.upsert_cooldown(ref, "missing")
+
+    assert await svc_check(ref, cooldown_days=7) == await repo.exists_active_cooldown(
+        ref, cooldown_days=7
+    )
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_record_search_ref_delegates(seeded_instances: None) -> None:
+    """services.cooldown.record_search_ref writes through the repository."""
+    from houndarr.services.cooldown import record_search_ref as svc_record
+
+    ref = ItemRef(1, 42, ItemType.episode)
+    await svc_record(ref, "missing")
+    assert await repo.exists_active_cooldown(ref, cooldown_days=7) is True
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_clear_cooldowns_delegates(seeded_instances: None) -> None:
+    """services.cooldown.clear_cooldowns returns the same count as the repo."""
+    from houndarr.services.cooldown import clear_cooldowns as svc_clear
+
+    await repo.upsert_cooldown(ItemRef(1, 1, ItemType.episode), "missing")
+    await repo.upsert_cooldown(ItemRef(1, 2, ItemType.episode), "missing")
+
+    assert await svc_clear(1) == 2

--- a/tests/test_repositories/test_instances_reads.py
+++ b/tests/test_repositories/test_instances_reads.py
@@ -1,0 +1,267 @@
+"""Pinning tests for the instances-repository read boundary.
+
+Locks the Track D.3 contract of ``get_instance`` / ``list_instances``
+and the row-mapper helpers that moved alongside them.  The service-
+layer delegators in :mod:`houndarr.services.instances` have to keep
+returning byte-equal :class:`~houndarr.services.instances.Instance`
+objects across every subsequent D batch, so each case below covers
+one boundary that the delegation has to preserve: empty result,
+single row, multi-row ordering, decryption correctness, and the
+tolerant fallback for rows that pre-date the v13 snapshot columns.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from houndarr.crypto import encrypt
+from houndarr.database import get_db
+from houndarr.repositories import instances as repo
+from houndarr.repositories.instances import (
+    _optional_row_int,
+    _optional_row_str,
+    _row_to_instance,
+)
+from houndarr.services.instances import (
+    Instance,
+    InstanceType,
+    SearchOrder,
+    SonarrSearchMode,
+    create_instance,
+)
+
+
+@pytest.fixture()
+def master_key() -> bytes:
+    """Fresh Fernet key per test."""
+    return Fernet.generate_key()
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_list_instances_empty(db: None, master_key: bytes) -> None:
+    """Empty ``instances`` table returns an empty list, not ``None``."""
+    rows = await repo.list_instances(master_key=master_key)
+    assert rows == []
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_get_instance_missing_returns_none(db: None, master_key: bytes) -> None:
+    """Missing id yields ``None`` from the repository."""
+    assert await repo.get_instance(999, master_key=master_key) is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_get_instance_roundtrip(db: None, master_key: bytes) -> None:
+    """A created instance reads back decrypted and with every column populated."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Sonarr Main",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="top-secret",
+    )
+
+    fetched = await repo.get_instance(created.id, master_key=master_key)
+    assert fetched is not None
+    assert isinstance(fetched, Instance)
+    assert fetched.id == created.id
+    assert fetched.name == "Sonarr Main"
+    assert fetched.type == InstanceType.sonarr
+    assert fetched.url == "http://sonarr:8989"
+    assert fetched.api_key == "top-secret"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_list_instances_orders_by_id_ascending(db: None, master_key: bytes) -> None:
+    """list_instances returns rows in id-ascending order regardless of insert order."""
+    first = await create_instance(
+        master_key=master_key,
+        name="Alpha",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="k1",
+    )
+    second = await create_instance(
+        master_key=master_key,
+        name="Bravo",
+        type=InstanceType.sonarr,
+        url="http://sonarr2:8989",
+        api_key="k2",
+    )
+    third = await create_instance(
+        master_key=master_key,
+        name="Charlie",
+        type=InstanceType.sonarr,
+        url="http://sonarr3:8989",
+        api_key="k3",
+    )
+
+    rows = await repo.list_instances(master_key=master_key)
+    assert [r.id for r in rows] == [first.id, second.id, third.id]
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_list_instances_decrypts_each_api_key(db: None, master_key: bytes) -> None:
+    """Every row in the list has its api_key decrypted to plaintext."""
+    await create_instance(
+        master_key=master_key,
+        name="One",
+        type=InstanceType.sonarr,
+        url="http://s1:8989",
+        api_key="plain-one",
+    )
+    await create_instance(
+        master_key=master_key,
+        name="Two",
+        type=InstanceType.radarr,
+        url="http://r1:7878",
+        api_key="plain-two",
+    )
+
+    rows = await repo.list_instances(master_key=master_key)
+    assert {r.api_key for r in rows} == {"plain-one", "plain-two"}
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_get_instance_decrypts_with_correct_key(db: None, master_key: bytes) -> None:
+    """Reading with a different master_key raises a decryption error."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Secure",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="s3cret",
+    )
+    other_key = Fernet.generate_key()
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        await repo.get_instance(created.id, master_key=other_key)
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_row_to_instance_preserves_all_enum_coercions(db: None, master_key: bytes) -> None:
+    """Row mapper turns every mode column into the correct StrEnum variant."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Modes",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="k",
+        sonarr_search_mode=SonarrSearchMode.season_context,
+        search_order=SearchOrder.random,
+    )
+    fetched = await repo.get_instance(created.id, master_key=master_key)
+    assert fetched is not None
+    assert fetched.type is InstanceType.sonarr
+    assert fetched.sonarr_search_mode is SonarrSearchMode.season_context
+    assert fetched.search_order is SearchOrder.random
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_optional_row_helpers_tolerate_pre_v13_rows(db: None, master_key: bytes) -> None:
+    """Reading a row inserted without the v13 snapshot columns yields default zeros."""
+    # Seed a minimal row lacking the v13 snapshot columns (they stay NULL in SQLite).
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO instances (name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?)",
+            ("Legacy", "sonarr", "http://sonarr:8989", encrypt("legacy-key", master_key)),
+        )
+        await conn.commit()
+        async with conn.execute("SELECT id FROM instances WHERE name = ?", ("Legacy",)) as cur:
+            row = await cur.fetchone()
+    assert row is not None
+    legacy_id = int(row["id"])
+
+    fetched = await repo.get_instance(legacy_id, master_key=master_key)
+    assert fetched is not None
+    assert fetched.monitored_total == 0
+    assert fetched.unreleased_count == 0
+    assert fetched.snapshot_refreshed_at == ""
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_optional_row_int_default_on_missing_column() -> None:
+    """The int helper returns 0 when the column is not part of the row object."""
+
+    class _FakeRow:
+        def __getitem__(self, key: str) -> object:
+            raise IndexError(key)
+
+    assert _optional_row_int(_FakeRow(), "nope") == 0  # type: ignore[arg-type]
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_optional_row_int_default_on_null_value() -> None:
+    """A literal ``None`` in the row maps to 0, not a crash."""
+
+    class _FakeRow:
+        def __getitem__(self, key: str) -> object:
+            return None
+
+    assert _optional_row_int(_FakeRow(), "col") == 0  # type: ignore[arg-type]
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_optional_row_str_default_on_missing_column() -> None:
+    """The str helper returns the empty string on a missing column."""
+
+    class _FakeRow:
+        def __getitem__(self, key: str) -> object:
+            raise KeyError(key)
+
+    assert _optional_row_str(_FakeRow(), "nope") == ""  # type: ignore[arg-type]
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_get_instance_delegates_to_repo(db: None, master_key: bytes) -> None:
+    """The service-layer wrapper returns the same object the repo would."""
+    from houndarr.services.instances import get_instance as svc_get
+
+    created = await create_instance(
+        master_key=master_key,
+        name="Delegated",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="shared",
+    )
+    via_repo = await repo.get_instance(created.id, master_key=master_key)
+    via_service = await svc_get(created.id, master_key=master_key)
+    assert via_repo == via_service
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_list_instances_delegates_to_repo(db: None, master_key: bytes) -> None:
+    """The service-layer list wrapper returns the same rows as the repo."""
+    from houndarr.services.instances import list_instances as svc_list
+
+    await create_instance(
+        master_key=master_key,
+        name="One",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="x",
+    )
+    via_repo = await repo.list_instances(master_key=master_key)
+    via_service = await svc_list(master_key=master_key)
+    assert via_repo == via_service
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_row_to_instance_is_importable_from_repository(db: None, master_key: bytes) -> None:
+    """The row mapper lives in the repository now; importing it from there works."""
+    assert _row_to_instance is not None
+    assert callable(_row_to_instance)

--- a/tests/test_repositories/test_instances_writes.py
+++ b/tests/test_repositories/test_instances_writes.py
@@ -1,0 +1,450 @@
+"""Pinning tests for the instances-repository write boundary.
+
+Locks the Track D.4 contract: the ``InstanceInsert`` /
+``InstanceUpdate`` payload dataclasses, ``insert_instance``,
+``update_instance``, ``delete_instance``, and
+``update_instance_snapshot``.  Every case below has to stay
+byte-equal through the D.10 + D.24 + D.25 route and service
+migrations that push business logic outward while the SQL stays
+here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields as dataclass_fields
+
+import pytest
+from cryptography.fernet import Fernet
+
+from houndarr.database import get_db
+from houndarr.repositories import instances as repo
+from houndarr.repositories.instances import (
+    InstanceInsert,
+    InstanceUpdate,
+    delete_instance,
+    insert_instance,
+    update_instance,
+    update_instance_snapshot,
+)
+from houndarr.services.instances import (
+    InstanceType,
+    SearchOrder,
+    SonarrSearchMode,
+    create_instance,
+)
+
+
+@pytest.fixture()
+def master_key() -> bytes:
+    """Fresh Fernet key per test."""
+    return Fernet.generate_key()
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_insert_instance_returns_new_primary_key(db: None, master_key: bytes) -> None:
+    """insert_instance returns the SQLite-assigned rowid."""
+    payload = InstanceInsert(
+        name="Inserted",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="plain-text",
+    )
+    row_id = await insert_instance(payload, master_key=master_key)
+    assert isinstance(row_id, int)
+    assert row_id >= 1
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_insert_instance_encrypts_api_key_before_storage(db: None, master_key: bytes) -> None:
+    """The api_key written to SQL is the ciphertext, not the plaintext payload."""
+    payload = InstanceInsert(
+        name="Encrypted",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="plaintext-key",
+    )
+    row_id = await insert_instance(payload, master_key=master_key)
+
+    async with (
+        get_db() as conn,
+        conn.execute("SELECT encrypted_api_key FROM instances WHERE id = ?", (row_id,)) as cur,
+    ):
+        row = await cur.fetchone()
+    assert row is not None
+    assert row["encrypted_api_key"] != "plaintext-key"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_insert_instance_applies_schema_defaults(db: None, master_key: bytes) -> None:
+    """Minimal payload ends up with the legacy column defaults when read back."""
+    payload = InstanceInsert(
+        name="Defaults",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="k",
+    )
+    row_id = await insert_instance(payload, master_key=master_key)
+
+    inst = await repo.get_instance(row_id, master_key=master_key)
+    assert inst is not None
+    assert inst.enabled is True
+    assert inst.batch_size == 2
+    assert inst.sleep_interval_mins == 30
+    assert inst.hourly_cap == 4
+    assert inst.cooldown_days == 14
+    assert inst.post_release_grace_hrs == 6
+    assert inst.queue_limit == 0
+    assert inst.cutoff_enabled is False
+    assert inst.cutoff_batch_size == 1
+    assert inst.cutoff_cooldown_days == 21
+    assert inst.cutoff_hourly_cap == 1
+    assert inst.sonarr_search_mode is SonarrSearchMode.episode
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_update_instance_applies_single_field(db: None, master_key: bytes) -> None:
+    """Supplying one non-None field rewrites exactly that column."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Before",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+    await update_instance(created.id, InstanceUpdate(name="After"), master_key=master_key)
+    inst = await repo.get_instance(created.id, master_key=master_key)
+    assert inst is not None
+    assert inst.name == "After"
+    assert inst.url == "http://s:8989"  # other fields untouched
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_update_instance_is_noop_when_payload_is_empty(db: None, master_key: bytes) -> None:
+    """Every-None InstanceUpdate skips SQL entirely; updated_at does not change."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Stable",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+    original_updated_at = created.updated_at
+
+    await update_instance(created.id, InstanceUpdate(), master_key=master_key)
+
+    inst = await repo.get_instance(created.id, master_key=master_key)
+    assert inst is not None
+    assert inst.updated_at == original_updated_at
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_update_instance_reencrypts_api_key(db: None, master_key: bytes) -> None:
+    """api_key in InstanceUpdate is plaintext; the repo re-encrypts it."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Rotate",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="old-key",
+    )
+
+    await update_instance(created.id, InstanceUpdate(api_key="rotated-key"), master_key=master_key)
+
+    # Repo read decrypts to plaintext
+    inst = await repo.get_instance(created.id, master_key=master_key)
+    assert inst is not None
+    assert inst.api_key == "rotated-key"
+
+    # Raw SQL row holds ciphertext, not the plaintext
+    async with (
+        get_db() as conn,
+        conn.execute("SELECT encrypted_api_key FROM instances WHERE id = ?", (created.id,)) as cur,
+    ):
+        row = await cur.fetchone()
+    assert row is not None
+    assert row["encrypted_api_key"] != "rotated-key"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_update_instance_coerces_enum_fields(db: None, master_key: bytes) -> None:
+    """Enum-valued fields flatten to the underlying str before SQL."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Modes",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+
+    await update_instance(
+        created.id,
+        InstanceUpdate(
+            sonarr_search_mode=SonarrSearchMode.season_context,
+            search_order=SearchOrder.random,
+        ),
+        master_key=master_key,
+    )
+
+    inst = await repo.get_instance(created.id, master_key=master_key)
+    assert inst is not None
+    assert inst.sonarr_search_mode is SonarrSearchMode.season_context
+    assert inst.search_order is SearchOrder.random
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_update_instance_coerces_bool_fields(db: None, master_key: bytes) -> None:
+    """Bool fields become 0/1 ints in SQL; round-trip preserves bool-ness."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Toggled",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+
+    await update_instance(
+        created.id,
+        InstanceUpdate(enabled=False, cutoff_enabled=True, upgrade_enabled=True),
+        master_key=master_key,
+    )
+    inst = await repo.get_instance(created.id, master_key=master_key)
+    assert inst is not None
+    assert inst.enabled is False
+    assert inst.cutoff_enabled is True
+    assert inst.upgrade_enabled is True
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_update_instance_bumps_updated_at(db: None, master_key: bytes) -> None:
+    """Any non-empty update moves updated_at forward of created_at."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Stamp",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+
+    await update_instance(created.id, InstanceUpdate(name="Stamped"), master_key=master_key)
+    inst = await repo.get_instance(created.id, master_key=master_key)
+    assert inst is not None
+    # updated_at is a ISO-8601 string; lexicographic compare == chronological
+    assert inst.updated_at >= created.updated_at
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_instance_returns_true_when_row_existed(db: None, master_key: bytes) -> None:
+    """delete_instance returns True when a row was removed."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Doomed",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+
+    deleted = await delete_instance(created.id)
+    assert deleted is True
+    assert await repo.get_instance(created.id, master_key=master_key) is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_instance_returns_false_when_row_missing(db: None) -> None:
+    """delete_instance returns False when no row matched the id."""
+    deleted = await delete_instance(9999)
+    assert deleted is False
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_update_instance_snapshot_writes_three_columns(db: None, master_key: bytes) -> None:
+    """update_instance_snapshot populates monitored_total, unreleased_count, timestamp."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Snapshot",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+    assert created.monitored_total == 0
+    assert created.snapshot_refreshed_at == ""
+
+    await update_instance_snapshot(created.id, monitored_total=42, unreleased_count=7)
+
+    inst = await repo.get_instance(created.id, master_key=master_key)
+    assert inst is not None
+    assert inst.monitored_total == 42
+    assert inst.unreleased_count == 7
+    assert inst.snapshot_refreshed_at != ""  # ISO-8601 filled by strftime
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_update_instance_snapshot_overwrites_prior_values(
+    db: None, master_key: bytes
+) -> None:
+    """Repeated snapshot writes replace the previous numbers."""
+    created = await create_instance(
+        master_key=master_key,
+        name="Refreshed",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+    await update_instance_snapshot(created.id, monitored_total=100, unreleased_count=10)
+    await update_instance_snapshot(created.id, monitored_total=200, unreleased_count=20)
+
+    inst = await repo.get_instance(created.id, master_key=master_key)
+    assert inst is not None
+    assert inst.monitored_total == 200
+    assert inst.unreleased_count == 20
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_create_instance_delegates_to_repo(db: None, master_key: bytes) -> None:
+    """The service-layer create still works end-to-end through the repo payload."""
+    inst = await create_instance(
+        master_key=master_key,
+        name="Delegated",
+        type=InstanceType.radarr,
+        url="http://radarr:7878",
+        api_key="rkey",
+    )
+    assert inst.id >= 1
+    assert inst.name == "Delegated"
+    assert inst.api_key == "rkey"
+    assert inst.type is InstanceType.radarr
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_update_instance_filters_unrecognized_kwargs(
+    db: None, master_key: bytes
+) -> None:
+    """Unknown kwargs on services.update_instance are silently dropped."""
+    from houndarr.services.instances import update_instance as svc_update
+
+    created = await create_instance(
+        master_key=master_key,
+        name="Filter",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+
+    inst = await svc_update(
+        created.id,
+        master_key=master_key,
+        name="Renamed",
+        nonexistent_field="ignored",
+        another_bogus_kwarg=123,
+    )
+    assert inst is not None
+    assert inst.name == "Renamed"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_update_instance_returns_none_for_missing_id(
+    db: None, master_key: bytes
+) -> None:
+    """Updating a non-existent id returns None, matching pre-refactor behaviour."""
+    from houndarr.services.instances import update_instance as svc_update
+
+    result = await svc_update(999, master_key=master_key, name="Nope")
+    assert result is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_service_delete_instance_delegates_to_repo(db: None, master_key: bytes) -> None:
+    """services.delete_instance returns the repo's bool directly."""
+    from houndarr.services.instances import delete_instance as svc_delete
+
+    created = await create_instance(
+        master_key=master_key,
+        name="Trashed",
+        type=InstanceType.sonarr,
+        url="http://s:8989",
+        api_key="k",
+    )
+    assert await svc_delete(created.id) is True
+    assert await svc_delete(created.id) is False
+
+
+@pytest.mark.pinning()
+def test_instance_insert_is_frozen_dataclass_with_slots() -> None:
+    """InstanceInsert is a frozen slotted dataclass for immutability + memory."""
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        payload = InstanceInsert(
+            name="x",
+            type=InstanceType.sonarr,
+            url="http://x",
+            api_key="k",
+        )
+        payload.name = "mutated"  # type: ignore[misc]
+
+
+@pytest.mark.pinning()
+def test_instance_update_is_frozen_dataclass_with_slots() -> None:
+    """InstanceUpdate is a frozen slotted dataclass for immutability + memory."""
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        payload = InstanceUpdate(name="x")
+        payload.name = "mutated"  # type: ignore[misc]
+
+
+@pytest.mark.pinning()
+def test_instance_update_has_every_updatable_column() -> None:
+    """InstanceUpdate covers every updatable column the service previously allowed."""
+    expected = {
+        "name",
+        "type",
+        "url",
+        "api_key",
+        "enabled",
+        "batch_size",
+        "sleep_interval_mins",
+        "hourly_cap",
+        "cooldown_days",
+        "post_release_grace_hrs",
+        "queue_limit",
+        "cutoff_enabled",
+        "cutoff_batch_size",
+        "cutoff_cooldown_days",
+        "cutoff_hourly_cap",
+        "sonarr_search_mode",
+        "lidarr_search_mode",
+        "readarr_search_mode",
+        "whisparr_search_mode",
+        "upgrade_enabled",
+        "upgrade_batch_size",
+        "upgrade_cooldown_days",
+        "upgrade_hourly_cap",
+        "upgrade_sonarr_search_mode",
+        "upgrade_lidarr_search_mode",
+        "upgrade_readarr_search_mode",
+        "upgrade_whisparr_search_mode",
+        "upgrade_item_offset",
+        "upgrade_series_offset",
+        "missing_page_offset",
+        "cutoff_page_offset",
+        "allowed_time_window",
+        "search_order",
+        "monitored_total",
+        "unreleased_count",
+        "snapshot_refreshed_at",
+    }
+    actual = {f.name for f in dataclass_fields(InstanceUpdate)}
+    assert actual == expected

--- a/tests/test_repositories/test_search_log.py
+++ b/tests/test_repositories/test_search_log.py
@@ -332,3 +332,23 @@ async def test_engine_write_log_delegates_through_repo(seeded_instances: None) -
     assert row["cycle_id"] == "c-eng"
     assert row["cycle_trigger"] == "scheduled"
     assert row["item_label"] == "Delegated Episode"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_purge_old_logs_lives_on_repository(db: None) -> None:
+    """``purge_old_logs`` lives on the search-log repository post-Phase 6b.
+
+    The function's disable-on-zero semantics and the empty-table
+    return shape are pinned here; detailed row-deletion coverage
+    stays in tests/test_database_edge_cases.py.  A companion
+    assertion catches a future re-introduction of a shim on
+    :mod:`houndarr.database`.
+    """
+    import houndarr.database as _database_mod
+    from houndarr.repositories.search_log import purge_old_logs
+
+    assert await purge_old_logs(0) == 0
+    assert await purge_old_logs(-5) == 0
+    assert await purge_old_logs(30) == 0
+    assert not hasattr(_database_mod, "purge_old_logs")

--- a/tests/test_repositories/test_search_log.py
+++ b/tests/test_repositories/test_search_log.py
@@ -1,0 +1,334 @@
+"""Pinning tests for the search_log-repository SQL boundary.
+
+Locks the Track D.6 contract of ``insert_log_row``,
+``fetch_log_rows``, ``fetch_recent_searches``, and
+``delete_logs_for_instance``.  The golden-log characterisation test
+(``tests/test_engine/test_golden_search_log.py``) pins the engine's
+``_write_log`` byte shape; these tests pin the repository primitives
+the engine delegator now rests on, plus the fetch surface D.9 will
+consume.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+
+from houndarr.database import get_db
+from houndarr.repositories import search_log as repo
+
+
+@pytest_asyncio.fixture()
+async def seeded_instances(db: None) -> AsyncGenerator[None, None]:
+    """Two stub instance rows so FK constraints are satisfied."""
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url) VALUES (?, ?, ?, ?)",
+            [
+                (1, "Sonarr Test", "sonarr", "http://sonarr:8989"),
+                (2, "Radarr Test", "radarr", "http://radarr:7878"),
+            ],
+        )
+        await conn.commit()
+    yield
+
+
+async def _count_logs() -> int:
+    async with get_db() as conn, conn.execute("SELECT COUNT(*) FROM search_log") as cur:
+        row = await cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_insert_log_row_full_row_round_trip(seeded_instances: None) -> None:
+    """Every kwarg survives into a column that reads back identically."""
+    await repo.insert_log_row(
+        instance_id=1,
+        item_id=42,
+        item_type="episode",
+        action="searched",
+        search_kind="missing",
+        cycle_id="c-1",
+        cycle_trigger="scheduled",
+        item_label="Example S01E01",
+        reason=None,
+        message=None,
+    )
+
+    rows = await repo.fetch_log_rows(instance_id=1)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["instance_id"] == 1
+    assert row["item_id"] == 42
+    assert row["item_type"] == "episode"
+    assert row["action"] == "searched"
+    assert row["search_kind"] == "missing"
+    assert row["cycle_id"] == "c-1"
+    assert row["cycle_trigger"] == "scheduled"
+    assert row["item_label"] == "Example S01E01"
+    assert row["reason"] is None
+    assert row["message"] is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_insert_log_row_accepts_null_instance(seeded_instances: None) -> None:
+    """System-scope rows carry a null instance_id; the FK allows it."""
+    await repo.insert_log_row(
+        instance_id=None,
+        item_id=None,
+        item_type=None,
+        action="info",
+        message="app started",
+    )
+    rows = await repo.fetch_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["instance_id"] is None
+    assert rows[0]["action"] == "info"
+    assert rows[0]["message"] == "app started"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_insert_log_row_populates_timestamp_from_default(
+    seeded_instances: None,
+) -> None:
+    """timestamp is not a parameter; the schema default fills it in."""
+    await repo.insert_log_row(
+        instance_id=1,
+        item_id=None,
+        item_type=None,
+        action="info",
+        message="hello",
+    )
+    rows = await repo.fetch_log_rows(instance_id=1)
+    assert rows[0]["timestamp"].endswith("Z")
+    assert "T" in rows[0]["timestamp"]
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_log_rows_returns_empty_list_on_empty_table(seeded_instances: None) -> None:
+    """Empty table returns [], not None."""
+    assert await repo.fetch_log_rows() == []
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_log_rows_orders_newest_first(seeded_instances: None) -> None:
+    """Rows sort by timestamp DESC, id DESC so the newest row leads."""
+    for idx in range(3):
+        await repo.insert_log_row(
+            instance_id=1,
+            item_id=idx,
+            item_type="episode",
+            action="searched",
+            search_kind="missing",
+            cycle_id=f"cycle-{idx}",
+        )
+
+    rows = await repo.fetch_log_rows()
+    assert [r["cycle_id"] for r in rows] == ["cycle-2", "cycle-1", "cycle-0"]
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_log_rows_applies_instance_filter(seeded_instances: None) -> None:
+    """instance_id filter limits results to the named instance."""
+    await repo.insert_log_row(
+        instance_id=1, item_id=1, item_type="episode", action="searched", search_kind="missing"
+    )
+    await repo.insert_log_row(
+        instance_id=2, item_id=1, item_type="movie", action="searched", search_kind="missing"
+    )
+
+    rows_1 = await repo.fetch_log_rows(instance_id=1)
+    rows_2 = await repo.fetch_log_rows(instance_id=2)
+    assert [r["instance_id"] for r in rows_1] == [1]
+    assert [r["instance_id"] for r in rows_2] == [2]
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_log_rows_applies_action_and_kind_filters(
+    seeded_instances: None,
+) -> None:
+    """Filters combine via AND; only matching rows survive."""
+    await repo.insert_log_row(
+        instance_id=1, item_id=1, item_type="episode", action="searched", search_kind="missing"
+    )
+    await repo.insert_log_row(
+        instance_id=1, item_id=2, item_type="episode", action="skipped", search_kind="missing"
+    )
+    await repo.insert_log_row(
+        instance_id=1, item_id=3, item_type="episode", action="searched", search_kind="cutoff"
+    )
+
+    rows = await repo.fetch_log_rows(action="searched", search_kind="missing")
+    assert len(rows) == 1
+    assert rows[0]["item_id"] == 1
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_log_rows_limit_and_cursor(seeded_instances: None) -> None:
+    """limit clamps the page size; after_id advances to the next page."""
+    ids = []
+    for idx in range(5):
+        await repo.insert_log_row(
+            instance_id=1,
+            item_id=idx,
+            item_type="episode",
+            action="searched",
+            search_kind="missing",
+        )
+        rows = await repo.fetch_log_rows(limit=1)
+        ids.append(rows[0]["id"])
+
+    page = await repo.fetch_log_rows(limit=2)
+    assert len(page) == 2
+    # Newest first: the two highest ids
+    assert page[0]["id"] == ids[-1]
+
+    next_page = await repo.fetch_log_rows(limit=2, after_id=page[-1]["id"])
+    assert len(next_page) == 2
+    # After-id is strict (<), so the cursor row itself is excluded
+    assert next_page[0]["id"] < page[-1]["id"]
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_recent_searches_counts_only_searched(seeded_instances: None) -> None:
+    """fetch_recent_searches only counts action='searched', inside the window."""
+    await repo.insert_log_row(
+        instance_id=1, item_id=1, item_type="episode", action="searched", search_kind="missing"
+    )
+    await repo.insert_log_row(
+        instance_id=1, item_id=2, item_type="episode", action="skipped", search_kind="missing"
+    )
+    await repo.insert_log_row(
+        instance_id=1, item_id=3, item_type="episode", action="error", search_kind="missing"
+    )
+
+    count = await repo.fetch_recent_searches(1, search_kind="missing", within_seconds=3600)
+    assert count == 1
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_recent_searches_applies_time_window(seeded_instances: None) -> None:
+    """Rows outside the trailing window do not count."""
+    # Fresh row (inside any positive window)
+    await repo.insert_log_row(
+        instance_id=1, item_id=1, item_type="episode", action="searched", search_kind="missing"
+    )
+    # Stale row (backdate by 10 hours)
+    stale = (datetime.now(UTC) - timedelta(hours=10)).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO search_log (instance_id, item_id, item_type, action, search_kind,"
+            " timestamp) VALUES (?, ?, ?, ?, ?, ?)",
+            (1, 2, "episode", "searched", "missing", stale),
+        )
+        await conn.commit()
+
+    within_hour = await repo.fetch_recent_searches(1, search_kind="missing", within_seconds=3600)
+    within_day = await repo.fetch_recent_searches(1, search_kind="missing", within_seconds=86400)
+    assert within_hour == 1
+    assert within_day == 2
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_recent_searches_short_circuits_on_non_positive_window(
+    seeded_instances: None,
+) -> None:
+    """Zero / negative within_seconds returns 0 without querying."""
+    await repo.insert_log_row(
+        instance_id=1, item_id=1, item_type="episode", action="searched", search_kind="missing"
+    )
+    assert await repo.fetch_recent_searches(1, search_kind="missing", within_seconds=0) == 0
+    assert await repo.fetch_recent_searches(1, search_kind="missing", within_seconds=-1) == 0
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_fetch_recent_searches_scopes_to_instance_and_kind(
+    seeded_instances: None,
+) -> None:
+    """Only rows that match instance_id AND search_kind count."""
+    await repo.insert_log_row(
+        instance_id=1, item_id=1, item_type="episode", action="searched", search_kind="missing"
+    )
+    await repo.insert_log_row(
+        instance_id=1, item_id=2, item_type="episode", action="searched", search_kind="cutoff"
+    )
+    await repo.insert_log_row(
+        instance_id=2, item_id=3, item_type="movie", action="searched", search_kind="missing"
+    )
+
+    assert await repo.fetch_recent_searches(1, search_kind="missing", within_seconds=3600) == 1
+    assert await repo.fetch_recent_searches(1, search_kind="cutoff", within_seconds=3600) == 1
+    assert await repo.fetch_recent_searches(2, search_kind="missing", within_seconds=3600) == 1
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_logs_for_instance_returns_row_count(seeded_instances: None) -> None:
+    """delete_logs_for_instance returns the number of rows removed."""
+    await repo.insert_log_row(
+        instance_id=1, item_id=1, item_type="episode", action="searched", search_kind="missing"
+    )
+    await repo.insert_log_row(
+        instance_id=1, item_id=2, item_type="episode", action="skipped", search_kind="missing"
+    )
+    await repo.insert_log_row(
+        instance_id=2, item_id=1, item_type="movie", action="searched", search_kind="missing"
+    )
+
+    deleted = await repo.delete_logs_for_instance(1)
+    assert deleted == 2
+    assert await _count_logs() == 1
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_logs_for_instance_returns_zero_when_empty(
+    seeded_instances: None,
+) -> None:
+    """delete_logs_for_instance returns 0 when there are no matching rows."""
+    assert await repo.delete_logs_for_instance(1) == 0
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_engine_write_log_delegates_through_repo(seeded_instances: None) -> None:
+    """The engine's _write_log helper writes the same row shape the repo would."""
+    from houndarr.engine.search_loop import _write_log
+
+    await _write_log(
+        1,
+        42,
+        "episode",
+        "searched",
+        search_kind="missing",
+        cycle_id="c-eng",
+        cycle_trigger="scheduled",
+        item_label="Delegated Episode",
+    )
+
+    rows = await repo.fetch_log_rows(instance_id=1)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["instance_id"] == 1
+    assert row["item_id"] == 42
+    assert row["item_type"] == "episode"
+    assert row["action"] == "searched"
+    assert row["search_kind"] == "missing"
+    assert row["cycle_id"] == "c-eng"
+    assert row["cycle_trigger"] == "scheduled"
+    assert row["item_label"] == "Delegated Episode"

--- a/tests/test_repositories/test_settings.py
+++ b/tests/test_repositories/test_settings.py
@@ -1,0 +1,132 @@
+"""Pinning tests for the settings-repository SQL boundary.
+
+Locks the Track D.2 contract of
+:mod:`houndarr.repositories.settings` and the transitional
+delegation from :mod:`houndarr.database`: every case below has to
+stay byte-equal through later D batches so route callers and the
+``database`` module can be migrated one file at a time without
+regressing behaviour at the edges.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.repositories import settings as repo
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_get_setting_returns_none_for_missing_key(db: None) -> None:
+    """Missing keys yield ``None``; no implicit default in the repo API."""
+    assert await repo.get_setting("does_not_exist") is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_get_setting_returns_stored_value(db: None) -> None:
+    """set_setting round-trips through get_setting for a simple value."""
+    await repo.set_setting("alpha", "one")
+    assert await repo.get_setting("alpha") == "one"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_set_setting_upserts_existing_key(db: None) -> None:
+    """Second set overwrites the first via ON CONFLICT DO UPDATE."""
+    await repo.set_setting("beta", "first")
+    await repo.set_setting("beta", "second")
+    assert await repo.get_setting("beta") == "second"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_set_setting_preserves_empty_string(db: None) -> None:
+    """Empty string is stored verbatim and is distinct from a missing row."""
+    await repo.set_setting("gamma", "")
+    assert await repo.get_setting("gamma") == ""
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_set_setting_preserves_unicode(db: None) -> None:
+    """Non-ASCII values round-trip byte-equal (TEXT column, UTF-8 on SQLite)."""
+    value = "héllo ☃ world"
+    await repo.set_setting("unicode_key", value)
+    assert await repo.get_setting("unicode_key") == value
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_setting_removes_existing_key(db: None) -> None:
+    """delete_setting erases the row so a subsequent read returns None."""
+    await repo.set_setting("delta", "value")
+    await repo.delete_setting("delta")
+    assert await repo.get_setting("delta") is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_setting_noop_on_missing_key(db: None) -> None:
+    """delete_setting is idempotent: calling it on a missing key succeeds."""
+    await repo.delete_setting("never_was_there")
+    assert await repo.get_setting("never_was_there") is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_delete_setting_only_removes_named_key(db: None) -> None:
+    """delete_setting does not touch unrelated rows."""
+    await repo.set_setting("keep_me", "still_here")
+    await repo.set_setting("drop_me", "gone")
+    await repo.delete_setting("drop_me")
+    assert await repo.get_setting("keep_me") == "still_here"
+    assert await repo.get_setting("drop_me") is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_database_get_setting_returns_default_on_missing_key(db: None) -> None:
+    """Legacy wrapper preserves the ``default=`` behaviour its callers rely on."""
+    from houndarr.database import get_setting as db_get
+
+    assert await db_get("absent_key", default="fallback") == "fallback"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_database_get_setting_returns_none_without_default(db: None) -> None:
+    """Legacy wrapper still returns ``None`` when no default is supplied."""
+    from houndarr.database import get_setting as db_get
+
+    assert await db_get("also_absent") is None
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_database_get_setting_prefers_stored_value_over_default(db: None) -> None:
+    """A stored value wins over the caller's default in the legacy path."""
+    from houndarr.database import get_setting as db_get
+
+    await repo.set_setting("real_key", "real_value")
+    assert await db_get("real_key", default="fallback") == "real_value"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_database_set_setting_delegates_to_repo(db: None) -> None:
+    """A write through the legacy wrapper is visible via the repository read."""
+    from houndarr.database import set_setting as db_set
+
+    await db_set("shared_key", "via_db_wrapper")
+    assert await repo.get_setting("shared_key") == "via_db_wrapper"
+
+
+@pytest.mark.pinning()
+@pytest.mark.asyncio()
+async def test_repo_set_setting_visible_to_database_wrapper(db: None) -> None:
+    """A write through the repository is visible via the legacy wrapper read."""
+    from houndarr.database import get_setting as db_get
+
+    await repo.set_setting("shared_key_2", "via_repo")
+    assert await db_get("shared_key_2") == "via_repo"


### PR DESCRIPTION
## Summary

Land the `houndarr.repositories/` namespace and migrate the four aggregates declared in `houndarr.protocols` (settings, instances, cooldowns, search_log) onto it. Each module is function-based, scoped to a single aggregate, and wraps `get_db()` only; migration helpers stay on `houndarr.database`. The service layer thins to delegators that keep their existing public signatures so engine and route callers do not need to change.

Closes #468

## Changes

- `src/houndarr/repositories/__init__.py`: namespace landing pad with the locked-decision rationale (function-based, module-per-aggregate).
- `src/houndarr/repositories/settings.py`: `get_setting` / `set_setting` / `delete_setting`. The `houndarr.database.get_setting` wrapper stays as a `default=` shim until route callers migrate; `auth.py` migrates in this PR.
- `src/houndarr/repositories/instances.py`: `list_instances` / `get_instance` / `insert_instance` / `update_instance` / `delete_instance` / `update_instance_snapshot` plus the `_row_to_instance` mapper, the optional-column readers, and `InstanceInsert` + `InstanceUpdate` payload dataclasses. Service-layer reads and writes thin to delegators that keep their public `id=` parameter name.
- `src/houndarr/repositories/cooldowns.py`: `exists_active_cooldown` / `upsert_cooldown` / `delete_cooldowns_for_instance` plus the `_iso` / `_now_utc` timestamp helpers. The LRU skip-log sentinel (`should_log_skip`) stays on `services/cooldown.py` because it gates log writes, not SQL. `count_searches_last_hour` stays on the service module as inline SQL alongside the positional shims so the engine has a single import path; D.6 in a later batch can migrate it in.
- `src/houndarr/repositories/search_log.py`: `insert_log_row` / `fetch_log_rows` / `fetch_recent_searches` / `count_searches_last_hour` / `delete_logs_for_instance` / `purge_old_logs`. `fetch_log_rows` filters via a column allowlist so the dynamic WHERE never touches user-supplied identifiers (the single `f"{column} = ?"` reference is annotated with the repo's standard `S608` / `B608` suppression pair).
- `src/houndarr/protocols.py`: tighten `InstanceRepository` signatures to declare the `master_key` kwarg and `delete_instance` returning `bool` so the Protocol matches the concrete API.
- `src/houndarr/database.py`: drop `purge_old_logs` (moves to repositories.search_log). Keep `get_setting` / `set_setting` shim wrappers so callers still importing from `houndarr.database` continue to work.
- `src/houndarr/app.py`: import `purge_old_logs` from the repository.
- Pinning tests under `tests/test_repositories/` (settings, instances reads, instances writes, cooldowns, search_log) lock the row-mapping invariants, encryption round-trips, payload column coverage, upsert semantics, FK-cascade behaviour, filter allowlists, cursor pagination, and retention disable-on-zero.

## Testing

All gates green locally (1473 tests).

## Type of Change

- [x] Refactoring (`refactor:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
