### PR TITLE
refactor(auth): split auth.py into auth/ seam package

### DIFF
--- a/src/houndarr/auth.py
+++ b/src/houndarr/auth.py
@@ -7,7 +7,6 @@ import os
 import re
 import secrets
 import time
-from collections.abc import Callable
 from hmac import compare_digest
 from typing import Any
 
@@ -15,7 +14,7 @@ import bcrypt
 from fastapi import Request, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.types import ASGIApp
 
 from houndarr.config import get_settings
@@ -471,7 +470,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
     def __init__(self, app: ASGIApp) -> None:
         super().__init__(app)
 
-    async def dispatch(self, request: Request, call_next: Callable[..., Any]) -> Any:
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        """Route each request to the proxy-auth or built-in auth path.
+
+        Per-request dispatch keeps the middleware thin and lets each
+        branch handle its own public-path and CSRF rules.
+        """
         path = request.url.path
 
         if _is_proxy_auth_mode():
@@ -485,9 +493,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
     async def _dispatch_builtin(
         self,
         request: Request,
-        call_next: Callable[..., Any],
+        call_next: RequestResponseEndpoint,
         path: str,
-    ) -> Any:
+    ) -> Response:
         # Always allow logout so stale/broken sessions can be cleared
         if path == _LOGOUT_PATH and request.method == "POST":
             return await call_next(request)
@@ -525,9 +533,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
     async def _dispatch_proxy(
         self,
         request: Request,
-        call_next: Callable[..., Any],
+        call_next: RequestResponseEndpoint,
         path: str,
-    ) -> Any:
+    ) -> Response:
         # Health check and static assets remain public
         if path.startswith("/api/health") or path.startswith("/static"):
             return await call_next(request)
@@ -536,9 +544,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if path in _PROXY_DEAD_PATHS:
             return RedirectResponse(url="/", status_code=302)
         if path == _LOGOUT_PATH and request.method == "POST":
-            response = RedirectResponse(url="/", status_code=302)
-            response.delete_cookie(CSRF_COOKIE_NAME)
-            return response
+            logout_response = RedirectResponse(url="/", status_code=302)
+            logout_response.delete_cookie(CSRF_COOKIE_NAME)
+            return logout_response
 
         # --- IP trust gate ---
         direct_ip = request.client.host if request.client else "unknown"

--- a/src/houndarr/auth.py
+++ b/src/houndarr/auth.py
@@ -375,31 +375,46 @@ def _is_proxy_auth_mode() -> bool:
     return get_settings().auth_mode == "proxy"
 
 
-def _validate_proxy_auth(request: Request) -> str | None:
-    """Extract the authenticated username from a proxy header.
+def _is_trusted_proxy(request: Request) -> bool:
+    """Return True when the direct connection IP is in the trusted proxy set.
 
-    Security: the header is ONLY read after verifying the direct connection
-    IP is in the configured trusted proxy set.  Untrusted IPs cannot spoof
-    the header because it is never read for untrusted connections.
-
-    Returns:
-        The username string if the request is authenticated, or ``None``
-        if authentication fails (untrusted IP, missing header, etc.).
+    Security: ``trusted_proxy_set()`` returning an empty set means the
+    operator has not configured any trusted proxy, in which case every
+    request is untrusted regardless of the direct IP.  This guards
+    against header spoofing by untrusted clients: callers that read the
+    auth header must gate the read behind this check.
     """
     settings = get_settings()
-    direct_ip = request.client.host if request.client else "unknown"
     trusted = settings.trusted_proxy_set()
+    if not trusted:
+        return False
+    direct_ip = request.client.host if request.client else "unknown"
+    return direct_ip in trusted
 
-    # Gate 1: direct connection MUST originate from a trusted proxy
-    if not trusted or direct_ip not in trusted:
-        return None
 
-    # Gate 2: the auth header must be present and non-empty
+def _extract_proxy_username(request: Request) -> str | None:
+    """Return the proxy-supplied username, or ``None`` if the header is absent.
+
+    Assumes the caller has already verified the direct IP is trusted via
+    :func:`_is_trusted_proxy`; this function does not re-check.
+    """
+    settings = get_settings()
     username = request.headers.get(settings.auth_proxy_header, "").strip()
-    if not username:
-        return None
+    return username or None
 
-    return username
+
+def _validate_proxy_auth(request: Request) -> str | None:
+    """Return the authenticated proxy username, or ``None`` on any failure.
+
+    Composes :func:`_is_trusted_proxy` (direct IP must be in the trusted
+    set) and :func:`_extract_proxy_username` (header must be present and
+    non-empty).  Both primitives are the single source of truth for the
+    middleware's ``_dispatch_proxy``; this helper is the convenience form
+    for callers that only need the binary "authenticated?" answer.
+    """
+    if not _is_trusted_proxy(request):
+        return None
+    return _extract_proxy_username(request)
 
 
 async def _validate_proxy_csrf(request: Request) -> bool:
@@ -549,11 +564,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return logout_response
 
         # --- IP trust gate ---
-        direct_ip = request.client.host if request.client else "unknown"
-        settings = get_settings()
-        trusted = settings.trusted_proxy_set()
-
-        if not trusted or direct_ip not in trusted:
+        if not _is_trusted_proxy(request):
+            direct_ip = request.client.host if request.client else "unknown"
             logger.warning(
                 "Proxy auth: blocked request from untrusted IP %s to %s",
                 direct_ip,
@@ -569,11 +581,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             )
 
         # --- Auth header gate ---
-        username = request.headers.get(settings.auth_proxy_header, "").strip()
-        if not username:
+        username = _extract_proxy_username(request)
+        if username is None:
+            direct_ip = request.client.host if request.client else "unknown"
             logger.warning(
                 "Proxy auth: missing header '%s' from trusted proxy %s for %s",
-                settings.auth_proxy_header,
+                get_settings().auth_proxy_header,
                 direct_ip,
                 path,
             )

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -1,4 +1,12 @@
-"""Authentication: password hashing, session management, login middleware."""
+"""Authentication package: password hashing, session, CSRF, proxy auth, middleware.
+
+The auth surface is intentionally wide: password hashing, session
+serialization, CSRF enforcement, first-run setup, proxy-auth trust
+gate, rate limiting, and the ASGI middleware that composes them.
+Each concern is being lifted out of this ``__init__.py`` into its
+own submodule over the seven Phase 2 commits; every public name
+remains importable from ``houndarr.auth`` for consumer stability.
+"""
 
 from __future__ import annotations
 
@@ -10,15 +18,21 @@ import time
 from hmac import compare_digest
 from typing import Any
 
-import bcrypt
 from fastapi import Request, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.types import ASGIApp
 
+from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
 from houndarr.config import get_settings
 from houndarr.repositories.settings import get_setting, set_setting
+
+__all__ = [
+    "BCRYPT_COST",
+    "hash_password",
+    "verify_password",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +42,6 @@ logger = logging.getLogger(__name__)
 SESSION_COOKIE_NAME = "houndarr_session"
 CSRF_COOKIE_NAME = "houndarr_csrf"
 SESSION_MAX_AGE_SECONDS = 86400  # 24 hours
-BCRYPT_COST = 12
 USERNAME_MIN_LENGTH = 3
 USERNAME_MAX_LENGTH = 32
 _USERNAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
@@ -50,25 +63,6 @@ _PUBLIC_PATHS = frozenset(
 # allow it without CSRF/session validation so stale legacy sessions can always
 # be cleared after upgrades.
 _LOGOUT_PATH = "/logout"
-
-
-# ---------------------------------------------------------------------------
-# Password hashing
-# ---------------------------------------------------------------------------
-
-
-def hash_password(password: str) -> str:
-    """Hash a plain-text password with bcrypt cost 12."""
-    salt = bcrypt.gensalt(rounds=BCRYPT_COST)
-    return bcrypt.hashpw(password.encode(), salt).decode()
-
-
-def verify_password(password: str, hashed: str) -> bool:
-    """Return True if password matches the bcrypt hash."""
-    try:
-        return bool(bcrypt.checkpw(password.encode(), hashed.encode()))
-    except Exception:
-        return False
 
 
 # ---------------------------------------------------------------------------

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -27,6 +27,7 @@ from starlette.types import ASGIApp
 from houndarr.auth import session as _session
 from houndarr.auth import setup as _setup
 from houndarr.auth.csrf import _CSRF_PROTECTED_METHODS, validate_csrf
+from houndarr.auth.identity import resolve_signed_in_as
 from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
 
 # Proxy-auth seam: re-exported for the middleware's _dispatch_proxy
@@ -127,6 +128,7 @@ __all__ = [
     "record_failed_login",
     "reset_auth_caches",
     "reset_login_attempts",
+    "resolve_signed_in_as",
     "rotate_session_secret",
     "set_password",
     "set_username",
@@ -177,23 +179,6 @@ _PUBLIC_PATHS = frozenset(
 # allow it without CSRF/session validation so stale legacy sessions can always
 # be cleared after upgrades.
 _LOGOUT_PATH = "/logout"
-
-
-async def resolve_signed_in_as(request: Request) -> str:
-    """Return the identity label for the signed-in admin.
-
-    In proxy auth mode this is the username the upstream proxy forwarded
-    (stashed on ``request.state.proxy_auth_user`` by the middleware); in
-    builtin mode it is the configured single-admin username. Falls back to
-    ``"admin"`` when no other value is available, so templates always have
-    something meaningful to render.
-    """
-    if _is_proxy_auth_mode():
-        proxy_user = getattr(request.state, "proxy_auth_user", None)
-        if proxy_user:
-            return str(proxy_user)
-    stored = await get_username()
-    return stored or "admin"
 
 
 # ---------------------------------------------------------------------------

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -14,16 +14,21 @@ import logging
 import os
 import re
 import secrets
-import time
+
+# time is re-imported here so tests can monkeypatch ``houndarr.auth.time.time``
+# to freeze the clock across every call site (the ``time`` module is a
+# singleton, so patching via the auth namespace still affects
+# ``houndarr.auth.rate_limit``'s usage).
+import time  # noqa: F401
 from hmac import compare_digest
 from typing import Any
 
 from fastapi import Request, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
-from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.types import ASGIApp
 
+from houndarr.auth import session as _session
 from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
 
 # Rate-limit seam: re-exported for consumer stability.  Underscore-prefixed
@@ -41,31 +46,68 @@ from houndarr.auth.rate_limit import (
     record_failed_login,
     reset_login_attempts,
 )
+
+# Session seam: re-exported from the session submodule.  ``_serializer``
+# deliberately stays OUT of this import list and is resolved through the
+# module-level ``__getattr__`` below so ``houndarr.auth._serializer``
+# always reads the current value in ``houndarr.auth.session`` instead of
+# a stale None bound at package-import time.
+from houndarr.auth.session import (
+    CSRF_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
+    SESSION_MAX_AGE_SECONDS,
+    _get_serializer,
+    clear_session,
+    create_session,
+    get_session_csrf_token,
+    validate_session,
+)
 from houndarr.config import get_settings
 from houndarr.repositories.settings import get_setting, set_setting
 
 __all__ = [
     "BCRYPT_COST",
+    "CSRF_COOKIE_NAME",
+    "SESSION_COOKIE_NAME",
+    "SESSION_MAX_AGE_SECONDS",
     "_LOGIN_MAX_ATTEMPTS",
     "_LOGIN_WINDOW_SECONDS",
     "_client_ip",
+    "_get_serializer",
     "_login_attempts",
     "check_login_rate_limit",
     "clear_login_attempts",
+    "clear_session",
+    "create_session",
+    "get_session_csrf_token",
     "hash_password",
     "record_failed_login",
     "reset_login_attempts",
+    "validate_session",
     "verify_password",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve ``_serializer`` live from the session submodule.
+
+    Package-level ``from .session import _serializer`` would bind the
+    name at import time and miss every later re-assignment inside
+    ``session.py`` (``_get_serializer`` sets it; ``reset_serializer``
+    clears it).  Routing attribute access through ``__getattr__``
+    keeps ``houndarr.auth._serializer`` showing the authoritative
+    value every time a test or caller inspects it.
+    """
+    if name == "_serializer":
+        return _session._serializer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Constants
+# Constants (remaining; SESSION_* constants live in session.py)
 # ---------------------------------------------------------------------------
-SESSION_COOKIE_NAME = "houndarr_session"
-CSRF_COOKIE_NAME = "houndarr_csrf"
-SESSION_MAX_AGE_SECONDS = 86400  # 24 hours
 USERNAME_MIN_LENGTH = 3
 USERNAME_MAX_LENGTH = 32
 _USERNAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
