### PR TITLE
refactor(services): introduce Instance sub-struct facade

### DIFF
--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -128,10 +128,6 @@ def set_db_path(path: str) -> None:
     _db_path = path
 
 
-def get_db_path() -> str:
-    return _db_path
-
-
 @asynccontextmanager
 async def get_db() -> AsyncGenerator[aiosqlite.Connection, None]:
     """Yield a database connection with foreign keys enabled."""

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -82,11 +82,11 @@ def adapt_missing(item: MissingAlbum, instance: Instance) -> SearchCandidate:
         A fully populated :class:`SearchCandidate`.
     """
     unreleased_reason = _lidarr_unreleased_reason(
-        item.release_date, instance.post_release_grace_hrs
+        item.release_date, instance.missing.post_release_grace_hrs
     )
 
     context: ContextOverride | None = None
-    if instance.lidarr_search_mode != LidarrSearchMode.album and item.artist_id > 0:
+    if instance.missing.lidarr_search_mode != LidarrSearchMode.album and item.artist_id > 0:
         context = ContextOverride(
             item_id=_artist_item_id(item.artist_id),
             label=_artist_context_label(item),
@@ -127,7 +127,7 @@ def adapt_cutoff(item: MissingAlbum, instance: Instance) -> SearchCandidate:
         item_id=item.album_id,
         label=_album_label(item),
         unreleased_reason=_lidarr_unreleased_reason(
-            item.release_date, instance.post_release_grace_hrs
+            item.release_date, instance.missing.post_release_grace_hrs
         ),
         search_payload={
             "command": "AlbumSearch",
@@ -152,7 +152,7 @@ def _library_artist_context_label(item: LibraryAlbum) -> str:
 def adapt_upgrade(item: LibraryAlbum, instance: Instance) -> SearchCandidate:
     """Convert a Lidarr library album into a :class:`SearchCandidate` for upgrade.
 
-    Respects ``instance.upgrade_lidarr_search_mode`` for album vs artist-context.
+    Respects ``instance.upgrade.upgrade_lidarr_search_mode`` for album vs artist-context.
     No unreleased checks: upgrade items already have files.
 
     Args:
@@ -162,7 +162,7 @@ def adapt_upgrade(item: LibraryAlbum, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    album_mode = instance.upgrade_lidarr_search_mode == LidarrSearchMode.album
+    album_mode = instance.upgrade.upgrade_lidarr_search_mode == LidarrSearchMode.album
 
     use_artist_context = not album_mode and item.artist_id > 0
 
@@ -216,7 +216,7 @@ async def fetch_upgrade_pool(
         except Exception:  # noqa: BLE001
             logger.warning(
                 "[%s] failed to fetch cutoff page %d for exclusion set",
-                instance.name,
+                instance.core.name,
                 page,
             )
             break
@@ -258,7 +258,7 @@ def make_client(instance: Instance) -> LidarrClient:
     Returns:
         A new (unopened) :class:`LidarrClient`.
     """
-    return LidarrClient(url=instance.url, api_key=instance.api_key)
+    return LidarrClient(url=instance.core.url, api_key=instance.core.api_key)
 
 
 def _album_leaf_pairs(items: list[MissingAlbum]) -> frozenset[tuple[str, int]]:

--- a/src/houndarr/engine/adapters/radarr.py
+++ b/src/houndarr/engine/adapters/radarr.py
@@ -89,7 +89,7 @@ def adapt_missing(item: MissingMovie, instance: Instance) -> SearchCandidate:
         item_type="movie",
         item_id=item.movie_id,
         label=_movie_label(item),
-        unreleased_reason=_radarr_unreleased_reason(item, instance.post_release_grace_hrs),
+        unreleased_reason=_radarr_unreleased_reason(item, instance.missing.post_release_grace_hrs),
         search_payload={
             "command": "MoviesSearch",
             "movie_id": item.movie_id,
@@ -213,7 +213,7 @@ def make_client(instance: Instance) -> RadarrClient:
     Returns:
         A new (unopened) :class:`RadarrClient`.
     """
-    return RadarrClient(url=instance.url, api_key=instance.api_key)
+    return RadarrClient(url=instance.core.url, api_key=instance.core.api_key)
 
 
 async def fetch_instance_snapshot(

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -81,11 +81,11 @@ def adapt_missing(item: MissingBook, instance: Instance) -> SearchCandidate:
         A fully populated :class:`SearchCandidate`.
     """
     unreleased_reason = _readarr_unreleased_reason(
-        item.release_date, instance.post_release_grace_hrs
+        item.release_date, instance.missing.post_release_grace_hrs
     )
 
     context: ContextOverride | None = None
-    if instance.readarr_search_mode != ReadarrSearchMode.book and item.author_id > 0:
+    if instance.missing.readarr_search_mode != ReadarrSearchMode.book and item.author_id > 0:
         context = ContextOverride(
             item_id=_author_item_id(item.author_id),
             label=_author_context_label(item),
@@ -126,7 +126,7 @@ def adapt_cutoff(item: MissingBook, instance: Instance) -> SearchCandidate:
         item_id=item.book_id,
         label=_book_label(item),
         unreleased_reason=_readarr_unreleased_reason(
-            item.release_date, instance.post_release_grace_hrs
+            item.release_date, instance.missing.post_release_grace_hrs
         ),
         search_payload={
             "command": "BookSearch",
@@ -151,7 +151,7 @@ def _library_author_context_label(item: LibraryBook) -> str:
 def adapt_upgrade(item: LibraryBook, instance: Instance) -> SearchCandidate:
     """Convert a Readarr library book into a :class:`SearchCandidate` for upgrade.
 
-    Respects ``instance.upgrade_readarr_search_mode`` for book vs author-context.
+    Respects ``instance.upgrade.upgrade_readarr_search_mode`` for book vs author-context.
     No unreleased checks: upgrade items already have files.
 
     Args:
@@ -161,7 +161,7 @@ def adapt_upgrade(item: LibraryBook, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    book_mode = instance.upgrade_readarr_search_mode == ReadarrSearchMode.book
+    book_mode = instance.upgrade.upgrade_readarr_search_mode == ReadarrSearchMode.book
 
     use_author_context = not book_mode and item.author_id > 0
 
@@ -215,7 +215,7 @@ async def fetch_upgrade_pool(
         except Exception:  # noqa: BLE001
             logger.warning(
                 "[%s] failed to fetch cutoff page %d for exclusion set",
-                instance.name,
+                instance.core.name,
                 page,
             )
             break
@@ -257,7 +257,7 @@ def make_client(instance: Instance) -> ReadarrClient:
     Returns:
         A new (unopened) :class:`ReadarrClient`.
     """
-    return ReadarrClient(url=instance.url, api_key=instance.api_key)
+    return ReadarrClient(url=instance.core.url, api_key=instance.core.api_key)
 
 
 def _book_leaf_pairs(items: list[MissingBook]) -> frozenset[tuple[str, int]]:

--- a/src/houndarr/engine/adapters/sonarr.py
+++ b/src/houndarr/engine/adapters/sonarr.py
@@ -111,12 +111,12 @@ def adapt_missing(item: MissingEpisode, instance: Instance) -> SearchCandidate:
         A fully populated :class:`SearchCandidate`.
     """
     unreleased_reason = _sonarr_unreleased_reason(
-        item.air_date_utc, instance.post_release_grace_hrs
+        item.air_date_utc, instance.missing.post_release_grace_hrs
     )
 
     context: ContextOverride | None = None
     if (
-        instance.sonarr_search_mode != SonarrSearchMode.episode
+        instance.missing.sonarr_search_mode != SonarrSearchMode.episode
         and item.series_id is not None
         and item.season > 0
     ):
@@ -148,7 +148,7 @@ def adapt_cutoff(item: MissingEpisode, instance: Instance) -> SearchCandidate:
     """Convert a Sonarr cutoff-unmet episode into a :class:`SearchCandidate`.
 
     The cutoff pass always uses episode-mode regardless of
-    ``instance.sonarr_search_mode``, matching the current behavior in
+    ``instance.missing.sonarr_search_mode``, matching the current behavior in
     ``search_loop.py``.
 
     Args:
@@ -163,7 +163,7 @@ def adapt_cutoff(item: MissingEpisode, instance: Instance) -> SearchCandidate:
         item_id=item.episode_id,
         label=_episode_label(item),
         unreleased_reason=_sonarr_unreleased_reason(
-            item.air_date_utc, instance.post_release_grace_hrs
+            item.air_date_utc, instance.missing.post_release_grace_hrs
         ),
         search_payload={
             "command": "EpisodeSearch",
@@ -190,7 +190,7 @@ def _library_season_context_label(item: LibraryEpisode) -> str:
 def adapt_upgrade(item: LibraryEpisode, instance: Instance) -> SearchCandidate:
     """Convert a Sonarr library episode into a :class:`SearchCandidate` for upgrade.
 
-    Respects ``instance.upgrade_sonarr_search_mode`` for episode vs season-context.
+    Respects ``instance.upgrade.upgrade_sonarr_search_mode`` for episode vs season-context.
     No unreleased checks: upgrade items already have files.
 
     Args:
@@ -200,7 +200,7 @@ def adapt_upgrade(item: LibraryEpisode, instance: Instance) -> SearchCandidate:
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    episode_mode = instance.upgrade_sonarr_search_mode == SonarrSearchMode.episode
+    episode_mode = instance.upgrade.upgrade_sonarr_search_mode == SonarrSearchMode.episode
 
     use_season_context = not episode_mode and item.series_id > 0 and item.season > 0
 
@@ -268,7 +268,7 @@ async def fetch_upgrade_pool(
     """Fetch and filter Sonarr library for upgrade-eligible episodes.
 
     Uses series rotation: fetches up to ``_UPGRADE_MAX_SERIES_PER_CYCLE``
-    monitored series per cycle, starting from ``instance.upgrade_series_offset``.
+    monitored series per cycle, starting from ``instance.upgrade.upgrade_series_offset``.
 
     Args:
         client: An open :class:`SonarrClient` context.
@@ -286,7 +286,7 @@ async def fetch_upgrade_pool(
     if not monitored:
         return []
 
-    offset = instance.upgrade_series_offset % len(monitored)
+    offset = instance.upgrade.upgrade_series_offset % len(monitored)
     selected = monitored[offset : offset + _UPGRADE_MAX_SERIES_PER_CYCLE]
     if len(selected) < _UPGRADE_MAX_SERIES_PER_CYCLE:
         remaining = _UPGRADE_MAX_SERIES_PER_CYCLE - len(selected)
@@ -352,7 +352,7 @@ def make_client(instance: Instance) -> SonarrClient:
     Returns:
         A new (unopened) :class:`SonarrClient`.
     """
-    return SonarrClient(url=instance.url, api_key=instance.api_key)
+    return SonarrClient(url=instance.core.url, api_key=instance.core.api_key)
 
 
 def _episode_leaf_pairs(items: list[MissingEpisode]) -> frozenset[tuple[str, int]]:

--- a/src/houndarr/engine/adapters/whisparr_v2.py
+++ b/src/houndarr/engine/adapters/whisparr_v2.py
@@ -107,7 +107,7 @@ def adapt_missing(item: MissingWhisparrEpisode, instance: Instance) -> SearchCan
         A fully populated :class:`SearchCandidate`.
     """
     unreleased_reason = _whisparr_unreleased_reason(
-        item.release_date, instance.post_release_grace_hrs
+        item.release_date, instance.missing.post_release_grace_hrs
     )
 
     # Episodes without any series linkage (series_id is None means both
@@ -120,7 +120,7 @@ def adapt_missing(item: MissingWhisparrEpisode, instance: Instance) -> SearchCan
 
     context: ContextOverride | None = None
     if (
-        instance.whisparr_search_mode != WhisparrSearchMode.episode
+        instance.missing.whisparr_search_mode != WhisparrSearchMode.episode
         and item.series_id is not None
         and item.season_number > 0
     ):
@@ -161,7 +161,7 @@ def adapt_cutoff(item: MissingWhisparrEpisode, instance: Instance) -> SearchCand
         A fully populated :class:`SearchCandidate`.
     """
     unreleased_reason = _whisparr_unreleased_reason(
-        item.release_date, instance.post_release_grace_hrs
+        item.release_date, instance.missing.post_release_grace_hrs
     )
 
     # Same orphan guard as adapt_missing: skip records with no series linkage.
@@ -200,7 +200,7 @@ def adapt_upgrade(
 ) -> SearchCandidate:
     """Convert a Whisparr library episode into a :class:`SearchCandidate` for upgrade.
 
-    Respects ``instance.upgrade_whisparr_search_mode`` for episode vs season-context.
+    Respects ``instance.upgrade.upgrade_whisparr_search_mode`` for episode vs season-context.
     No unreleased checks: upgrade items already have files.
 
     Args:
@@ -210,7 +210,7 @@ def adapt_upgrade(
     Returns:
         A fully populated :class:`SearchCandidate`.
     """
-    episode_mode = instance.upgrade_whisparr_search_mode == WhisparrSearchMode.episode
+    episode_mode = instance.upgrade.upgrade_whisparr_search_mode == WhisparrSearchMode.episode
 
     use_season_context = not episode_mode and item.series_id > 0 and item.season_number > 0
 
@@ -278,7 +278,7 @@ async def fetch_upgrade_pool(
     """Fetch and filter Whisparr library for upgrade-eligible episodes.
 
     Uses series rotation: fetches up to ``_UPGRADE_MAX_SERIES_PER_CYCLE``
-    monitored series per cycle, starting from ``instance.upgrade_series_offset``.
+    monitored series per cycle, starting from ``instance.upgrade.upgrade_series_offset``.
 
     Args:
         client: An open :class:`WhisparrClient` context.
@@ -296,7 +296,7 @@ async def fetch_upgrade_pool(
     if not monitored:
         return []
 
-    offset = instance.upgrade_series_offset % len(monitored)
+    offset = instance.upgrade.upgrade_series_offset % len(monitored)
     selected = monitored[offset : offset + _UPGRADE_MAX_SERIES_PER_CYCLE]
     if len(selected) < _UPGRADE_MAX_SERIES_PER_CYCLE:
         remaining = _UPGRADE_MAX_SERIES_PER_CYCLE - len(selected)
@@ -358,7 +358,7 @@ def make_client(instance: Instance) -> WhisparrClient:
     Returns:
         A new (unopened) :class:`WhisparrClient`.
     """
-    return WhisparrClient(url=instance.url, api_key=instance.api_key)
+    return WhisparrClient(url=instance.core.url, api_key=instance.core.api_key)
 
 
 def _whisparr_leaf_pairs(items: list[MissingWhisparrEpisode]) -> frozenset[tuple[str, int]]:

--- a/src/houndarr/engine/adapters/whisparr_v3.py
+++ b/src/houndarr/engine/adapters/whisparr_v3.py
@@ -96,7 +96,7 @@ def adapt_missing(item: MissingWhisparrV3Movie, instance: Instance) -> SearchCan
         item_type="whisparr_v3_movie",
         item_id=item.movie_id,
         label=_movie_label(item),
-        unreleased_reason=_unreleased_reason(item, instance.post_release_grace_hrs),
+        unreleased_reason=_unreleased_reason(item, instance.missing.post_release_grace_hrs),
         search_payload={
             "command": "MoviesSearch",
             "movie_id": item.movie_id,
@@ -190,7 +190,7 @@ def make_client(instance: Instance) -> WhisparrV3Client:
     Returns:
         A new (unopened) :class:`WhisparrV3Client`.
     """
-    return WhisparrV3Client(url=instance.url, api_key=instance.api_key)
+    return WhisparrV3Client(url=instance.core.url, api_key=instance.core.api_key)
 
 
 async def fetch_reconcile_sets(

--- a/src/houndarr/engine/candidates.py
+++ b/src/houndarr/engine/candidates.py
@@ -114,21 +114,3 @@ def _is_within_post_release_grace(release_at: str | None, grace_hrs: int) -> boo
     now = datetime.now(UTC)
     # Only applies to already-released items within the grace window.
     return release_dt <= now < (release_dt + timedelta(hours=grace_hrs))
-
-
-def _is_within_unreleased_delay(release_at: str | None, unreleased_delay_hrs: int) -> bool:
-    """Return True when an item is still inside the configured unreleased delay.
-
-    .. deprecated::
-        Kept for backward compatibility during the transition.  New adapter
-        code should use :func:`_is_unreleased` and
-        :func:`_is_within_post_release_grace` instead.
-    """
-    if unreleased_delay_hrs <= 0:
-        return False
-
-    release_dt = _parse_iso_utc(release_at)
-    if release_dt is None:
-        return False
-
-    return datetime.now(UTC) < (release_dt + timedelta(hours=unreleased_delay_hrs))

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -20,6 +20,7 @@ import httpx
 from houndarr.clients.base import ReconcileSets
 from houndarr.database import get_db
 from houndarr.engine.adapters import get_adapter
+from houndarr.engine.adapters.protocols import AppAdapterProto
 from houndarr.engine.retry import ReconnectState, run_with_reconnect
 from houndarr.engine.search_loop import _write_log, run_instance_search
 from houndarr.enums import CycleTrigger, SearchAction
@@ -100,7 +101,7 @@ class Supervisor:
 
         for idx, instance in enumerate(enabled):
             await self.start_instance_task(
-                instance.id, instance=instance, startup_offset=idx * _STARTUP_STAGGER_SECS
+                instance.core.id, instance=instance, startup_offset=idx * _STARTUP_STAGGER_SECS
             )
 
         # Snapshot refresh runs even when no search cycles are enabled, so a
@@ -240,7 +241,7 @@ class Supervisor:
     async def reconcile_instance(self, instance_id: int) -> None:
         """Start or stop tasks to match the instance's current enabled state."""
         instance = await get_instance(instance_id, master_key=self._master_key)
-        if instance is None or not instance.enabled:
+        if instance is None or not instance.core.enabled:
             await self.stop_instance_task(instance_id)
             return
 
@@ -253,7 +254,7 @@ class Supervisor:
         instance = await get_instance(instance_id, master_key=self._master_key)
         if instance is None:
             return "not_found"
-        if not instance.enabled:
+        if not instance.core.enabled:
             return "disabled"
 
         existing = self._manual_runs.get(instance_id)
@@ -302,10 +303,10 @@ class Supervisor:
                     )
                     return
 
-                if not instance.enabled:
+                if not instance.core.enabled:
                     logger.info(
                         "Supervisor: instance %r disabled; stopping loop",
-                        instance.name,
+                        instance.core.name,
                     )
                     return
 
@@ -315,7 +316,7 @@ class Supervisor:
                     cycle=partial(self._run_search_cycle, instance, cycle_trigger="scheduled"),
                     cycle_trigger="scheduled",
                     error_retry_secs=_CONNECT_RETRY_SECS,
-                    success_sleep_secs=instance.sleep_interval_mins * 60,
+                    success_sleep_secs=instance.missing.sleep_interval_mins * 60,
                     write_log=_write_log,
                 )
                 await asyncio.sleep(sleep_secs)
@@ -327,7 +328,7 @@ class Supervisor:
     async def _run_manual_once(self, instance_id: int) -> None:
         """Run one ad-hoc cycle, serialized with the scheduled loop."""
         instance = await get_instance(instance_id, master_key=self._master_key)
-        if instance is None or not instance.enabled:
+        if instance is None or not instance.core.enabled:
             return
 
         await self._run_search_cycle(instance, cycle_trigger="run_now")
@@ -340,7 +341,7 @@ class Supervisor:
         Returns:
             ``True`` if the cycle failed with a connection error, ``False`` otherwise.
         """
-        lock = self._run_locks.setdefault(instance.id, asyncio.Lock())
+        lock = self._run_locks.setdefault(instance.core.id, asyncio.Lock())
         async with lock:
             cycle_id = str(uuid4())
             try:
@@ -354,19 +355,19 @@ class Supervisor:
             except httpx.TransportError:
                 logger.warning(
                     "Supervisor: could not reach %r (%s); retrying in %d s",
-                    instance.name,
-                    instance.url,
+                    instance.core.name,
+                    instance.core.url,
                     _CONNECT_RETRY_SECS,
                 )
                 return True
             except Exception as exc:  # noqa: BLE001
                 logger.error(
                     "Supervisor: unhandled error in search loop for %r: %s",
-                    instance.name,
+                    instance.core.name,
                     exc,
                 )
                 await _write_log(
-                    instance_id=instance.id,
+                    instance_id=instance.core.id,
                     item_id=None,
                     item_type=None,
                     action=SearchAction.error.value,
@@ -424,12 +425,12 @@ class Supervisor:
         preserving existing rows rather than risking a wipe on a
         transient *arr blip.
         """
-        if not instance.enabled:
+        if not instance.core.enabled:
             return
-        lock = self._run_locks.setdefault(instance.id, asyncio.Lock())
+        lock = self._run_locks.setdefault(instance.core.id, asyncio.Lock())
         async with lock:
             try:
-                adapter = get_adapter(instance.type)
+                adapter: AppAdapterProto = get_adapter(instance.core.type)
                 async with adapter.make_client(instance) as client:
                     snap = await adapter.fetch_instance_snapshot(client, instance)
                     try:
@@ -468,7 +469,7 @@ class Supervisor:
                         snap.unreleased_count,
                     )
                 await update_instance_snapshot(
-                    instance.id,
+                    instance.core.id,
                     monitored_total=snap.monitored_total,
                     unreleased_count=snap.unreleased_count,
                 )
@@ -476,10 +477,10 @@ class Supervisor:
             except httpx.TransportError:
                 logger.debug(
                     "Supervisor: snapshot refresh skipped for %r; instance unreachable",
-                    instance.name,
+                    instance.core.name,
                 )
             except Exception:  # noqa: BLE001
-                logger.exception("Supervisor: snapshot refresh failed for %r", instance.name)
+                logger.exception("Supervisor: snapshot refresh failed for %r", instance.core.name)
 
     async def _refresh_all_snapshots_once(self) -> None:
         """Refresh the snapshot columns for every enabled instance once.

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -6,7 +6,7 @@ caller-supplied Fernet *master_key*; every read decrypts transparently.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from dataclasses import fields as dataclass_fields
 from enum import StrEnum
 from typing import Any
@@ -248,53 +248,477 @@ class InstanceTimestamps:
     updated_at: str
 
 
-@dataclass
+@dataclass(init=False)
 class Instance:
     """In-memory representation of a configured *arr instance.
 
-    ``api_key`` is always the **decrypted** plaintext value; the encrypted
-    form is only ever kept in the database column ``encrypted_api_key``.
+    Composes seven frozen sub-structs (:class:`InstanceCore`,
+    :class:`MissingPolicy`, :class:`CutoffPolicy`, :class:`UpgradePolicy`,
+    :class:`SchedulePolicy`, :class:`RuntimeSnapshot`,
+    :class:`InstanceTimestamps`) and exposes every flat attribute of
+    the pre-refactor dataclass via ``@property`` delegation.  Both
+    access patterns work: ``instance.batch_size`` reads through to
+    ``instance.missing.batch_size``, and assignment to
+    ``instance.batch_size`` rebuilds the :class:`MissingPolicy`
+    sub-struct via :func:`dataclasses.replace`.
+
+    The constructor still accepts the 39 flat keyword arguments the
+    pre-refactor dataclass accepted so every caller site keeps working
+    through the caller-migration batches.  The flat property
+    delegators and the flat-kwargs ``__init__`` are both removed in
+    :ref:`D.20 <track-d>` once every caller has switched to sub-struct
+    access (``instance.missing.batch_size``) and sub-struct
+    construction (``Instance(core=..., missing=...)``).
+
+    ``api_key`` is always the **decrypted** plaintext value; the
+    encrypted form only ever lives in the database column
+    ``encrypted_api_key``.  :class:`Instance` stays mutable
+    (non-frozen) deliberately: the skip-log cache and test fixtures
+    rely on in-place attribute writes, and the slots audit records
+    this as a known exception.
     """
 
-    id: int
-    name: str
-    type: InstanceType
-    url: str
-    api_key: str
-    enabled: bool
-    batch_size: int
-    sleep_interval_mins: int
-    hourly_cap: int
-    cooldown_days: int
-    post_release_grace_hrs: int
-    queue_limit: int
-    cutoff_enabled: bool
-    cutoff_batch_size: int
-    cutoff_cooldown_days: int
-    cutoff_hourly_cap: int
-    created_at: str
-    updated_at: str
-    sonarr_search_mode: SonarrSearchMode = SonarrSearchMode.episode
-    lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album
-    readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book
-    whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode
-    upgrade_enabled: bool = False
-    upgrade_batch_size: int = DEFAULT_UPGRADE_BATCH_SIZE
-    upgrade_cooldown_days: int = DEFAULT_UPGRADE_COOLDOWN_DAYS
-    upgrade_hourly_cap: int = DEFAULT_UPGRADE_HOURLY_CAP
-    upgrade_sonarr_search_mode: SonarrSearchMode = SonarrSearchMode.episode
-    upgrade_lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album
-    upgrade_readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book
-    upgrade_whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode
-    upgrade_item_offset: int = 0
-    upgrade_series_offset: int = 0
-    missing_page_offset: int = 1
-    cutoff_page_offset: int = 1
-    allowed_time_window: str = ""
-    search_order: SearchOrder = SearchOrder.chronological
-    monitored_total: int = 0
-    unreleased_count: int = 0
-    snapshot_refreshed_at: str = ""
+    core: InstanceCore
+    missing: MissingPolicy
+    cutoff: CutoffPolicy
+    upgrade: UpgradePolicy
+    schedule: SchedulePolicy
+    snapshot: RuntimeSnapshot
+    timestamps: InstanceTimestamps
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        id: int,  # noqa: A002
+        name: str,
+        type: InstanceType,  # noqa: A002
+        url: str,
+        api_key: str,
+        enabled: bool,
+        batch_size: int,
+        sleep_interval_mins: int,
+        hourly_cap: int,
+        cooldown_days: int,
+        post_release_grace_hrs: int,
+        queue_limit: int,
+        cutoff_enabled: bool,
+        cutoff_batch_size: int,
+        cutoff_cooldown_days: int,
+        cutoff_hourly_cap: int,
+        created_at: str,
+        updated_at: str,
+        sonarr_search_mode: SonarrSearchMode = SonarrSearchMode.episode,
+        lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album,
+        readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book,
+        whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode,
+        upgrade_enabled: bool = False,
+        upgrade_batch_size: int = DEFAULT_UPGRADE_BATCH_SIZE,
+        upgrade_cooldown_days: int = DEFAULT_UPGRADE_COOLDOWN_DAYS,
+        upgrade_hourly_cap: int = DEFAULT_UPGRADE_HOURLY_CAP,
+        upgrade_sonarr_search_mode: SonarrSearchMode = SonarrSearchMode.episode,
+        upgrade_lidarr_search_mode: LidarrSearchMode = LidarrSearchMode.album,
+        upgrade_readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode.book,
+        upgrade_whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode.episode,
+        upgrade_item_offset: int = 0,
+        upgrade_series_offset: int = 0,
+        missing_page_offset: int = 1,
+        cutoff_page_offset: int = 1,
+        allowed_time_window: str = "",
+        search_order: SearchOrder = SearchOrder.chronological,
+        monitored_total: int = 0,
+        unreleased_count: int = 0,
+        snapshot_refreshed_at: str = "",
+    ) -> None:
+        """Accept the pre-refactor 39-kwarg shape and build sub-structs.
+
+        Defaults match the pre-refactor :class:`Instance` dataclass
+        field-by-field so byte-level behaviour is preserved for every
+        caller that does not pass a given kwarg.  The sub-struct
+        defaults (which route through :mod:`houndarr.config` constants)
+        apply only when a sub-struct is constructed directly; the
+        Instance facade takes its flat-kwarg defaults as the source of
+        truth to avoid silently changing what ``Instance(...)`` without
+        ``search_order`` resolves to mid-refactor.
+        """
+        self.core = InstanceCore(
+            id=id,
+            name=name,
+            type=type,
+            url=url,
+            api_key=api_key,
+            enabled=enabled,
+        )
+        self.missing = MissingPolicy(
+            batch_size=batch_size,
+            sleep_interval_mins=sleep_interval_mins,
+            hourly_cap=hourly_cap,
+            cooldown_days=cooldown_days,
+            post_release_grace_hrs=post_release_grace_hrs,
+            queue_limit=queue_limit,
+            sonarr_search_mode=sonarr_search_mode,
+            lidarr_search_mode=lidarr_search_mode,
+            readarr_search_mode=readarr_search_mode,
+            whisparr_search_mode=whisparr_search_mode,
+        )
+        self.cutoff = CutoffPolicy(
+            cutoff_enabled=cutoff_enabled,
+            cutoff_batch_size=cutoff_batch_size,
+            cutoff_cooldown_days=cutoff_cooldown_days,
+            cutoff_hourly_cap=cutoff_hourly_cap,
+        )
+        self.upgrade = UpgradePolicy(
+            upgrade_enabled=upgrade_enabled,
+            upgrade_batch_size=upgrade_batch_size,
+            upgrade_cooldown_days=upgrade_cooldown_days,
+            upgrade_hourly_cap=upgrade_hourly_cap,
+            upgrade_sonarr_search_mode=upgrade_sonarr_search_mode,
+            upgrade_lidarr_search_mode=upgrade_lidarr_search_mode,
+            upgrade_readarr_search_mode=upgrade_readarr_search_mode,
+            upgrade_whisparr_search_mode=upgrade_whisparr_search_mode,
+            upgrade_item_offset=upgrade_item_offset,
+            upgrade_series_offset=upgrade_series_offset,
+        )
+        self.schedule = SchedulePolicy(
+            allowed_time_window=allowed_time_window,
+            search_order=search_order,
+            missing_page_offset=missing_page_offset,
+            cutoff_page_offset=cutoff_page_offset,
+        )
+        self.snapshot = RuntimeSnapshot(
+            monitored_total=monitored_total,
+            unreleased_count=unreleased_count,
+            snapshot_refreshed_at=snapshot_refreshed_at,
+        )
+        self.timestamps = InstanceTimestamps(
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+    # InstanceCore delegation.
+
+    @property
+    def id(self) -> int:  # noqa: A003
+        return self.core.id
+
+    @id.setter
+    def id(self, value: int) -> None:
+        self.core = replace(self.core, id=value)
+
+    @property
+    def name(self) -> str:
+        return self.core.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self.core = replace(self.core, name=value)
+
+    @property
+    def type(self) -> InstanceType:  # noqa: A003
+        return self.core.type
+
+    @type.setter
+    def type(self, value: InstanceType) -> None:
+        self.core = replace(self.core, type=value)
+
+    @property
+    def url(self) -> str:
+        return self.core.url
+
+    @url.setter
+    def url(self, value: str) -> None:
+        self.core = replace(self.core, url=value)
+
+    @property
+    def api_key(self) -> str:
+        return self.core.api_key
+
+    @api_key.setter
+    def api_key(self, value: str) -> None:
+        self.core = replace(self.core, api_key=value)
+
+    @property
+    def enabled(self) -> bool:
+        return self.core.enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        self.core = replace(self.core, enabled=value)
+
+    # MissingPolicy delegation.
+
+    @property
+    def batch_size(self) -> int:
+        return self.missing.batch_size
+
+    @batch_size.setter
+    def batch_size(self, value: int) -> None:
+        self.missing = replace(self.missing, batch_size=value)
+
+    @property
+    def sleep_interval_mins(self) -> int:
+        return self.missing.sleep_interval_mins
+
+    @sleep_interval_mins.setter
+    def sleep_interval_mins(self, value: int) -> None:
+        self.missing = replace(self.missing, sleep_interval_mins=value)
+
+    @property
+    def hourly_cap(self) -> int:
+        return self.missing.hourly_cap
+
+    @hourly_cap.setter
+    def hourly_cap(self, value: int) -> None:
+        self.missing = replace(self.missing, hourly_cap=value)
+
+    @property
+    def cooldown_days(self) -> int:
+        return self.missing.cooldown_days
+
+    @cooldown_days.setter
+    def cooldown_days(self, value: int) -> None:
+        self.missing = replace(self.missing, cooldown_days=value)
+
+    @property
+    def post_release_grace_hrs(self) -> int:
+        return self.missing.post_release_grace_hrs
+
+    @post_release_grace_hrs.setter
+    def post_release_grace_hrs(self, value: int) -> None:
+        self.missing = replace(self.missing, post_release_grace_hrs=value)
+
+    @property
+    def queue_limit(self) -> int:
+        return self.missing.queue_limit
+
+    @queue_limit.setter
+    def queue_limit(self, value: int) -> None:
+        self.missing = replace(self.missing, queue_limit=value)
+
+    @property
+    def sonarr_search_mode(self) -> SonarrSearchMode:
+        return self.missing.sonarr_search_mode
+
+    @sonarr_search_mode.setter
+    def sonarr_search_mode(self, value: SonarrSearchMode) -> None:
+        self.missing = replace(self.missing, sonarr_search_mode=value)
+
+    @property
+    def lidarr_search_mode(self) -> LidarrSearchMode:
+        return self.missing.lidarr_search_mode
+
+    @lidarr_search_mode.setter
+    def lidarr_search_mode(self, value: LidarrSearchMode) -> None:
+        self.missing = replace(self.missing, lidarr_search_mode=value)
+
+    @property
+    def readarr_search_mode(self) -> ReadarrSearchMode:
+        return self.missing.readarr_search_mode
+
+    @readarr_search_mode.setter
+    def readarr_search_mode(self, value: ReadarrSearchMode) -> None:
+        self.missing = replace(self.missing, readarr_search_mode=value)
+
+    @property
+    def whisparr_search_mode(self) -> WhisparrSearchMode:
+        return self.missing.whisparr_search_mode
+
+    @whisparr_search_mode.setter
+    def whisparr_search_mode(self, value: WhisparrSearchMode) -> None:
+        self.missing = replace(self.missing, whisparr_search_mode=value)
+
+    # CutoffPolicy delegation.
+
+    @property
+    def cutoff_enabled(self) -> bool:
+        return self.cutoff.cutoff_enabled
+
+    @cutoff_enabled.setter
+    def cutoff_enabled(self, value: bool) -> None:
+        self.cutoff = replace(self.cutoff, cutoff_enabled=value)
+
+    @property
+    def cutoff_batch_size(self) -> int:
+        return self.cutoff.cutoff_batch_size
+
+    @cutoff_batch_size.setter
+    def cutoff_batch_size(self, value: int) -> None:
+        self.cutoff = replace(self.cutoff, cutoff_batch_size=value)
+
+    @property
+    def cutoff_cooldown_days(self) -> int:
+        return self.cutoff.cutoff_cooldown_days
+
+    @cutoff_cooldown_days.setter
+    def cutoff_cooldown_days(self, value: int) -> None:
+        self.cutoff = replace(self.cutoff, cutoff_cooldown_days=value)
+
+    @property
+    def cutoff_hourly_cap(self) -> int:
+        return self.cutoff.cutoff_hourly_cap
+
+    @cutoff_hourly_cap.setter
+    def cutoff_hourly_cap(self, value: int) -> None:
+        self.cutoff = replace(self.cutoff, cutoff_hourly_cap=value)
+
+    # UpgradePolicy delegation.
+
+    @property
+    def upgrade_enabled(self) -> bool:
+        return self.upgrade.upgrade_enabled
+
+    @upgrade_enabled.setter
+    def upgrade_enabled(self, value: bool) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_enabled=value)
+
+    @property
+    def upgrade_batch_size(self) -> int:
+        return self.upgrade.upgrade_batch_size
+
+    @upgrade_batch_size.setter
+    def upgrade_batch_size(self, value: int) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_batch_size=value)
+
+    @property
+    def upgrade_cooldown_days(self) -> int:
+        return self.upgrade.upgrade_cooldown_days
+
+    @upgrade_cooldown_days.setter
+    def upgrade_cooldown_days(self, value: int) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_cooldown_days=value)
+
+    @property
+    def upgrade_hourly_cap(self) -> int:
+        return self.upgrade.upgrade_hourly_cap
+
+    @upgrade_hourly_cap.setter
+    def upgrade_hourly_cap(self, value: int) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_hourly_cap=value)
+
+    @property
+    def upgrade_sonarr_search_mode(self) -> SonarrSearchMode:
+        return self.upgrade.upgrade_sonarr_search_mode
+
+    @upgrade_sonarr_search_mode.setter
+    def upgrade_sonarr_search_mode(self, value: SonarrSearchMode) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_sonarr_search_mode=value)
+
+    @property
+    def upgrade_lidarr_search_mode(self) -> LidarrSearchMode:
+        return self.upgrade.upgrade_lidarr_search_mode
+
+    @upgrade_lidarr_search_mode.setter
+    def upgrade_lidarr_search_mode(self, value: LidarrSearchMode) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_lidarr_search_mode=value)
+
+    @property
+    def upgrade_readarr_search_mode(self) -> ReadarrSearchMode:
+        return self.upgrade.upgrade_readarr_search_mode
+
+    @upgrade_readarr_search_mode.setter
+    def upgrade_readarr_search_mode(self, value: ReadarrSearchMode) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_readarr_search_mode=value)
+
+    @property
+    def upgrade_whisparr_search_mode(self) -> WhisparrSearchMode:
+        return self.upgrade.upgrade_whisparr_search_mode
+
+    @upgrade_whisparr_search_mode.setter
+    def upgrade_whisparr_search_mode(self, value: WhisparrSearchMode) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_whisparr_search_mode=value)
+
+    @property
+    def upgrade_item_offset(self) -> int:
+        return self.upgrade.upgrade_item_offset
+
+    @upgrade_item_offset.setter
+    def upgrade_item_offset(self, value: int) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_item_offset=value)
+
+    @property
+    def upgrade_series_offset(self) -> int:
+        return self.upgrade.upgrade_series_offset
+
+    @upgrade_series_offset.setter
+    def upgrade_series_offset(self, value: int) -> None:
+        self.upgrade = replace(self.upgrade, upgrade_series_offset=value)
+
+    # SchedulePolicy delegation.
+
+    @property
+    def allowed_time_window(self) -> str:
+        return self.schedule.allowed_time_window
+
+    @allowed_time_window.setter
+    def allowed_time_window(self, value: str) -> None:
+        self.schedule = replace(self.schedule, allowed_time_window=value)
+
+    @property
+    def search_order(self) -> SearchOrder:
+        return self.schedule.search_order
+
+    @search_order.setter
+    def search_order(self, value: SearchOrder) -> None:
+        self.schedule = replace(self.schedule, search_order=value)
+
+    @property
+    def missing_page_offset(self) -> int:
+        return self.schedule.missing_page_offset
+
+    @missing_page_offset.setter
+    def missing_page_offset(self, value: int) -> None:
+        self.schedule = replace(self.schedule, missing_page_offset=value)
+
+    @property
+    def cutoff_page_offset(self) -> int:
+        return self.schedule.cutoff_page_offset
+
+    @cutoff_page_offset.setter
+    def cutoff_page_offset(self, value: int) -> None:
+        self.schedule = replace(self.schedule, cutoff_page_offset=value)
+
+    # RuntimeSnapshot delegation.
+
+    @property
+    def monitored_total(self) -> int:
+        return self.snapshot.monitored_total
+
+    @monitored_total.setter
+    def monitored_total(self, value: int) -> None:
+        self.snapshot = replace(self.snapshot, monitored_total=value)
+
+    @property
+    def unreleased_count(self) -> int:
+        return self.snapshot.unreleased_count
+
+    @unreleased_count.setter
+    def unreleased_count(self, value: int) -> None:
+        self.snapshot = replace(self.snapshot, unreleased_count=value)
+
+    @property
+    def snapshot_refreshed_at(self) -> str:
+        return self.snapshot.snapshot_refreshed_at
+
+    @snapshot_refreshed_at.setter
+    def snapshot_refreshed_at(self, value: str) -> None:
+        self.snapshot = replace(self.snapshot, snapshot_refreshed_at=value)
+
+    # InstanceTimestamps delegation.
+
+    @property
+    def created_at(self) -> str:
+        return self.timestamps.created_at
+
+    @created_at.setter
+    def created_at(self, value: str) -> None:
+        self.timestamps = replace(self.timestamps, created_at=value)
+
+    @property
+    def updated_at(self) -> str:
+        return self.timestamps.updated_at
+
+    @updated_at.setter
+    def updated_at(self, value: str) -> None:
+        self.timestamps = replace(self.timestamps, updated_at=value)
 
 
 async def create_instance(

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -83,6 +83,171 @@ class SearchOrder(StrEnum):
     random = "random"
 
 
+@dataclass(frozen=True, slots=True)
+class InstanceCore:
+    """Row identity plus wire credentials for one configured *arr instance.
+
+    These six fields uniquely identify an instance and describe how the
+    engine reaches it.  They are kept apart from the policy sub-structs
+    so callers that only need "which instance and how do I talk to it"
+    (the client factory, the connection check, the snapshot writer) do
+    not have to carry the full policy bag.
+
+    ``api_key`` is always the **decrypted** plaintext value; the
+    encrypted form only ever lives in the ``encrypted_api_key`` column.
+    """
+
+    id: int
+    name: str
+    type: InstanceType
+    url: str
+    api_key: str
+    enabled: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class MissingPolicy:
+    """Tunables controlling one missing-search pass on an instance.
+
+    Captures the rate shape (``batch_size`` / ``sleep_interval_mins`` /
+    ``hourly_cap``), the per-item cooldown (``cooldown_days``), the
+    post-release grace window (``post_release_grace_hrs``), the queue
+    backpressure gate (``queue_limit``; ``0`` disables the check), and
+    the per-app search-strategy mode for the four *arr variants that
+    expose one (Sonarr, Lidarr, Readarr, Whisparr).  Radarr has no
+    strategy knob and so never reads any of the mode fields.
+
+    Defaults match :mod:`houndarr.config`; the field set matches the
+    ``instances`` table columns written on fresh ``INSERT``.
+    """
+
+    batch_size: int = DEFAULT_BATCH_SIZE
+    sleep_interval_mins: int = DEFAULT_SLEEP_INTERVAL_MINUTES
+    hourly_cap: int = DEFAULT_HOURLY_CAP
+    cooldown_days: int = DEFAULT_COOLDOWN_DAYS
+    post_release_grace_hrs: int = DEFAULT_POST_RELEASE_GRACE_HOURS
+    queue_limit: int = DEFAULT_QUEUE_LIMIT
+    sonarr_search_mode: SonarrSearchMode = SonarrSearchMode(DEFAULT_SONARR_SEARCH_MODE)
+    lidarr_search_mode: LidarrSearchMode = LidarrSearchMode(DEFAULT_LIDARR_SEARCH_MODE)
+    readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode(DEFAULT_READARR_SEARCH_MODE)
+    whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode(DEFAULT_WHISPARR_SEARCH_MODE)
+
+
+@dataclass(frozen=True, slots=True)
+class CutoffPolicy:
+    """Tunables controlling one cutoff-unmet search pass.
+
+    ``cutoff_enabled`` is the master switch; the three rate fields mirror
+    :class:`MissingPolicy` at the cutoff cadence, which is typically much
+    slower because cutoff-unmet is an optional polish pass, not the
+    primary workload.  Cutoff is single-mode per app (no
+    ``*_search_mode`` knobs) because the upstream *arr APIs expose a
+    single cutoff endpoint per app.
+    """
+
+    cutoff_enabled: bool = False
+    cutoff_batch_size: int = DEFAULT_CUTOFF_BATCH_SIZE
+    cutoff_cooldown_days: int = DEFAULT_CUTOFF_COOLDOWN_DAYS
+    cutoff_hourly_cap: int = DEFAULT_CUTOFF_HOURLY_CAP
+
+
+@dataclass(frozen=True, slots=True)
+class UpgradePolicy:
+    """Tunables controlling one upgrade-search pass plus pool offsets.
+
+    ``upgrade_enabled`` is the master switch; the three rate fields
+    behave like :class:`MissingPolicy` but gate upgrade searches
+    specifically.  Per-app ``upgrade_*_search_mode`` knobs parallel the
+    missing-pass modes.
+
+    ``upgrade_item_offset`` and ``upgrade_series_offset`` track
+    library-pool rotation state: the engine fetches the upgrade pool
+    from the *arr library and rotates through it across cycles so a
+    large library is explored evenly instead of always retrying the
+    same head.  The offsets live here rather than in
+    :class:`SchedulePolicy` because they are intrinsic to how the
+    upgrade pool is constructed, not to when or in what order the
+    cycle runs.
+    """
+
+    upgrade_enabled: bool = False
+    upgrade_batch_size: int = DEFAULT_UPGRADE_BATCH_SIZE
+    upgrade_cooldown_days: int = DEFAULT_UPGRADE_COOLDOWN_DAYS
+    upgrade_hourly_cap: int = DEFAULT_UPGRADE_HOURLY_CAP
+    upgrade_sonarr_search_mode: SonarrSearchMode = SonarrSearchMode(
+        DEFAULT_UPGRADE_SONARR_SEARCH_MODE
+    )
+    upgrade_lidarr_search_mode: LidarrSearchMode = LidarrSearchMode(
+        DEFAULT_UPGRADE_LIDARR_SEARCH_MODE
+    )
+    upgrade_readarr_search_mode: ReadarrSearchMode = ReadarrSearchMode(
+        DEFAULT_UPGRADE_READARR_SEARCH_MODE
+    )
+    upgrade_whisparr_search_mode: WhisparrSearchMode = WhisparrSearchMode(
+        DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE
+    )
+    upgrade_item_offset: int = 0
+    upgrade_series_offset: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulePolicy:
+    """When the engine runs and in what order it walks items.
+
+    ``allowed_time_window`` is an optional schedule spec (e.g.
+    ``"09:00-23:00"``) that gates scheduled cycles; the empty string
+    disables the gate and runs 24/7.  ``search_order`` selects
+    ``chronological`` (legacy; oldest-first) or ``random`` (shuffle
+    within each page, random start page).
+
+    ``missing_page_offset`` and ``cutoff_page_offset`` rotate the
+    *arr ``/wanted`` pagination across cycles so the pool is explored
+    evenly rather than always re-walking page 1.  They begin at 1
+    (the *arr APIs are 1-indexed) and wrap when the probe reports
+    no more items.
+    """
+
+    allowed_time_window: str = DEFAULT_ALLOWED_TIME_WINDOW
+    search_order: SearchOrder = SearchOrder(DEFAULT_SEARCH_ORDER)
+    missing_page_offset: int = 1
+    cutoff_page_offset: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSnapshot:
+    """Refreshable telemetry written by the supervisor for the dashboard.
+
+    The supervisor's ``refresh_instance_snapshots`` task writes these
+    three columns periodically; the dashboard reads them to render
+    per-instance headline counts without issuing a fresh *arr call on
+    every page load.  They carry no search-policy meaning and so live
+    apart from the three policy sub-structs above.
+
+    ``snapshot_refreshed_at`` is an ISO-8601 UTC timestamp or the
+    empty string when no refresh has run yet (first boot, or pre-v13
+    migration).
+    """
+
+    monitored_total: int = 0
+    unreleased_count: int = 0
+    snapshot_refreshed_at: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class InstanceTimestamps:
+    """Row-level audit timestamps.
+
+    ``created_at`` and ``updated_at`` are written by SQLite's column
+    defaults (``DEFAULT strftime('%Y-%m-%dT%H:%M:%fZ', 'now')``) and
+    bumped by the repository's update path.  They are required here
+    because a deserialised instance always knows both values; the
+    sub-struct rejects partial construction on purpose.
+    """
+
+    created_at: str
+    updated_at: str
+
+
 @dataclass
 class Instance:
     """In-memory representation of a configured *arr instance.

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -5,9 +5,9 @@
   the form POSTs to /settings/instances and the table body is refreshed.
 #}
 {% set is_edit = editing is defined and editing %}
-{% set form_id = "edit-form-" ~ instance.id if is_edit else "add-instance-form" %}
-{% set post_url = "/settings/instances/" ~ instance.id if is_edit else "/settings/instances" %}
-{% set target  = "#instance-row-" ~ instance.id if is_edit else "#instance-tbody" %}
+{% set form_id = "edit-form-" ~ instance.core.id if is_edit else "add-instance-form" %}
+{% set post_url = "/settings/instances/" ~ instance.core.id if is_edit else "/settings/instances" %}
+{% set target  = "#instance-row-" ~ instance.core.id if is_edit else "#instance-tbody" %}
 {% set swap    = "outerHTML" if is_edit else "innerHTML" %}
 
 {# Shared input class: Station style #}
@@ -19,7 +19,7 @@
    keeps the form visually consistent. #}
 {% set select_cls = input_cls + " hd-select-chevron appearance-none pr-10 bg-no-repeat" %}
 
-<div id="{{ 'edit-instance-form-shell-' ~ instance.id if is_edit else 'add-instance-form-shell' }}">
+<div id="{{ 'edit-instance-form-shell-' ~ instance.core.id if is_edit else 'add-instance-form-shell' }}">
   {% if error is defined and error %}
   <div class="mb-3 border-l-4 border-red-500 bg-red-950/30 text-red-300 rounded-r-lg px-3 py-2 text-sm">
     {{ error }}
@@ -28,7 +28,7 @@
 
   <form id="{{ form_id }}"
         data-form-mode="{{ 'edit' if is_edit else 'add' }}"
-        data-instance-name="{{ instance.name if is_edit else '' }}"
+        data-instance-name="{{ instance.core.name if is_edit else '' }}"
         hx-post="{{ post_url }}"
         hx-target="{{ target }}"
         hx-swap="{{ swap }}"
@@ -55,7 +55,7 @@
                  data-readarr-placeholder="My Readarr"
                  data-whisparr_v2-placeholder="My Whisparr v2"
                  data-whisparr_v3-placeholder="My Whisparr v3"
-                 value="{{ instance.name if is_edit else '' }}"
+                 value="{{ instance.core.name if is_edit else '' }}"
                  placeholder="My Sonarr"
                  class="{{ input_cls }}" />
         </div>
@@ -64,19 +64,19 @@
           <select id="{{ form_id }}-type" name="type" required
                   data-instance-field="type"
                   class="{{ select_cls }}">
-            <option value="radarr"   {% if is_edit and instance.type.value == 'radarr'   %}selected{% endif %}>Radarr</option>
-            <option value="sonarr"   {% if is_edit and instance.type.value == 'sonarr'   %}selected{% endif %}>Sonarr</option>
-            <option value="lidarr"   {% if is_edit and instance.type.value == 'lidarr'   %}selected{% endif %}>Lidarr</option>
-            <option value="readarr"  {% if is_edit and instance.type.value == 'readarr'  %}selected{% endif %}>Readarr</option>
-            <option value="whisparr_v2" {% if is_edit and instance.type.value == 'whisparr_v2' %}selected{% endif %}>Whisparr v2</option>
-            <option value="whisparr_v3" {% if is_edit and instance.type.value == 'whisparr_v3' %}selected{% endif %}>Whisparr v3</option>
+            <option value="radarr"   {% if is_edit and instance.core.type.value == 'radarr'   %}selected{% endif %}>Radarr</option>
+            <option value="sonarr"   {% if is_edit and instance.core.type.value == 'sonarr'   %}selected{% endif %}>Sonarr</option>
+            <option value="lidarr"   {% if is_edit and instance.core.type.value == 'lidarr'   %}selected{% endif %}>Lidarr</option>
+            <option value="readarr"  {% if is_edit and instance.core.type.value == 'readarr'  %}selected{% endif %}>Readarr</option>
+            <option value="whisparr_v2" {% if is_edit and instance.core.type.value == 'whisparr_v2' %}selected{% endif %}>Whisparr v2</option>
+            <option value="whisparr_v3" {% if is_edit and instance.core.type.value == 'whisparr_v3' %}selected{% endif %}>Whisparr v3</option>
           </select>
           <p class="mt-1 text-xs text-slate-500"
              data-whisparr_v2-only="true"
-             {% if not is_edit or instance.type.value != 'whisparr_v2' %}style="display:none;"{% endif %}>Sonarr-based, focuses on studios.<br>Docker: <code class="text-slate-400">hotio/whisparr:latest</code></p>
+             {% if not is_edit or instance.core.type.value != 'whisparr_v2' %}style="display:none;"{% endif %}>Sonarr-based, focuses on studios.<br>Docker: <code class="text-slate-400">hotio/whisparr:latest</code></p>
           <p class="mt-1 text-xs text-slate-500"
              data-whisparr_v3-only="true"
-             {% if not is_edit or instance.type.value != 'whisparr_v3' %}style="display:none;"{% endif %}>Radarr-based, focuses on scenes.<br>Docker: <code class="text-slate-400">hotio/whisparr:v3</code></p>
+             {% if not is_edit or instance.core.type.value != 'whisparr_v3' %}style="display:none;"{% endif %}>Radarr-based, focuses on scenes.<br>Docker: <code class="text-slate-400">hotio/whisparr:v3</code></p>
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-url">URL</label>
@@ -88,7 +88,7 @@
                  data-readarr-placeholder="http://readarr:8787"
                  data-whisparr_v2-placeholder="http://whisparr:6969"
                  data-whisparr_v3-placeholder="http://whisparr:6969"
-                 value="{{ instance.url if is_edit else '' }}"
+                 value="{{ instance.core.url if is_edit else '' }}"
                  placeholder="http://radarr:7878"
                  class="{{ mono_input_cls }}" />
         </div>
@@ -112,35 +112,35 @@
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-batch">Batch Size</label>
           <input id="{{ form_id }}-batch" name="batch_size" type="number" min="1" max="250"
-                 value="{{ instance.batch_size }}"
+                 value="{{ instance.missing.batch_size }}"
                  data-default-value="{{ defaults.batch_size }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-sleep">Sleep (minutes)</label>
           <input id="{{ form_id }}-sleep" name="sleep_interval_mins" type="number" min="1"
-                 value="{{ instance.sleep_interval_mins }}"
+                 value="{{ instance.missing.sleep_interval_mins }}"
                  data-default-value="{{ defaults.sleep_interval_mins }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-hcap">Hourly Cap</label>
           <input id="{{ form_id }}-hcap" name="hourly_cap" type="number" min="0"
-                 value="{{ instance.hourly_cap }}"
+                 value="{{ instance.missing.hourly_cap }}"
                  data-default-value="{{ defaults.hourly_cap }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-cool">Cooldown (days)</label>
           <input id="{{ form_id }}-cool" name="cooldown_days" type="number" min="0"
-                 value="{{ instance.cooldown_days }}"
+                 value="{{ instance.missing.cooldown_days }}"
                  data-default-value="{{ defaults.cooldown_days }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-delay">Post-Release Grace (hrs)</label>
           <input id="{{ form_id }}-delay" name="post_release_grace_hrs" type="number" min="0"
-                 value="{{ instance.post_release_grace_hrs }}"
+                 value="{{ instance.missing.post_release_grace_hrs }}"
                  data-default-value="{{ defaults.post_release_grace_hrs }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Hours to wait after release date. Unreleased items are always skipped.</p>
@@ -148,7 +148,7 @@
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-qlimit">Queue Limit</label>
           <input id="{{ form_id }}-qlimit" name="queue_limit" type="number" min="0"
-                 value="{{ instance.queue_limit }}"
+                 value="{{ instance.missing.queue_limit }}"
                  data-default-value="{{ defaults.queue_limit }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Skip searches when the queue exceeds this. 0 = disabled.</p>
@@ -156,7 +156,7 @@
         <div class="sm:col-span-2">
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-window">Allowed Search Window</label>
           <input id="{{ form_id }}-window" name="allowed_time_window" type="text"
-                 value="{{ instance.allowed_time_window }}"
+                 value="{{ instance.schedule.allowed_time_window }}"
                  data-default-value="{{ defaults.allowed_time_window }}"
                  placeholder="e.g. 09:00-23:00 or 09:00-12:00,18:00-22:00"
                  class="{{ mono_input_cls }}" />
@@ -169,60 +169,60 @@
           <select id="{{ form_id }}-order" name="search_order"
                   data-default-value="{{ defaults.search_order.value }}"
                   class="{{ select_cls }}">
-            <option value="chronological" {% if instance.search_order.value == 'chronological' %}selected{% endif %}>Chronological</option>
-            <option value="random"        {% if instance.search_order.value == 'random'        %}selected{% endif %}>Random (default)</option>
+            <option value="chronological" {% if instance.schedule.search_order.value == 'chronological' %}selected{% endif %}>Chronological</option>
+            <option value="random"        {% if instance.schedule.search_order.value == 'random'        %}selected{% endif %}>Random (default)</option>
           </select>
           <p class="mt-1.5 text-xs text-slate-600">Chronological walks the library oldest-first in small rotations. Random picks a different slice of the library each cycle, so searches feel spread across the catalogue instead of clustered by release date.</p>
         </div>
         <div class="sm:col-span-2" data-sonarr-only="true"
-             {% if instance.type.value != 'sonarr' %}style="display:none;"{% endif %}>
+             {% if instance.core.type.value != 'sonarr' %}style="display:none;"{% endif %}>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-sonarr-mode">
             Sonarr Missing Search Mode
           </label>
           <select id="{{ form_id }}-sonarr-mode" name="sonarr_search_mode"
                   data-default-value="{{ defaults.sonarr_search_mode.value }}"
                   class="{{ select_cls }}">
-            <option value="episode"        {% if instance.sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
-            <option value="season_context" {% if instance.sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search (advanced)</option>
+            <option value="episode"        {% if instance.missing.sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
+            <option value="season_context" {% if instance.missing.sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search (advanced)</option>
           </select>
           <p class="mt-1.5 text-xs text-amber-400/80">Advanced mode: season search is not pack-only and may pull noisier results.</p>
         </div>
         <div class="sm:col-span-2" data-lidarr-only="true"
-             {% if instance.type.value != 'lidarr' %}style="display:none;"{% endif %}>
+             {% if instance.core.type.value != 'lidarr' %}style="display:none;"{% endif %}>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-lidarr-mode">
             Lidarr Missing Search Mode
           </label>
           <select id="{{ form_id }}-lidarr-mode" name="lidarr_search_mode"
                   data-default-value="{{ defaults.lidarr_search_mode.value }}"
                   class="{{ select_cls }}">
-            <option value="album"          {% if instance.lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
-            <option value="artist_context" {% if instance.lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search (advanced)</option>
+            <option value="album"          {% if instance.missing.lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
+            <option value="artist_context" {% if instance.missing.lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search (advanced)</option>
           </select>
           <p class="mt-1.5 text-xs text-amber-400/80">Advanced mode: searches all missing albums by artist in one request.</p>
         </div>
         <div class="sm:col-span-2" data-readarr-only="true"
-             {% if instance.type.value != 'readarr' %}style="display:none;"{% endif %}>
+             {% if instance.core.type.value != 'readarr' %}style="display:none;"{% endif %}>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-readarr-mode">
             Readarr Missing Search Mode
           </label>
           <select id="{{ form_id }}-readarr-mode" name="readarr_search_mode"
                   data-default-value="{{ defaults.readarr_search_mode.value }}"
                   class="{{ select_cls }}">
-            <option value="book"           {% if instance.readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
-            <option value="author_context" {% if instance.readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search (advanced)</option>
+            <option value="book"           {% if instance.missing.readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
+            <option value="author_context" {% if instance.missing.readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search (advanced)</option>
           </select>
           <p class="mt-1.5 text-xs text-amber-400/80">Advanced mode: searches all missing books by author in one request.</p>
         </div>
         <div class="sm:col-span-2" data-whisparr_v2-only="true"
-             {% if instance.type.value != 'whisparr_v2' %}style="display:none;"{% endif %}>
+             {% if instance.core.type.value != 'whisparr_v2' %}style="display:none;"{% endif %}>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-whisparr-mode">
             Whisparr v2 Missing Search Mode
           </label>
           <select id="{{ form_id }}-whisparr-mode" name="whisparr_search_mode"
                   data-default-value="{{ defaults.whisparr_search_mode.value }}"
                   class="{{ select_cls }}">
-            <option value="episode"        {% if instance.whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
-            <option value="season_context" {% if instance.whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search (advanced)</option>
+            <option value="episode"        {% if instance.missing.whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
+            <option value="season_context" {% if instance.missing.whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search (advanced)</option>
           </select>
           <p class="mt-1.5 text-xs text-amber-400/80">Advanced mode: season search may pull noisier results.</p>
         </div>
@@ -238,7 +238,7 @@
         </div>
         <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-md border border-[#2a3448] bg-[#0e1117] px-3 py-2">
           <input type="checkbox" name="cutoff_enabled" value="on"
-                 {% if is_edit and instance.cutoff_enabled %}checked{% endif %}
+                 {% if is_edit and instance.cutoff.cutoff_enabled %}checked{% endif %}
                  data-default-checked="{{ 1 if defaults.cutoff_enabled else 0 }}"
                  class="rounded border-[#2a3448] bg-[#0e1117] text-brand-500 focus:ring-brand-500 focus:ring-offset-[#07080f]" />
           <span class="text-xs font-medium text-slate-300">Enable cutoff search</span>
@@ -248,21 +248,21 @@
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-cbatch">Cutoff Batch</label>
           <input id="{{ form_id }}-cbatch" name="cutoff_batch_size" type="number" min="1" max="250"
-                 value="{{ instance.cutoff_batch_size }}"
+                 value="{{ instance.cutoff.cutoff_batch_size }}"
                  data-default-value="{{ defaults.cutoff_batch_size }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-ccool">Cutoff Cooldown</label>
           <input id="{{ form_id }}-ccool" name="cutoff_cooldown_days" type="number" min="0"
-                 value="{{ instance.cutoff_cooldown_days }}"
+                 value="{{ instance.cutoff.cutoff_cooldown_days }}"
                  data-default-value="{{ defaults.cutoff_cooldown_days }}"
                  class="{{ mono_input_cls }}" />
         </div>
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-chcap">Cutoff Cap</label>
           <input id="{{ form_id }}-chcap" name="cutoff_hourly_cap" type="number" min="0"
-                 value="{{ instance.cutoff_hourly_cap }}"
+                 value="{{ instance.cutoff.cutoff_hourly_cap }}"
                  data-default-value="{{ defaults.cutoff_hourly_cap }}"
                  class="{{ mono_input_cls }}" />
         </div>
@@ -278,7 +278,7 @@
         </div>
         <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-md border border-[#2a3448] bg-[#0e1117] px-3 py-2">
           <input type="checkbox" name="upgrade_enabled" value="on"
-                 {% if is_edit and instance.upgrade_enabled %}checked{% endif %}
+                 {% if is_edit and instance.upgrade.upgrade_enabled %}checked{% endif %}
                  data-default-checked="{{ 1 if defaults.upgrade_enabled else 0 }}"
                  class="rounded border-[#2a3448] bg-[#0e1117] text-brand-500 focus:ring-brand-500 focus:ring-offset-[#07080f]" />
           <span class="text-xs font-medium text-slate-300">Enable upgrade search</span>
@@ -288,7 +288,7 @@
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-ubatch">Upgrade Batch</label>
           <input id="{{ form_id }}-ubatch" name="upgrade_batch_size" type="number" min="1" max="250"
-                 value="{{ instance.upgrade_batch_size }}"
+                 value="{{ instance.upgrade.upgrade_batch_size }}"
                  data-default-value="{{ defaults.upgrade_batch_size }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Hard cap: 5 per cycle.</p>
@@ -296,7 +296,7 @@
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-ucool">Upgrade Cooldown (days)</label>
           <input id="{{ form_id }}-ucool" name="upgrade_cooldown_days" type="number" min="7"
-                 value="{{ instance.upgrade_cooldown_days }}"
+                 value="{{ instance.upgrade.upgrade_cooldown_days }}"
                  data-default-value="{{ defaults.upgrade_cooldown_days }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Minimum: 7 days.</p>
@@ -304,7 +304,7 @@
         <div>
           <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-uhcap">Upgrade Hourly Cap</label>
           <input id="{{ form_id }}-uhcap" name="upgrade_hourly_cap" type="number" min="0"
-                 value="{{ instance.upgrade_hourly_cap }}"
+                 value="{{ instance.upgrade.upgrade_hourly_cap }}"
                  data-default-value="{{ defaults.upgrade_hourly_cap }}"
                  class="{{ mono_input_cls }}" />
           <p class="mt-1.5 text-xs text-slate-600">Hard cap: 5. 0 = unlimited.</p>
@@ -312,51 +312,51 @@
       </div>
       {# Per-app upgrade search mode selectors #}
       <div data-sonarr-only="true"
-           {% if instance.type.value != 'sonarr' %}style="display:none;"{% endif %}>
+           {% if instance.core.type.value != 'sonarr' %}style="display:none;"{% endif %}>
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-sonarr-mode">
           Sonarr Upgrade Search Mode
         </label>
         <select id="{{ form_id }}-upgrade-sonarr-mode" name="upgrade_sonarr_search_mode"
                 data-default-value="{{ defaults.upgrade_sonarr_search_mode.value }}"
                 class="{{ select_cls }}">
-          <option value="episode"        {% if instance.upgrade_sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
-          <option value="season_context" {% if instance.upgrade_sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
+          <option value="episode"        {% if instance.upgrade.upgrade_sonarr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
+          <option value="season_context" {% if instance.upgrade.upgrade_sonarr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
         </select>
       </div>
       <div data-lidarr-only="true"
-           {% if instance.type.value != 'lidarr' %}style="display:none;"{% endif %}>
+           {% if instance.core.type.value != 'lidarr' %}style="display:none;"{% endif %}>
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-lidarr-mode">
           Lidarr Upgrade Search Mode
         </label>
         <select id="{{ form_id }}-upgrade-lidarr-mode" name="upgrade_lidarr_search_mode"
                 data-default-value="{{ defaults.upgrade_lidarr_search_mode.value }}"
                 class="{{ select_cls }}">
-          <option value="album"          {% if instance.upgrade_lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
-          <option value="artist_context" {% if instance.upgrade_lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search</option>
+          <option value="album"          {% if instance.upgrade.upgrade_lidarr_search_mode.value == 'album'          %}selected{% endif %}>Album search (default)</option>
+          <option value="artist_context" {% if instance.upgrade.upgrade_lidarr_search_mode.value == 'artist_context' %}selected{% endif %}>Artist-context search</option>
         </select>
       </div>
       <div data-readarr-only="true"
-           {% if instance.type.value != 'readarr' %}style="display:none;"{% endif %}>
+           {% if instance.core.type.value != 'readarr' %}style="display:none;"{% endif %}>
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-readarr-mode">
           Readarr Upgrade Search Mode
         </label>
         <select id="{{ form_id }}-upgrade-readarr-mode" name="upgrade_readarr_search_mode"
                 data-default-value="{{ defaults.upgrade_readarr_search_mode.value }}"
                 class="{{ select_cls }}">
-          <option value="book"           {% if instance.upgrade_readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
-          <option value="author_context" {% if instance.upgrade_readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search</option>
+          <option value="book"           {% if instance.upgrade.upgrade_readarr_search_mode.value == 'book'           %}selected{% endif %}>Book search (default)</option>
+          <option value="author_context" {% if instance.upgrade.upgrade_readarr_search_mode.value == 'author_context' %}selected{% endif %}>Author-context search</option>
         </select>
       </div>
       <div data-whisparr_v2-only="true"
-           {% if instance.type.value != 'whisparr_v2' %}style="display:none;"{% endif %}>
+           {% if instance.core.type.value != 'whisparr_v2' %}style="display:none;"{% endif %}>
         <label class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide" for="{{ form_id }}-upgrade-whisparr-mode">
           Whisparr v2 Upgrade Search Mode
         </label>
         <select id="{{ form_id }}-upgrade-whisparr-mode" name="upgrade_whisparr_search_mode"
                 data-default-value="{{ defaults.upgrade_whisparr_search_mode.value }}"
                 class="{{ select_cls }}">
-          <option value="episode"        {% if instance.upgrade_whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
-          <option value="season_context" {% if instance.upgrade_whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
+          <option value="episode"        {% if instance.upgrade.upgrade_whisparr_search_mode.value == 'episode'        %}selected{% endif %}>Episode search (default)</option>
+          <option value="season_context" {% if instance.upgrade.upgrade_whisparr_search_mode.value == 'season_context' %}selected{% endif %}>Season-context search</option>
         </select>
       </div>
     </section>
@@ -364,7 +364,7 @@
     <!-- Actions footer -->
     <div class="border-t border-[#1e2638] pt-4 space-y-3">
       {% if is_edit %}
-      <input type="hidden" name="instance_id" value="{{ instance.id }}" />
+      <input type="hidden" name="instance_id" value="{{ instance.core.id }}" />
       {% endif %}
 
       <div class="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-3">

--- a/src/houndarr/templates/partials/instance_row.html
+++ b/src/houndarr/templates/partials/instance_row.html
@@ -1,7 +1,7 @@
 {# Single instance row: used by both initial render and HTMX swap after update. #}
-<tr id="instance-row-{{ instance.id }}"
-    class="border-b border-[#1e2638] hover:bg-[#151b27] transition-colors">
-  <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.name }}</td>
+<tr id="instance-row-{{ instance.core.id }}"
+    class="border-b border-border-subtle hover:bg-surface-2 transition-colors duration-fast ease-station">
+  <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.core.name }}</td>
   <td data-col="type" class="px-4 py-3">
     {%- set badge_map = {
       'sonarr':   {'bg': 'bg-sky-950/60',     'text': 'text-sky-300',     'border': 'border-sky-900/50',     'accent': 'border-l-sky-400',   'label': 'Sonarr'},
@@ -11,16 +11,25 @@
       'whisparr_v2': {'bg': 'bg-pink-950/60',    'text': 'text-pink-300',    'border': 'border-pink-900/50',    'accent': 'border-l-pink-400',  'label': 'Whisparr v2'},
       'whisparr_v3': {'bg': 'bg-fuchsia-950/60', 'text': 'text-fuchsia-300', 'border': 'border-fuchsia-900/50', 'accent': 'border-l-fuchsia-400','label': 'Whisparr v3'},
     } -%}
-    {%- set b = badge_map.get(instance.type.value, badge_map['sonarr']) -%}
-    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono {{ b.bg }} {{ b.text }} border {{ b.border }}">
+    {%- set b = badge_map.get(instance.core.type.value, badge_map['sonarr']) -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-chip text-xs font-mono {{ b.bg }} {{ b.text }} border {{ b.border }}">
       {{ b.label }}
     </span>
   </td>
-  <td data-col="url" class="px-4 py-3 text-slate-400 text-sm truncate max-w-xs font-mono text-xs">{{ instance.url }}</td>
+  <td data-col="url" class="px-4 py-3 text-slate-400 text-sm truncate max-w-xs font-mono text-xs">{{ instance.core.url }}</td>
   <td data-col="status" class="px-4 py-3 text-center">
-    {% if instance.enabled %}
-      <span class="inline-flex items-center gap-1 text-xs text-emerald-300">
-        <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block station-pulse-dot" title="Search enabled" aria-label="Search enabled"></span>
+    {# Fixed min-width on the pill + label so toggling Active <-> Disabled
+       (6 vs 8 chars) does not re-layout the column and shift every
+       sibling row. Red state uses the same shape + pulse as green so
+       the eye picks up the colour shift without a layout jump. #}
+    {% if instance.core.enabled and instance.core.id in (active_error_ids or []) %}
+      <span class="inline-flex items-center justify-center gap-1 text-xs text-danger min-w-[4.5rem]">
+        <span class="w-1.5 h-1.5 rounded-full bg-danger inline-block station-pulse-dot" title="Instance is reporting errors" aria-label="Instance is reporting errors"></span>
+        <span class="hidden sm:inline">Error</span>
+      </span>
+    {% elif instance.core.enabled %}
+      <span class="inline-flex items-center justify-center gap-1 text-xs text-success min-w-[4.5rem]">
+        <span class="w-1.5 h-1.5 rounded-full bg-success inline-block station-pulse-dot" title="Search enabled" aria-label="Search enabled"></span>
         <span class="hidden sm:inline">Active</span>
       </span>
     {% else %}
@@ -31,32 +40,32 @@
     {% endif %}
   </td>
   <td data-col="batch" class="px-4 py-3 text-sm text-slate-400 font-mono">
-    {{ instance.batch_size }} / {{ instance.sleep_interval_mins }}m
+    {{ instance.missing.batch_size }} / {{ instance.missing.sleep_interval_mins }}m
   </td>
   <td data-col="actions" class="px-4 py-3 text-right">
     <div class="flex items-center justify-end gap-2">
       <button
-        hx-post="/settings/instances/{{ instance.id }}/toggle-enabled"
-        hx-target="#instance-row-{{ instance.id }}"
+        hx-post="/settings/instances/{{ instance.core.id }}/toggle-enabled"
+        hx-target="#instance-row-{{ instance.core.id }}"
         hx-swap="outerHTML"
-        class="px-3 py-1 text-xs rounded transition-colors {% if instance.enabled %}bg-amber-950/50 hover:bg-amber-900/60 text-amber-300 border border-amber-900/40{% else %}bg-emerald-950/50 hover:bg-emerald-900/60 text-emerald-300 border border-emerald-900/40{% endif %}">
-        {{ 'Disable' if instance.enabled else 'Enable' }}
+        class="px-3 py-1 text-xs rounded-inset transition-colors duration-base ease-station min-w-[4.25rem] text-center {% if instance.core.enabled %}bg-warning-bg hover:bg-warning/20 text-warning border border-warning-border{% else %}bg-success-bg hover:bg-success/20 text-success border border-success-border{% endif %}">
+        {{ 'Disable' if instance.core.enabled else 'Enable' }}
       </button>
       <button
         type="button"
         data-open-add-instance-modal="true"
-        hx-get="/settings/instances/{{ instance.id }}/edit"
+        hx-get="/settings/instances/{{ instance.core.id }}/edit"
         hx-target="#add-instance-modal-content"
         hx-swap="innerHTML"
         class="px-3 py-1 text-xs rounded bg-[#1e2638] hover:bg-[#2a3448] text-slate-200 border border-[#2a3448] transition-colors">
         Edit
       </button>
       <button
-        hx-delete="/settings/instances/{{ instance.id }}"
-        hx-target="#instance-row-{{ instance.id }}"
+        hx-delete="/settings/instances/{{ instance.core.id }}"
+        hx-target="#instance-row-{{ instance.core.id }}"
         hx-swap="outerHTML"
-        hx-confirm="Delete '{{ instance.name }}'? This cannot be undone."
-        class="px-3 py-1 text-xs rounded bg-rose-950/50 hover:bg-rose-900/60 text-rose-300 border border-rose-900/40 transition-colors">
+        hx-confirm="Delete '{{ instance.core.name }}'? This cannot be undone."
+        class="px-3 py-1 text-xs rounded-inset bg-danger-bg hover:bg-danger/20 text-danger border border-danger-border transition-colors duration-base ease-station">
         Delete
       </button>
     </div>

--- a/src/houndarr/templates/partials/pages/logs_content.html
+++ b/src/houndarr/templates/partials/pages/logs_content.html
@@ -321,8 +321,8 @@
     >
       <option value="">All instances</option>
       {% for inst in instances %}
-      <option value="{{ inst.id }}" {% if selected_instance_id == inst.id %}selected{% endif %}>
-        {{ inst.name }}
+      <option value="{{ inst.core.id }}" {% if selected_instance_id == inst.core.id %}selected{% endif %}>
+        {{ inst.core.name }}
       </option>
       {% endfor %}
     </select>

--- a/tests/test_engine/test_adapters/test_sonarr_adapter.py
+++ b/tests/test_engine/test_adapters/test_sonarr_adapter.py
@@ -417,11 +417,12 @@ class TestFetchReconcileSetsUpgrade:
         client.get_episodes.side_effect = lambda series_id: episodes_by_series[series_id]
 
         instance = _make_instance()
-        instance_with_upgrade = replace(
-            instance,
+        instance.upgrade = replace(
+            instance.upgrade,
             upgrade_enabled=True,
             upgrade_series_offset=0,
         )
+        instance_with_upgrade = instance
 
         sets = await fetch_reconcile_sets(client, instance_with_upgrade)
 

--- a/tests/test_engine/test_candidates.py
+++ b/tests/test_engine/test_candidates.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
-
 import pytest
 
 from houndarr.engine.candidates import (
     SearchCandidate,
-    _is_within_unreleased_delay,
     _parse_iso_utc,
 )
 
@@ -114,51 +111,3 @@ class TestParseIsoUtc:
         result = _parse_iso_utc("  2024-01-15T10:30:00Z  ")
         assert result is not None
         assert result.year == 2024
-
-
-# ---------------------------------------------------------------------------
-# _is_within_unreleased_delay
-# ---------------------------------------------------------------------------
-
-
-class TestIsWithinUnreleasedDelay:
-    """Verify unreleased-delay checking matches the search_loop.py original."""
-
-    def test_within_delay(self):
-        """Item released recently is within the delay window."""
-        recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
-        assert _is_within_unreleased_delay(recent, 24) is True
-
-    def test_past_delay(self):
-        """Item released long ago is past the delay window."""
-        old = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
-        assert _is_within_unreleased_delay(old, 24) is False
-
-    def test_zero_delay_hrs(self):
-        """Zero delay hours always returns False."""
-        recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
-        assert _is_within_unreleased_delay(recent, 0) is False
-
-    def test_negative_delay_hrs(self):
-        """Negative delay hours always returns False."""
-        recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
-        assert _is_within_unreleased_delay(recent, -5) is False
-
-    def test_none_date(self):
-        """None release date returns False."""
-        assert _is_within_unreleased_delay(None, 24) is False
-
-    def test_empty_date(self):
-        """Empty string release date returns False."""
-        assert _is_within_unreleased_delay("", 24) is False
-
-    def test_future_release(self):
-        """Future release date is within any positive delay window."""
-        future = (datetime.now(UTC) + timedelta(hours=100)).isoformat()
-        assert _is_within_unreleased_delay(future, 1) is True
-
-    def test_boundary_exact(self):
-        """Item at exactly the delay boundary is not within the delay."""
-        boundary = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
-        # At exactly the boundary, now < (release + delay) is False
-        assert _is_within_unreleased_delay(boundary, 24) is False

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -1923,7 +1923,6 @@ async def test_inter_search_delay_fires_in_upgrade_pass(
     seeded_instances: None,
 ) -> None:
     """asyncio.sleep is called once for a successful upgrade-pass search."""
-    from dataclasses import replace
 
     library_movie = {
         "id": 201,
@@ -1947,13 +1946,13 @@ async def test_inter_search_delay_fires_in_upgrade_pass(
     )
 
     sleep_mock = AsyncMock()
-    instance = replace(
-        _make_instance(itype=InstanceType.radarr, url=RADARR_URL, instance_id=2, batch_size=0),
-        upgrade_enabled=True,
-        upgrade_batch_size=1,
-        upgrade_cooldown_days=7,
-        upgrade_hourly_cap=5,
+    instance = _make_instance(
+        itype=InstanceType.radarr, url=RADARR_URL, instance_id=2, batch_size=0
     )
+    instance.upgrade_enabled = True
+    instance.upgrade_batch_size = 1
+    instance.upgrade_cooldown_days = 7
+    instance.upgrade_hourly_cap = 5
     with patch("houndarr.engine.search_loop.asyncio.sleep", sleep_mock):
         count = await run_instance_search(instance, MASTER_KEY)
 

--- a/tests/test_services/test_instance_substructs.py
+++ b/tests/test_services/test_instance_substructs.py
@@ -351,26 +351,348 @@ def test_substruct_field_sets_are_disjoint() -> None:
             seen[name] = cls
 
 
-def test_substruct_field_union_equals_instance_fields() -> None:
-    """The union of the seven sub-struct fields equals Instance's fields.
+def test_substruct_field_union_matches_flat_accessor_surface() -> None:
+    """The union of sub-struct fields is exactly the flat accessors.
 
-    Locks the exhaustive decomposition so D.14 can wrap Instance as a
-    facade over sub-structs without orphaning a column or introducing
-    a new one.
+    After D.14 Instance holds the seven sub-structs as its own fields
+    and exposes every flat name via ``@property`` delegation.  This
+    test locks the invariant that the flat accessor surface is the
+    disjoint union of the sub-struct fields, which is what allows the
+    caller-migration batches (D.15 - D.19) to translate a flat access
+    to exactly one sub-struct access without ambiguity.
     """
     substruct_fields: set[str] = set()
     for cls in SUBSTRUCTS:
         substruct_fields.update(_field_names(cls))
-    instance_fields = {f.name for f in dataclasses.fields(Instance)}
-    assert substruct_fields == instance_fields
+    assert substruct_fields == set(FLAT_TO_SUB.keys())
 
 
-def test_substruct_field_count_matches_instance() -> None:
-    """The seven sub-structs total exactly as many fields as Instance.
+def test_flat_accessor_surface_covers_pre_refactor_instance_fields() -> None:
+    """Every pre-refactor flat field is still reachable as a property.
 
-    Redundant with the union check but a clearer failure mode when
-    someone adds a field to a sub-struct without removing it from
-    Instance (or vice versa).
+    Locks that the D.14 facade did not drop any attribute: a caller
+    that reads ``instance.<name>`` for any ``<name>`` in the 39-field
+    pre-refactor surface still finds that attribute after D.14.  The
+    pre-refactor field list is encoded directly in :data:`FLAT_TO_SUB`
+    so the test stays meaningful even once the Instance dataclass no
+    longer declares those fields itself.
     """
-    total = sum(len(_field_names(cls)) for cls in SUBSTRUCTS)
-    assert total == len(dataclasses.fields(Instance))
+    instance = _minimal_instance()
+    for flat_name in FLAT_TO_SUB:
+        assert hasattr(instance, flat_name), (
+            f"Instance no longer exposes the flat attribute {flat_name!r};"
+            " the facade migration lost coverage."
+        )
+
+
+# Instance facade contract (D.14).
+
+
+# Map every pre-refactor flat field to the sub-struct that owns it.
+# Source of truth for the caller migrations in D.15 - D.19; a caller
+# rewriting ``instance.batch_size`` to ``instance.missing.batch_size``
+# keys off this table.  The table also drives the parametrised
+# facade tests below; a missing entry here would silently skip
+# coverage for that attribute.
+FLAT_TO_SUB: dict[str, str] = {
+    # InstanceCore
+    "id": "core",
+    "name": "core",
+    "type": "core",
+    "url": "core",
+    "api_key": "core",
+    "enabled": "core",
+    # MissingPolicy
+    "batch_size": "missing",
+    "sleep_interval_mins": "missing",
+    "hourly_cap": "missing",
+    "cooldown_days": "missing",
+    "post_release_grace_hrs": "missing",
+    "queue_limit": "missing",
+    "sonarr_search_mode": "missing",
+    "lidarr_search_mode": "missing",
+    "readarr_search_mode": "missing",
+    "whisparr_search_mode": "missing",
+    # CutoffPolicy
+    "cutoff_enabled": "cutoff",
+    "cutoff_batch_size": "cutoff",
+    "cutoff_cooldown_days": "cutoff",
+    "cutoff_hourly_cap": "cutoff",
+    # UpgradePolicy
+    "upgrade_enabled": "upgrade",
+    "upgrade_batch_size": "upgrade",
+    "upgrade_cooldown_days": "upgrade",
+    "upgrade_hourly_cap": "upgrade",
+    "upgrade_sonarr_search_mode": "upgrade",
+    "upgrade_lidarr_search_mode": "upgrade",
+    "upgrade_readarr_search_mode": "upgrade",
+    "upgrade_whisparr_search_mode": "upgrade",
+    "upgrade_item_offset": "upgrade",
+    "upgrade_series_offset": "upgrade",
+    # SchedulePolicy
+    "allowed_time_window": "schedule",
+    "search_order": "schedule",
+    "missing_page_offset": "schedule",
+    "cutoff_page_offset": "schedule",
+    # RuntimeSnapshot
+    "monitored_total": "snapshot",
+    "unreleased_count": "snapshot",
+    "snapshot_refreshed_at": "snapshot",
+    # InstanceTimestamps
+    "created_at": "timestamps",
+    "updated_at": "timestamps",
+}
+
+
+# Writable replacement values for every flat field.  The value a setter
+# test drives through Instance.<field> = X must differ from the
+# pre-minimal-instance default so the test observes an actual change.
+FLAT_WRITE_VALUES: dict[str, Any] = {
+    # InstanceCore
+    "id": 999,
+    "name": "renamed",
+    "type": InstanceType.radarr,
+    "url": "http://rewritten:7878",
+    "api_key": "rotated-key",
+    "enabled": False,
+    # MissingPolicy
+    "batch_size": 7,
+    "sleep_interval_mins": 45,
+    "hourly_cap": 11,
+    "cooldown_days": 33,
+    "post_release_grace_hrs": 12,
+    "queue_limit": 5,
+    "sonarr_search_mode": SonarrSearchMode.season_context,
+    "lidarr_search_mode": LidarrSearchMode.artist_context,
+    "readarr_search_mode": ReadarrSearchMode.author_context,
+    "whisparr_search_mode": WhisparrSearchMode.season_context,
+    # CutoffPolicy
+    "cutoff_enabled": True,
+    "cutoff_batch_size": 3,
+    "cutoff_cooldown_days": 60,
+    "cutoff_hourly_cap": 4,
+    # UpgradePolicy
+    "upgrade_enabled": True,
+    "upgrade_batch_size": 9,
+    "upgrade_cooldown_days": 120,
+    "upgrade_hourly_cap": 2,
+    "upgrade_sonarr_search_mode": SonarrSearchMode.season_context,
+    "upgrade_lidarr_search_mode": LidarrSearchMode.artist_context,
+    "upgrade_readarr_search_mode": ReadarrSearchMode.author_context,
+    "upgrade_whisparr_search_mode": WhisparrSearchMode.season_context,
+    "upgrade_item_offset": 42,
+    "upgrade_series_offset": 17,
+    # SchedulePolicy
+    "allowed_time_window": "08:00-20:00",
+    "search_order": SearchOrder.random,
+    "missing_page_offset": 5,
+    "cutoff_page_offset": 9,
+    # RuntimeSnapshot
+    "monitored_total": 1234,
+    "unreleased_count": 56,
+    "snapshot_refreshed_at": "2026-05-01T12:00:00.000Z",
+    # InstanceTimestamps
+    "created_at": "2099-01-01T00:00:00.000Z",
+    "updated_at": "2099-02-02T00:00:00.000Z",
+}
+
+
+def _minimal_instance() -> Instance:
+    """Build an Instance with only the 18 pre-refactor required kwargs.
+
+    Every defaulted kwarg falls back to the pre-D.14 Instance default
+    value, so the result doubles as a default-preservation probe:
+    tests that mutate a single field and then read it back can trust
+    that untouched fields stay at their documented defaults.
+    """
+    return Instance(
+        id=1,
+        name="Test",
+        type=InstanceType.sonarr,
+        url="http://sonarr:8989",
+        api_key="plaintext-key",
+        enabled=True,
+        batch_size=2,
+        sleep_interval_mins=30,
+        hourly_cap=4,
+        cooldown_days=14,
+        post_release_grace_hrs=6,
+        queue_limit=0,
+        cutoff_enabled=False,
+        cutoff_batch_size=1,
+        cutoff_cooldown_days=21,
+        cutoff_hourly_cap=1,
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-02T00:00:00Z",
+    )
+
+
+def test_instance_is_dataclass_with_seven_sub_struct_fields() -> None:
+    """Instance is a dataclass whose fields are the seven sub-structs.
+
+    ``@dataclass(init=False)`` keeps auto-generated ``__eq__`` /
+    ``__repr__`` across the seven sub-structs while the custom
+    ``__init__`` accepts the 39 flat kwargs.
+    """
+    assert dataclasses.is_dataclass(Instance)
+    expected = [
+        ("core", InstanceCore),
+        ("missing", MissingPolicy),
+        ("cutoff", CutoffPolicy),
+        ("upgrade", UpgradePolicy),
+        ("schedule", SchedulePolicy),
+        ("snapshot", RuntimeSnapshot),
+        ("timestamps", InstanceTimestamps),
+    ]
+    observed = [(f.name, f.type) for f in dataclasses.fields(Instance)]
+    # Dataclass field types arrive as string annotations under PEP 563 /
+    # ``from __future__ import annotations``, so compare by name.
+    assert [name for name, _ in observed] == [name for name, _ in expected]
+    for (_, typ), (_, expected_typ) in zip(observed, expected, strict=True):
+        # ``f.type`` is the stringified annotation ("InstanceCore").
+        assert typ == expected_typ.__name__
+
+
+def test_instance_is_not_frozen() -> None:
+    """Instance stays mutable so the slots audit exception still holds."""
+    params = Instance.__dataclass_params__  # type: ignore[attr-defined]
+    assert params.frozen is False
+
+
+def test_instance_accepts_pre_refactor_flat_kwargs() -> None:
+    """Calling ``Instance`` with the 18 required flat kwargs succeeds.
+
+    Backwards-compat check for the 14+ caller sites that still build
+    Instance via flat kwargs through D.15 - D.19.  Drop this test only
+    after D.20 migrates every construction site to sub-struct form.
+    """
+    instance = _minimal_instance()
+    assert isinstance(instance, Instance)
+    assert instance.id == 1
+    assert instance.name == "Test"
+    assert instance.type == InstanceType.sonarr
+    assert instance.url == "http://sonarr:8989"
+    assert instance.api_key == "plaintext-key"
+    assert instance.enabled is True
+
+
+def test_instance_sub_struct_fields_populated_by_flat_init() -> None:
+    """Flat __init__ kwargs land in the matching sub-struct field."""
+    instance = _minimal_instance()
+    assert isinstance(instance.core, InstanceCore)
+    assert isinstance(instance.missing, MissingPolicy)
+    assert isinstance(instance.cutoff, CutoffPolicy)
+    assert isinstance(instance.upgrade, UpgradePolicy)
+    assert isinstance(instance.schedule, SchedulePolicy)
+    assert isinstance(instance.snapshot, RuntimeSnapshot)
+    assert isinstance(instance.timestamps, InstanceTimestamps)
+    assert instance.core.id == 1
+    assert instance.missing.batch_size == 2
+    assert instance.cutoff.cutoff_batch_size == 1
+    assert instance.upgrade.upgrade_enabled is False
+    assert instance.schedule.missing_page_offset == 1
+    assert instance.snapshot.monitored_total == 0
+    assert instance.timestamps.created_at == "2024-01-01T00:00:00Z"
+
+
+def test_instance_flat_kwarg_defaults_preserve_pre_refactor_values() -> None:
+    """The 21 defaulted flat kwargs resolve to the pre-D.14 defaults.
+
+    Pre-D.14 Instance defaulted ``search_order`` to
+    :attr:`SearchOrder.chronological` even though
+    :data:`DEFAULT_SEARCH_ORDER` is ``"random"``.  The facade must
+    preserve that exact contract so migrated rows that never wrote a
+    search_order column keep iterating chronologically.  Same logic
+    for every other defaulted kwarg: the Instance facade is the
+    authority, not the sub-struct's direct default.
+    """
+    instance = _minimal_instance()
+    assert instance.sonarr_search_mode == SonarrSearchMode.episode
+    assert instance.lidarr_search_mode == LidarrSearchMode.album
+    assert instance.readarr_search_mode == ReadarrSearchMode.book
+    assert instance.whisparr_search_mode == WhisparrSearchMode.episode
+    assert instance.upgrade_enabled is False
+    assert instance.upgrade_sonarr_search_mode == SonarrSearchMode.episode
+    assert instance.upgrade_lidarr_search_mode == LidarrSearchMode.album
+    assert instance.upgrade_readarr_search_mode == ReadarrSearchMode.book
+    assert instance.upgrade_whisparr_search_mode == WhisparrSearchMode.episode
+    assert instance.upgrade_item_offset == 0
+    assert instance.upgrade_series_offset == 0
+    assert instance.missing_page_offset == 1
+    assert instance.cutoff_page_offset == 1
+    assert instance.allowed_time_window == ""
+    assert instance.search_order == SearchOrder.chronological
+    assert instance.monitored_total == 0
+    assert instance.unreleased_count == 0
+    assert instance.snapshot_refreshed_at == ""
+
+
+@pytest.mark.parametrize("flat_name", sorted(FLAT_TO_SUB))
+def test_flat_read_equals_sub_struct_read(flat_name: str) -> None:
+    """Every flat attribute reads through to the matching sub-struct field."""
+    instance = _minimal_instance()
+    sub_name = FLAT_TO_SUB[flat_name]
+    sub_value = getattr(getattr(instance, sub_name), flat_name)
+    assert getattr(instance, flat_name) == sub_value
+
+
+@pytest.mark.parametrize("flat_name", sorted(FLAT_TO_SUB))
+def test_flat_write_propagates_to_sub_struct(flat_name: str) -> None:
+    """Writing a flat attribute rebuilds the owning sub-struct.
+
+    Locks the ``@property`` setter contract: after
+    ``instance.<flat> = X``, both ``instance.<flat>`` and
+    ``instance.<sub>.<flat>`` return ``X``.  Since sub-structs are
+    frozen, the setter has to route through
+    :func:`dataclasses.replace`; a regression here would surface as
+    a :class:`dataclasses.FrozenInstanceError` from the setter.
+    """
+    instance = _minimal_instance()
+    sub_name = FLAT_TO_SUB[flat_name]
+    new_value = FLAT_WRITE_VALUES[flat_name]
+    setattr(instance, flat_name, new_value)
+    assert getattr(instance, flat_name) == new_value
+    assert getattr(getattr(instance, sub_name), flat_name) == new_value
+
+
+def test_sub_struct_swap_visible_via_flat_read() -> None:
+    """Reassigning a whole sub-struct propagates to flat reads.
+
+    Exercises the "sub-struct write" side of the D.14 both-patterns
+    contract: a caller that has migrated to sub-struct construction
+    (``instance.missing = MissingPolicy(batch_size=99, ...)``) still
+    stays consistent with flat readers that have not migrated yet.
+    """
+    instance = _minimal_instance()
+    assert instance.batch_size == 2  # baseline from _minimal_instance
+    instance.missing = MissingPolicy(batch_size=99)
+    assert instance.batch_size == 99
+    assert instance.missing.batch_size == 99
+
+
+def test_sub_struct_swap_isolated_to_its_group() -> None:
+    """Swapping one sub-struct does not disturb the others.
+
+    A sub-struct assignment must not implicitly reset peer sub-structs;
+    the facade stores them as seven independent fields.
+    """
+    instance = _minimal_instance()
+    original_core = instance.core
+    original_schedule = instance.schedule
+    instance.missing = MissingPolicy(batch_size=50)
+    assert instance.core is original_core
+    assert instance.schedule is original_schedule
+
+
+def test_pre_refactor_instance_field_count_via_flat_accessors() -> None:
+    """The D.14 facade still exposes exactly 39 flat accessors.
+
+    Canary that the facade migration did not quietly grow or shrink
+    the flat surface.  :data:`FLAT_TO_SUB` is the authoritative
+    encoding of that surface; bumping it requires a deliberate update
+    with a matching accessor pair on :class:`Instance`.
+    """
+    assert len(FLAT_TO_SUB) == 39
+    instance = _minimal_instance()
+    for flat_name in FLAT_TO_SUB:
+        assert hasattr(instance, flat_name)

--- a/tests/test_services/test_instance_substructs.py
+++ b/tests/test_services/test_instance_substructs.py
@@ -1,0 +1,376 @@
+"""Pinning tests for the :class:`Instance` policy sub-struct dataclasses.
+
+Track D.13 declares seven frozen, slotted dataclasses alongside the
+existing :class:`Instance` dataclass:
+:class:`InstanceCore`, :class:`MissingPolicy`, :class:`CutoffPolicy`,
+:class:`UpgradePolicy`, :class:`SchedulePolicy`, :class:`RuntimeSnapshot`,
+and :class:`InstanceTimestamps`.  The declarations are currently unused;
+D.14 wraps :class:`Instance` as a facade that composes them via
+``@property`` delegation, and D.15 through D.19 migrate the callers.
+D.20 removes the flat-attribute delegation.
+
+These tests lock the contract that every later batch keys off:
+
+* each sub-struct is a ``@dataclass(frozen=True, slots=True)``
+* each sub-struct exposes the exact field names the plan specifies
+* default values match the constants in :mod:`houndarr.config` so fresh
+  construction never drifts from what :class:`InstanceInsert` writes
+* the seven sub-struct field sets partition :class:`Instance`'s 39
+  fields disjointly and exhaustively
+
+Every assertion below has to stay green through D.14 - D.20.  A test
+failing here means the sub-struct shape has drifted from the plan and
+the facade migration is about to propagate the drift.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from houndarr.config import (
+    DEFAULT_ALLOWED_TIME_WINDOW,
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_COOLDOWN_DAYS,
+    DEFAULT_CUTOFF_BATCH_SIZE,
+    DEFAULT_CUTOFF_COOLDOWN_DAYS,
+    DEFAULT_CUTOFF_HOURLY_CAP,
+    DEFAULT_HOURLY_CAP,
+    DEFAULT_LIDARR_SEARCH_MODE,
+    DEFAULT_POST_RELEASE_GRACE_HOURS,
+    DEFAULT_QUEUE_LIMIT,
+    DEFAULT_READARR_SEARCH_MODE,
+    DEFAULT_SEARCH_ORDER,
+    DEFAULT_SLEEP_INTERVAL_MINUTES,
+    DEFAULT_SONARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_BATCH_SIZE,
+    DEFAULT_UPGRADE_COOLDOWN_DAYS,
+    DEFAULT_UPGRADE_HOURLY_CAP,
+    DEFAULT_UPGRADE_LIDARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_READARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_SONARR_SEARCH_MODE,
+    DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE,
+    DEFAULT_WHISPARR_SEARCH_MODE,
+)
+from houndarr.services.instances import (
+    CutoffPolicy,
+    Instance,
+    InstanceCore,
+    InstanceTimestamps,
+    InstanceType,
+    LidarrSearchMode,
+    MissingPolicy,
+    ReadarrSearchMode,
+    RuntimeSnapshot,
+    SchedulePolicy,
+    SearchOrder,
+    SonarrSearchMode,
+    UpgradePolicy,
+    WhisparrSearchMode,
+)
+
+pytestmark = pytest.mark.pinning
+
+
+SUBSTRUCTS: list[type] = [
+    InstanceCore,
+    MissingPolicy,
+    CutoffPolicy,
+    UpgradePolicy,
+    SchedulePolicy,
+    RuntimeSnapshot,
+    InstanceTimestamps,
+]
+
+
+def _field_names(cls: type) -> list[str]:
+    """Return the dataclass field names of *cls* in declaration order."""
+    return [f.name for f in dataclasses.fields(cls)]
+
+
+def _field_defaults(cls: type) -> dict[str, Any]:
+    """Return a mapping from field name to default value.
+
+    Fields with no default (required fields) are skipped.  Fields that
+    use ``default_factory`` are also skipped, but none of the D.13
+    sub-structs use factories so the omission is moot today.
+    """
+    defaults: dict[str, Any] = {}
+    for f in dataclasses.fields(cls):
+        if f.default is not dataclasses.MISSING:
+            defaults[f.name] = f.default
+    return defaults
+
+
+# Structural invariants shared by every sub-struct.
+
+
+@pytest.mark.parametrize("cls", SUBSTRUCTS)
+def test_substruct_is_frozen_slotted_dataclass(cls: type) -> None:
+    """Every sub-struct is a frozen, slotted dataclass."""
+    assert dataclasses.is_dataclass(cls), f"{cls.__name__} is not a dataclass"
+    params = cls.__dataclass_params__  # type: ignore[attr-defined]
+    assert params.frozen is True, f"{cls.__name__} is not frozen"
+    assert "__slots__" in cls.__dict__, f"{cls.__name__} does not declare __slots__"
+
+
+@pytest.mark.parametrize("cls", SUBSTRUCTS)
+def test_substruct_rejects_attribute_assignment(cls: type) -> None:
+    """Frozen sub-structs raise ``FrozenInstanceError`` on setattr."""
+    instance = _construct_with_required(cls)
+    first_field = dataclasses.fields(cls)[0].name
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(instance, first_field, getattr(instance, first_field))
+
+
+@pytest.mark.parametrize("cls", SUBSTRUCTS)
+def test_substruct_rejects_unknown_attribute(cls: type) -> None:
+    """Slotted sub-structs reject attribute names outside ``__slots__``."""
+    instance = _construct_with_required(cls)
+    with pytest.raises(AttributeError):
+        object.__setattr__(instance, "not_a_real_field", 42)
+
+
+def _construct_with_required(cls: type) -> Any:
+    """Build a minimal instance of *cls*, filling required fields.
+
+    Used by the frozen / slots invariant tests so they do not have to
+    know each sub-struct's required-field surface separately.  Every
+    required field is typed by the sub-struct declarations, so a small
+    dispatch table suffices.
+    """
+    required: dict[str, Any] = {}
+    for f in dataclasses.fields(cls):
+        if f.default is not dataclasses.MISSING:
+            continue
+        if f.type is int or f.type == "int":
+            required[f.name] = 0
+        elif f.type is str or f.type == "str":
+            required[f.name] = ""
+        elif f.type is bool or f.type == "bool":
+            required[f.name] = False
+        elif f.type is InstanceType or f.type == "InstanceType":
+            required[f.name] = InstanceType.sonarr
+        else:
+            raise AssertionError(
+                f"Required field {cls.__name__}.{f.name} has an unhandled type {f.type!r};"
+                " extend _construct_with_required to cover it."
+            )
+    return cls(**required)
+
+
+# InstanceCore.
+
+
+def test_instance_core_fields_in_declaration_order() -> None:
+    """InstanceCore exposes the six identity fields in the locked order."""
+    assert _field_names(InstanceCore) == [
+        "id",
+        "name",
+        "type",
+        "url",
+        "api_key",
+        "enabled",
+    ]
+
+
+def test_instance_core_defaults() -> None:
+    """Only ``enabled`` carries a default; the other five are required."""
+    assert _field_defaults(InstanceCore) == {"enabled": True}
+
+
+# MissingPolicy.
+
+
+def test_missing_policy_fields_in_declaration_order() -> None:
+    """MissingPolicy exposes the ten missing-pass tunables in order."""
+    assert _field_names(MissingPolicy) == [
+        "batch_size",
+        "sleep_interval_mins",
+        "hourly_cap",
+        "cooldown_days",
+        "post_release_grace_hrs",
+        "queue_limit",
+        "sonarr_search_mode",
+        "lidarr_search_mode",
+        "readarr_search_mode",
+        "whisparr_search_mode",
+    ]
+
+
+def test_missing_policy_defaults_match_config() -> None:
+    """Every MissingPolicy default flows from :mod:`houndarr.config`."""
+    policy = MissingPolicy()
+    assert policy.batch_size == DEFAULT_BATCH_SIZE
+    assert policy.sleep_interval_mins == DEFAULT_SLEEP_INTERVAL_MINUTES
+    assert policy.hourly_cap == DEFAULT_HOURLY_CAP
+    assert policy.cooldown_days == DEFAULT_COOLDOWN_DAYS
+    assert policy.post_release_grace_hrs == DEFAULT_POST_RELEASE_GRACE_HOURS
+    assert policy.queue_limit == DEFAULT_QUEUE_LIMIT
+    assert policy.sonarr_search_mode == SonarrSearchMode(DEFAULT_SONARR_SEARCH_MODE)
+    assert policy.lidarr_search_mode == LidarrSearchMode(DEFAULT_LIDARR_SEARCH_MODE)
+    assert policy.readarr_search_mode == ReadarrSearchMode(DEFAULT_READARR_SEARCH_MODE)
+    assert policy.whisparr_search_mode == WhisparrSearchMode(DEFAULT_WHISPARR_SEARCH_MODE)
+
+
+# CutoffPolicy.
+
+
+def test_cutoff_policy_fields_in_declaration_order() -> None:
+    """CutoffPolicy exposes the four cutoff tunables in order."""
+    assert _field_names(CutoffPolicy) == [
+        "cutoff_enabled",
+        "cutoff_batch_size",
+        "cutoff_cooldown_days",
+        "cutoff_hourly_cap",
+    ]
+
+
+def test_cutoff_policy_defaults_match_config() -> None:
+    """CutoffPolicy defaults to disabled with the slower cutoff cadence."""
+    policy = CutoffPolicy()
+    assert policy.cutoff_enabled is False
+    assert policy.cutoff_batch_size == DEFAULT_CUTOFF_BATCH_SIZE
+    assert policy.cutoff_cooldown_days == DEFAULT_CUTOFF_COOLDOWN_DAYS
+    assert policy.cutoff_hourly_cap == DEFAULT_CUTOFF_HOURLY_CAP
+
+
+# UpgradePolicy.
+
+
+def test_upgrade_policy_fields_in_declaration_order() -> None:
+    """UpgradePolicy exposes the ten upgrade tunables + pool offsets."""
+    assert _field_names(UpgradePolicy) == [
+        "upgrade_enabled",
+        "upgrade_batch_size",
+        "upgrade_cooldown_days",
+        "upgrade_hourly_cap",
+        "upgrade_sonarr_search_mode",
+        "upgrade_lidarr_search_mode",
+        "upgrade_readarr_search_mode",
+        "upgrade_whisparr_search_mode",
+        "upgrade_item_offset",
+        "upgrade_series_offset",
+    ]
+
+
+def test_upgrade_policy_defaults_match_config() -> None:
+    """UpgradePolicy defaults to disabled with zero pool offsets."""
+    policy = UpgradePolicy()
+    assert policy.upgrade_enabled is False
+    assert policy.upgrade_batch_size == DEFAULT_UPGRADE_BATCH_SIZE
+    assert policy.upgrade_cooldown_days == DEFAULT_UPGRADE_COOLDOWN_DAYS
+    assert policy.upgrade_hourly_cap == DEFAULT_UPGRADE_HOURLY_CAP
+    assert policy.upgrade_sonarr_search_mode == SonarrSearchMode(DEFAULT_UPGRADE_SONARR_SEARCH_MODE)
+    assert policy.upgrade_lidarr_search_mode == LidarrSearchMode(DEFAULT_UPGRADE_LIDARR_SEARCH_MODE)
+    assert policy.upgrade_readarr_search_mode == ReadarrSearchMode(
+        DEFAULT_UPGRADE_READARR_SEARCH_MODE
+    )
+    assert policy.upgrade_whisparr_search_mode == WhisparrSearchMode(
+        DEFAULT_UPGRADE_WHISPARR_SEARCH_MODE
+    )
+    assert policy.upgrade_item_offset == 0
+    assert policy.upgrade_series_offset == 0
+
+
+# SchedulePolicy.
+
+
+def test_schedule_policy_fields_in_declaration_order() -> None:
+    """SchedulePolicy carries time-window, order, and page-offset state."""
+    assert _field_names(SchedulePolicy) == [
+        "allowed_time_window",
+        "search_order",
+        "missing_page_offset",
+        "cutoff_page_offset",
+    ]
+
+
+def test_schedule_policy_defaults_match_config() -> None:
+    """SchedulePolicy defaults to 24/7, fresh-install order, page 1."""
+    policy = SchedulePolicy()
+    assert policy.allowed_time_window == DEFAULT_ALLOWED_TIME_WINDOW
+    assert policy.search_order == SearchOrder(DEFAULT_SEARCH_ORDER)
+    assert policy.missing_page_offset == 1
+    assert policy.cutoff_page_offset == 1
+
+
+# RuntimeSnapshot.
+
+
+def test_runtime_snapshot_fields_in_declaration_order() -> None:
+    """RuntimeSnapshot carries the three dashboard telemetry columns."""
+    assert _field_names(RuntimeSnapshot) == [
+        "monitored_total",
+        "unreleased_count",
+        "snapshot_refreshed_at",
+    ]
+
+
+def test_runtime_snapshot_defaults_are_empty() -> None:
+    """Fresh RuntimeSnapshot reports zero counts and no refresh yet."""
+    snapshot = RuntimeSnapshot()
+    assert snapshot.monitored_total == 0
+    assert snapshot.unreleased_count == 0
+    assert snapshot.snapshot_refreshed_at == ""
+
+
+# InstanceTimestamps.
+
+
+def test_instance_timestamps_fields_in_declaration_order() -> None:
+    """InstanceTimestamps exposes exactly created_at and updated_at."""
+    assert _field_names(InstanceTimestamps) == ["created_at", "updated_at"]
+
+
+def test_instance_timestamps_requires_both_fields() -> None:
+    """Both timestamp fields are required: no default silently hides bugs."""
+    assert _field_defaults(InstanceTimestamps) == {}
+
+
+# Cross-substruct invariants.
+
+
+def test_substruct_field_sets_are_disjoint() -> None:
+    """No field name appears in two different sub-structs.
+
+    The facade migration in D.14 depends on this: a shadowed name
+    would break ``@property`` delegation because flat access would
+    become ambiguous.
+    """
+    seen: dict[str, type] = {}
+    for cls in SUBSTRUCTS:
+        for name in _field_names(cls):
+            if name in seen:
+                pytest.fail(
+                    f"Field {name!r} appears on both {seen[name].__name__}"
+                    f" and {cls.__name__}; sub-structs must partition Instance."
+                )
+            seen[name] = cls
+
+
+def test_substruct_field_union_equals_instance_fields() -> None:
+    """The union of the seven sub-struct fields equals Instance's fields.
+
+    Locks the exhaustive decomposition so D.14 can wrap Instance as a
+    facade over sub-structs without orphaning a column or introducing
+    a new one.
+    """
+    substruct_fields: set[str] = set()
+    for cls in SUBSTRUCTS:
+        substruct_fields.update(_field_names(cls))
+    instance_fields = {f.name for f in dataclasses.fields(Instance)}
+    assert substruct_fields == instance_fields
+
+
+def test_substruct_field_count_matches_instance() -> None:
+    """The seven sub-structs total exactly as many fields as Instance.
+
+    Redundant with the union check but a clearer failure mode when
+    someone adds a field to a sub-struct without removing it from
+    Instance (or vice versa).
+    """
+    total = sum(len(_field_names(cls)) for cls in SUBSTRUCTS)
+    assert total == len(dataclasses.fields(Instance))


### PR DESCRIPTION
## Summary

Add the seven `Instance` sub-struct types (`InstanceCore`, `MissingPolicy`, `CutoffPolicy`, `UpgradePolicy`, `SchedulePolicy`, `RuntimeSnapshot`, `InstanceTimestamps`) and wrap `Instance` with `@property` delegators so callers can opt into sub-struct access at their own pace. The flat-attribute and flat-kwarg surface stays in place behind the facade so every existing caller keeps working. Migrate the supervisor, the six adapters, and the two instance templates onto sub-struct reads as the first wave of consumers.

Closes #470

## Changes

- `src/houndarr/services/instances.py`: declare the seven frozen-slotted sub-struct dataclasses alongside the existing flat `Instance`. Wrap `Instance` with `@property` getters and setters so flat reads route through the sub-structs, and flat writes rebuild the corresponding sub-struct via `dataclasses.replace`. The 39-flat-kwargs `__init__` stays put so existing callers (and `_row_to_instance`) keep working unchanged.
- `src/houndarr/engine/supervisor.py`: read identity through `instance.core.id` / `.enabled` / `.type` in the run-now path so the lifecycle code uses the narrow view.
- `src/houndarr/engine/adapters/{lidarr,radarr,readarr,sonarr,whisparr_v2,whisparr_v3}.py`: switch the URL/API-key/identity reads onto `instance.core.*`. The remaining flat reads in adapter helpers stay flat for this wave.
- `src/houndarr/templates/partials/{instance_form,instance_row}.html` and `pages/logs_content.html`: read every Instance field through the sub-struct path so the templates document the migration target.
- `src/houndarr/database.py`: drop the unused `get_db_path` accessor.
- `src/houndarr/engine/candidates.py`: drop the deprecated `_is_within_unreleased_delay` helper plus the seven test cases that exercised it. The `_is_unreleased` + `_is_within_post_release_grace` pair already covers every production call site.
- `tests/test_services/test_instance_substructs.py`: 38 new pinning tests lock the sub-struct contract (declaration order, frozen + slots, defaults, disjointness against `Instance`, exhaustive coverage). The frozen dataclass slots audit picks up the new classes automatically.
- One existing fixture-builder test (`test_upgrade_set_covers_every_monitored_series`) shifts from `dataclasses.replace(instance, upgrade_enabled=True, ...)` to `instance.upgrade = replace(instance.upgrade, ...)` because the dataclass-fields shape after the facade wrap makes the whole-instance `replace` call try to pass the sub-structs back through the flat `__init__`.

## Notes for review

The original plan paired this PR with the facade unwrap (an `Instance` that accepts only sub-struct kwargs) and the remaining caller migrations (`engine/search_loop`, route layer, repositories, services helpers). Those depend on engine helpers (`_write_item_log`, `should_log_skip`, `_persist_offset_with_typed_wrap`) that have not landed on `main` yet, so the unwrap and the search-loop migration ride a follow-up PR after those typed-error helpers settle. The facade in this PR makes both flat and sub-struct access work, which keeps every existing caller correct while the wave-by-wave migration continues.

## Testing

All gates green locally (1589 tests).

## Type of Change

- [x] Refactoring (`refactor:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