@@ -89,106 +131,7 @@ _PUBLIC_PATHS = frozenset(
 _LOGOUT_PATH = "/logout"
 
 
-# ---------------------------------------------------------------------------
-# Session serializer (lazy-initialized from DB secret)
-# ---------------------------------------------------------------------------
-
-_serializer: URLSafeTimedSerializer | None = None
 _setup_complete: bool | None = None
-
-
-async def _get_serializer() -> URLSafeTimedSerializer:
-    global _serializer  # noqa: PLW0603
-    if _serializer is None:
-        secret = await get_setting("session_secret")
-        if not secret:
-            secret = os.urandom(32).hex()
-            await set_setting("session_secret", secret)
-        _serializer = URLSafeTimedSerializer(secret, salt="session")
-    return _serializer
-
-
-# ---------------------------------------------------------------------------
-# Session helpers
-# ---------------------------------------------------------------------------
-
-
-async def create_session(response: Response) -> str:
-    """Create a new session, set the session cookie, and return a CSRF token.
-
-    The session cookie is ``HttpOnly`` (JS cannot read it).  A separate
-    CSRF cookie (``houndarr_csrf``) is set without ``HttpOnly`` so that
-    JavaScript / HTMX can read it and include it in request headers.
-
-    Args:
-        response: The outgoing HTTP response to attach cookies to.
-
-    Returns:
-        The CSRF token string (also stored in the CSRF cookie).
-    """
-    settings = get_settings()
-    serializer = await _get_serializer()
-    csrf_token = secrets.token_hex(32)
-    payload = {"ts": int(time.time()), "csrf": csrf_token}
-    token = serializer.dumps(payload)
-
-    cookie_kwargs: dict[str, Any] = {
-        "max_age": SESSION_MAX_AGE_SECONDS,
-        "httponly": True,
-        "samesite": settings.cookie_samesite,
-        "secure": settings.secure_cookies,
-    }
-
-    response.set_cookie(key=SESSION_COOKIE_NAME, value=token, **cookie_kwargs)
-
-    # CSRF cookie: readable by JS/HTMX, NOT httponly
-    response.set_cookie(
-        key=CSRF_COOKIE_NAME,
-        value=csrf_token,
-        max_age=SESSION_MAX_AGE_SECONDS,
-        httponly=False,
-        samesite=settings.cookie_samesite,
-        secure=settings.secure_cookies,
-    )
-
-    return csrf_token
-
-
-async def validate_session(request: Request) -> bool:
-    """Return True if the request has a valid, non-expired session."""
-    token = request.cookies.get(SESSION_COOKIE_NAME)
-    if not token:
-        return False
-    try:
-        serializer = await _get_serializer()
-        serializer.loads(token, max_age=SESSION_MAX_AGE_SECONDS)
-        return True
-    except (SignatureExpired, BadSignature):
-        return False
-
-
-async def get_session_csrf_token(request: Request) -> str | None:
-    """Extract the CSRF token embedded in the signed session cookie.
-
-    Returns:
-        The CSRF token string, or ``None`` if the session is invalid/missing.
-    """
-    token = request.cookies.get(SESSION_COOKIE_NAME)
-    if not token:
-        return None
-    try:
-        serializer = await _get_serializer()
-        payload: dict[str, Any] = serializer.loads(token, max_age=SESSION_MAX_AGE_SECONDS)
-        csrf: str | None = payload.get("csrf")
-        return csrf
-    except (SignatureExpired, BadSignature):
-        return None
-
-
-def clear_session(response: Response) -> None:
-    """Delete the session and CSRF cookies."""
-    response.delete_cookie(SESSION_COOKIE_NAME)
-    response.delete_cookie(CSRF_COOKIE_NAME)
 
 
 # ---------------------------------------------------------------------------
@@ -260,6 +203,19 @@ async def set_password(password: str) -> None:
     _setup_complete = True
 
 
+async def rotate_session_secret() -> None:
+    """Regenerate the session signing secret and drop the serializer cache.
+
+    Every cookie signed with the previous secret fails signature verification
+    afterwards, so a stolen cookie cannot outlive a password change. The
+    caller is responsible for issuing the current admin a fresh
+    :func:`create_session` cookie on the outgoing response so the password
+    change does not also sign them out of the tab they made it from.
+    """
+    await set_setting("session_secret", os.urandom(32).hex())
+    _session.reset_serializer()
+
+
 def normalize_username(username: str) -> str:
     """Return a normalized username for storage and comparison."""
     return username.strip().lower()
@@ -315,6 +271,40 @@ async def check_credentials(username: str, password: str) -> bool:
         return True
 
     return compare_digest(normalized_username, normalize_username(stored_username))
+
+
+def reset_auth_caches() -> None:
+    """Clear every module-level auth cache used by the builtin flow.
+
+    Called by :func:`houndarr.services.admin.factory_reset` after the
+    database is wiped so a subsequent ``/setup`` request is not short-
+    circuited by a stale ``_setup_complete=True`` (or a serializer keyed
+    to the old session_secret) and so brute-force counters start fresh.
+    In proxy-mode installs these caches are not consulted for routing
+    decisions, but resetting them keeps the module honest if the operator
+    later switches modes.
+    """
+    global _setup_complete  # noqa: PLW0603
+    _session.reset_serializer()
+    _setup_complete = None
+    reset_login_attempts()
+
+
+async def resolve_signed_in_as(request: Request) -> str:
+    """Return the identity label for the signed-in admin.
+
+    In proxy auth mode this is the username the upstream proxy forwarded
+    (stashed on ``request.state.proxy_auth_user`` by the middleware); in
+    builtin mode it is the configured single-admin username. Falls back to
+    ``"admin"`` when no other value is available, so templates always have
+    something meaningful to render.
+    """
+    if _is_proxy_auth_mode():
+        proxy_user = getattr(request.state, "proxy_auth_user", None)
+        if proxy_user:
+            return str(proxy_user)
+    stored = await get_username()
+    return stored or "admin"
 
 
 # ---------------------------------------------------------------------------

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -28,6 +28,7 @@ from starlette.types import ASGIApp
 
 from houndarr.auth import session as _session
 from houndarr.auth import setup as _setup
+from houndarr.auth.csrf import _CSRF_PROTECTED_METHODS, validate_csrf
 from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
 
 # Rate-limit seam: re-exported for consumer stability.  Underscore-prefixed
@@ -89,6 +90,7 @@ __all__ = [
     "SESSION_MAX_AGE_SECONDS",
     "USERNAME_MAX_LENGTH",
     "USERNAME_MIN_LENGTH",
+    "_CSRF_PROTECTED_METHODS",
     "_LOGIN_MAX_ATTEMPTS",
     "_LOGIN_WINDOW_SECONDS",
     "_client_ip",
@@ -111,6 +113,7 @@ __all__ = [
     "rotate_session_secret",
     "set_password",
     "set_username",
+    "validate_csrf",
     "validate_session",
     "validate_username",
     "verify_password",
@@ -139,12 +142,9 @@ def __getattr__(name: str) -> Any:
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Constants (middleware-facing; USERNAME_* and SESSION_* constants live
-# in their owning submodules)
+# Constants (middleware-facing; USERNAME_*, SESSION_* and
+# _CSRF_PROTECTED_METHODS live in their owning submodules)
 # ---------------------------------------------------------------------------
-
-# HTTP methods that mutate state and require CSRF protection.
-_CSRF_PROTECTED_METHODS = frozenset(["POST", "PUT", "PATCH", "DELETE"])
 
 # Routes that don't require authentication
 _PUBLIC_PATHS = frozenset(
@@ -160,48 +160,6 @@ _PUBLIC_PATHS = frozenset(
 # allow it without CSRF/session validation so stale legacy sessions can always
 # be cleared after upgrades.
 _LOGOUT_PATH = "/logout"
-
-
-# ---------------------------------------------------------------------------
-# CSRF validation
-# ---------------------------------------------------------------------------
-
-
-async def validate_csrf(request: Request) -> bool:
-    """Return True if the request carries a valid CSRF token.
-
-    Accepts the token from either:
-    - ``X-CSRF-Token`` request header (HTMX sends this when configured via
-      ``hx-headers``), or
-    - ``csrf_token`` form field (plain HTML form submissions).
-
-    The token is compared against the one embedded in the signed session
-    cookie using a constant-time comparison to prevent timing attacks.
-
-    Args:
-        request: The incoming HTTP request.
-
-    Returns:
-        ``True`` if the CSRF token is present and valid; ``False`` otherwise.
-    """
-    expected = await get_session_csrf_token(request)
-    if not expected:
-        return False
-
-    # Try header first (HTMX), then form body
-    submitted = request.headers.get("X-CSRF-Token")
-    if not submitted:
-        # Form data requires us to peek at the body; HTMX always uses the header
-        try:
-            form = await request.form()
-            submitted = form.get("csrf_token")  # type: ignore[assignment]
-        except Exception:
-            return False
-
-    if not submitted:
-        return False
-
-    return compare_digest(str(submitted), expected)
 
 
 async def resolve_signed_in_as(request: Request) -> str:

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -1,37 +1,35 @@
-"""Authentication package: password hashing, session, CSRF, proxy auth, middleware.
+"""Authentication package: re-export shim for the auth seams.
 
-The auth surface is intentionally wide: password hashing, session
-serialization, CSRF enforcement, first-run setup, proxy-auth trust
-gate, rate limiting, and the ASGI middleware that composes them.
-Each concern is being lifted out of this ``__init__.py`` into its
-own submodule over the seven Phase 2 commits; every public name
-remains importable from ``houndarr.auth`` for consumer stability.
+The auth surface was deliberately split into submodules over seven
+refactor commits (password, rate_limit, session, setup, csrf,
+proxy_auth, identity, middleware).  This ``__init__.py`` is now a
+pure re-export shim so every pre-split consumer import
+(``from houndarr.auth import AuthMiddleware``, ``hash_password``,
+``reset_auth_caches``, ``CSRF_COOKIE_NAME``, and so on) keeps
+resolving to the same public names.
+
+State-bearing module globals (``_serializer``, ``_setup_complete``,
+``_USERNAME_PATTERN``) are resolved live through ``__getattr__``
+because a ``from .submodule import _name`` binding would fork from
+the authoritative value the submodule owns.
 """
 
 from __future__ import annotations
 
-import logging
-
-# time is re-imported here so tests can monkeypatch ``houndarr.auth.time.time``
-# to freeze the clock across every call site (the ``time`` module is a
-# singleton, so patching via the auth namespace still affects
-# ``houndarr.auth.rate_limit``'s usage).
+# time is re-exported so tests that monkeypatch
+# ``houndarr.auth.time.time`` continue to propagate the patch through
+# to ``houndarr.auth.rate_limit``'s usage (the ``time`` module is a
+# singleton, so patching via the auth namespace affects every
+# importer).
 import time  # noqa: F401
 from typing import Any
-
-from fastapi import Request, Response
-from fastapi.responses import HTMLResponse, RedirectResponse
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from starlette.types import ASGIApp
 
 from houndarr.auth import session as _session
 from houndarr.auth import setup as _setup
 from houndarr.auth.csrf import _CSRF_PROTECTED_METHODS, validate_csrf
 from houndarr.auth.identity import resolve_signed_in_as
+from houndarr.auth.middleware import _LOGOUT_PATH, _PUBLIC_PATHS, AuthMiddleware
 from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
-
-# Proxy-auth seam: re-exported for the middleware's _dispatch_proxy
-# path and for tests that monkeypatch the trust-gate composition.
 from houndarr.auth.proxy_auth import (
     _PROXY_DEAD_PATHS,
     _ensure_proxy_csrf_cookie,
@@ -41,12 +39,6 @@ from houndarr.auth.proxy_auth import (
     _validate_proxy_auth,
     _validate_proxy_csrf,
 )
-
-# Rate-limit seam: re-exported for consumer stability.  Underscore-prefixed
-# names are module-private by convention but are consumed by tests
-# (``houndarr.auth._login_attempts``) and by routes that display client
-# IPs (``_client_ip``).  Keeping them in ``__all__`` keeps mypy's
-# explicit-export check green without updating every caller.
 from houndarr.auth.rate_limit import (
     _LOGIN_MAX_ATTEMPTS,
     _LOGIN_WINDOW_SECONDS,
@@ -57,12 +49,6 @@ from houndarr.auth.rate_limit import (
     record_failed_login,
     reset_login_attempts,
 )
-
-# Session seam: re-exported from the session submodule.  ``_serializer``
-# deliberately stays OUT of this import list and is resolved through the
-# module-level ``__getattr__`` below so ``houndarr.auth._serializer``
-# always reads the current value in ``houndarr.auth.session`` instead of
-# a stale None bound at package-import time.
 from houndarr.auth.session import (
     CSRF_COOKIE_NAME,
     SESSION_COOKIE_NAME,
@@ -73,11 +59,6 @@ from houndarr.auth.session import (
     get_session_csrf_token,
     validate_session,
 )
-
-# Setup seam: re-exported from the setup submodule.  ``_setup_complete``
-# and ``_USERNAME_PATTERN`` pass through ``__getattr__`` alongside
-# ``_serializer`` so tests that inspect the module's state always read
-# the authoritative value.
 from houndarr.auth.setup import (
     USERNAME_MAX_LENGTH,
     USERNAME_MIN_LENGTH,
@@ -92,7 +73,6 @@ from houndarr.auth.setup import (
     set_username,
     validate_username,
 )
-from houndarr.config import get_settings
 
 __all__ = [
     "BCRYPT_COST",
@@ -101,10 +81,13 @@ __all__ = [
     "SESSION_MAX_AGE_SECONDS",
     "USERNAME_MAX_LENGTH",
     "USERNAME_MIN_LENGTH",
+    "AuthMiddleware",
     "_CSRF_PROTECTED_METHODS",
     "_LOGIN_MAX_ATTEMPTS",
     "_LOGIN_WINDOW_SECONDS",
+    "_LOGOUT_PATH",
     "_PROXY_DEAD_PATHS",
+    "_PUBLIC_PATHS",
     "_client_ip",
     "_ensure_proxy_csrf_cookie",
     "_extract_proxy_username",
@@ -156,192 +139,3 @@ def __getattr__(name: str) -> Any:
     if name == "_USERNAME_PATTERN":
         return _setup._USERNAME_PATTERN
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Constants (middleware-facing; USERNAME_*, SESSION_* and
-# _CSRF_PROTECTED_METHODS live in their owning submodules)
-# ---------------------------------------------------------------------------
-
-# Routes that don't require authentication
-_PUBLIC_PATHS = frozenset(
-    [
-        "/setup",
-        "/login",
-        "/api/health",
-        "/static",
-    ]
-)
-
-# Logout is a safe, destructive-free action (session invalidation only). We
-# allow it without CSRF/session validation so stale legacy sessions can always
-# be cleared after upgrades.
-_LOGOUT_PATH = "/logout"
-
-
-# ---------------------------------------------------------------------------
-# Auth + CSRF middleware
-# ---------------------------------------------------------------------------
-
-
-class AuthMiddleware(BaseHTTPMiddleware):
-    """Enforce authentication and CSRF protection on all non-public routes.
-
-    Supports two mutually exclusive authentication modes:
-
-    **Builtin mode** (default):
-        Session-based authentication.  Redirects unauthenticated requests to
-        ``/login`` (or ``/setup`` if first-run setup has not been completed).
-
-    **Proxy mode** (``HOUNDARR_AUTH_MODE=proxy``):
-        Delegates authentication to a reverse proxy.  Requests are
-        authenticated by a trusted header from a trusted proxy IP.  Requests
-        from untrusted IPs receive ``403``; requests from trusted proxies
-        without the auth header receive ``401``.
-
-    CSRF protection is enforced in both modes.  State-changing requests
-    (POST, PUT, PATCH, DELETE) must carry a valid CSRF token in either the
-    ``X-CSRF-Token`` header or the ``csrf_token`` form field.
-    """
-
-    def __init__(self, app: ASGIApp) -> None:
-        super().__init__(app)
-
-    async def dispatch(
-        self,
-        request: Request,
-        call_next: RequestResponseEndpoint,
-    ) -> Response:
-        """Route each request to the proxy-auth or built-in auth path.
-
-        Per-request dispatch keeps the middleware thin and lets each
-        branch handle its own public-path and CSRF rules.
-        """
-        path = request.url.path
-
-        if _is_proxy_auth_mode():
-            return await self._dispatch_proxy(request, call_next, path)
-        return await self._dispatch_builtin(request, call_next, path)
-
-    # ------------------------------------------------------------------
-    # Builtin auth path (existing behaviour, unchanged)
-    # ------------------------------------------------------------------
-
-    async def _dispatch_builtin(
-        self,
-        request: Request,
-        call_next: RequestResponseEndpoint,
-        path: str,
-    ) -> Response:
-        # Always allow logout so stale/broken sessions can be cleared
-        if path == _LOGOUT_PATH and request.method == "POST":
-            return await call_next(request)
-
-        # Always allow public paths and static files
-        if any(path.startswith(p) for p in _PUBLIC_PATHS):
-            return await call_next(request)
-
-        setup_done = await is_setup_complete()
-        if not setup_done:
-            return RedirectResponse(url="/setup", status_code=302)
-
-        if not await validate_session(request):
-            return RedirectResponse(url="/login", status_code=302)
-
-        # CSRF check on state-changing methods
-        if request.method in _CSRF_PROTECTED_METHODS and not await validate_csrf(request):
-            logger.warning(
-                "CSRF validation failed for %s %s from %s",
-                request.method,
-                path,
-                _client_ip(request),
-            )
-            return HTMLResponse(
-                content="<h1>403 Forbidden</h1><p>CSRF token invalid or missing.</p>",
-                status_code=403,
-            )
-
-        return await call_next(request)
-
-    # ------------------------------------------------------------------
-    # Proxy auth path
-    # ------------------------------------------------------------------
-
-    async def _dispatch_proxy(
-        self,
-        request: Request,
-        call_next: RequestResponseEndpoint,
-        path: str,
-    ) -> Response:
-        # Health check and static assets remain public
-        if path.startswith("/api/health") or path.startswith("/static"):
-            return await call_next(request)
-
-        # Setup, login, and logout serve no purpose in proxy mode
-        if path in _PROXY_DEAD_PATHS:
-            return RedirectResponse(url="/", status_code=302)
-        if path == _LOGOUT_PATH and request.method == "POST":
-            logout_response = RedirectResponse(url="/", status_code=302)
-            logout_response.delete_cookie(CSRF_COOKIE_NAME)
-            return logout_response
-
-        # --- IP trust gate ---
-        if not _is_trusted_proxy(request):
-            direct_ip = request.client.host if request.client else "unknown"
-            logger.warning(
-                "Proxy auth: blocked request from untrusted IP %s to %s",
-                direct_ip,
-                path,
-            )
-            return HTMLResponse(
-                content=(
-                    "<h1>403 Forbidden</h1>"
-                    "<p>This Houndarr instance requires access through "
-                    "an authenticating reverse proxy.</p>"
-                ),
-                status_code=403,
-            )
-
-        # --- Auth header gate ---
-        username = _extract_proxy_username(request)
-        if username is None:
-            direct_ip = request.client.host if request.client else "unknown"
-            logger.warning(
-                "Proxy auth: missing header '%s' from trusted proxy %s for %s",
-                get_settings().auth_proxy_header,
-                direct_ip,
-                path,
-            )
-            return HTMLResponse(
-                content=(
-                    "<h1>401 Unauthorized</h1>"
-                    "<p>Authentication header missing. "
-                    "Check your reverse proxy configuration.</p>"
-                ),
-                status_code=401,
-            )
-
-        # Authenticated: store username on request state for downstream use
-        request.state.proxy_auth_user = username
-
-        # CSRF check on state-changing methods
-        if request.method in _CSRF_PROTECTED_METHODS and not await _validate_proxy_csrf(request):
-            logger.warning(
-                "CSRF validation failed (proxy mode) for %s %s from user %s",
-                request.method,
-                path,
-                username,
-            )
-            return HTMLResponse(
-                content="<h1>403 Forbidden</h1><p>CSRF token invalid or missing.</p>",
-                status_code=403,
-            )
-
-        response = await call_next(request)
-
-        # Ensure the CSRF cookie exists on every authenticated response
-        _ensure_proxy_csrf_cookie(request, response)
-
-        return response

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -11,8 +11,6 @@ remains importable from ``houndarr.auth`` for consumer stability.
 from __future__ import annotations
 
 import logging
-import os
-import re
 import secrets
 
 # time is re-imported here so tests can monkeypatch ``houndarr.auth.time.time``
@@ -29,6 +27,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.types import ASGIApp
 
 from houndarr.auth import session as _session
+from houndarr.auth import setup as _setup
 from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
 
 # Rate-limit seam: re-exported for consumer stability.  Underscore-prefixed
@@ -62,55 +61,87 @@ from houndarr.auth.session import (
     get_session_csrf_token,
     validate_session,
 )
+
+# Setup seam: re-exported from the setup submodule.  ``_setup_complete``
+# and ``_USERNAME_PATTERN`` pass through ``__getattr__`` alongside
+# ``_serializer`` so tests that inspect the module's state always read
+# the authoritative value.
+from houndarr.auth.setup import (
+    USERNAME_MAX_LENGTH,
+    USERNAME_MIN_LENGTH,
+    check_credentials,
+    check_password,
+    get_username,
+    is_setup_complete,
+    normalize_username,
+    reset_auth_caches,
+    rotate_session_secret,
+    set_password,
+    set_username,
+    validate_username,
+)
 from houndarr.config import get_settings
-from houndarr.repositories.settings import get_setting, set_setting
 
 __all__ = [
     "BCRYPT_COST",
     "CSRF_COOKIE_NAME",
     "SESSION_COOKIE_NAME",
     "SESSION_MAX_AGE_SECONDS",
+    "USERNAME_MAX_LENGTH",
+    "USERNAME_MIN_LENGTH",
     "_LOGIN_MAX_ATTEMPTS",
     "_LOGIN_WINDOW_SECONDS",
     "_client_ip",
     "_get_serializer",
     "_login_attempts",
+    "check_credentials",
     "check_login_rate_limit",
+    "check_password",
     "clear_login_attempts",
     "clear_session",
     "create_session",
     "get_session_csrf_token",
+    "get_username",
     "hash_password",
+    "is_setup_complete",
+    "normalize_username",
     "record_failed_login",
+    "reset_auth_caches",
     "reset_login_attempts",
+    "rotate_session_secret",
+    "set_password",
+    "set_username",
     "validate_session",
+    "validate_username",
     "verify_password",
 ]
 
 
 def __getattr__(name: str) -> Any:
-    """Resolve ``_serializer`` live from the session submodule.
+    """Resolve state-bearing globals live from their owning submodule.
 
-    Package-level ``from .session import _serializer`` would bind the
-    name at import time and miss every later re-assignment inside
-    ``session.py`` (``_get_serializer`` sets it; ``reset_serializer``
-    clears it).  Routing attribute access through ``__getattr__``
-    keeps ``houndarr.auth._serializer`` showing the authoritative
-    value every time a test or caller inspects it.
+    Package-level ``from X import Y`` binds Y at import time and misses
+    later re-assignments inside the owning submodule.  For the globals
+    tests and external callers inspect (``_serializer``,
+    ``_setup_complete``, ``_USERNAME_PATTERN``), routing attribute
+    access through ``__getattr__`` keeps ``houndarr.auth.<name>``
+    showing the authoritative value every time.
     """
     if name == "_serializer":
         return _session._serializer
+    if name == "_setup_complete":
+        return _setup._setup_complete
+    if name == "_USERNAME_PATTERN":
+        return _setup._USERNAME_PATTERN
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Constants (remaining; SESSION_* constants live in session.py)
+# Constants (middleware-facing; USERNAME_* and SESSION_* constants live
+# in their owning submodules)
 # ---------------------------------------------------------------------------
-USERNAME_MIN_LENGTH = 3
-USERNAME_MAX_LENGTH = 32
-_USERNAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
 
 # HTTP methods that mutate state and require CSRF protection.
 _CSRF_PROTECTED_METHODS = frozenset(["POST", "PUT", "PATCH", "DELETE"])
@@ -129,9 +160,6 @@ _PUBLIC_PATHS = frozenset(
 # allow it without CSRF/session validation so stale legacy sessions can always
 # be cleared after upgrades.
 _LOGOUT_PATH = "/logout"
-
-
-_setup_complete: bool | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -174,120 +202,6 @@ async def validate_csrf(request: Request) -> bool:
         return False
 
     return compare_digest(str(submitted), expected)
-
-
-# ---------------------------------------------------------------------------
-# Setup state helpers
-# ---------------------------------------------------------------------------
-
-
-async def is_setup_complete() -> bool:
-    """Return True if the initial password has been set.
-
-    The result is cached once True because the password_hash setting is
-    monotonic: it transitions from absent to present and is never deleted.
-    """
-    global _setup_complete  # noqa: PLW0603
-    if _setup_complete is True:
-        return True
-    result = (await get_setting("password_hash")) is not None
-    if result:
-        _setup_complete = True
-    return result
-
-
-async def set_password(password: str) -> None:
-    """Hash and persist the application password."""
-    global _setup_complete  # noqa: PLW0603
-    await set_setting("password_hash", hash_password(password))
-    _setup_complete = True
-
-
-async def rotate_session_secret() -> None:
-    """Regenerate the session signing secret and drop the serializer cache.
-
-    Every cookie signed with the previous secret fails signature verification
-    afterwards, so a stolen cookie cannot outlive a password change. The
-    caller is responsible for issuing the current admin a fresh
-    :func:`create_session` cookie on the outgoing response so the password
-    change does not also sign them out of the tab they made it from.
-    """
-    await set_setting("session_secret", os.urandom(32).hex())
-    _session.reset_serializer()
-
-
-def normalize_username(username: str) -> str:
-    """Return a normalized username for storage and comparison."""
-    return username.strip().lower()
-
-
-def validate_username(username: str) -> str | None:
-    """Return an error message if username is invalid, else None."""
-    normalized = normalize_username(username)
-    if not normalized:
-        return "Username is required."
-    if len(normalized) < USERNAME_MIN_LENGTH or len(normalized) > USERNAME_MAX_LENGTH:
-        return "Username must be 3-32 characters."
-    if _USERNAME_PATTERN.fullmatch(normalized) is None:
-        return "Username may only contain lowercase letters, numbers, dots, dashes, or underscores."
-    return None
-
-
-async def set_username(username: str) -> None:
-    """Persist the normalized single-admin username."""
-    await set_setting("username", normalize_username(username))
-
-
-async def get_username() -> str | None:
-    """Return the configured single-admin username."""
-    return await get_setting("username")
-
-
-async def check_password(password: str) -> bool:
-    """Return True if password matches the stored hash."""
-    stored = await get_setting("password_hash")
-    if not stored:
-        return False
-    return verify_password(password, stored)
-
-
-async def check_credentials(username: str, password: str) -> bool:
-    """Return True if the provided username and password are valid.
-
-    If a legacy install has a password hash but no username yet, the first
-    successful password login claims the submitted username.
-    """
-    normalized_username = normalize_username(username)
-    username_error = validate_username(normalized_username)
-    if username_error is not None:
-        return False
-
-    if not await check_password(password):
-        return False
-
-    stored_username = await get_username()
-    if stored_username is None:
-        await set_username(normalized_username)
-        return True
-
-    return compare_digest(normalized_username, normalize_username(stored_username))
-
-
-def reset_auth_caches() -> None:
-    """Clear every module-level auth cache used by the builtin flow.
-
-    Called by :func:`houndarr.services.admin.factory_reset` after the
-    database is wiped so a subsequent ``/setup`` request is not short-
-    circuited by a stale ``_setup_complete=True`` (or a serializer keyed
-    to the old session_secret) and so brute-force counters start fresh.
-    In proxy-mode installs these caches are not consulted for routing
-    decisions, but resetting them keeps the module honest if the operator
-    later switches modes.
-    """
-    global _setup_complete  # noqa: PLW0603
-    _session.reset_serializer()
-    _setup_complete = None
-    reset_login_attempts()
 
 
 async def resolve_signed_in_as(request: Request) -> str:

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -25,12 +25,36 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.types import ASGIApp
 
 from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
+
+# Rate-limit seam: re-exported for consumer stability.  Underscore-prefixed
+# names are module-private by convention but are consumed by tests
+# (``houndarr.auth._login_attempts``) and by routes that display client
+# IPs (``_client_ip``).  Keeping them in ``__all__`` keeps mypy's
+# explicit-export check green without updating every caller.
+from houndarr.auth.rate_limit import (
+    _LOGIN_MAX_ATTEMPTS,
+    _LOGIN_WINDOW_SECONDS,
+    _client_ip,
+    _login_attempts,
+    check_login_rate_limit,
+    clear_login_attempts,
+    record_failed_login,
+    reset_login_attempts,
+)
 from houndarr.config import get_settings
 from houndarr.repositories.settings import get_setting, set_setting
 
 __all__ = [
     "BCRYPT_COST",
+    "_LOGIN_MAX_ATTEMPTS",
+    "_LOGIN_WINDOW_SECONDS",
+    "_client_ip",
+    "_login_attempts",
+    "check_login_rate_limit",
+    "clear_login_attempts",
     "hash_password",
+    "record_failed_login",
+    "reset_login_attempts",
     "verify_password",
 ]
 
@@ -291,69 +315,6 @@ async def check_credentials(username: str, password: str) -> bool:
         return True
 
     return compare_digest(normalized_username, normalize_username(stored_username))
-
-
-# ---------------------------------------------------------------------------
-# Brute-force rate limiter (in-memory, resets on restart)
-# ---------------------------------------------------------------------------
-
-_login_attempts: dict[str, list[float]] = {}
-_LOGIN_MAX_ATTEMPTS = 5
-_LOGIN_WINDOW_SECONDS = 60
-
-
-def _client_ip(request: Request) -> str:
-    """Return the real client IP, honouring ``X-Forwarded-For`` only from
-    configured trusted proxies.
-
-    When ``HOUNDARR_TRUSTED_PROXIES`` is set (a comma-separated list of
-    proxy IPs or CIDR subnets), and the direct connection IP matches one
-    of those proxies or falls within a trusted subnet, the left-most IP
-    in ``X-Forwarded-For`` is used as the client IP.
-
-    When no trusted proxies are configured (the default), only
-    ``request.client.host`` is used, preventing header spoofing.
-
-    Args:
-        request: The incoming HTTP request.
-
-    Returns:
-        The best-effort client IP string, or ``"unknown"`` as a fallback.
-    """
-    direct_ip = request.client.host if request.client else "unknown"
-    settings = get_settings()
-    trusted = settings.trusted_proxy_set()
-    if trusted and direct_ip in trusted:
-        forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-    return direct_ip
-
-
-def check_login_rate_limit(request: Request) -> bool:
-    """Return True if the client is allowed to attempt login."""
-    ip = _client_ip(request)
-    now = time.time()
-    attempts = _login_attempts.get(ip, [])
-    # Remove attempts outside the window
-    attempts = [t for t in attempts if now - t < _LOGIN_WINDOW_SECONDS]
-    _login_attempts[ip] = attempts
-    return len(attempts) < _LOGIN_MAX_ATTEMPTS
-
-
-def record_failed_login(request: Request) -> None:
-    """Record a failed login attempt for rate limiting."""
-    ip = _client_ip(request)
-    now = time.time()
-    attempts = _login_attempts.get(ip, [])
-    attempts.append(now)
-    _login_attempts[ip] = attempts
-
-
-def clear_login_attempts(request: Request) -> None:
-    """Clear login attempts on successful login."""
-    ip = _client_ip(request)
-    _login_attempts.pop(ip, None)
 
 
 # ---------------------------------------------------------------------------

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -11,14 +11,12 @@ remains importable from ``houndarr.auth`` for consumer stability.
 from __future__ import annotations
 
 import logging
-import secrets
 
 # time is re-imported here so tests can monkeypatch ``houndarr.auth.time.time``
 # to freeze the clock across every call site (the ``time`` module is a
 # singleton, so patching via the auth namespace still affects
 # ``houndarr.auth.rate_limit``'s usage).
 import time  # noqa: F401
-from hmac import compare_digest
 from typing import Any
 
 from fastapi import Request, Response
@@ -30,6 +28,18 @@ from houndarr.auth import session as _session
 from houndarr.auth import setup as _setup
 from houndarr.auth.csrf import _CSRF_PROTECTED_METHODS, validate_csrf
 from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
+
+# Proxy-auth seam: re-exported for the middleware's _dispatch_proxy
+# path and for tests that monkeypatch the trust-gate composition.
+from houndarr.auth.proxy_auth import (
+    _PROXY_DEAD_PATHS,
+    _ensure_proxy_csrf_cookie,
+    _extract_proxy_username,
+    _is_proxy_auth_mode,
+    _is_trusted_proxy,
+    _validate_proxy_auth,
+    _validate_proxy_csrf,
+)
 
 # Rate-limit seam: re-exported for consumer stability.  Underscore-prefixed
 # names are module-private by convention but are consumed by tests
@@ -93,9 +103,16 @@ __all__ = [
     "_CSRF_PROTECTED_METHODS",
     "_LOGIN_MAX_ATTEMPTS",
     "_LOGIN_WINDOW_SECONDS",
+    "_PROXY_DEAD_PATHS",
     "_client_ip",
+    "_ensure_proxy_csrf_cookie",
+    "_extract_proxy_username",
     "_get_serializer",
+    "_is_proxy_auth_mode",
+    "_is_trusted_proxy",
     "_login_attempts",
+    "_validate_proxy_auth",
+    "_validate_proxy_csrf",
     "check_credentials",
     "check_login_rate_limit",
     "check_password",
@@ -177,101 +194,6 @@ async def resolve_signed_in_as(request: Request) -> str:
             return str(proxy_user)
     stored = await get_username()
     return stored or "admin"
-
-
-# ---------------------------------------------------------------------------
-# Proxy authentication helpers
-# ---------------------------------------------------------------------------
-
-# Paths that serve no purpose in proxy mode and redirect to the dashboard.
-_PROXY_DEAD_PATHS = frozenset(["/setup", "/login"])
-
-
-def _is_proxy_auth_mode() -> bool:
-    """Return True if proxy-header authentication is active."""
-    return get_settings().auth_mode == "proxy"
-
-
-def _is_trusted_proxy(request: Request) -> bool:
-    """Return True when the direct connection IP is in the trusted proxy set.
-
-    Security: ``trusted_proxy_set()`` returning an empty set means the
-    operator has not configured any trusted proxy, in which case every
-    request is untrusted regardless of the direct IP.  This guards
-    against header spoofing by untrusted clients: callers that read the
-    auth header must gate the read behind this check.
-    """
-    settings = get_settings()
-    trusted = settings.trusted_proxy_set()
-    if not trusted:
-        return False
-    direct_ip = request.client.host if request.client else "unknown"
-    return direct_ip in trusted
-
-
-def _extract_proxy_username(request: Request) -> str | None:
-    """Return the proxy-supplied username, or ``None`` if the header is absent.
-
-    Assumes the caller has already verified the direct IP is trusted via
-    :func:`_is_trusted_proxy`; this function does not re-check.
-    """
-    settings = get_settings()
-    username = request.headers.get(settings.auth_proxy_header, "").strip()
-    return username or None
-
-
-def _validate_proxy_auth(request: Request) -> str | None:
-    """Return the authenticated proxy username, or ``None`` on any failure.
-
-    Composes :func:`_is_trusted_proxy` (direct IP must be in the trusted
-    set) and :func:`_extract_proxy_username` (header must be present and
-    non-empty).  Both primitives are the single source of truth for the
-    middleware's ``_dispatch_proxy``; this helper is the convenience form
-    for callers that only need the binary "authenticated?" answer.
-    """
-    if not _is_trusted_proxy(request):
-        return None
-    return _extract_proxy_username(request)
-
-
-async def _validate_proxy_csrf(request: Request) -> bool:
-    """Validate CSRF for proxy auth mode using double-submit cookie pattern.
-
-    The CSRF cookie value must match the value submitted in the
-    ``X-CSRF-Token`` header or ``csrf_token`` form field.
-    """
-    cookie_token = request.cookies.get(CSRF_COOKIE_NAME)
-    if not cookie_token:
-        return False
-
-    # Try header first (HTMX), then form body
-    submitted = request.headers.get("X-CSRF-Token")
-    if not submitted:
-        try:
-            form = await request.form()
-            submitted = form.get("csrf_token")  # type: ignore[assignment]
-        except Exception:
-            return False
-
-    if not submitted:
-        return False
-
-    return compare_digest(str(submitted), cookie_token)
-
-
-def _ensure_proxy_csrf_cookie(request: Request, response: Response) -> None:
-    """Set the CSRF cookie on an authenticated proxy-mode response if absent."""
-    if request.cookies.get(CSRF_COOKIE_NAME):
-        return
-    settings = get_settings()
-    response.set_cookie(
-        key=CSRF_COOKIE_NAME,
-        value=secrets.token_hex(32),
-        max_age=SESSION_MAX_AGE_SECONDS,
-        httponly=False,
-        samesite=settings.cookie_samesite,
-        secure=settings.secure_cookies,
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/houndarr/auth/csrf.py
+++ b/src/houndarr/auth/csrf.py
@@ -1,0 +1,58 @@
+"""CSRF validation for the built-in-auth middleware path.
+
+Double-submit style: the session cookie carries a signed CSRF token
+(see :mod:`houndarr.auth.session`); HTMX (or a plain form submission)
+must echo the same token back via ``X-CSRF-Token`` or the
+``csrf_token`` form field.  This module owns the comparison.
+
+Proxy-auth mode uses a different shape (cookie + header double-submit,
+no session cookie) and lives in :mod:`houndarr.auth.proxy_auth`.
+"""
+
+from __future__ import annotations
+
+from hmac import compare_digest
+
+from fastapi import Request
+
+from houndarr.auth.session import get_session_csrf_token
+
+# HTTP methods that mutate state and require CSRF protection.
+_CSRF_PROTECTED_METHODS = frozenset(["POST", "PUT", "PATCH", "DELETE"])
+
+
+async def validate_csrf(request: Request) -> bool:
+    """Return True if the request carries a valid CSRF token.
+
+    Accepts the token from either:
+    - ``X-CSRF-Token`` request header (HTMX sends this when configured via
+      ``hx-headers``), or
+    - ``csrf_token`` form field (plain HTML form submissions).
+
+    The token is compared against the one embedded in the signed session
+    cookie using a constant-time comparison to prevent timing attacks.
+
+    Args:
+        request: The incoming HTTP request.
+
+    Returns:
+        ``True`` if the CSRF token is present and valid; ``False`` otherwise.
+    """
+    expected = await get_session_csrf_token(request)
+    if not expected:
+        return False
+
+    # Try header first (HTMX), then form body
+    submitted = request.headers.get("X-CSRF-Token")
+    if not submitted:
+        # Form data requires us to peek at the body; HTMX always uses the header
+        try:
+            form = await request.form()
+            submitted = form.get("csrf_token")  # type: ignore[assignment]
+        except Exception:
+            return False
+
+    if not submitted:
+        return False
+
+    return compare_digest(str(submitted), expected)

--- a/src/houndarr/auth/identity.py
+++ b/src/houndarr/auth/identity.py
@@ -1,0 +1,31 @@
+"""Identity resolution for the signed-in admin.
+
+Composes the proxy-auth and setup seams: when proxy mode is active
+the forwarded header wins, otherwise the builtin single-admin
+username (stored in ``settings.username``) is used.  The
+"Signed in as" chip on the Settings page is the only consumer.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from houndarr.auth.proxy_auth import _is_proxy_auth_mode
+from houndarr.auth.setup import get_username
+
+
+async def resolve_signed_in_as(request: Request) -> str:
+    """Return the identity label for the signed-in admin.
+
+    In proxy auth mode this is the username the upstream proxy forwarded
+    (stashed on ``request.state.proxy_auth_user`` by the middleware); in
+    builtin mode it is the configured single-admin username. Falls back to
+    ``"admin"`` when no other value is available, so templates always have
+    something meaningful to render.
+    """
+    if _is_proxy_auth_mode():
+        proxy_user = getattr(request.state, "proxy_auth_user", None)
+        if proxy_user:
+            return str(proxy_user)
+    stored = await get_username()
+    return stored or "admin"

--- a/src/houndarr/auth/middleware.py
+++ b/src/houndarr/auth/middleware.py
@@ -1,0 +1,210 @@
+"""ASGI middleware that composes every auth seam.
+
+Two dispatch branches share the same middleware: ``_dispatch_builtin``
+for session-cookie mode (the default) and ``_dispatch_proxy`` for
+reverse-proxy / SSO mode.  Each branch reads its public-path list and
+then delegates trust, identity, and CSRF decisions to the appropriate
+seam submodule.
+
+Helpers are called through their owning modules (for example
+``proxy_auth._is_trusted_proxy(request)`` instead of a direct
+``from .proxy_auth import _is_trusted_proxy`` binding) so tests that
+monkeypatch the module attribute propagate the patch into the
+middleware without also having to update the import site.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Request, Response
+from fastapi.responses import HTMLResponse, RedirectResponse
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.types import ASGIApp
+
+from houndarr.auth import proxy_auth as _proxy_auth
+from houndarr.auth import rate_limit as _rate_limit
+from houndarr.auth.csrf import _CSRF_PROTECTED_METHODS, validate_csrf
+from houndarr.auth.session import CSRF_COOKIE_NAME, validate_session
+from houndarr.auth.setup import is_setup_complete
+from houndarr.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# Routes that don't require authentication
+_PUBLIC_PATHS = frozenset(
+    [
+        "/setup",
+        "/login",
+        "/api/health",
+        "/static",
+    ]
+)
+
+# Logout is a safe, destructive-free action (session invalidation only).
+# We allow it without CSRF/session validation so stale legacy sessions
+# can always be cleared after upgrades.
+_LOGOUT_PATH = "/logout"
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Enforce authentication and CSRF protection on all non-public routes.
+
+    Supports two mutually exclusive authentication modes:
+
+    **Builtin mode** (default):
+        Session-based authentication.  Redirects unauthenticated requests to
+        ``/login`` (or ``/setup`` if first-run setup has not been completed).
+
+    **Proxy mode** (``HOUNDARR_AUTH_MODE=proxy``):
+        Delegates authentication to a reverse proxy.  Requests are
+        authenticated by a trusted header from a trusted proxy IP.  Requests
+        from untrusted IPs receive ``403``; requests from trusted proxies
+        without the auth header receive ``401``.
+
+    CSRF protection is enforced in both modes.  State-changing requests
+    (POST, PUT, PATCH, DELETE) must carry a valid CSRF token in either the
+    ``X-CSRF-Token`` header or the ``csrf_token`` form field.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        """Route each request to the proxy-auth or built-in auth path.
+
+        Per-request dispatch keeps the middleware thin and lets each
+        branch handle its own public-path and CSRF rules.
+        """
+        path = request.url.path
+
+        if _proxy_auth._is_proxy_auth_mode():
+            return await self._dispatch_proxy(request, call_next, path)
+        return await self._dispatch_builtin(request, call_next, path)
+
+    # ------------------------------------------------------------------
+    # Builtin auth path (existing behaviour, unchanged)
+    # ------------------------------------------------------------------
+
+    async def _dispatch_builtin(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+        path: str,
+    ) -> Response:
+        # Always allow logout so stale/broken sessions can be cleared
+        if path == _LOGOUT_PATH and request.method == "POST":
+            return await call_next(request)
+
+        # Always allow public paths and static files
+        if any(path.startswith(p) for p in _PUBLIC_PATHS):
+            return await call_next(request)
+
+        setup_done = await is_setup_complete()
+        if not setup_done:
+            return RedirectResponse(url="/setup", status_code=302)
+
+        if not await validate_session(request):
+            return RedirectResponse(url="/login", status_code=302)
+
+        # CSRF check on state-changing methods
+        if request.method in _CSRF_PROTECTED_METHODS and not await validate_csrf(request):
+            logger.warning(
+                "CSRF validation failed for %s %s from %s",
+                request.method,
+                path,
+                _rate_limit._client_ip(request),
+            )
+            return HTMLResponse(
+                content="<h1>403 Forbidden</h1><p>CSRF token invalid or missing.</p>",
+                status_code=403,
+            )
+
+        return await call_next(request)
+
+    # ------------------------------------------------------------------
+    # Proxy auth path
+    # ------------------------------------------------------------------
+
+    async def _dispatch_proxy(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+        path: str,
+    ) -> Response:
+        # Health check and static assets remain public
+        if path.startswith("/api/health") or path.startswith("/static"):
+            return await call_next(request)
+
+        # Setup, login, and logout serve no purpose in proxy mode
+        if path in _proxy_auth._PROXY_DEAD_PATHS:
+            return RedirectResponse(url="/", status_code=302)
+        if path == _LOGOUT_PATH and request.method == "POST":
+            logout_response = RedirectResponse(url="/", status_code=302)
+            logout_response.delete_cookie(CSRF_COOKIE_NAME)
+            return logout_response
+
+        # --- IP trust gate ---
+        if not _proxy_auth._is_trusted_proxy(request):
+            direct_ip = request.client.host if request.client else "unknown"
+            logger.warning(
+                "Proxy auth: blocked request from untrusted IP %s to %s",
+                direct_ip,
+                path,
+            )
+            return HTMLResponse(
+                content=(
+                    "<h1>403 Forbidden</h1>"
+                    "<p>This Houndarr instance requires access through "
+                    "an authenticating reverse proxy.</p>"
+                ),
+                status_code=403,
+            )
+
+        # --- Auth header gate ---
+        username = _proxy_auth._extract_proxy_username(request)
+        if username is None:
+            direct_ip = request.client.host if request.client else "unknown"
+            logger.warning(
+                "Proxy auth: missing header '%s' from trusted proxy %s for %s",
+                get_settings().auth_proxy_header,
+                direct_ip,
+                path,
+            )
+            return HTMLResponse(
+                content=(
+                    "<h1>401 Unauthorized</h1>"
+                    "<p>Authentication header missing. "
+                    "Check your reverse proxy configuration.</p>"
+                ),
+                status_code=401,
+            )
+
+        # Authenticated: store username on request state for downstream use
+        request.state.proxy_auth_user = username
+
+        # CSRF check on state-changing methods
+        if request.method in _CSRF_PROTECTED_METHODS and not await _proxy_auth._validate_proxy_csrf(
+            request
+        ):
+            logger.warning(
+                "CSRF validation failed (proxy mode) for %s %s from user %s",
+                request.method,
+                path,
+                username,
+            )
+            return HTMLResponse(
+                content="<h1>403 Forbidden</h1><p>CSRF token invalid or missing.</p>",
+                status_code=403,
+            )
+
+        response = await call_next(request)
+
+        # Ensure the CSRF cookie exists on every authenticated response
+        _proxy_auth._ensure_proxy_csrf_cookie(request, response)
+
+        return response

--- a/src/houndarr/auth/password.py
+++ b/src/houndarr/auth/password.py
@@ -1,0 +1,37 @@
+"""Password hashing and verification helpers.
+
+Thin bcrypt wrapper that the rest of the auth package and the route
+layer compose over.  The cost factor is pinned at 12 so a future
+rotation cannot silently weaken newly-hashed passwords; the
+verification path is tolerant of malformed hashes because the
+persisted ``password_hash`` setting can be corrupted in the wild.
+"""
+
+from __future__ import annotations
+
+import bcrypt
+
+BCRYPT_COST = 12
+
+
+def hash_password(password: str) -> str:
+    """Hash a plain-text password with bcrypt cost 12."""
+    salt = bcrypt.gensalt(rounds=BCRYPT_COST)
+    return bcrypt.hashpw(password.encode(), salt).decode()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Return True if password matches the bcrypt hash.
+
+    Every failure mode collapses to ``False`` so a corrupted
+    ``password_hash`` setting cannot surface as a 500 at the login
+    route.  bcrypt.checkpw raises ``ValueError`` on malformed hashes,
+    ``UnicodeDecodeError`` on non-UTF8 content, ``TypeError`` on
+    wrong argument types, and the modern Python bcrypt package also
+    rejects >72-byte passwords with ``ValueError``; this catch-all
+    covers every one of them.
+    """
+    try:
+        return bool(bcrypt.checkpw(password.encode(), hashed.encode()))
+    except Exception:  # noqa: BLE001
+        return False

--- a/src/houndarr/auth/proxy_auth.py
+++ b/src/houndarr/auth/proxy_auth.py
@@ -1,0 +1,120 @@
+"""Proxy-authentication helpers for reverse-proxy / SSO deployments.
+
+Proxy mode (``HOUNDARR_AUTH_MODE=proxy``) delegates identity to a
+reverse proxy that injects the authenticated username into a
+configured header (``HOUNDARR_AUTH_PROXY_HEADER``, default
+``Remote-User``).  This module owns every primitive the middleware
+composes to decide whether a request should be admitted:
+
+- :func:`_is_trusted_proxy` gates the header read on the direct
+  connection IP being inside the configured trusted-proxy set.
+- :func:`_extract_proxy_username` reads the header AFTER the trust
+  check; it MUST NOT be called independently on untrusted input.
+- :func:`_validate_proxy_auth` composes the two for callers that only
+  need the binary authenticated-or-not answer.
+
+CSRF in proxy mode uses a double-submit pattern (cookie value must
+match submitted token) because there is no server-signed session
+cookie to embed the token in; :func:`_validate_proxy_csrf` and
+:func:`_ensure_proxy_csrf_cookie` own that state.
+"""
+
+from __future__ import annotations
+
+import secrets
+from hmac import compare_digest
+
+from fastapi import Request, Response
+
+from houndarr.auth.session import CSRF_COOKIE_NAME, SESSION_MAX_AGE_SECONDS
+from houndarr.config import get_settings
+
+# Paths that serve no purpose in proxy mode and redirect to the dashboard.
+_PROXY_DEAD_PATHS = frozenset(["/setup", "/login"])
+
+
+def _is_proxy_auth_mode() -> bool:
+    """Return True if proxy-header authentication is active."""
+    return get_settings().auth_mode == "proxy"
+
+
+def _is_trusted_proxy(request: Request) -> bool:
+    """Return True when the direct connection IP is in the trusted proxy set.
+
+    Security: ``trusted_proxy_set()`` returning an empty set means the
+    operator has not configured any trusted proxy, in which case every
+    request is untrusted regardless of the direct IP.  This guards
+    against header spoofing by untrusted clients: callers that read the
+    auth header must gate the read behind this check.
+    """
+    settings = get_settings()
+    trusted = settings.trusted_proxy_set()
+    if not trusted:
+        return False
+    direct_ip = request.client.host if request.client else "unknown"
+    return direct_ip in trusted
+
+
+def _extract_proxy_username(request: Request) -> str | None:
+    """Return the proxy-supplied username, or ``None`` if the header is absent.
+
+    Assumes the caller has already verified the direct IP is trusted via
+    :func:`_is_trusted_proxy`; this function does not re-check.
+    """
+    settings = get_settings()
+    username = request.headers.get(settings.auth_proxy_header, "").strip()
+    return username or None
+
+
+def _validate_proxy_auth(request: Request) -> str | None:
+    """Return the authenticated proxy username, or ``None`` on any failure.
+
+    Composes :func:`_is_trusted_proxy` (direct IP must be in the trusted
+    set) and :func:`_extract_proxy_username` (header must be present and
+    non-empty).  Both primitives are the single source of truth for the
+    middleware's ``_dispatch_proxy``; this helper is the convenience form
+    for callers that only need the binary "authenticated?" answer.
+    """
+    if not _is_trusted_proxy(request):
+        return None
+    return _extract_proxy_username(request)
+
+
+async def _validate_proxy_csrf(request: Request) -> bool:
+    """Validate CSRF for proxy auth mode using double-submit cookie pattern.
+
+    The CSRF cookie value must match the value submitted in the
+    ``X-CSRF-Token`` header or ``csrf_token`` form field.
+    """
+    cookie_token = request.cookies.get(CSRF_COOKIE_NAME)
+    if not cookie_token:
+        return False
+
+    # Try header first (HTMX), then form body
+    submitted = request.headers.get("X-CSRF-Token")
+    if not submitted:
+        try:
+            form = await request.form()
+            submitted = form.get("csrf_token")  # type: ignore[assignment]
+        except Exception:
+            return False
+
+    if not submitted:
+        return False
+
+    return compare_digest(str(submitted), cookie_token)
+
+
+def _ensure_proxy_csrf_cookie(request: Request, response: Response) -> None:
+    """Set the CSRF cookie on an authenticated proxy-mode response if absent."""
+    if request.cookies.get(CSRF_COOKIE_NAME):
+        return
+    settings = get_settings()
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=secrets.token_hex(32),
+        max_age=SESSION_MAX_AGE_SECONDS,
+        httponly=False,
+        samesite=settings.cookie_samesite,
+        secure=settings.secure_cookies,
+    )

--- a/src/houndarr/auth/rate_limit.py
+++ b/src/houndarr/auth/rate_limit.py
@@ -1,0 +1,90 @@
+"""Brute-force rate limiter for the login route.
+
+In-memory sliding-window counter keyed on the direct-connection IP
+(or the left-most ``X-Forwarded-For`` entry when the connection
+comes from a configured trusted proxy).  The bucket resets on
+process restart; long-term lockout is not a goal, short-term
+friction against credential stuffing is.
+
+The module also owns ``_client_ip`` because the rate-limit and
+proxy-auth dispatch both read the same real-client IP; ``auth.py``
+previously housed both next to each other and the test surface
+keeps pinning the helper here.
+"""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import Request
+
+from houndarr.config import get_settings
+
+_login_attempts: dict[str, list[float]] = {}
+_LOGIN_MAX_ATTEMPTS = 5
+_LOGIN_WINDOW_SECONDS = 60
+
+
+def _client_ip(request: Request) -> str:
+    """Return the real client IP, honouring ``X-Forwarded-For`` only from
+    configured trusted proxies.
+
+    When ``HOUNDARR_TRUSTED_PROXIES`` is set (a comma-separated list of
+    proxy IPs or CIDR subnets), and the direct connection IP matches one
+    of those proxies or falls within a trusted subnet, the left-most IP
+    in ``X-Forwarded-For`` is used as the client IP.
+
+    When no trusted proxies are configured (the default), only
+    ``request.client.host`` is used, preventing header spoofing.
+
+    Args:
+        request: The incoming HTTP request.
+
+    Returns:
+        The best-effort client IP string, or ``"unknown"`` as a fallback.
+    """
+    direct_ip = request.client.host if request.client else "unknown"
+    settings = get_settings()
+    trusted = settings.trusted_proxy_set()
+    if trusted and direct_ip in trusted:
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+    return direct_ip
+
+
+def check_login_rate_limit(request: Request) -> bool:
+    """Return True if the client is allowed to attempt login."""
+    ip = _client_ip(request)
+    now = time.time()
+    attempts = _login_attempts.get(ip, [])
+    # Remove attempts outside the window
+    attempts = [t for t in attempts if now - t < _LOGIN_WINDOW_SECONDS]
+    _login_attempts[ip] = attempts
+    return len(attempts) < _LOGIN_MAX_ATTEMPTS
+
+
+def record_failed_login(request: Request) -> None:
+    """Record a failed login attempt for rate limiting."""
+    ip = _client_ip(request)
+    now = time.time()
+    attempts = _login_attempts.get(ip, [])
+    attempts.append(now)
+    _login_attempts[ip] = attempts
+
+
+def clear_login_attempts(request: Request) -> None:
+    """Clear login attempts on successful login."""
+    ip = _client_ip(request)
+    _login_attempts.pop(ip, None)
+
+
+def reset_login_attempts() -> None:
+    """Drop every tracked bucket.
+
+    Called from the factory-reset path in the setup seam.  Kept as a
+    dedicated helper (rather than ``_login_attempts.clear()`` inline
+    at the call site) so cross-seam callers never reach into another
+    seam's module-private dict.
+    """
+    _login_attempts.clear()

--- a/src/houndarr/auth/session.py
+++ b/src/houndarr/auth/session.py
@@ -1,0 +1,140 @@
+"""Session cookies and the signed CSRF payload they carry.
+
+The session cookie is an ``itsdangerous``-signed JSON blob with a
+timestamp and a per-session CSRF token.  A sibling ``houndarr_csrf``
+cookie carries the plaintext CSRF token so HTMX can read it from
+JavaScript and include it in the ``X-CSRF-Token`` request header; the
+middleware cross-checks the two.
+
+``_get_serializer`` lazy-loads a ``URLSafeTimedSerializer`` keyed on
+the DB-stored ``session_secret`` the first time a cookie needs to be
+signed or validated.  The setup seam's ``rotate_session_secret`` calls
+:func:`reset_serializer` after persisting a new secret so every existing
+cookie becomes unverifiable; that is how Houndarr invalidates every
+other signed-in tab after a password change.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import time
+from typing import Any
+
+from fastapi import Request, Response
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+from houndarr.config import get_settings
+from houndarr.repositories.settings import get_setting, set_setting
+
+SESSION_COOKIE_NAME = "houndarr_session"
+CSRF_COOKIE_NAME = "houndarr_csrf"
+SESSION_MAX_AGE_SECONDS = 86400  # 24 hours
+
+_serializer: URLSafeTimedSerializer | None = None
+
+
+async def _get_serializer() -> URLSafeTimedSerializer:
+    """Return the lazily-initialized session serializer.
+
+    First call generates (or reads) the DB-persisted ``session_secret``;
+    every subsequent call reuses the cached serializer until
+    :func:`reset_serializer` clears it.
+    """
+    global _serializer  # noqa: PLW0603
+    if _serializer is None:
+        secret = await get_setting("session_secret")
+        if not secret:
+            secret = os.urandom(32).hex()
+            await set_setting("session_secret", secret)
+        _serializer = URLSafeTimedSerializer(secret, salt="session")
+    return _serializer
+
+
+def reset_serializer() -> None:
+    """Drop the cached serializer so the next call re-reads the secret.
+
+    Composed by ``setup.rotate_session_secret`` (post-password-change)
+    and ``reset_auth_caches`` (factory reset) so cross-seam callers
+    never touch this module's global directly.
+    """
+    global _serializer  # noqa: PLW0603
+    _serializer = None
+
+
+async def create_session(response: Response) -> str:
+    """Create a new session, set the session cookie, and return a CSRF token.
+
+    The session cookie is ``HttpOnly`` (JS cannot read it).  A separate
+    CSRF cookie (``houndarr_csrf``) is set without ``HttpOnly`` so that
+    JavaScript / HTMX can read it and include it in request headers.
+
+    Args:
+        response: The outgoing HTTP response to attach cookies to.
+
+    Returns:
+        The CSRF token string (also stored in the CSRF cookie).
+    """
+    settings = get_settings()
+    serializer = await _get_serializer()
+    csrf_token = secrets.token_hex(32)
+    payload = {"ts": int(time.time()), "csrf": csrf_token}
+    token = serializer.dumps(payload)
+
+    cookie_kwargs: dict[str, Any] = {
+        "max_age": SESSION_MAX_AGE_SECONDS,
+        "httponly": True,
+        "samesite": settings.cookie_samesite,
+        "secure": settings.secure_cookies,
+    }
+
+    response.set_cookie(key=SESSION_COOKIE_NAME, value=token, **cookie_kwargs)
+
+    # CSRF cookie: readable by JS/HTMX, NOT httponly
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        max_age=SESSION_MAX_AGE_SECONDS,
+        httponly=False,
+        samesite=settings.cookie_samesite,
+        secure=settings.secure_cookies,
+    )
+
+    return csrf_token
+
+
+async def validate_session(request: Request) -> bool:
+    """Return True if the request has a valid, non-expired session."""
+    token = request.cookies.get(SESSION_COOKIE_NAME)
+    if not token:
+        return False
+    try:
+        serializer = await _get_serializer()
+        serializer.loads(token, max_age=SESSION_MAX_AGE_SECONDS)
+        return True
+    except (SignatureExpired, BadSignature):
+        return False
+
+
+async def get_session_csrf_token(request: Request) -> str | None:
+    """Extract the CSRF token embedded in the signed session cookie.
+
+    Returns:
+        The CSRF token string, or ``None`` if the session is invalid/missing.
+    """
+    token = request.cookies.get(SESSION_COOKIE_NAME)
+    if not token:
+        return None
+    try:
+        serializer = await _get_serializer()
+        payload: dict[str, Any] = serializer.loads(token, max_age=SESSION_MAX_AGE_SECONDS)
+        csrf: str | None = payload.get("csrf")
+        return csrf
+    except (SignatureExpired, BadSignature):
+        return None
+
+
+def clear_session(response: Response) -> None:
+    """Delete the session and CSRF cookies."""
+    response.delete_cookie(SESSION_COOKIE_NAME)
+    response.delete_cookie(CSRF_COOKIE_NAME)

--- a/src/houndarr/auth/setup.py
+++ b/src/houndarr/auth/setup.py
@@ -1,0 +1,146 @@
+"""First-run setup + credential management.
+
+Houndarr supports exactly one admin account; this module owns every
+piece of state that defines it:
+
+- the one-time ``/setup`` gate controlled by ``is_setup_complete``,
+- the ``password_hash`` and ``username`` settings persisted in SQLite,
+- the ``check_credentials`` entry point the login route composes with
+  the rate limiter and session creator,
+- ``rotate_session_secret`` for the password-change flow, which
+  invalidates every previously-signed cookie by asking the session
+  seam to drop its cached serializer,
+- ``reset_auth_caches`` for the factory-reset flow, which clears every
+  module-level cache owned by the auth package.
+
+The module is asynchronous-heavy because every SQLite read goes
+through ``aiosqlite``; only ``normalize_username`` and
+``validate_username`` are synchronous pure helpers.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from hmac import compare_digest
+
+from houndarr.auth import rate_limit as _rate_limit
+from houndarr.auth import session as _session
+from houndarr.auth.password import hash_password, verify_password
+from houndarr.repositories.settings import get_setting, set_setting
+
+USERNAME_MIN_LENGTH = 3
+USERNAME_MAX_LENGTH = 32
+_USERNAME_PATTERN = re.compile(r"^[a-z0-9_.-]+$")
+
+_setup_complete: bool | None = None
+
+
+async def is_setup_complete() -> bool:
+    """Return True if the initial password has been set.
+
+    The result is cached once True because the password_hash setting is
+    monotonic: it transitions from absent to present and is never deleted.
+    """
+    global _setup_complete  # noqa: PLW0603
+    if _setup_complete is True:
+        return True
+    result = (await get_setting("password_hash")) is not None
+    if result:
+        _setup_complete = True
+    return result
+
+
+async def set_password(password: str) -> None:
+    """Hash and persist the application password."""
+    global _setup_complete  # noqa: PLW0603
+    await set_setting("password_hash", hash_password(password))
+    _setup_complete = True
+
+
+async def rotate_session_secret() -> None:
+    """Regenerate the session signing secret and drop the serializer cache.
+
+    Every cookie signed with the previous secret fails signature verification
+    afterwards, so a stolen cookie cannot outlive a password change. The
+    caller is responsible for issuing the current admin a fresh
+    :func:`houndarr.auth.session.create_session` cookie on the outgoing
+    response so the password change does not also sign them out of the tab
+    they made it from.
+    """
+    await set_setting("session_secret", os.urandom(32).hex())
+    _session.reset_serializer()
+
+
+def normalize_username(username: str) -> str:
+    """Return a normalized username for storage and comparison."""
+    return username.strip().lower()
+
+
+def validate_username(username: str) -> str | None:
+    """Return an error message if username is invalid, else None."""
+    normalized = normalize_username(username)
+    if not normalized:
+        return "Username is required."
+    if len(normalized) < USERNAME_MIN_LENGTH or len(normalized) > USERNAME_MAX_LENGTH:
+        return "Username must be 3-32 characters."
+    if _USERNAME_PATTERN.fullmatch(normalized) is None:
+        return "Username may only contain lowercase letters, numbers, dots, dashes, or underscores."
+    return None
+
+
+async def set_username(username: str) -> None:
+    """Persist the normalized single-admin username."""
+    await set_setting("username", normalize_username(username))
+
+
+async def get_username() -> str | None:
+    """Return the configured single-admin username."""
+    return await get_setting("username")
+
+
+async def check_password(password: str) -> bool:
+    """Return True if password matches the stored hash."""
+    stored = await get_setting("password_hash")
+    if not stored:
+        return False
+    return verify_password(password, stored)
+
+
+async def check_credentials(username: str, password: str) -> bool:
+    """Return True if the provided username and password are valid.
+
+    If a legacy install has a password hash but no username yet, the first
+    successful password login claims the submitted username.
+    """
+    normalized_username = normalize_username(username)
+    username_error = validate_username(normalized_username)
+    if username_error is not None:
+        return False
+
+    if not await check_password(password):
+        return False
+
+    stored_username = await get_username()
+    if stored_username is None:
+        await set_username(normalized_username)
+        return True
+
+    return compare_digest(normalized_username, normalize_username(stored_username))
+
+
+def reset_auth_caches() -> None:
+    """Clear every module-level auth cache used by the builtin flow.
+
+    Called by :func:`houndarr.services.admin.factory_reset` after the
+    database is wiped so a subsequent ``/setup`` request is not short-
+    circuited by a stale ``_setup_complete=True`` (or a serializer keyed
+    to the old session_secret) and so brute-force counters start fresh.
+    In proxy-mode installs these caches are not consulted for routing
+    decisions, but resetting them keeps the module honest if the operator
+    later switches modes.
+    """
+    global _setup_complete  # noqa: PLW0603
+    _session.reset_serializer()
+    _setup_complete = None
+    _rate_limit.reset_login_attempts()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,14 +72,12 @@ async def db(tmp_data_dir: str) -> AsyncGenerator[None, None]:
 def test_settings(tmp_data_dir: str) -> AppSettings:
     """Return AppSettings pointing at tmp data dir."""
     settings = bootstrap_settings(data_dir=tmp_data_dir)
-    # Reset auth module singletons so each test starts with a clean state.
-    # - _serializer: re-initialized with the new test DB's session_secret.
-    # - _login_attempts: cleared so rate-limit counters don't bleed between tests.
-    import houndarr.auth as _auth
+    # Reset every auth-package cache so each test starts clean.  Covers
+    # the session serializer (re-keyed on next ``_get_serializer()``),
+    # the setup-complete flag, and the in-memory rate-limit buckets.
+    from houndarr.auth import reset_auth_caches
 
-    _auth._serializer = None  # noqa: SLF001
-    _auth._setup_complete = None  # noqa: SLF001
-    _auth._login_attempts.clear()  # noqa: SLF001
+    reset_auth_caches()
     return settings
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,14 @@ import pytest
 from fastapi.testclient import TestClient
 
 from houndarr.auth import (
+    _CSRF_PROTECTED_METHODS,
+    _LOGOUT_PATH,
+    _PUBLIC_PATHS,
+    BCRYPT_COST,
+    CSRF_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
     check_credentials,
+    get_session_csrf_token,
     hash_password,
     is_setup_complete,
     verify_password,
@@ -599,3 +606,457 @@ def test_rate_limiter_uses_direct_ip_by_default(app: TestClient) -> None:
     # not trusted and the real IP is still tracked).  It must NOT be 401 due to
     # XFF bypass - i.e., a different XFF must not reset the counter.
     assert response2.status_code in (429, 401)  # Either is fine; must not bypass rate limit
+
+
+# ---------------------------------------------------------------------------
+# Characterisation pins for the final refactor wave.
+#
+# Phase 1 of the final refactor wave locks every auth contract that the
+# subsequent seam split will move into `src/houndarr/auth/`.  Each test
+# below exercises one load-bearing invariant.  `@pytest.mark.pinning`
+# joins the characterisation suite surfaced by `just pin`.
+# ---------------------------------------------------------------------------
+
+
+# Password seam
+
+
+@pytest.mark.pinning()
+def test_bcrypt_cost_is_12() -> None:
+    """The configured bcrypt work factor must stay at cost 12.
+
+    Lowering the cost would silently weaken every newly-hashed password
+    after a rotation; raising it without a throughput review could turn
+    every login into a denial of service on small hosts.
+    """
+    assert BCRYPT_COST == 12
+    # The resulting hash encodes the cost in its ``$2b$NN$`` prefix;
+    # pin that encoding too so a future rotation cannot diverge the
+    # constant from the actual bcrypt output.
+    hashed = hash_password("work-factor-probe")
+    assert hashed.startswith("$2b$12$")
+
+
+@pytest.mark.pinning()
+def test_bcrypt_verify_accepts_exactly_72_byte_password() -> None:
+    """72-byte password must round-trip through hash + verify.
+
+    bcrypt's upstream cliff sits at 72 bytes; older binaries silently
+    truncated longer input.  The modern ``bcrypt`` Python package
+    rejects >72-byte input with ``ValueError``, which
+    :func:`verify_password` collapses to ``False`` via the catch-all
+    at `auth.py:70`.  Pin the 72-byte acceptance branch so a future
+    dependency upgrade cannot silently change the effective password
+    length ceiling.
+    """
+    prefix = "a" * 72
+    hashed = hash_password(prefix)
+    assert verify_password(prefix, hashed) is True
+    # A divergence within the first 72 bytes must still fail.
+    assert verify_password("a" * 71 + "b", hashed) is False
+    # A longer input must not raise; verify_password collapses to False.
+    assert verify_password("a" * 200, hashed) is False
+
+
+@pytest.mark.pinning()
+def test_bcrypt_verify_returns_false_on_malformed_hash() -> None:
+    """verify_password must collapse every malformed-hash error to False.
+
+    The catch-all at `auth.py:70` protects the login path from a
+    corrupted `password_hash` setting surfacing as a 500.  Specifically
+    pin the three error types bcrypt.checkpw can raise: ``ValueError``
+    (bad hash shape), ``UnicodeDecodeError`` (hash contains non-UTF8),
+    and ``TypeError`` (wrong argument type).
+    """
+    assert verify_password("anything", "not-a-bcrypt-hash") is False
+    assert verify_password("anything", "") is False
+    # Bytes masquerading as a hash would raise TypeError on encode().
+    # verify_password takes str hashes; a pathological None coerced to
+    # str via its default docstring contract still returns False.
+    assert verify_password("anything", "$2b$12$" + "!" * 53) is False
+
+
+# Rate-limit seam
+
+
+@pytest.mark.pinning()
+def test_clear_login_attempts_drops_bucket(test_settings: object) -> None:
+    """clear_login_attempts must drop the per-IP bucket entirely.
+
+    Called on every successful login (auth.py:407).  A residual bucket
+    would let an attacker lock the owner out by exhausting the window
+    with wrong guesses and the owner's subsequent correct login would
+    not clear the record.
+    """
+    from unittest.mock import MagicMock
+
+    from houndarr.auth import (
+        _login_attempts,  # noqa: SLF001
+        check_login_rate_limit,
+        clear_login_attempts,
+        record_failed_login,
+    )
+
+    request = MagicMock()
+    request.client.host = "198.51.100.7"
+    request.headers.get.return_value = None
+    for _ in range(3):
+        record_failed_login(request)
+    assert "198.51.100.7" in _login_attempts
+    clear_login_attempts(request)
+    assert "198.51.100.7" not in _login_attempts
+    assert check_login_rate_limit(request) is True
+
+
+@pytest.mark.pinning()
+def test_check_login_rate_limit_prunes_stale_entries(
+    test_settings: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entries older than the window must fall off the sliding count.
+
+    Without pruning, a client could be locked out by attempts that
+    scrolled past the window hours ago, and the counter would grow
+    unboundedly in memory.  Pin the semantics by clock-travelling past
+    the window and confirming the limiter re-admits the client.
+    """
+    from unittest.mock import MagicMock
+
+    import houndarr.auth as _auth
+    from houndarr.auth import (
+        _LOGIN_WINDOW_SECONDS,  # noqa: SLF001
+        _login_attempts,  # noqa: SLF001
+        check_login_rate_limit,
+        record_failed_login,
+    )
+
+    now = {"t": 1_700_000_000.0}
+    monkeypatch.setattr(_auth.time, "time", lambda: now["t"])
+
+    request = MagicMock()
+    request.client.host = "198.51.100.9"
+    request.headers.get.return_value = None
+    for _ in range(5):
+        record_failed_login(request)
+    assert check_login_rate_limit(request) is False
+
+    # Advance past the window; the next check must prune and re-admit.
+    now["t"] += _LOGIN_WINDOW_SECONDS + 1
+    assert check_login_rate_limit(request) is True
+    assert _login_attempts["198.51.100.9"] == []
+
+
+# Setup seam
+
+
+@pytest.mark.asyncio()
+@pytest.mark.pinning()
+async def test_reset_auth_caches_clears_every_module_global(db: None) -> None:
+    """reset_auth_caches must clear _serializer, _setup_complete, _login_attempts.
+
+    Called on factory reset (services/admin.py:263).  A stale
+    ``_setup_complete=True`` after the database is wiped would short-
+    circuit the `/setup` redirect and strand the operator without a
+    way to configure a new owner.
+    """
+    from unittest.mock import MagicMock
+
+    import houndarr.auth as _auth
+    from houndarr.auth import (
+        _get_serializer,  # noqa: SLF001
+        record_failed_login,
+        reset_auth_caches,
+        set_password,
+    )
+
+    # Prime every cache.
+    await set_password("SomePass1!")
+    await _get_serializer()
+    req = MagicMock()
+    req.client.host = "198.51.100.11"
+    req.headers.get.return_value = None
+    record_failed_login(req)
+
+    assert _auth._setup_complete is True  # noqa: SLF001
+    assert _auth._serializer is not None  # noqa: SLF001
+    assert _auth._login_attempts  # noqa: SLF001
+
+    reset_auth_caches()
+
+    assert _auth._setup_complete is None  # noqa: SLF001
+    assert _auth._serializer is None  # noqa: SLF001
+    assert _auth._login_attempts == {}  # noqa: SLF001
+
+
+# Session seam
+
+
+@pytest.mark.asyncio()
+@pytest.mark.pinning()
+async def test_get_serializer_lazy_init_reads_session_secret(db: None) -> None:
+    """First call generates-and-persists the secret; subsequent calls reuse it."""
+    import houndarr.auth as _auth
+    from houndarr.auth import _get_serializer  # noqa: SLF001
+
+    assert _auth._serializer is None  # noqa: SLF001
+    assert await get_setting("session_secret") is None
+
+    first = await _get_serializer()
+    assert _auth._serializer is first  # noqa: SLF001
+    persisted = await get_setting("session_secret")
+    assert persisted is not None and len(persisted) == 64  # 32 bytes hex
+
+    # Second call must not rotate the secret.
+    second = await _get_serializer()
+    assert second is first
+    assert await get_setting("session_secret") == persisted
+
+
+@pytest.mark.asyncio()
+@pytest.mark.pinning()
+async def test_rotate_session_secret_invalidates_prior_token(db: None) -> None:
+    """A token signed with the prior secret must fail verification after rotate.
+
+    Critical for the password-change flow: rotating the session secret
+    is how Houndarr invalidates every other signed-in tab after a
+    credential change.
+    """
+    from itsdangerous import BadSignature
+
+    from houndarr.auth import _get_serializer, rotate_session_secret  # noqa: SLF001
+
+    serializer = await _get_serializer()
+    signed = serializer.dumps({"ts": 1, "csrf": "tok"})
+
+    await rotate_session_secret()
+    refreshed = await _get_serializer()
+
+    with pytest.raises(BadSignature):
+        refreshed.loads(signed, max_age=60)
+
+
+@pytest.mark.asyncio()
+@pytest.mark.pinning()
+async def test_get_session_csrf_token_extracts_payload(app: TestClient) -> None:
+    """get_session_csrf_token reads the CSRF value embedded in the session cookie.
+
+    Same cookie both stores the session and carries the per-session
+    CSRF token; the cookie value is signed and must round-trip through
+    ``itsdangerous`` before the CSRF check can compare-digest against
+    the submitted header.
+    """
+    from fastapi import Request
+
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+    session_cookie = app.cookies.get(SESSION_COOKIE_NAME)
+    csrf_cookie = app.cookies.get(CSRF_COOKIE_NAME)
+    assert session_cookie is not None
+    assert csrf_cookie is not None
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"cookie", f"{SESSION_COOKIE_NAME}={session_cookie}".encode())],
+        "query_string": b"",
+    }
+    request = Request(scope)
+    extracted = await get_session_csrf_token(request)
+    assert extracted == csrf_cookie
+
+
+# Username helpers
+
+
+@pytest.mark.pinning()
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("  ADMIN  ", "admin"),
+        ("MixedCase", "mixedcase"),
+        ("\talice\n", "alice"),
+        ("", ""),
+        ("a", "a"),
+    ],
+)
+def test_normalize_username_lowercases_and_strips(raw: str, expected: str) -> None:
+    from houndarr.auth import normalize_username
+
+    assert normalize_username(raw) == expected
+
+
+@pytest.mark.pinning()
+@pytest.mark.parametrize(
+    "raw,error_fragment",
+    [
+        ("", "Username is required"),
+        ("ab", "3-32 characters"),
+        ("a" * 33, "3-32 characters"),
+        ("has space", "lowercase letters"),
+        ("CAPITAL", None),  # normalized to 'capital', passes
+        ("bad!char", "lowercase letters"),
+        ("ok.name_1", None),
+        ("dotted.name-here", None),
+    ],
+)
+def test_validate_username_error_messages(raw: str, error_fragment: str | None) -> None:
+    from houndarr.auth import validate_username
+
+    result = validate_username(raw)
+    if error_fragment is None:
+        assert result is None
+    else:
+        assert result is not None
+        assert error_fragment in result
+
+
+# Module constants (pin the exact values)
+
+
+@pytest.mark.pinning()
+def test_logout_path_constant_is_slash_logout() -> None:
+    """_LOGOUT_PATH must stay '/logout'; any drift would silently break logout."""
+    assert _LOGOUT_PATH == "/logout"
+
+
+@pytest.mark.pinning()
+def test_csrf_protected_methods_constant() -> None:
+    """The set of CSRF-protected methods must stay exactly {POST, PUT, PATCH, DELETE}."""
+    assert frozenset(["POST", "PUT", "PATCH", "DELETE"]) == _CSRF_PROTECTED_METHODS
+
+
+@pytest.mark.pinning()
+def test_public_paths_constant_has_exact_contents() -> None:
+    """_PUBLIC_PATHS must stay exactly {/setup, /login, /api/health, /static}.
+
+    Each entry is matched via ``path.startswith`` in the middleware, so
+    the breadth is deliberately small; widening it without updating
+    every consumer (proxy-auth dead-path redirects included) would
+    silently bypass the auth check.
+    """
+    assert frozenset(["/setup", "/login", "/api/health", "/static"]) == _PUBLIC_PATHS
+
+
+# Proxy-auth seam
+
+
+@pytest.mark.pinning()
+def test_extract_proxy_username_returns_none_on_missing_or_blank(
+    tmp_data_dir: str,
+) -> None:
+    """_extract_proxy_username returns None for absent or whitespace-only headers.
+
+    The middleware composes this with `_is_trusted_proxy`; returning an
+    empty string would let the Auth middleware treat a blank header as
+    an authenticated identity.
+    """
+    from unittest.mock import MagicMock
+
+    from houndarr.auth import _extract_proxy_username  # noqa: SLF001
+    from houndarr.config import bootstrap_settings
+
+    try:
+        bootstrap_settings(
+            data_dir=tmp_data_dir,
+            auth_mode="proxy",
+            auth_proxy_header="Remote-User",
+            trusted_proxies="172.18.0.5",
+        )
+        request = MagicMock()
+        request.headers.get.return_value = ""
+        assert _extract_proxy_username(request) is None
+        request.headers.get.return_value = "   "
+        assert _extract_proxy_username(request) is None
+        request.headers.get.return_value = None
+        # get(header, "") returns "" when absent; MagicMock autospec'd to
+        # return None still exercises the empty-string branch correctly.
+        request.headers.get.return_value = ""
+        assert _extract_proxy_username(request) is None
+    finally:
+        bootstrap_settings()
+
+
+@pytest.mark.pinning()
+def test_validate_csrf_reads_form_body_csrf_token_field(app: TestClient) -> None:
+    """The form-body fallback at `auth.py:208` must accept csrf_token inputs.
+
+    Covered transitively elsewhere, but pinned in isolation here so the
+    header-first / body-fallback order survives the csrf seam split.
+    """
+    from tests.conftest import get_csrf_token
+
+    app.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    app.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+    token = get_csrf_token(app)
+    assert token
+
+    # Post without the X-CSRF-Token header; the form body must supply it.
+    resp = app.post("/logout", data={"csrf_token": token}, follow_redirects=False)
+    assert resp.status_code == 303
+
+
+# Middleware seam (ordering invariant)
+
+
+@pytest.mark.asyncio()
+@pytest.mark.pinning()
+async def test_dispatch_proxy_calls_trust_gate_before_header_read(
+    tmp_data_dir: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The proxy dispatch must call `_is_trusted_proxy` before reading the header.
+
+    The trust gate owns the IP check.  Reading the auth header before
+    the IP check would allow a spoofed ``Remote-User`` header from any
+    client to influence a log message even if the middleware still
+    rejected the request.  Pin the call order so the middleware seam
+    split cannot silently reorder the two helpers.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from houndarr.auth import AuthMiddleware
+    from houndarr.auth import proxy_auth as _proxy_auth
+    from houndarr.config import bootstrap_settings
+
+    try:
+        bootstrap_settings(
+            data_dir=tmp_data_dir,
+            auth_mode="proxy",
+            auth_proxy_header="Remote-User",
+            trusted_proxies="172.18.0.5",
+        )
+        calls: list[str] = []
+
+        def fake_is_trusted(request: object) -> bool:
+            calls.append("trust")
+            return False  # force early return
+
+        def fake_extract(request: object) -> str | None:
+            calls.append("extract")
+            return "never-seen"
+
+        # Patch the proxy_auth module directly: the middleware resolves
+        # each helper via ``proxy_auth.<name>`` at call time so the patch
+        # propagates without also having to update the import site.
+        monkeypatch.setattr(_proxy_auth, "_is_trusted_proxy", fake_is_trusted)
+        monkeypatch.setattr(_proxy_auth, "_extract_proxy_username", fake_extract)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        request = MagicMock()
+        request.url.path = "/settings"
+        request.method = "GET"
+        request.client.host = "10.0.0.1"
+        call_next = AsyncMock()
+        await middleware._dispatch_proxy(request, call_next, "/settings")  # noqa: SLF001
+
+        assert calls == ["trust"], (
+            f"expected only trust gate to run when IP is untrusted, got {calls!r}"
+        )
+    finally:
+        bootstrap_settings()


### PR DESCRIPTION
## Summary

Split `src/houndarr/auth.py` into a seam package: `houndarr.auth.password`, `.rate_limit`, `.session`, `.setup`, `.csrf`, `.proxy_auth`, `.identity`, and `.middleware`. The package `__init__.py` re-exports every public name so callers that still import from `houndarr.auth` continue to work unchanged. The middleware reads the trust gate via the submodule path (`proxy_auth._is_trusted_proxy(request)`) so test monkeypatches of the module attribute propagate.

Closes #472

## Changes

- `src/houndarr/auth/password.py`: bcrypt cost constant plus `hash_password` / `verify_password`.
- `src/houndarr/auth/rate_limit.py`: per-IP login attempt tracking, `_client_ip`, `check_login_rate_limit`, `record_failed_login`, `clear_login_attempts`, `reset_login_attempts`.
- `src/houndarr/auth/session.py`: signed-cookie serializer, `create_session` / `validate_session` / `clear_session` / `get_session_csrf_token` / `reset_serializer`.
- `src/houndarr/auth/setup.py`: first-run admin setup state plus the `_setup_complete` cache. `houndarr.auth._setup_complete` always reads the live value owned by setup.py.
- `src/houndarr/auth/csrf.py`: CSRF double-submit token validation.
- `src/houndarr/auth/proxy_auth.py`: trusted-proxy IP gate plus header read primitives. The gate is `proxy_auth._is_trusted_proxy(request)`, and the header read is `proxy_auth._extract_proxy_username(request)`. The middleware's `_dispatch_proxy` and the standalone `_validate_proxy_auth` both compose these.
- `src/houndarr/auth/identity.py`: `resolve_signed_in_as` reconciles proxy-mode identity (forwarded username) with builtin-mode identity (stored single-admin username). Falls back to "admin" when nothing is configured.
- `src/houndarr/auth/middleware.py`: the ASGI dispatch class with the `RequestResponseEndpoint` / `Response` annotation pair. Calls submodule helpers via the module path so `monkeypatch.setattr(houndarr.auth.proxy_auth, "_is_trusted_proxy", ...)` in tests still affects routing.
- `src/houndarr/auth/__init__.py`: shrinks to imports plus a public re-export `__all__`. Mypy's explicit-export check stays green without touching any downstream caller.
- Two preparation refactors land first: narrow `AuthMiddleware.dispatch` to `RequestResponseEndpoint` and `Response` (`e5e6f75`), and split the proxy-auth gate logic into `_is_trusted_proxy` and `_extract_proxy_username` so the middleware's `_dispatch_proxy` and the standalone `_validate_proxy_auth` share one implementation (`8de3d62`).
- `tests/conftest.py` switches the per-test fixture from three raw attribute pokes to `reset_auth_caches()` so it cannot silently desynchronise the session and rate-limit caches after the split.

## Notes for review

The original plan paired this PR with a security fix (`ad90171`: rate-limit password check + rotate session on change), a CSS design-token migration (`7728a89`), and a Playwright visual-pin batch (`50ddd92`, `f1ad787`). Those depend on the admin module (`routes/admin.py`, `services/admin.py`), the auth-fields CSS bundle, and the auth Playwright pages, none of which exist on `main` yet. They ride later PRs.

## Testing

All gates green locally (1617 tests).

## Type of Change

- [x] Refactoring (`refactor:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
