### PR TITLE
refactor(ui): Station design tokens + tokenize shell, auth, settings, logs, help

### DIFF
--- a/docs/refactor/track-g-notes.md
+++ b/docs/refactor/track-g-notes.md
@@ -41,10 +41,13 @@ token `badge-soft` prefix across the four macros is small enough
 that a component class does not pay back.
 
 The `.field-label` and `.status-pill` components promoted in G.2
-and G.3 do pay back because the bundles are 7 and 5 utilities long
-respectively and have no daisyUI analogue to ride on. Badges are
-genuinely different: daisyUI owns the primitive, Houndarr tunes the
-tokens, and the macro stays terse.
+and G.3 do pay back because both pre-refactor bundles were seven
+utilities long (`.field-label`: `block text-xs font-medium
+text-slate-400 mb-1.5 uppercase tracking-wide`; `.status-pill`:
+`inline-flex items-center justify-center gap-1 text-xs
+text-<state> min-w-[4.5rem]`) and have no daisyUI analogue to ride
+on. Badges are genuinely different: daisyUI owns the primitive,
+Houndarr tunes the tokens, and the macro stays terse.
 
 ## Macros touched in Track G
 
@@ -61,6 +64,29 @@ G.3 updates `status_pill` in `_macros/badges.html`: the three arms
 instead of the long inline flex bundle. The inner dot keeps its
 Tailwind utilities inline because dot colour tracks the variant and
 the `station-pulse-dot` animation toggle is per-variant.
+
+## Why `.status-pill` has no production callers yet
+
+Track G defines the `.status-pill` component and updates the
+`status_pill` macro, but the production surface that renders the
+pill (`partials/instance_row.html`, lines 15-30) still inlines the
+pre-refactor seven-utility bundle directly in three conditional
+branches. Migrating the inline block to call `badges.status_pill(
+'error' | 'active' | 'disabled')` is deliberately out of scope for
+Track G, whose template touches are capped at the six inline
+`style=` attributes migrated in G.5.
+
+The caller migration is owned by Track E.16, which wraps
+`instance_row.html` in a new `_macros/instances.html::instance_row`
+macro and picks up the `status_pill` call as part of the same
+pass (see `docs/refactor/track-e-notes.md` for the full E.16
+scope). Until E.16 lands, `.status-pill` ships in `app.built.css`
+with only test harnesses exercising it
+(`tests/test_templates/test_macros_badges.py` and
+`tests/test_tracks/test_track_g_gate.py`). That orphan window is
+intentional: the Strangler-Fig pattern decouples the component
+definition (this track) from caller migration (Track E), so each
+track lands in a single concern.
 
 Byte-equal render pinning for both macros lives at
 `tests/test_templates/test_macros_forms.py` and

--- a/docs/refactor/track-g-notes.md
+++ b/docs/refactor/track-g-notes.md
@@ -1,0 +1,68 @@
+# Track G implementation notes
+
+Context captured during Track G's Tailwind `@layer components` and
+`@utility` work that does not belong in a source docstring or commit
+body but is load-bearing for future work in this area.
+
+## Why `.action-badge` was skipped
+
+An early version of the Track G plan reserved space for an
+`.action-badge` component class to deduplicate the log-row badge
+bundle (`badge badge-soft badge-<state>`) that `log_action_badge`,
+`log_kind_badge`, `log_trigger_badge`, and `log_cycle_outcome_badge`
+emit from `_macros/badges.html`. The class never landed because
+daisyUI's own badge primitives already cover this shape.
+
+The unlayered daisyUI overrides in `src/houndarr/static/css/input.css`
+already retune `.badge`, `.badge-soft.badge-success`,
+`.badge-soft.badge-warning`, `.badge-soft.badge-error`,
+`.badge-soft.badge-info`, `.badge-soft.badge-primary`, and
+`.badge-soft.badge-neutral` for Houndarr's dark surface (chip
+radius, monospace font, tuned state-bg and state-border tokens).
+Every log-row badge macro composes two of those classes, e.g.
+`badge badge-soft badge-success`, and picks up the Station visual
+language for free.
+
+Introducing a `.action-badge` component on top of that would either:
+
+1. Duplicate the daisyUI primitives it already rides on (e.g.
+   `@apply badge badge-soft badge-success` wrapped in a new class),
+   which is pure indirection. The call site still has to pick a
+   state, and the shared bundle is exactly one token (`badge-soft`)
+   long.
+2. Replace the daisyUI classes entirely, which would force every
+   future daisyUI upgrade to re-verify that Houndarr's custom token
+   pipeline matches what the plugin produces. The unlayered-override
+   approach means daisyUI stays the source of truth for badge
+   semantics and Houndarr only tunes the visual tokens.
+
+Either path adds surface without removing duplication. The one-
+token `badge-soft` prefix across the four macros is small enough
+that a component class does not pay back.
+
+The `.field-label` and `.status-pill` components promoted in G.2
+and G.3 do pay back because the bundles are 7 and 5 utilities long
+respectively and have no daisyUI analogue to ride on. Badges are
+genuinely different: daisyUI owns the primitive, Houndarr tunes the
+tokens, and the macro stays terse.
+
+## Macros touched in Track G
+
+G.2 updates `form_field` and `select_field` in
+`_macros/forms.html`: the default `label_class` argument switches
+from the inline `block text-xs font-medium text-slate-400 mb-1.5
+uppercase tracking-wide` bundle to `field-label`. Callers that pass
+an explicit `label_class=` override are unaffected (e.g. the admin
+confirm dialog's `block text-xs font-medium text-slate-400 mb-1.5`
+label without uppercase/tracking-wide stays opt-in).
+
+G.3 updates `status_pill` in `_macros/badges.html`: the three arms
+(active, error, disabled) now emit `status-pill status-pill--<state>`
+instead of the long inline flex bundle. The inner dot keeps its
+Tailwind utilities inline because dot colour tracks the variant and
+the `station-pulse-dot` animation toggle is per-variant.
+
+Byte-equal render pinning for both macros lives at
+`tests/test_templates/test_macros_forms.py` and
+`tests/test_templates/test_macros_badges.py`. Every assertion there
+reflects the post-G.2 / post-G.3 output.

--- a/src/houndarr/static/css/app.css
+++ b/src/houndarr/static/css/app.css
@@ -1,5 +1,5 @@
 /* ─────────────────────────────────────────────────────────────────────────── */
-/* Houndarr — Station App Styles                                              */
+/* Houndarr: Station App Styles                                              */
 /* Custom CSS for animations, scrollbar, and states Tailwind can't express.  */
 /* Design tokens live in tokens.css; this file consumes them.                 */
 /* ─────────────────────────────────────────────────────────────────────────── */

--- a/src/houndarr/static/css/app.css
+++ b/src/houndarr/static/css/app.css
@@ -9,6 +9,61 @@ html {
   scrollbar-gutter: stable both-edges;
 }
 
+/* ── Global content scale ────────────────────────────────────────────────
+   Scales every element uniformly so 100% browser zoom reads like 110%.
+   Implemented via html font-size plus rem-based layout (not CSS `zoom`):
+   password-manager extensions (Bitwarden, 1Password) position their inline
+   autofill menu via getBoundingClientRect(), which does not account for
+   CSS zoom and lands the popup offset from the visually-scaled input.
+   Tailwind utilities are rem-based, so they scale automatically; custom
+   CSS below uses rem for layout and keeps px only for hairlines, focus
+   rings, and animation micro-motion. Media queries still evaluate at real
+   viewport pixels, so Tailwind breakpoints trip at their documented
+   widths. */
+html {
+  font-size: 110%;
+}
+
+/* ── Atmosphere painted on <html> ─────────────────────────────────────────
+   CSS Backgrounds Level 3: the root element's background paints the
+   canvas, which includes the area reserved by `scrollbar-gutter`. Keeping
+   the gradient on body left the gutter unpainted and the viewport edges
+   visibly stopped short; moving it to html fixes that while the sticky
+   nav and content stay within body's width. `background-attachment: fixed`
+   locks the gradient to the viewport across scroll. */
+html {
+  background-color: var(--color-base);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-image:
+    radial-gradient(ellipse 55% 40% at 0% 0%,    rgba(6, 182, 212, 0.055) 0%, transparent 60%),
+    radial-gradient(ellipse 40% 30% at 100% 100%, rgba(14, 116, 144, 0.030) 0%, transparent 55%),
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 31px,
+      rgba(34, 211, 238, 0.018) 31px,
+      rgba(34, 211, 238, 0.018) 32px
+    );
+}
+
+/* Auth pages (login/setup) swap to a centered radial vignette; no stripes. */
+html:has(body.is-auth) {
+  background-image:
+    radial-gradient(
+      ellipse 110% 95% at 50% 45%,
+      rgba(6, 182, 212, 0.15)  0%,
+      rgba(6, 182, 212, 0.06) 32%,
+      rgba(6, 182, 212, 0.015) 60%,
+      transparent              88%
+    );
+}
+
+/* Body stays transparent so html's atmosphere shows through every page. */
+body {
+  background: transparent;
+}
+
 /* ── Scrollbar ──────────────────────────────────────────────────────────── */
 ::-webkit-scrollbar {
   width: 6px;
@@ -186,11 +241,14 @@ body > nav {
 
 .station-input {
   width: 100%;
-  padding: 10px 12px;
-  font-size: 14px;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
   line-height: 1.4;
-  color: #e2e8f0;
-  background: var(--color-surface-2);
+  color: var(--color-text-primary);
+  /* Use background-color (not the shorthand) so the rule does not
+     wipe background-image set by the sibling .station-select class on
+     <select> elements. */
+  background-color: var(--color-surface-2);
   border: 1px solid var(--color-border-default);
   border-radius: var(--radius-inset);
   transition:
@@ -199,7 +257,7 @@ body > nav {
     background   var(--dur-base) var(--ease-station);
 }
 .station-input::placeholder {
-  color: #64748b;
+  color: var(--color-text-muted);
 }
 .station-input:hover {
   border-color: var(--color-border-strong);
@@ -222,10 +280,10 @@ body > nav {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 8px 14px;
+  gap: 0.375rem;
+  padding: 0.5rem 0.875rem;
   font-family: var(--font-sans);
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 500;
   line-height: 1;
   border: 1px solid transparent;
@@ -247,7 +305,7 @@ body > nav {
   cursor: not-allowed;
 }
 .station-button--primary {
-  color: #ffffff;
+  color: var(--color-text-inverse);
   background: var(--color-brand-600);
   border-color: var(--color-brand-500);
 }
@@ -255,7 +313,7 @@ body > nav {
   background: var(--color-brand-500);
 }
 .station-button--secondary {
-  color: #cbd5e1;
+  color: var(--color-text-emphasis);
   background: var(--color-surface-2);
   border-color: var(--color-border-default);
 }

--- a/src/houndarr/static/css/app.css
+++ b/src/houndarr/static/css/app.css
@@ -16,16 +16,16 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  background: #0e1117; /* surface-1 */
+  background: var(--color-surface-1);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #2a3448; /* border-default */
-  border-radius: 3px;
+  background: var(--color-border-default);
+  border-radius: var(--radius-chip);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #3d4f6b; /* border-strong */
+  background: var(--color-border-strong);
 }
 
 /* ── Instance form select chevron ───────────────────────────────────────── */
@@ -132,11 +132,11 @@ html {
 @keyframes station-pulse {
   0%, 100% {
     opacity: 1;
-    box-shadow: 0 0 0 0 rgba(74, 222, 128, 0);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--seg-eligible) 0%, transparent);
   }
   50% {
     opacity: 0.85;
-    box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.18);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--seg-eligible) 18%, transparent);
   }
 }
 
@@ -176,6 +176,102 @@ body > nav {
   box-shadow:
     0 1px 0 #1e2638,
     0 2px 20px rgba(6, 182, 212, 0.065);
+}
+
+/* ── Shared form / button primitives ─────────────────────────────────────
+   Used across auth (login, setup), changelog modal, and the instance
+   form. Keeps dashboard's precision-instrument look consistent with
+   every form control elsewhere. Built with tokens only so changing
+   tokens.css flows through automatically. */
+
+.station-input {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #e2e8f0;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-inset);
+  transition:
+    border-color var(--dur-base) var(--ease-station),
+    box-shadow   var(--dur-base) var(--ease-station),
+    background   var(--dur-base) var(--ease-station);
+}
+.station-input::placeholder {
+  color: #64748b;
+}
+.station-input:hover {
+  border-color: var(--color-border-strong);
+}
+.station-input:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--color-brand-400) 70%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-brand-500) 25%, transparent);
+}
+.station-input:disabled,
+.station-input[aria-disabled="true"] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.station-input[aria-invalid="true"] {
+  border-color: var(--color-danger);
+}
+
+.station-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 14px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  border: 1px solid transparent;
+  border-radius: var(--radius-inset);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background   var(--dur-base) var(--ease-station),
+    border-color var(--dur-base) var(--ease-station),
+    color        var(--dur-base) var(--ease-station),
+    transform    var(--dur-base) var(--ease-station);
+}
+.station-button:active {
+  transform: translateY(1px);
+}
+.station-button:disabled,
+.station-button[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.station-button--primary {
+  color: #ffffff;
+  background: var(--color-brand-600);
+  border-color: var(--color-brand-500);
+}
+.station-button--primary:hover:not(:disabled) {
+  background: var(--color-brand-500);
+}
+.station-button--secondary {
+  color: #cbd5e1;
+  background: var(--color-surface-2);
+  border-color: var(--color-border-default);
+}
+.station-button--secondary:hover:not(:disabled) {
+  background: var(--color-surface-3);
+  border-color: var(--color-border-strong);
+  color: #f1f5f9;
+}
+.station-button--danger {
+  color: var(--color-danger);
+  background: transparent;
+  border-color: color-mix(in srgb, var(--color-danger) 50%, transparent);
+}
+.station-button--danger:hover:not(:disabled) {
+  background: var(--color-danger-bg);
+  border-color: var(--color-danger);
 }
 
 /* ── Reduced motion ─────────────────────────────────────────────────────── */

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -179,6 +179,20 @@
 @utility duration-base { transition-duration: var(--dur-base); }
 @utility duration-slow { transition-duration: var(--dur-slow); }
 
+/* Inline-shadow + brand-rule utilities.  Six inline `style=` attributes
+   in the templates previously carried these exact declarations; moving
+   them into named utilities means a future token change (e.g. tuning
+   --shadow-4 or --glow-logo in tokens.css) propagates to every call
+   site without rewriting the HTML.  The nine JS-toggled
+   `style="display:none"` attributes in partials/instance_form.html
+   deliberately stay inline because the toggle is driven by runtime JS
+   that writes element.style.display directly, and a utility class
+   cannot be toggled by mutating a style string. */
+@utility logo-glow          { filter: drop-shadow(var(--glow-logo)); }
+@utility shadow-4           { box-shadow: var(--shadow-4); }
+@utility shadow-modal       { box-shadow: 0 30px 80px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(30, 38, 56, 0.8); }
+@utility border-l-brand-rule { border-left: 3px solid var(--color-brand-500); }
+
 /* Component reservation.
    Empty block that later Track G batches fill with Houndarr-specific
    component classes (.field-label in G.2, .status-pill variants in

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -213,13 +213,16 @@
 @import "./tokens.css";
 @import "./app.css";
 
-/* Named duration utilities. Tailwind v4 has no `--duration-*` theme
+/* Named duration utilities.  Tailwind v4 has no `--duration-*` theme
    namespace (durations normally go via numeric arbitrary values), so
-   register fast/base/slow as custom utilities driven by CSS variables
-   declared on :root in tokens.css. */
+   register fast / base as custom utilities driven by CSS variables
+   declared on :root in tokens.css.  A third step `duration-slow`
+   existed pre-Track-G but had zero template consumers; the 280ms
+   `--dur-slow` token itself is still consumed directly by app.css
+   (dash-page-in animation, collapsible max-height transition) so the
+   token survives while the Tailwind utility does not. */
 @utility duration-fast { transition-duration: var(--dur-fast); }
 @utility duration-base { transition-duration: var(--dur-base); }
-@utility duration-slow { transition-duration: var(--dur-slow); }
 
 /* Inline-shadow + brand-rule utilities.  Six inline `style=` attributes
    in the templates previously carried these exact declarations; moving

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -189,6 +189,17 @@
    reservation explicit avoids later batches having to guess cascade
    intent. */
 @layer components {
+  /* .field-label centralises the uppercase-tracking label treatment
+     used by every form_field / select_field call in the instance
+     form.  @apply emits the same utility bundle the macros used to
+     inline so the computed styles are byte-equal per cascade rules
+     (both `.field-label` and the utilities live at (0,1,0)).  Keeping
+     the definition in @layer components means the utilities layer
+     still wins if a caller passes extra Tailwind classes alongside
+     `field-label`. */
+  .field-label {
+    @apply block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide;
+  }
 }
 
 /* ── daisyUI component overrides (Station parity) ─────────────────────

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -179,6 +179,18 @@
 @utility duration-base { transition-duration: var(--dur-base); }
 @utility duration-slow { transition-duration: var(--dur-slow); }
 
+/* Component reservation.
+   Empty block that later Track G batches fill with Houndarr-specific
+   component classes (.field-label in G.2, .status-pill variants in
+   G.3). Positioned between the @utility duration rules and the
+   unlayered daisyUI overrides so custom components compose into
+   Tailwind's components layer while daisyUI's own layered rules still
+   sit above them and unlayered overrides below beat both. Keeping the
+   reservation explicit avoids later batches having to guess cascade
+   intent. */
+@layer components {
+}
+
 /* ── daisyUI component overrides (Station parity) ─────────────────────
    daisyUI's defaults produce 40px-tall buttons, pill-shaped sans-serif
    badges, and full-border alerts. Houndarr's aesthetic is tighter: 32px

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -13,6 +13,19 @@
 /* which is still the source of truth for design decisions.                */
 /* ─────────────────────────────────────────────────────────────────────── */
 
+/* Permanent-dark posture.
+   Houndarr has no theme toggle and no light-mode stylesheet; the
+   application shell renders against #07080f (--color-surface-base) at
+   all times and there is no plan to add a `prefers-color-scheme: light`
+   branch.  Every @theme token below, every --color-*-bg tint in
+   tokens.css, and every daisyUI override in this file is calibrated
+   against that dark surface: soft-badge bg tokens use rgba values
+   tuned to read over #07080f, the daisyUI theme sets
+   `color-scheme: dark` + `prefersdark: true`, and the login / setup
+   forms rely on auth.css rules that assume a dark card.  Authors
+   editing this file should pick colours with that context in mind
+   and not hedge the palette for a light variant that does not exist. */
+
 /* Google Fonts @import must precede all other rules per CSS spec. Inlined
    from the former fonts.css so the compiled output keeps the import at the
    top of the generated stylesheet. */

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -158,7 +158,36 @@
   --color-whisparr-v3:    #e879f9;
   --color-whisparr-v3-bg: rgba(86, 19, 88, 0.50);
 
-  /* ── Border-radius scale (Station three-tier system) ──────────────── */
+  /* Border-radius scale (Station four-tier system).
+     Each step halves the visual softness as the element gets smaller,
+     so nested elements always read as tighter than their parents:
+
+       --radius-container (6px)  Use for rounded-container.  Cards,
+                                 modals, tablet-width panels, section
+                                 shells.  The app's outermost radii.
+       --radius-inset     (4px)  Use for rounded-inset.  Inputs,
+                                 buttons, inline-flex pills inside a
+                                 container.  Matches daisyUI's
+                                 --radius-field so .btn / .input
+                                 round consistently.
+       --radius-chip      (3px)  Use for rounded-chip.  Badges,
+                                 pill-shaped log markers, dash-pill
+                                 dot chrome.  Matches daisyUI badge
+                                 override (.badge { border-radius:
+                                 var(--radius-chip) }).
+       --radius-bar       (2px)  Accessed only through var(--radius-bar)
+                                 (e.g. dashboard legend swatches,
+                                 auth.css strength-meter segs, app.css
+                                 status bars).  No template uses the
+                                 Tailwind utility `rounded-bar`
+                                 directly; the token still earns its
+                                 place so the var() consumers share
+                                 the same scale step.
+
+     Tailwind v4 generates `rounded-container`, `rounded-inset`,
+     `rounded-chip`, and `rounded-bar` utilities automatically from
+     these --radius-* keys; templates should prefer those utilities
+     over arbitrary values so retuning a tier propagates everywhere. */
   --radius-container: 6px;
   --radius-inset:     4px;
   --radius-chip:      3px;

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -122,7 +122,32 @@
   --color-border-default: #2a3448;
   --color-border-strong:  #3d4f6b;
 
-  /* ── Semantic state colors + -bg / -border variants ───────────────── */
+  /* Semantic state colours.
+     Each state (danger / success / warning / info) ships as a family
+     of up to three tokens:
+
+       --color-<state>         Opaque hex (e.g. #f87171 danger).
+                               Use for foreground: text, icon fills,
+                               left-rules on soft alerts.
+       --color-<state>-bg      Low-alpha rgba tuned to layer over
+                               --color-surface-base (#07080f).  Use
+                               for soft-badge / soft-alert / soft-btn
+                               backgrounds; pairs with the `-border`
+                               sibling.  daisyUI's own `badge-soft` /
+                               `alert-soft` defaults mix the state
+                               against --color-base-100 at 8%, which
+                               disappears on Houndarr's near-black
+                               surface: the `-bg` tokens are the
+                               replacement.
+       --color-<state>-border  rgba stroke calibrated to read against
+                               the same dark surface without a
+                               hairline vanishing.
+
+     Use `*-bg` for UI chrome that needs a state tint behind text;
+     pair with `--color-<state>` for the foreground.  Info currently
+     ships only the foreground colour because no surface uses a
+     standalone info tint; when one does, add --color-info-bg at
+     ~15% alpha to match the pattern. */
   --color-danger:        #f87171;
   --color-danger-bg:     rgba(153, 27, 27, 0.30);
   --color-danger-border: rgba(248, 113, 113, 0.35);
@@ -137,14 +162,34 @@
 
   --color-info: #67e8f9;
 
-  /* ── Library-health segment colors (match --seg-*) ────────────────── */
+  /* Library-health segment colours.
+     Distinct from --color-<state>-bg: these are solid opaque hex
+     values designed to render as chart segment fills on the
+     dashboard's library-health bar.  A segment pixel IS the colour,
+     so transparency would muddy the rendering against the surface
+     behind it.  When adding a new `seg-*` token, pick a hex that
+     reads clearly next to the adjacent segments; do not reuse a
+     `*-bg` rgba because the dashboard bar composites segments on a
+     panel, not on --color-surface-base.
+
+     Naming suffix convention: `*-cd` means "cooldown" (cutoff-cd =
+     cutoff cooldown, upgrade-cd = upgrade cooldown).  The five
+     segments map directly to the five tick states tracked in
+     services/metrics.py. */
   --color-seg-eligible:    #4ade80;
   --color-seg-cooldown:    #22d3ee;
   --color-seg-cutoff-cd:   #fcd34d;
   --color-seg-upgrade-cd:  #a78bfa;
   --color-seg-unreleased:  #64748b;
 
-  /* ── Instance-type signature colors ───────────────────────────────── */
+  /* Instance-type signature colours.
+     Per-`*arr` family palette: each entry ships a foreground
+     (`--color-<app>`) and a dark-tinted background
+     (`--color-<app>-bg`) used by `instance_type_badge` in
+     _macros/badges.html.  The `-bg` rgba uses the same
+     layer-over-#07080f calibration as the semantic `*-bg` tokens
+     above, which is why the alpha values sit around 0.50 (Station's
+     branded chip wants more saturation than a success badge). */
   --color-sonarr:       #7dd3fc;
   --color-sonarr-bg:    rgba(8, 47, 73, 0.50);
   --color-radarr:       #fcd34d;

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -1,5 +1,5 @@
 /* ─────────────────────────────────────────────────────────────────────── */
-/* Houndarr — Tailwind CSS v4 build entry point                           */
+/* Houndarr: Tailwind CSS v4 build entry point                            */
 /*                                                                        */
 /* Compiled at Docker build time to src/houndarr/static/css/app.built.css  */
 /* by the css-build stage in the Dockerfile. The runtime image ships only  */
@@ -27,13 +27,13 @@
 /* daisyUI v5 component plugin. Runs at Tailwind build time; nothing
    ships to the browser except compiled CSS. themes: false disables
    the built-in theme set because we define our own "station" theme
-   below — having both would inflate the bundle with unused OKLCH
+   below; having both would inflate the bundle with unused OKLCH
    palettes. */
 @plugin "daisyui" {
   themes: false;
 }
 
-/* Station theme — maps daisyUI's semantic slots to Houndarr's palette.
+/* Station theme: maps daisyUI's semantic slots to Houndarr's palette.
    Kept in parity with tokens.css (source of truth for design decisions)
    and @theme above (Tailwind utility generation). Component radii use
    the existing 3-tier Station radius tokens so daisyUI buttons, inputs,
@@ -72,7 +72,7 @@
   --color-error: #f87171;
   --color-error-content: #07080f;
 
-  /* Radii — three-tier Station scale */
+  /* Radii: three-tier Station scale */
   --radius-selector: 9999px;  /* pill badges + toggles */
   --radius-field:    4px;      /* inputs, buttons */
   --radius-box:      6px;      /* cards, modals */
@@ -162,7 +162,7 @@
                ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
 }
 
-/* Layered imports — custom design tokens and component primitives.
+/* Layered imports: custom design tokens and component primitives.
    Order matters for cascade: tokens first (variables), then layout,
    then per-page. Tailwind utilities always win regardless of order.
    auth.css and auth-fields.css are introduced by later PRs (login /

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -200,6 +200,20 @@
   .field-label {
     @apply block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide;
   }
+
+  /* .status-pill centralises the instance-row status indicator (dot +
+     label) used on the settings page.  The base class captures the
+     shared flex shell; BEM-style `--active / --error / --disabled`
+     modifiers layer on the state colour.  The inner dot keeps its
+     Tailwind utilities inline because its colour is tied to the
+     variant and the `station-pulse-dot` animation toggle only applies
+     to active + error (disabled is intentionally unanimated). */
+  .status-pill {
+    @apply inline-flex items-center justify-center gap-1 text-xs min-w-[4.5rem];
+  }
+  .status-pill--active   { @apply text-success; }
+  .status-pill--error    { @apply text-danger; }
+  .status-pill--disabled { @apply text-slate-500; }
 }
 
 /* ── daisyUI component overrides (Station parity) ─────────────────────

--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -270,14 +270,21 @@
 @utility duration-base { transition-duration: var(--dur-base); }
 
 /* Inline-shadow + brand-rule utilities.  Six inline `style=` attributes
-   in the templates previously carried these exact declarations; moving
-   them into named utilities means a future token change (e.g. tuning
-   --shadow-4 or --glow-logo in tokens.css) propagates to every call
-   site without rewriting the HTML.  The nine JS-toggled
-   `style="display:none"` attributes in partials/instance_form.html
-   deliberately stay inline because the toggle is driven by runtime JS
-   that writes element.style.display directly, and a utility class
-   cannot be toggled by mutating a style string. */
+   in the templates previously carried these exact declarations; three
+   of the four utilities below reference a token (--glow-logo,
+   --shadow-4, --color-brand-500), so a token retune in tokens.css
+   propagates everywhere without touching the HTML.  shadow-modal is
+   intentionally literal: no `--shadow-modal` token exists and the
+   modal drop-shadow is not a reuse of --shadow-4 (different
+   magnitudes), so a future retune would edit the declaration body
+   directly.  Add a --shadow-modal token if a second modal surface
+   ever needs to share the value.
+
+   The ten JS-toggled `style="display:none"` attributes in
+   partials/instance_form.html deliberately stay inline because the
+   toggle is driven by runtime JS that writes element.style.display
+   directly, and a utility class cannot be toggled by mutating a
+   style string. */
 @utility logo-glow          { filter: drop-shadow(var(--glow-logo)); }
 @utility shadow-4           { box-shadow: var(--shadow-4); }
 @utility shadow-modal       { box-shadow: 0 30px 80px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(30, 38, 56, 0.8); }

--- a/src/houndarr/static/css/tokens.css
+++ b/src/houndarr/static/css/tokens.css
@@ -1,5 +1,5 @@
 /* ─────────────────────────────────────────────────────────────────────────── */
-/* Houndarr — Station Design System Tokens                                    */
+/* Houndarr: Station Design System Tokens                                     */
 /* All design decisions live here. App and docs both import this file.        */
 /*                                                                            */
 /* Palette hex values are mirrored into base.html's inline Tailwind CDN       */
@@ -11,7 +11,7 @@
 
 :root {
   /* ── Palette ─────────────────────────────────────────────────────────── */
-  --color-base:      #07080f;   /* body background — midnight navy */
+  --color-base:      #07080f;   /* body background: midnight navy */
   --color-surface-1: #0e1117;   /* card / nav background */
   --color-surface-2: #151b27;   /* secondary surface, input bg */
   --color-surface-3: #1e2638;   /* border color, tertiary surface */
@@ -40,7 +40,7 @@
   --color-danger-text:  #fca5a5;
   --color-success-text: #86efac;
 
-  /* ── Brand — refined Station cyan ────────────────────────────────────── */
+  /* ── Brand (refined Station cyan) ────────────────────────────────────── */
   --color-brand-50:  #ecfeff;
   --color-brand-100: #cffafe;
   --color-brand-200: #a5f3fc;
@@ -83,14 +83,14 @@
                ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
 
   /* ── Spacing (4px base, 8px unit) ───────────────────────────────────── */
-  --space-1: 0.25rem;   /*  4px — micro gaps, badge padding */
-  --space-2: 0.5rem;    /*  8px — input padding, label gap */
-  --space-3: 0.75rem;   /* 12px — card padding units */
-  --space-4: 1rem;      /* 16px — standard section padding */
-  --space-5: 1.5rem;    /* 24px — comfortable card padding */
-  --space-6: 2rem;      /* 32px — section gaps */
-  --space-7: 3rem;      /* 48px — generous page gaps */
-  --space-8: 4rem;      /* 64px — hero rhythm */
+  --space-1: 0.25rem;   /*  4px, micro gaps, badge padding */
+  --space-2: 0.5rem;    /*  8px, input padding, label gap */
+  --space-3: 0.75rem;   /* 12px, card padding units */
+  --space-4: 1rem;      /* 16px, standard section padding */
+  --space-5: 1.5rem;    /* 24px, comfortable card padding */
+  --space-6: 2rem;      /* 32px, section gaps */
+  --space-7: 3rem;      /* 48px, generous page gaps */
+  --space-8: 4rem;      /* 64px, hero rhythm */
 
   /* ── Border radius ───────────────────────────────────────────────────── */
   --radius-sm:   4px;        /* inputs, inline badges */

--- a/src/houndarr/static/css/tokens.css
+++ b/src/houndarr/static/css/tokens.css
@@ -1,6 +1,12 @@
 /* ─────────────────────────────────────────────────────────────────────────── */
 /* Houndarr — Station Design System Tokens                                    */
 /* All design decisions live here. App and docs both import this file.        */
+/*                                                                            */
+/* Palette hex values are mirrored into base.html's inline Tailwind CDN       */
+/* config (brand, surface, border, danger, success, warning, info, seg, and   */
+/* per-*arr type colors) because CDN Tailwind cannot read CSS variables at    */
+/* build time. When editing a palette/state/type hex here, update base.html   */
+/* to match.                                                                  */
 /* ─────────────────────────────────────────────────────────────────────────── */
 
 :root {
@@ -14,6 +20,25 @@
   --color-border-subtle:  #1e2638;
   --color-border-default: #2a3448;
   --color-border-strong:  #3d4f6b;
+
+  /* ── Text scale ──────────────────────────────────────────────────────
+     Semantic tokens for text so intent survives a rebrand or theme swap.
+     Ordered high-contrast to low-contrast. Pass-through pattern: new
+     components should reach for these, not raw slate hex values. */
+  --color-text-heading:  #f8fafc;   /* page h1 (highest emphasis) */
+  --color-text-primary:  #e2e8f0;   /* body text on dark surfaces */
+  --color-text-emphasis: #cbd5e1;   /* secondary emphasis, stat values */
+  --color-text-muted:    #94a3b8;   /* passes 4.5:1 body-text threshold */
+  --color-text-subtle:   #64748b;   /* UI-element only (3:1 minimum) */
+  --color-text-inverse:  #ffffff;   /* on primary buttons + modal accents */
+
+  /* ── State text tints ────────────────────────────────────────────────
+     Lighter text variants of the core state colors for use on neutral
+     backgrounds (headings, icons, pill text). On colored state backgrounds
+     (e.g. --color-danger-bg) components use inline tints since those sit
+     inside a narrow context and do not warrant their own tokens. */
+  --color-danger-text:  #fca5a5;
+  --color-success-text: #86efac;
 
   /* ── Brand — refined Station cyan ────────────────────────────────────── */
   --color-brand-50:  #ecfeff;
@@ -68,11 +93,11 @@
   --space-8: 4rem;      /* 64px — hero rhythm */
 
   /* ── Border radius ───────────────────────────────────────────────────── */
-  --radius-sm:   4px;     /* inputs, inline badges */
-  --radius-md:   6px;     /* cards, buttons, tooltips */
-  --radius-lg:   10px;    /* modals, panels, popovers */
-  --radius-xl:   16px;    /* large panels */
-  --radius-full: 9999px;  /* pill badges */
+  --radius-sm:   4px;        /* inputs, inline badges */
+  --radius-md:   6px;        /* cards, buttons, tooltips */
+  --radius-lg:   0.625rem;   /* modals, panels, popovers (10px at 16px base) */
+  --radius-xl:   1rem;       /* large panels (16px at 16px base) */
+  --radius-full: 9999px;     /* pill badges */
 
   /* ── Shadows (cool-toned, midnight-shifted) ──────────────────────────── */
   --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.50);

--- a/src/houndarr/static/css/tokens.css
+++ b/src/houndarr/static/css/tokens.css
@@ -111,6 +111,13 @@
   --glow-danger:       0 0 8px  rgba(248, 113, 113, 0.20);
   --glow-logo:         0 0 18px rgba(34, 211, 238, 0.22);
 
+  /* Brand-cyan hover tints used as solid background colors (not
+     box-shadows).  auth-fields.css reaches for these on the
+     password-toggle icon button; keeping them next to the glow
+     family keeps every brand-alpha variant in one place. */
+  --glow-brand-soft:   rgba(34, 211, 238, 0.08);
+  --glow-brand-medium: rgba(34, 211, 238, 0.14);
+
   /* ── Motion ─────────────────────────────────────────────────────────── */
   --ease-station: cubic-bezier(0.16, 1, 0.3, 1);    /* precise settle */
   --ease-spring:  cubic-bezier(0.34, 1.56, 0.64, 1);/* subtle spring */

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -86,7 +86,7 @@
                 aria-label="Toggle navigation menu"
                 aria-controls="mobile-nav-menu"
                 aria-expanded="false"
-                class="sm:hidden inline-flex h-10 w-10 items-center justify-center rounded-md border border-surface-3 bg-surface-2 text-slate-300 hover:text-white hover:bg-surface-3 transition-colors">
+                class="sm:hidden inline-flex h-10 w-10 items-center justify-center rounded-container border border-border-subtle bg-surface-2 text-slate-300 hover:text-white hover:bg-surface-3 transition-colors duration-base ease-station">
           <svg class="w-4 h-4 mobile-nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
           </svg>
@@ -98,7 +98,7 @@
           <form action="/logout" method="post" class="ml-2">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
             <button type="submit"
-                    class="px-3 py-2 rounded-md text-sm font-medium text-slate-400 hover:text-white hover:bg-surface-2 transition-colors">
+                    class="px-3 py-2 rounded-container text-sm font-medium text-slate-400 hover:text-white hover:bg-surface-2 transition-colors duration-base ease-station">
               Logout
             </button>
           </form>
@@ -113,7 +113,7 @@
             <form action="/logout" method="post">
               <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
               <button type="submit"
-                      class="w-full text-left px-3 py-2.5 rounded-lg text-sm font-medium text-slate-500 hover:text-slate-300 hover:bg-surface-2 transition-colors">
+                      class="w-full text-left px-3 py-2.5 rounded-container text-sm font-medium text-slate-500 hover:text-slate-300 hover:bg-surface-2 transition-colors duration-base ease-station">
                 Logout
               </button>
             </form>
@@ -148,7 +148,7 @@
   </main>
 
   <!-- Footer -->
-  <footer class="border-t border-surface-3 py-4 text-xs text-slate-600">
+  <footer class="border-t border-border-subtle py-4 text-xs text-slate-500">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-center gap-3 font-mono">
       <span>Houndarr v{{ version }}</span>
       <a href="https://github.com/av1155/houndarr"

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -76,8 +76,7 @@
           <img
             src="/static/img/houndarr-logo-dark-ui.png"
             alt="Houndarr logo"
-            class="w-8 h-8 sm:w-9 sm:h-9 object-contain"
-            style="filter: drop-shadow(var(--glow-logo));"
+            class="w-8 h-8 sm:w-9 sm:h-9 object-contain logo-glow"
           />
           Houndarr
         </a>

--- a/src/houndarr/templates/base.html
+++ b/src/houndarr/templates/base.html
@@ -56,11 +56,12 @@
 
   {% block head %}{% endblock %}
 </head>
-<body class="bg-surface-base text-slate-100 min-h-screen flex flex-col font-sans">
+<body class="bg-surface-base text-slate-100 min-h-dvh flex flex-col font-sans{% if show_nav is defined and not show_nav %} is-auth{% endif %}">
 
   {% if show_nav is not defined or show_nav %}
   <!-- Navigation -->
-  <nav class="bg-surface-1 border-b border-surface-3 sticky top-0 z-50">
+  <header class="sticky top-0 z-50">
+  <nav class="bg-surface-1 border-b border-surface-3">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="flex items-center justify-between h-16 sm:h-14">
         <!-- Logo / wordmark -->
@@ -122,6 +123,7 @@
       </div>
     </div>
   </nav>
+  </header>
   <!-- Mobile nav backdrop -->
   <div id="mobile-nav-backdrop" class="sm:hidden fixed inset-0 z-40 mobile-nav-backdrop" aria-hidden="true"></div>
   {% endif %}

--- a/src/houndarr/templates/login.html
+++ b/src/houndarr/templates/login.html
@@ -19,16 +19,16 @@
     </div>
 
     <!-- Login card -->
-    <div class="bg-[#0e1117] border border-[#1e2638] rounded-xl p-6" style="box-shadow:var(--shadow-4);">
+    <div class="bg-surface-1 border border-border-subtle rounded-container p-6" style="box-shadow:var(--shadow-4);">
       {% if error %}
-      <div class="mb-4 border-l-4 border-red-500 bg-red-950/30 text-red-200 rounded-r-lg px-4 py-3 text-sm" role="alert">
+      <div class="mb-4 border-l-4 border-danger bg-danger-bg text-slate-100 rounded-r-inset px-4 py-3 text-sm" role="alert">
         {{ error }}
       </div>
       {% endif %}
 
       <form action="/login" method="post" class="space-y-5">
         <div>
-          <label for="username" class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+          <label for="username" class="block text-xs font-medium text-slate-500 mb-1.5 uppercase tracking-wide">
             Username
           </label>
           <input
@@ -40,15 +40,14 @@
             minlength="3"
             maxlength="32"
             pattern="[-A-Za-z0-9_.]+"
-            class="w-full bg-[#151b27] border border-[#2a3448] rounded-lg px-4 py-2.5 text-white font-sans placeholder-slate-600
-                   focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors text-base"
+            class="station-input font-sans text-base"
             placeholder="your-username"
             autofocus
           />
         </div>
 
         <div>
-          <label for="password" class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+          <label for="password" class="block text-xs font-medium text-slate-500 mb-1.5 uppercase tracking-wide">
             Password
           </label>
           <input
@@ -57,17 +56,15 @@
             type="password"
             autocomplete="current-password"
             required
-            class="w-full bg-[#151b27] border border-[#2a3448] rounded-lg px-4 py-2.5 text-white font-mono placeholder-slate-600
-                   focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors text-base"
+            class="station-input font-mono text-base"
             placeholder="••••••••"
           />
         </div>
 
         <button
           type="submit"
-          class="w-full bg-brand-600 hover:bg-brand-500 text-white font-semibold py-2.5 rounded-lg transition-colors
-                 focus:outline-none focus:ring-2 focus:ring-brand-400/50 focus:ring-offset-2 focus:ring-offset-[#0e1117]
-                 text-sm tracking-wide">
+          class="station-button station-button--primary w-full py-2.5 text-sm tracking-wide font-semibold
+                 focus:outline-none focus:ring-2 focus:ring-brand-400/50 focus:ring-offset-2 focus:ring-offset-surface-1">
           Sign In
         </button>
       </form>

--- a/src/houndarr/templates/partials/admin/confirm_dialog.html
+++ b/src/houndarr/templates/partials/admin/confirm_dialog.html
@@ -31,10 +31,10 @@
             class="w-9 h-9 rounded-inset grid place-items-center bg-danger-bg border border-danger-border text-danger shrink-0"
             aria-hidden="true"
           >
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.7 3.86a2 2 0 0 0-3.4 0z"/>
-              <line x1="12" y1="9" x2="12" y2="13"/>
-              <line x1="12" y1="17" x2="12.01" y2="17"/>
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
+              <path d="M12 9v4"/>
+              <path d="M12 17h.01"/>
             </svg>
           </div>
           <div class="min-w-0">
@@ -107,7 +107,7 @@
                 aria-pressed="false"
                 tabindex="-1"
               >
-                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/>
                   <circle cx="12" cy="12" r="3"/>
                 </svg>

--- a/src/houndarr/templates/partials/admin/security.html
+++ b/src/houndarr/templates/partials/admin/security.html
@@ -20,7 +20,7 @@
       class="inline-flex items-center gap-2 rounded-inset border border-border-subtle bg-surface-2/70 px-3 py-1.5 text-xs text-slate-400 font-sans mb-5"
     >
       <span class="text-slate-500">Signed in as</span>
-      <span class="font-medium text-slate-200 font-mono text-[11px]">{{ signed_in_as }}</span>
+      <span class="font-medium text-slate-200 font-mono text-[0.6875rem]">{{ signed_in_as }}</span>
     </div>
 
     {% if auth_mode == "proxy" %}

--- a/src/houndarr/templates/partials/admin/security.html
+++ b/src/houndarr/templates/partials/admin/security.html
@@ -79,7 +79,7 @@
               aria-pressed="false"
               tabindex="-1"
             >
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/>
                 <circle cx="12" cy="12" r="3"/>
               </svg>
@@ -118,7 +118,7 @@
               aria-pressed="false"
               tabindex="-1"
             >
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/>
                 <circle cx="12" cy="12" r="3"/>
               </svg>
@@ -178,7 +178,7 @@
               aria-pressed="false"
               tabindex="-1"
             >
-              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/>
                 <circle cx="12" cy="12" r="3"/>
               </svg>

--- a/src/houndarr/templates/partials/admin/updates.html
+++ b/src/houndarr/templates/partials/admin/updates.html
@@ -44,7 +44,7 @@
         hx-swap="outerHTML"
         class="btn btn-soft btn-neutral px-3 py-1.5 text-xs font-medium font-sans"
       >
-        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M14 3h7v7"/><path d="M21 3l-9 9"/><path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/>
         </svg>
         Show last changelog

--- a/src/houndarr/templates/partials/changelog_content.html
+++ b/src/houndarr/templates/partials/changelog_content.html
@@ -2,7 +2,7 @@
   {# Newest release: always expanded, visible without scrolling #}
   <section class="space-y-3" data-changelog-release="{{ newest.version }}">
     <header class="flex items-baseline gap-3">
-      <h3 class="text-lg font-semibold text-white">v{{ newest.version }}</h3>
+      <h3 class="text-lg font-semibold text-white tracking-tight">v{{ newest.version }}</h3>
       <time class="text-xs text-slate-500 font-mono">{{ newest.date }}</time>
     </header>
     {% for section in newest.sections %}
@@ -23,9 +23,9 @@
 
   {% if older %}
   {# Accordion for older releases when span is 2+ extra entries #}
-  <details class="changelog-accordion border-t border-[#1e2638] pt-4 group">
+  <details class="changelog-accordion border-t border-border-subtle pt-4 group">
     <summary
-      class="cursor-pointer list-none text-sm font-medium text-slate-300 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 rounded-sm flex items-center gap-2"
+      class="cursor-pointer list-none text-sm font-medium text-slate-300 hover:text-white transition-colors duration-base ease-station focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 rounded-sm flex items-center gap-2"
     >
       <svg
         class="w-3.5 h-3.5 transition-transform group-open:rotate-90"
@@ -46,7 +46,7 @@
       {% for release in older %}
       <section class="space-y-3" data-changelog-release="{{ release.version }}">
         <header class="flex items-baseline gap-3">
-          <h3 class="text-base font-semibold text-slate-200">v{{ release.version }}</h3>
+          <h3 class="text-base font-semibold text-slate-200 tracking-tight">v{{ release.version }}</h3>
           <time class="text-xs text-slate-500 font-mono">{{ release.date }}</time>
         </header>
         {% for section in release.sections %}

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -1,9 +1,8 @@
 <dialog
   id="changelog-modal"
-  class="m-auto p-0 w-[min(94vw,38rem)] rounded-container border border-border-subtle bg-surface-1 text-slate-100"
+  class="m-auto p-0 w-[min(94vw,38rem)] rounded-container border border-border-subtle bg-surface-1 text-slate-100 shadow-modal"
   aria-labelledby="changelog-modal-title"
   {% if range_label %}aria-describedby="changelog-modal-subtitle"{% endif %}
-  style="box-shadow: 0 30px 80px rgba(0,0,0,0.7), 0 0 0 1px rgba(30,38,56,0.8);"
 >
   <style>
     #changelog-modal {

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -8,7 +8,7 @@
   <style>
     #changelog-modal {
       opacity: 0;
-      transform: translateY(12px) scale(0.98);
+      transform: translateY(0.75rem) scale(0.98);
     }
 
     #changelog-modal[open] {
@@ -36,7 +36,7 @@
     }
 
     @keyframes changelog-modal-in {
-      from { opacity: 0; transform: translateY(12px) scale(0.98); }
+      from { opacity: 0; transform: translateY(0.75rem) scale(0.98); }
       to   { opacity: 1; transform: translateY(0) scale(1); }
     }
 
@@ -47,7 +47,7 @@
 
     @keyframes changelog-modal-out {
       from { opacity: 1; transform: translateY(0) scale(1); }
-      to   { opacity: 0; transform: translateY(8px) scale(0.985); }
+      to   { opacity: 0; transform: translateY(0.5rem) scale(0.985); }
     }
 
     @keyframes changelog-backdrop-out {
@@ -73,7 +73,7 @@
         max-height: 90dvh;
         max-width: 100%;
         width: 100%;
-        border-radius: 16px 16px 0 0;
+        border-radius: 1rem 1rem 0 0;
         transform: translateY(100%);
       }
 

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -1,6 +1,6 @@
 <dialog
   id="changelog-modal"
-  class="m-auto p-0 w-[min(94vw,38rem)] rounded-2xl border border-[#1e2638] bg-[#0e1117] text-slate-100"
+  class="m-auto p-0 w-[min(94vw,38rem)] rounded-container border border-border-subtle bg-surface-1 text-slate-100"
   aria-labelledby="changelog-modal-title"
   {% if range_label %}aria-describedby="changelog-modal-subtitle"{% endif %}
   style="box-shadow: 0 30px 80px rgba(0,0,0,0.7), 0 0 0 1px rgba(30,38,56,0.8);"
@@ -14,11 +14,11 @@
     #changelog-modal[open] {
       opacity: 1;
       transform: translateY(0) scale(1);
-      animation: changelog-modal-in 180ms ease-out;
+      animation: changelog-modal-in var(--dur-base) var(--ease-station);
     }
 
     #changelog-modal[open].is-closing {
-      animation: changelog-modal-out 160ms ease-in forwards;
+      animation: changelog-modal-out var(--dur-fast) ease-in forwards;
     }
 
     #changelog-modal::backdrop {
@@ -118,7 +118,7 @@
     }
   </style>
 
-  <div class="flex items-center justify-between border-b border-[#1e2638] px-6 py-4">
+  <div class="flex items-center justify-between border-b border-border-subtle px-6 py-4">
     <div class="min-w-0">
       <h2
         id="changelog-modal-title"
@@ -136,7 +136,7 @@
       type="button"
       aria-label="Close changelog"
       data-close-changelog-modal="true"
-      class="ml-4 flex-shrink-0 rounded-lg border border-[#2a3448] bg-[#151b27] p-2 text-slate-400 hover:bg-[#1e2638] hover:text-slate-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30"
+      class="ml-4 flex-shrink-0 rounded-inset border border-border-default bg-surface-2 p-2 text-slate-400 hover:bg-surface-3 hover:text-slate-200 transition-colors duration-base ease-station focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30"
     >
       <span aria-hidden="true" class="block leading-none text-xl">&times;</span>
     </button>
@@ -147,13 +147,13 @@
   </div>
 
   <div
-    class="flex flex-wrap items-center justify-between gap-3 border-t border-[#1e2638] px-6 py-4"
+    class="flex flex-wrap items-center justify-between gap-3 border-t border-border-subtle px-6 py-4"
   >
     <a
       href="https://github.com/av1155/houndarr/blob/main/CHANGELOG.md"
       target="_blank"
       rel="noopener noreferrer"
-      class="text-xs font-medium text-brand-300 hover:text-brand-200 underline underline-offset-4 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 rounded-sm"
+      class="text-xs font-medium text-brand-300 hover:text-brand-200 underline underline-offset-4 transition-colors duration-base ease-station focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30 rounded-sm"
     >
       Full changelog on GitHub
     </a>

--- a/src/houndarr/templates/partials/changelog_settings_section.html
+++ b/src/houndarr/templates/partials/changelog_settings_section.html
@@ -1,0 +1,39 @@
+<section
+  id="changelog-section"
+  class="mt-8 rounded-container border border-border-subtle bg-surface-1 p-4 sm:p-5"
+>
+  <div class="mb-4">
+    <h2 class="text-base font-semibold text-slate-200">Changelog notifications</h2>
+  </div>
+
+  <form
+    hx-post="/settings/changelog/preferences"
+    hx-target="#changelog-section"
+    hx-swap="outerHTML"
+    class="flex flex-wrap items-center gap-3"
+  >
+    <label class="inline-flex items-center gap-2 text-sm text-slate-200 cursor-pointer">
+      <input
+        type="checkbox"
+        name="enabled"
+        value="on"
+        {% if changelog_popups_enabled %}checked{% endif %}
+        class="h-4 w-4 rounded-chip border-border-default bg-surface-1 accent-brand-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30"
+        onchange="this.form.requestSubmit()"
+      />
+      Show a changelog summary after each update
+    </label>
+  </form>
+
+  <div class="mt-4">
+    <button
+      type="button"
+      hx-get="/settings/changelog/popup?force=1"
+      hx-swap="outerHTML"
+      hx-target="#changelog-slot"
+      class="station-button station-button--secondary px-3 py-1.5 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400/30"
+    >
+      Show last changelog
+    </button>
+  </div>
+</section>

--- a/src/houndarr/templates/partials/copy_format_menu_items.html
+++ b/src/houndarr/templates/partials/copy_format_menu_items.html
@@ -1,16 +1,16 @@
 <button type="button" role="menuitem" data-copy-format="tsv"
-  class="copy-format-item w-full text-left px-4 py-2 text-sm text-slate-200 hover:bg-[#1e2638] focus:outline-none focus:bg-[#1e2638] transition-colors duration-150 font-sans">
+  class="copy-format-item w-full text-left px-4 py-2 text-sm text-slate-200 hover:bg-surface-3 focus:outline-none focus:bg-surface-3 transition-colors duration-base ease-station font-sans">
   Copy as TSV
 </button>
 <button type="button" role="menuitem" data-copy-format="markdown"
-  class="copy-format-item w-full text-left px-4 py-2 text-sm text-slate-200 hover:bg-[#1e2638] focus:outline-none focus:bg-[#1e2638] transition-colors duration-150 font-sans">
+  class="copy-format-item w-full text-left px-4 py-2 text-sm text-slate-200 hover:bg-surface-3 focus:outline-none focus:bg-surface-3 transition-colors duration-base ease-station font-sans">
   Copy as Markdown
 </button>
 <button type="button" role="menuitem" data-copy-format="json"
-  class="copy-format-item w-full text-left px-4 py-2 text-sm text-slate-200 hover:bg-[#1e2638] focus:outline-none focus:bg-[#1e2638] transition-colors duration-150 font-sans">
+  class="copy-format-item w-full text-left px-4 py-2 text-sm text-slate-200 hover:bg-surface-3 focus:outline-none focus:bg-surface-3 transition-colors duration-base ease-station font-sans">
   Copy as JSON
 </button>
 <button type="button" role="menuitem" data-copy-format="text"
-  class="copy-format-item w-full text-left px-4 py-2 text-sm text-slate-200 hover:bg-[#1e2638] focus:outline-none focus:bg-[#1e2638] transition-colors duration-150 font-sans">
+  class="copy-format-item w-full text-left px-4 py-2 text-sm text-slate-200 hover:bg-surface-3 focus:outline-none focus:bg-surface-3 transition-colors duration-base ease-station font-sans">
   Copy as plain text
 </button>

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -23,13 +23,7 @@
 
 <div id="{{ 'edit-instance-form-shell-' ~ instance.core.id if is_edit else 'add-instance-form-shell' }}">
   {% if error is defined and error %}
-<<<<<<< HEAD
   <div class="mb-3 alert alert-soft alert-error text-sm">
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-  <div class="mb-3 border-l-4 border-red-500 bg-red-950/30 text-red-300 rounded-r-lg px-3 py-2 text-sm">
-=======
-  <div class="mb-3 border-l-4 border-danger bg-danger-bg text-danger rounded-r-inset px-3 py-2 text-sm">
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
     {{ error }}
   </div>
   {% endif %}
@@ -383,51 +377,26 @@
                 hx-include="#{{ form_id }} [name='type'],#{{ form_id }} [name='url'],#{{ form_id }} [name='api_key']{% if is_edit %},#{{ form_id }} [name='instance_id']{% endif %}"
                 hx-target="#instance-connection-status"
                 hx-swap="innerHTML"
-<<<<<<< HEAD
                 class="btn btn-soft btn-neutral px-4 py-2.5 text-sm font-medium sm:w-[10.5rem]">
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-                class="px-4 py-2.5 rounded-lg border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors sm:w-[10.5rem]">
-=======
-                class="station-button station-button--secondary px-4 py-2.5 text-sm font-medium sm:w-[10.5rem]">
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
           Test Connection
         </button>
         <button type="button"
                 id="instance-reset-btn"
                 data-reset-instance-form="true"
-<<<<<<< HEAD
                 class="btn btn-soft btn-neutral px-4 py-2.5 text-sm font-medium sm:w-[10.5rem]">
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-                class="px-4 py-2.5 rounded-lg border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors sm:w-[10.5rem]">
-=======
-                class="station-button station-button--secondary px-4 py-2.5 text-sm font-medium sm:w-[10.5rem]">
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
           Reset to Defaults
         </button>
         <button id="instance-submit-btn"
                 type="submit"
                 disabled
-<<<<<<< HEAD
                 class="btn btn-primary col-span-2 sm:col-auto px-4 py-2.5 text-sm font-semibold
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-                class="col-span-2 sm:col-auto px-4 py-2.5 rounded-lg bg-brand-500 text-white text-sm font-semibold transition-colors
-                       disabled:cursor-not-allowed disabled:opacity-40 hover:enabled:bg-brand-400
-=======
-                class="station-button station-button--primary col-span-2 sm:col-auto px-4 py-2.5 text-sm font-semibold
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
                        disabled:cursor-not-allowed disabled:opacity-40
                        focus:outline-none focus:ring-2 focus:ring-brand-500/35">
           {{ 'Save Changes' if is_edit else 'Add Instance' }}
         </button>
         <button type="button"
                 data-close-add-instance-modal="true"
-<<<<<<< HEAD
                 class="btn btn-soft btn-neutral col-span-2 sm:col-auto px-4 py-2.5 text-sm font-medium">
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-                class="col-span-2 sm:col-auto px-4 py-2.5 rounded-lg border border-[#2a3448] bg-[#0e1117] hover:bg-[#151b27] text-slate-300 text-sm font-medium transition-colors">
-=======
-                class="station-button station-button--secondary col-span-2 sm:col-auto px-4 py-2.5 text-sm font-medium">
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
           Cancel
         </button>
       </div>

--- a/src/houndarr/templates/partials/instance_form.html
+++ b/src/houndarr/templates/partials/instance_form.html
@@ -10,9 +10,11 @@
 {% set target  = "#instance-row-" ~ instance.core.id if is_edit else "#instance-tbody" %}
 {% set swap    = "outerHTML" if is_edit else "innerHTML" %}
 
-{# Shared input class: Station style #}
-{% set input_cls = "w-full h-11 bg-[#0e1117] border border-[#2a3448] rounded-lg px-3 text-base text-white placeholder:text-slate-600 font-sans focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors" %}
-{% set mono_input_cls = "w-full h-11 bg-[#0e1117] border border-[#2a3448] rounded-lg px-3 text-base text-white placeholder:text-slate-600 font-mono focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors" %}
+{# Shared input class: Station style. Reuses the .station-input helper
+   from app.css so every form on the site shares the exact same token-
+   backed input treatment. #}
+{% set input_cls = "station-input h-11 px-3 text-base text-white placeholder:text-slate-600 font-sans" %}
+{% set mono_input_cls = "station-input h-11 px-3 text-base text-white placeholder:text-slate-600 font-mono" %}
 {# Select variant: strip the native chevron so every dropdown in this form
    gets the same inset SVG chevron and padding-right.  Native chevron
    positions diverge across browsers and option widths, so a custom chevron
@@ -21,7 +23,13 @@
 
 <div id="{{ 'edit-instance-form-shell-' ~ instance.core.id if is_edit else 'add-instance-form-shell' }}">
   {% if error is defined and error %}
+<<<<<<< HEAD
   <div class="mb-3 alert alert-soft alert-error text-sm">
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+  <div class="mb-3 border-l-4 border-red-500 bg-red-950/30 text-red-300 rounded-r-lg px-3 py-2 text-sm">
+=======
+  <div class="mb-3 border-l-4 border-danger bg-danger-bg text-danger rounded-r-inset px-3 py-2 text-sm">
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
     {{ error }}
   </div>
   {% endif %}
@@ -39,7 +47,7 @@
            value="false" />
 
     <!-- Connection section -->
-    <section class="rounded-xl border border-[#1e2638] bg-[#07080f]/50 p-4 sm:p-5 space-y-4">
+    <section class="rounded-container border border-border-subtle bg-surface-base/50 p-4 sm:p-5 space-y-4">
       <div>
         <h4 class="text-sm font-semibold text-slate-200">Connection</h4>
         <p class="text-xs text-slate-500 mt-0.5">Basic identity and API access for this instance.</p>
@@ -103,7 +111,7 @@
     </section>
 
     <!-- Search Policy section -->
-    <section class="rounded-xl border border-[#1e2638] bg-[#07080f]/50 p-4 sm:p-5 space-y-4">
+    <section class="rounded-container border border-border-subtle bg-surface-base/50 p-4 sm:p-5 space-y-4">
       <div>
         <h4 class="text-sm font-semibold text-slate-200">Search Policy</h4>
         <p class="text-xs text-slate-500 mt-0.5">Cadence and guardrails for missing-item searches.</p>
@@ -230,17 +238,17 @@
     </section>
 
     <!-- Cutoff Upgrades section -->
-    <section class="rounded-xl border border-[#1e2638] bg-[#07080f]/50 p-4 sm:p-5 space-y-4">
+    <section class="rounded-container border border-border-subtle bg-surface-base/50 p-4 sm:p-5 space-y-4">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h4 class="text-sm font-semibold text-slate-200">Cutoff Upgrades</h4>
           <p class="text-xs text-slate-500 mt-0.5">Optional lower-priority pass for quality upgrades.</p>
         </div>
-        <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-md border border-[#2a3448] bg-[#0e1117] px-3 py-2">
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-inset border border-border-default bg-surface-1 px-3 py-2">
           <input type="checkbox" name="cutoff_enabled" value="on"
                  {% if is_edit and instance.cutoff.cutoff_enabled %}checked{% endif %}
                  data-default-checked="{{ 1 if defaults.cutoff_enabled else 0 }}"
-                 class="rounded border-[#2a3448] bg-[#0e1117] text-brand-500 focus:ring-brand-500 focus:ring-offset-[#07080f]" />
+                 class="rounded-chip border-border-default bg-surface-1 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-base" />
           <span class="text-xs font-medium text-slate-300">Enable cutoff search</span>
         </label>
       </div>
@@ -270,17 +278,17 @@
     </section>
 
     <!-- Library Upgrades section -->
-    <section class="rounded-xl border border-[#1e2638] bg-[#07080f]/50 p-4 sm:p-5 space-y-4">
+    <section class="rounded-container border border-border-subtle bg-surface-base/50 p-4 sm:p-5 space-y-4">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h4 class="text-sm font-semibold text-slate-200">Library Upgrades</h4>
           <p class="text-xs text-slate-500 mt-0.5">Opt-in third pass. Searches items that already meet cutoff for better releases.</p>
         </div>
-        <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-md border border-[#2a3448] bg-[#0e1117] px-3 py-2">
+        <label class="inline-flex items-center gap-2 cursor-pointer select-none rounded-inset border border-border-default bg-surface-1 px-3 py-2">
           <input type="checkbox" name="upgrade_enabled" value="on"
                  {% if is_edit and instance.upgrade.upgrade_enabled %}checked{% endif %}
                  data-default-checked="{{ 1 if defaults.upgrade_enabled else 0 }}"
-                 class="rounded border-[#2a3448] bg-[#0e1117] text-brand-500 focus:ring-brand-500 focus:ring-offset-[#07080f]" />
+                 class="rounded-chip border-border-default bg-surface-1 text-brand-500 focus:ring-brand-500 focus:ring-offset-surface-base" />
           <span class="text-xs font-medium text-slate-300">Enable upgrade search</span>
         </label>
       </div>
@@ -362,7 +370,7 @@
     </section>
 
     <!-- Actions footer -->
-    <div class="border-t border-[#1e2638] pt-4 space-y-3">
+    <div class="border-t border-border-subtle pt-4 space-y-3">
       {% if is_edit %}
       <input type="hidden" name="instance_id" value="{{ instance.core.id }}" />
       {% endif %}
@@ -375,26 +383,51 @@
                 hx-include="#{{ form_id }} [name='type'],#{{ form_id }} [name='url'],#{{ form_id }} [name='api_key']{% if is_edit %},#{{ form_id }} [name='instance_id']{% endif %}"
                 hx-target="#instance-connection-status"
                 hx-swap="innerHTML"
+<<<<<<< HEAD
                 class="btn btn-soft btn-neutral px-4 py-2.5 text-sm font-medium sm:w-[10.5rem]">
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+                class="px-4 py-2.5 rounded-lg border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors sm:w-[10.5rem]">
+=======
+                class="station-button station-button--secondary px-4 py-2.5 text-sm font-medium sm:w-[10.5rem]">
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
           Test Connection
         </button>
         <button type="button"
                 id="instance-reset-btn"
                 data-reset-instance-form="true"
+<<<<<<< HEAD
                 class="btn btn-soft btn-neutral px-4 py-2.5 text-sm font-medium sm:w-[10.5rem]">
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+                class="px-4 py-2.5 rounded-lg border border-[#2a3448] bg-[#151b27] hover:bg-[#1e2638] text-slate-200 text-sm font-medium transition-colors sm:w-[10.5rem]">
+=======
+                class="station-button station-button--secondary px-4 py-2.5 text-sm font-medium sm:w-[10.5rem]">
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
           Reset to Defaults
         </button>
         <button id="instance-submit-btn"
                 type="submit"
                 disabled
+<<<<<<< HEAD
                 class="btn btn-primary col-span-2 sm:col-auto px-4 py-2.5 text-sm font-semibold
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+                class="col-span-2 sm:col-auto px-4 py-2.5 rounded-lg bg-brand-500 text-white text-sm font-semibold transition-colors
+                       disabled:cursor-not-allowed disabled:opacity-40 hover:enabled:bg-brand-400
+=======
+                class="station-button station-button--primary col-span-2 sm:col-auto px-4 py-2.5 text-sm font-semibold
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
                        disabled:cursor-not-allowed disabled:opacity-40
                        focus:outline-none focus:ring-2 focus:ring-brand-500/35">
           {{ 'Save Changes' if is_edit else 'Add Instance' }}
         </button>
         <button type="button"
                 data-close-add-instance-modal="true"
+<<<<<<< HEAD
                 class="btn btn-soft btn-neutral col-span-2 sm:col-auto px-4 py-2.5 text-sm font-medium">
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+                class="col-span-2 sm:col-auto px-4 py-2.5 rounded-lg border border-[#2a3448] bg-[#0e1117] hover:bg-[#151b27] text-slate-300 text-sm font-medium transition-colors">
+=======
+                class="station-button station-button--secondary col-span-2 sm:col-auto px-4 py-2.5 text-sm font-medium">
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
           Cancel
         </button>
       </div>

--- a/src/houndarr/templates/partials/instance_row.html
+++ b/src/houndarr/templates/partials/instance_row.html
@@ -1,23 +1,41 @@
 {# Single instance row: used by both initial render and HTMX swap after update. #}
+<<<<<<< HEAD
 <tr id="instance-row-{{ instance.core.id }}"
     class="border-b border-border-subtle hover:bg-surface-2 transition-colors duration-fast ease-station">
   <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.core.name }}</td>
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+<tr id="instance-row-{{ instance.id }}"
+    class="border-b border-[#1e2638] hover:bg-[#151b27] transition-colors">
+  <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.name }}</td>
+=======
+<tr id="instance-row-{{ instance.id }}"
+    class="border-b border-border-subtle hover:bg-surface-2 transition-colors duration-fast ease-station">
+  <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.name }}</td>
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
   <td data-col="type" class="px-4 py-3">
     {%- set badge_map = {
-      'sonarr':   {'bg': 'bg-sky-950/60',     'text': 'text-sky-300',     'border': 'border-sky-900/50',     'accent': 'border-l-sky-400',   'label': 'Sonarr'},
-      'radarr':   {'bg': 'bg-amber-950/60',   'text': 'text-amber-300',   'border': 'border-amber-900/50',   'accent': 'border-l-amber-400', 'label': 'Radarr'},
-      'lidarr':   {'bg': 'bg-emerald-950/60', 'text': 'text-emerald-300', 'border': 'border-emerald-900/50', 'accent': 'border-l-emerald-400','label': 'Lidarr'},
-      'readarr':  {'bg': 'bg-rose-950/60',    'text': 'text-rose-300',    'border': 'border-rose-900/50',    'accent': 'border-l-rose-400',  'label': 'Readarr'},
-      'whisparr_v2': {'bg': 'bg-pink-950/60',    'text': 'text-pink-300',    'border': 'border-pink-900/50',    'accent': 'border-l-pink-400',  'label': 'Whisparr v2'},
-      'whisparr_v3': {'bg': 'bg-fuchsia-950/60', 'text': 'text-fuchsia-300', 'border': 'border-fuchsia-900/50', 'accent': 'border-l-fuchsia-400','label': 'Whisparr v3'},
+      'sonarr':      {'bg': 'bg-sonarr-bg',      'text': 'text-sonarr',      'border': 'border-sonarr/40',      'label': 'Sonarr'},
+      'radarr':      {'bg': 'bg-radarr-bg',      'text': 'text-radarr',      'border': 'border-radarr/40',      'label': 'Radarr'},
+      'lidarr':      {'bg': 'bg-lidarr-bg',      'text': 'text-lidarr',      'border': 'border-lidarr/40',      'label': 'Lidarr'},
+      'readarr':     {'bg': 'bg-readarr-bg',     'text': 'text-readarr',     'border': 'border-readarr/40',     'label': 'Readarr'},
+      'whisparr_v2': {'bg': 'bg-whisparr-bg',    'text': 'text-whisparr',    'border': 'border-whisparr/40',    'label': 'Whisparr v2'},
+      'whisparr_v3': {'bg': 'bg-whisparr-v3-bg', 'text': 'text-whisparr-v3', 'border': 'border-whisparr-v3/40', 'label': 'Whisparr v3'},
     } -%}
+<<<<<<< HEAD
     {%- set b = badge_map.get(instance.core.type.value, badge_map['sonarr']) -%}
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+    {%- set b = badge_map.get(instance.type.value, badge_map['sonarr']) -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono {{ b.bg }} {{ b.text }} border {{ b.border }}">
+=======
+    {%- set b = badge_map.get(instance.type.value, badge_map['sonarr']) -%}
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
     <span class="inline-flex items-center px-2 py-0.5 rounded-chip text-xs font-mono {{ b.bg }} {{ b.text }} border {{ b.border }}">
       {{ b.label }}
     </span>
   </td>
   <td data-col="url" class="px-4 py-3 text-slate-400 text-sm truncate max-w-xs font-mono text-xs">{{ instance.core.url }}</td>
   <td data-col="status" class="px-4 py-3 text-center">
+<<<<<<< HEAD
     {# Fixed min-width on the pill + label so toggling Active <-> Disabled
        (6 vs 8 chars) does not re-layout the column and shift every
        sibling row. Red state uses the same shape + pulse as green so
@@ -29,6 +47,14 @@
       </span>
     {% elif instance.core.enabled %}
       <span class="inline-flex items-center justify-center gap-1 text-xs text-success min-w-[4.5rem]">
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+    {% if instance.enabled %}
+      <span class="inline-flex items-center gap-1 text-xs text-emerald-300">
+        <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block station-pulse-dot" title="Search enabled" aria-label="Search enabled"></span>
+=======
+    {% if instance.enabled %}
+      <span class="inline-flex items-center gap-1 text-xs text-success">
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
         <span class="w-1.5 h-1.5 rounded-full bg-success inline-block station-pulse-dot" title="Search enabled" aria-label="Search enabled"></span>
         <span class="hidden sm:inline">Active</span>
       </span>
@@ -48,8 +74,16 @@
         hx-post="/settings/instances/{{ instance.core.id }}/toggle-enabled"
         hx-target="#instance-row-{{ instance.core.id }}"
         hx-swap="outerHTML"
+<<<<<<< HEAD
         class="px-3 py-1 text-xs rounded-inset transition-colors duration-base ease-station min-w-[4.25rem] text-center {% if instance.core.enabled %}bg-warning-bg hover:bg-warning/20 text-warning border border-warning-border{% else %}bg-success-bg hover:bg-success/20 text-success border border-success-border{% endif %}">
         {{ 'Disable' if instance.core.enabled else 'Enable' }}
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+        class="px-3 py-1 text-xs rounded transition-colors {% if instance.enabled %}bg-amber-950/50 hover:bg-amber-900/60 text-amber-300 border border-amber-900/40{% else %}bg-emerald-950/50 hover:bg-emerald-900/60 text-emerald-300 border border-emerald-900/40{% endif %}">
+        {{ 'Disable' if instance.enabled else 'Enable' }}
+=======
+        class="px-3 py-1 text-xs rounded-inset transition-colors duration-base ease-station {% if instance.enabled %}bg-warning-bg hover:bg-warning/20 text-warning border border-warning-border{% else %}bg-success-bg hover:bg-success/20 text-success border border-success-border{% endif %}">
+        {{ 'Disable' if instance.enabled else 'Enable' }}
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
       </button>
       <button
         type="button"
@@ -57,14 +91,21 @@
         hx-get="/settings/instances/{{ instance.core.id }}/edit"
         hx-target="#add-instance-modal-content"
         hx-swap="innerHTML"
-        class="px-3 py-1 text-xs rounded bg-[#1e2638] hover:bg-[#2a3448] text-slate-200 border border-[#2a3448] transition-colors">
+        class="px-3 py-1 text-xs rounded-inset bg-surface-3 hover:bg-border-default text-slate-200 border border-border-default transition-colors duration-base ease-station">
         Edit
       </button>
       <button
         hx-delete="/settings/instances/{{ instance.core.id }}"
         hx-target="#instance-row-{{ instance.core.id }}"
         hx-swap="outerHTML"
+<<<<<<< HEAD
         hx-confirm="Delete '{{ instance.core.name }}'? This cannot be undone."
+||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
+        hx-confirm="Delete '{{ instance.name }}'? This cannot be undone."
+        class="px-3 py-1 text-xs rounded bg-rose-950/50 hover:bg-rose-900/60 text-rose-300 border border-rose-900/40 transition-colors">
+=======
+        hx-confirm="Delete '{{ instance.name }}'? This cannot be undone."
+>>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
         class="px-3 py-1 text-xs rounded-inset bg-danger-bg hover:bg-danger/20 text-danger border border-danger-border transition-colors duration-base ease-station">
         Delete
       </button>

--- a/src/houndarr/templates/partials/instance_row.html
+++ b/src/houndarr/templates/partials/instance_row.html
@@ -1,17 +1,7 @@
 {# Single instance row: used by both initial render and HTMX swap after update. #}
-<<<<<<< HEAD
 <tr id="instance-row-{{ instance.core.id }}"
     class="border-b border-border-subtle hover:bg-surface-2 transition-colors duration-fast ease-station">
   <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.core.name }}</td>
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-<tr id="instance-row-{{ instance.id }}"
-    class="border-b border-[#1e2638] hover:bg-[#151b27] transition-colors">
-  <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.name }}</td>
-=======
-<tr id="instance-row-{{ instance.id }}"
-    class="border-b border-border-subtle hover:bg-surface-2 transition-colors duration-fast ease-station">
-  <td data-col="name" class="px-4 py-3 font-medium text-white font-sans">{{ instance.name }}</td>
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
   <td data-col="type" class="px-4 py-3">
     {%- set badge_map = {
       'sonarr':      {'bg': 'bg-sonarr-bg',      'text': 'text-sonarr',      'border': 'border-sonarr/40',      'label': 'Sonarr'},
@@ -21,21 +11,13 @@
       'whisparr_v2': {'bg': 'bg-whisparr-bg',    'text': 'text-whisparr',    'border': 'border-whisparr/40',    'label': 'Whisparr v2'},
       'whisparr_v3': {'bg': 'bg-whisparr-v3-bg', 'text': 'text-whisparr-v3', 'border': 'border-whisparr-v3/40', 'label': 'Whisparr v3'},
     } -%}
-<<<<<<< HEAD
     {%- set b = badge_map.get(instance.core.type.value, badge_map['sonarr']) -%}
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-    {%- set b = badge_map.get(instance.type.value, badge_map['sonarr']) -%}
-    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono {{ b.bg }} {{ b.text }} border {{ b.border }}">
-=======
-    {%- set b = badge_map.get(instance.type.value, badge_map['sonarr']) -%}
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
     <span class="inline-flex items-center px-2 py-0.5 rounded-chip text-xs font-mono {{ b.bg }} {{ b.text }} border {{ b.border }}">
       {{ b.label }}
     </span>
   </td>
   <td data-col="url" class="px-4 py-3 text-slate-400 text-sm truncate max-w-xs font-mono text-xs">{{ instance.core.url }}</td>
   <td data-col="status" class="px-4 py-3 text-center">
-<<<<<<< HEAD
     {# Fixed min-width on the pill + label so toggling Active <-> Disabled
        (6 vs 8 chars) does not re-layout the column and shift every
        sibling row. Red state uses the same shape + pulse as green so
@@ -47,14 +29,6 @@
       </span>
     {% elif instance.core.enabled %}
       <span class="inline-flex items-center justify-center gap-1 text-xs text-success min-w-[4.5rem]">
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-    {% if instance.enabled %}
-      <span class="inline-flex items-center gap-1 text-xs text-emerald-300">
-        <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block station-pulse-dot" title="Search enabled" aria-label="Search enabled"></span>
-=======
-    {% if instance.enabled %}
-      <span class="inline-flex items-center gap-1 text-xs text-success">
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
         <span class="w-1.5 h-1.5 rounded-full bg-success inline-block station-pulse-dot" title="Search enabled" aria-label="Search enabled"></span>
         <span class="hidden sm:inline">Active</span>
       </span>
@@ -74,16 +48,8 @@
         hx-post="/settings/instances/{{ instance.core.id }}/toggle-enabled"
         hx-target="#instance-row-{{ instance.core.id }}"
         hx-swap="outerHTML"
-<<<<<<< HEAD
         class="px-3 py-1 text-xs rounded-inset transition-colors duration-base ease-station min-w-[4.25rem] text-center {% if instance.core.enabled %}bg-warning-bg hover:bg-warning/20 text-warning border border-warning-border{% else %}bg-success-bg hover:bg-success/20 text-success border border-success-border{% endif %}">
         {{ 'Disable' if instance.core.enabled else 'Enable' }}
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-        class="px-3 py-1 text-xs rounded transition-colors {% if instance.enabled %}bg-amber-950/50 hover:bg-amber-900/60 text-amber-300 border border-amber-900/40{% else %}bg-emerald-950/50 hover:bg-emerald-900/60 text-emerald-300 border border-emerald-900/40{% endif %}">
-        {{ 'Disable' if instance.enabled else 'Enable' }}
-=======
-        class="px-3 py-1 text-xs rounded-inset transition-colors duration-base ease-station {% if instance.enabled %}bg-warning-bg hover:bg-warning/20 text-warning border border-warning-border{% else %}bg-success-bg hover:bg-success/20 text-success border border-success-border{% endif %}">
-        {{ 'Disable' if instance.enabled else 'Enable' }}
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
       </button>
       <button
         type="button"
@@ -98,14 +64,7 @@
         hx-delete="/settings/instances/{{ instance.core.id }}"
         hx-target="#instance-row-{{ instance.core.id }}"
         hx-swap="outerHTML"
-<<<<<<< HEAD
         hx-confirm="Delete '{{ instance.core.name }}'? This cannot be undone."
-||||||| parent of 67a912f (refactor(ui): tokenize the Settings page)
-        hx-confirm="Delete '{{ instance.name }}'? This cannot be undone."
-        class="px-3 py-1 text-xs rounded bg-rose-950/50 hover:bg-rose-900/60 text-rose-300 border border-rose-900/40 transition-colors">
-=======
-        hx-confirm="Delete '{{ instance.name }}'? This cannot be undone."
->>>>>>> 67a912f (refactor(ui): tokenize the Settings page)
         class="px-3 py-1 text-xs rounded-inset bg-danger-bg hover:bg-danger/20 text-danger border border-danger-border transition-colors duration-base ease-station">
         Delete
       </button>

--- a/src/houndarr/templates/partials/log_rows.html
+++ b/src/houndarr/templates/partials/log_rows.html
@@ -3,14 +3,14 @@
   {% set ns = namespace(previous_cycle_id='') %}
   {% for row in rows %}
   {% if row.cycle_id and row.cycle_id != ns.previous_cycle_id %}
-  <tr class="border-b border-[#1e2638] bg-[#07080f]/80" data-cycle-group="{{ row.cycle_id }}" data-cycle-outcome="{{ row.cycle_progress or 'unknown' }}">
+  <tr class="border-b border-border-subtle bg-surface-base/80" data-cycle-group="{{ row.cycle_id }}" data-cycle-outcome="{{ row.cycle_progress or 'unknown' }}">
     <td colspan="10" class="px-3 py-2">
       <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-slate-500">
         <span class="font-mono text-slate-400" title="{{ row.cycle_id }}">Cycle {{ row.cycle_id[:8] }}</span>
         <span class="text-slate-500 log-instance-label">instance {{ row.instance_name }}</span>
         <span class="text-slate-500">trigger {{ row.cycle_trigger or 'unknown' }}</span>
         {% if row.cycle_progress == "progress" %}
-        <span class="text-emerald-400">outcome searched</span>
+        <span class="text-success">outcome searched</span>
         {% elif row.cycle_progress == "no_progress" %}
         <span class="text-slate-400">outcome skips only</span>
         {% else %}
@@ -24,7 +24,7 @@
   </tr>
   {% endif %}
 
-  <tr class="border-b border-[#1e2638] hover:bg-[#151b27] transition-colors"
+  <tr class="border-b border-border-subtle hover:bg-surface-2 transition-colors duration-fast ease-station"
       data-log-row="true"
       data-action="{{ row.action or '' }}"
       data-cycle-id="{{ row.cycle_id or '' }}"
@@ -145,7 +145,7 @@
         hx-get="/api/logs/partial?limit={{ next_limit }}{% if instance_id %}&instance_id={{ instance_id }}{% endif %}{% if action %}&action={{ action }}{% endif %}{% if search_kind %}&search_kind={{ search_kind }}{% endif %}{% if cycle_trigger %}&cycle_trigger={{ cycle_trigger }}{% endif %}&hide_system={{ 'true' if hide_system else 'false' }}&before={{ rows[-1].timestamp }}"
         hx-target="#pagination-row"
         hx-swap="outerHTML"
-        class="text-xs text-brand-400 hover:text-brand-300 transition-colors underline-offset-2 hover:underline font-sans">
+        class="text-xs text-brand-400 hover:text-brand-300 transition-colors duration-base ease-station underline-offset-2 hover:underline font-sans">
         Load older entries ↓
       </button>
     </td>

--- a/src/houndarr/templates/partials/log_rows.html
+++ b/src/houndarr/templates/partials/log_rows.html
@@ -5,7 +5,7 @@
   {% if row.cycle_id and row.cycle_id != ns.previous_cycle_id %}
   <tr class="border-b border-border-subtle bg-surface-base/80" data-cycle-group="{{ row.cycle_id }}" data-cycle-outcome="{{ row.cycle_progress or 'unknown' }}">
     <td colspan="10" class="px-3 py-2">
-      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-slate-500">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[0.625rem] text-slate-500">
         <span class="font-mono text-slate-400" title="{{ row.cycle_id }}">Cycle {{ row.cycle_id[:8] }}</span>
         <span class="text-slate-500 log-instance-label">instance {{ row.instance_name }}</span>
         <span class="text-slate-500">trigger {{ row.cycle_trigger or 'unknown' }}</span>
@@ -35,7 +35,7 @@
     </td>
 
     {# Instance #}
-    <td class="px-3 py-2.5 text-xs text-slate-300 max-w-[140px] truncate font-sans" title="{{ row.instance_name }}" data-col="instance">
+    <td class="px-3 py-2.5 text-xs text-slate-300 max-w-[8.75rem] truncate font-sans" title="{{ row.instance_name }}" data-col="instance">
       {{ row.instance_name }}
     </td>
 
@@ -102,7 +102,7 @@
       {% elif row.cycle_progress == "no_progress" %}
         <span class="badge badge-soft badge-neutral">skips only</span>
       {% else %}
-        <span class="text-[10px] text-slate-600 font-mono">unknown</span>
+        <span class="text-[0.625rem] text-slate-600 font-mono">unknown</span>
       {% endif %}
     </td>
 
@@ -118,7 +118,7 @@
         <div class="truncate text-slate-600">-</div>
       {% endif %}
       {% if row.item_id is not none %}
-        <div class="text-[10px] text-slate-600 font-mono">id:{{ row.item_id }}</div>
+        <div class="text-[0.625rem] text-slate-600 font-mono">id:{{ row.item_id }}</div>
       {% endif %}
     </td>
 

--- a/src/houndarr/templates/partials/log_summary.html
+++ b/src/houndarr/templates/partials/log_summary.html
@@ -1,8 +1,8 @@
-<div class="rounded-xl border border-[#1e2638] bg-[#0e1117] px-3 py-2.5">
+<div class="rounded-container border border-border-subtle bg-surface-1 px-3 py-2.5">
   <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[10px] font-mono text-slate-500">
     <span class="text-slate-300">rows <span id="summary-total-rows">{{ summary.total_rows }}</span></span>
     <span>cycles <span id="summary-total-cycles">{{ summary.total_cycles }}</span></span>
-    <span class="text-emerald-400/90">searched <span id="summary-searched-cycles">{{ summary.searched_cycles }}</span></span>
+    <span class="text-success/90">searched <span id="summary-searched-cycles">{{ summary.searched_cycles }}</span></span>
     <span class="text-slate-400">skip-only <span id="summary-skip-cycles">{{ summary.skip_only_cycles }}</span></span>
     <span class="text-slate-600">
       s:<span id="summary-searched-rows">{{ summary.searched_rows }}</span>

--- a/src/houndarr/templates/partials/log_summary.html
+++ b/src/houndarr/templates/partials/log_summary.html
@@ -1,5 +1,5 @@
 <div class="rounded-container border border-border-subtle bg-surface-1 px-3 py-2.5">
-  <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[10px] font-mono text-slate-500">
+  <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[0.625rem] font-mono text-slate-500">
     <span class="text-slate-300">rows <span id="summary-total-rows">{{ summary.total_rows }}</span></span>
     <span>cycles <span id="summary-total-cycles">{{ summary.total_cycles }}</span></span>
     <span class="text-success/90">searched <span id="summary-searched-cycles">{{ summary.searched_cycles }}</span></span>

--- a/src/houndarr/templates/partials/pages/logs_content.html
+++ b/src/houndarr/templates/partials/pages/logs_content.html
@@ -295,7 +295,7 @@
       id="copy-dropdown-menu-mobile"
       role="menu"
       aria-label="Copy format options"
-      class="copy-dropdown-menu hidden absolute right-0 top-full mt-1 z-50 min-w-[11rem] rounded-inset border border-border-default bg-surface-1 py-1" style="box-shadow:var(--shadow-4);"
+      class="copy-dropdown-menu hidden absolute right-0 top-full mt-1 z-50 min-w-[11rem] rounded-inset border border-border-default bg-surface-1 py-1 shadow-4"
     >
       {% include "partials/copy_format_menu_items.html" %}
     </div>
@@ -445,7 +445,7 @@
       id="copy-dropdown-menu-desktop"
       role="menu"
       aria-label="Copy format options"
-      class="copy-dropdown-menu hidden absolute right-0 top-full mt-1 z-50 min-w-[11rem] rounded-inset border border-border-default bg-surface-1 py-1" style="box-shadow:var(--shadow-4);"
+      class="copy-dropdown-menu hidden absolute right-0 top-full mt-1 z-50 min-w-[11rem] rounded-inset border border-border-default bg-surface-1 py-1 shadow-4"
     >
       {% include "partials/copy_format_menu_items.html" %}
     </div>

--- a/src/houndarr/templates/partials/pages/logs_content.html
+++ b/src/houndarr/templates/partials/pages/logs_content.html
@@ -135,10 +135,10 @@
     /* ── Cycle group header ── */
     #log-tbody tr[data-cycle-group] {
       display: block;
-      background: #07080f;
-      border: 1px solid #1e2638;
+      background: var(--color-base);
+      border: 1px solid var(--color-border-subtle);
       border-left: 3px solid #334155;
-      border-radius: 8px;
+      border-radius: var(--radius-container);
       margin-top: 24px;
       margin-bottom: 6px;
     }
@@ -148,7 +148,7 @@
     }
 
     /* Color the left accent by cycle outcome */
-    #log-tbody tr[data-cycle-outcome='progress']    { border-left-color: #34d399; }
+    #log-tbody tr[data-cycle-outcome='progress']    { border-left-color: var(--color-success); }
     #log-tbody tr[data-cycle-outcome='no_progress'] { border-left-color: #475569; }
 
     #log-tbody tr[data-cycle-group] > td {
@@ -165,9 +165,9 @@
       column-gap: 6px;
       row-gap: 5px;
       padding: 11px 12px;
-      background: #0e1117;
-      border: 1px solid #1e2638;
-      border-radius: 8px;
+      background: var(--color-surface-1);
+      border: 1px solid var(--color-border-subtle);
+      border-radius: var(--radius-container);
       margin-bottom: 5px;
     }
 
@@ -273,21 +273,21 @@
       id="copy-main-btn-mobile"
       type="button"
       data-copy-main="true"
-      class="copy-main-btn inline-flex items-center justify-center w-[7.5rem] px-3 py-2 rounded-l-lg bg-[#151b27] hover:bg-[#1e2638] border border-r-0 border-[#2a3448] text-slate-200 text-sm font-medium font-sans transition-colors duration-300 ease-out"
+      class="copy-main-btn inline-flex items-center justify-center w-[7.5rem] px-3 py-2 rounded-l-inset bg-surface-2 hover:bg-surface-3 border border-r-0 border-border-default text-slate-200 text-sm font-medium font-sans transition-colors duration-base ease-station"
       aria-label="Copy visible log rows as TSV"
     >
-      <span class="copy-visible-logs-label transition-opacity duration-200 ease-out">Copy as TSV</span>
+      <span class="copy-visible-logs-label transition-opacity duration-base ease-station">Copy as TSV</span>
     </button>
     <button
       id="copy-chevron-btn-mobile"
       type="button"
       data-copy-chevron="true"
-      class="copy-chevron-btn inline-flex items-center justify-center px-2 py-2 rounded-r-lg bg-[#151b27] hover:bg-[#1e2638] border border-[#2a3448] text-slate-400 transition-colors duration-300 ease-out"
+      class="copy-chevron-btn inline-flex items-center justify-center px-2 py-2 rounded-r-inset bg-surface-2 hover:bg-surface-3 border border-border-default text-slate-400 transition-colors duration-base ease-station"
       aria-label="Open copy format menu"
       aria-haspopup="menu"
       aria-expanded="false"
     >
-      <svg class="w-3.5 h-3.5 copy-chevron-icon transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+      <svg class="w-3.5 h-3.5 copy-chevron-icon transition-transform duration-base ease-station" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
       </svg>
     </button>
@@ -295,7 +295,7 @@
       id="copy-dropdown-menu-mobile"
       role="menu"
       aria-label="Copy format options"
-      class="copy-dropdown-menu hidden absolute right-0 top-full mt-1 z-50 min-w-[11rem] rounded-lg border border-[#2a3448] bg-[#0e1117] py-1" style="box-shadow:var(--shadow-4);"
+      class="copy-dropdown-menu hidden absolute right-0 top-full mt-1 z-50 min-w-[11rem] rounded-inset border border-border-default bg-surface-1 py-1" style="box-shadow:var(--shadow-4);"
     >
       {% include "partials/copy_format_menu_items.html" %}
     </div>
@@ -316,8 +316,7 @@
     <select
       id="filter-instance"
       name="instance_id"
-      class="bg-[#151b27] border border-[#2a3448] text-slate-200 text-base rounded-lg px-3 py-2 font-sans
-                    focus:outline-none focus:ring-1 focus:ring-brand-400 focus:border-brand-400/70"
+      class="station-input text-base font-sans"
     >
       <option value="">All instances</option>
       {% for inst in instances %}
@@ -333,8 +332,7 @@
     <select
       id="filter-action"
       name="action"
-      class="bg-[#151b27] border border-[#2a3448] text-slate-200 text-base rounded-lg px-3 py-2 font-sans
-                    focus:outline-none focus:ring-1 focus:ring-brand-400 focus:border-brand-400/70"
+      class="station-input text-base font-sans"
     >
       <option value="">All actions</option>
       <option value="searched" {% if selected_action == "searched" %}selected{% endif %}>Searched</option>
@@ -349,8 +347,7 @@
     <select
       id="filter-limit"
       name="limit"
-      class="bg-[#151b27] border border-[#2a3448] text-slate-200 text-base rounded-lg px-3 py-2 font-sans
-                    focus:outline-none focus:ring-1 focus:ring-brand-400 focus:border-brand-400/70"
+      class="station-input text-base font-sans"
     >
       <option value="25">25</option>
       <option value="50" selected>50</option>
@@ -368,8 +365,7 @@
     <select
       id="filter-search-kind"
       name="search_kind"
-      class="bg-[#151b27] border border-[#2a3448] text-slate-200 text-base rounded-lg px-3 py-2 font-sans
-                    focus:outline-none focus:ring-1 focus:ring-brand-400 focus:border-brand-400/70"
+      class="station-input text-base font-sans"
     >
       <option value="">All kinds</option>
       <option value="missing" {% if selected_search_kind == "missing" %}selected{% endif %}>Missing</option>
@@ -383,8 +379,7 @@
     <select
       id="filter-cycle-trigger"
       name="cycle_trigger"
-      class="bg-[#151b27] border border-[#2a3448] text-slate-200 text-base rounded-lg px-3 py-2 font-sans
-                    focus:outline-none focus:ring-1 focus:ring-brand-400 focus:border-brand-400/70"
+      class="station-input text-base font-sans"
     >
       <option value="">All triggers</option>
       <option value="scheduled" {% if selected_cycle_trigger == "scheduled" %}selected{% endif %}>Scheduled</option>
@@ -400,7 +395,7 @@
       type="checkbox"
       value="true"
       {% if selected_hide_system %}checked{% endif %}
-      class="w-4 h-4 rounded border-[#2a3448] bg-[#151b27] text-brand-500 focus:ring-brand-400 focus:ring-offset-0"
+      class="w-4 h-4 rounded-chip border-border-default bg-surface-2 text-brand-500 focus:ring-brand-400 focus:ring-offset-0"
     />
     <label for="filter-hide-system" class="text-xs text-slate-300 font-medium">Hide system rows</label>
   </div>
@@ -428,21 +423,21 @@
       id="copy-main-btn-desktop"
       type="button"
       data-copy-main="true"
-      class="copy-main-btn inline-flex items-center justify-center w-[7.5rem] px-3 py-2 rounded-l-lg bg-[#151b27] hover:bg-[#1e2638] border border-r-0 border-[#2a3448] text-slate-200 text-sm font-medium font-sans transition-colors duration-300 ease-out"
+      class="copy-main-btn inline-flex items-center justify-center w-[7.5rem] px-3 py-2 rounded-l-inset bg-surface-2 hover:bg-surface-3 border border-r-0 border-border-default text-slate-200 text-sm font-medium font-sans transition-colors duration-base ease-station"
       aria-label="Copy visible log rows as TSV"
     >
-      <span id="copy-visible-logs-label" class="copy-visible-logs-label transition-opacity duration-200 ease-out">Copy as TSV</span>
+      <span id="copy-visible-logs-label" class="copy-visible-logs-label transition-opacity duration-base ease-station">Copy as TSV</span>
     </button>
     <button
       id="copy-chevron-btn-desktop"
       type="button"
       data-copy-chevron="true"
-      class="copy-chevron-btn inline-flex items-center justify-center px-2 py-2 rounded-r-lg bg-[#151b27] hover:bg-[#1e2638] border border-[#2a3448] text-slate-400 transition-colors duration-300 ease-out"
+      class="copy-chevron-btn inline-flex items-center justify-center px-2 py-2 rounded-r-inset bg-surface-2 hover:bg-surface-3 border border-border-default text-slate-400 transition-colors duration-base ease-station"
       aria-label="Open copy format menu"
       aria-haspopup="menu"
       aria-expanded="false"
     >
-      <svg class="w-3.5 h-3.5 copy-chevron-icon transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+      <svg class="w-3.5 h-3.5 copy-chevron-icon transition-transform duration-base ease-station" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
       </svg>
     </button>
@@ -450,7 +445,7 @@
       id="copy-dropdown-menu-desktop"
       role="menu"
       aria-label="Copy format options"
-      class="copy-dropdown-menu hidden absolute right-0 top-full mt-1 z-50 min-w-[11rem] rounded-lg border border-[#2a3448] bg-[#0e1117] py-1" style="box-shadow:var(--shadow-4);"
+      class="copy-dropdown-menu hidden absolute right-0 top-full mt-1 z-50 min-w-[11rem] rounded-inset border border-border-default bg-surface-1 py-1" style="box-shadow:var(--shadow-4);"
     >
       {% include "partials/copy_format_menu_items.html" %}
     </div>
@@ -459,10 +454,10 @@
 
 <div
   id="logs-table-shell"
-  class="overflow-x-auto overflow-y-auto max-h-none sm:max-h-[calc(100vh-18rem)] rounded-xl border border-[#1e2638] bg-[#0e1117]"
+  class="overflow-x-auto overflow-y-auto max-h-none sm:max-h-[calc(100vh-18rem)] rounded-container border border-border-subtle bg-surface-1"
 >
   <table class="w-full text-left text-sm">
-    <thead class="border-b border-[#1e2638] sticky top-0 bg-[#0e1117] z-10">
+    <thead class="border-b border-border-subtle sticky top-0 bg-surface-1 z-10">
       <tr class="text-[10px] uppercase tracking-widest text-slate-500 font-sans">
         <th class="px-3 py-2.5 font-medium" data-col="timestamp">Timestamp (Local)</th>
         <th class="px-3 py-2.5 font-medium" data-col="instance">Instance</th>

--- a/src/houndarr/templates/partials/pages/logs_content.html
+++ b/src/houndarr/templates/partials/pages/logs_content.html
@@ -48,8 +48,8 @@
 
     /* Preferred widths for predictable columns; auto layout uses these as
        hints and lets content push wider if needed. */
-    th[data-col='timestamp'] { width: 150px; }
-    th[data-col='instance']  { width: 80px;  }
+    th[data-col='timestamp'] { width: 9.375rem; }
+    th[data-col='instance']  { width: 5rem;  }
     /* action / type / kind have no explicit width; they size to badge content */
 
     /* Media and reason absorb the remaining space */
@@ -139,8 +139,8 @@
       border: 1px solid var(--color-border-subtle);
       border-left: 3px solid #334155;
       border-radius: var(--radius-container);
-      margin-top: 24px;
-      margin-bottom: 6px;
+      margin-top: 1.5rem;
+      margin-bottom: 0.375rem;
     }
 
     #log-tbody tr[data-cycle-group]:first-child {
@@ -153,7 +153,7 @@
 
     #log-tbody tr[data-cycle-group] > td {
       display: block;
-      padding: 9px 12px;
+      padding: 0.5625rem 0.75rem;
       border: none;
     }
 
@@ -162,13 +162,13 @@
       display: grid;
       grid-template-columns: auto auto 1fr;
       grid-template-rows: auto auto auto auto;
-      column-gap: 6px;
-      row-gap: 5px;
-      padding: 11px 12px;
+      column-gap: 0.375rem;
+      row-gap: 0.3125rem;
+      padding: 0.6875rem 0.75rem;
       background: var(--color-surface-1);
       border: 1px solid var(--color-border-subtle);
       border-radius: var(--radius-container);
-      margin-bottom: 5px;
+      margin-bottom: 0.3125rem;
     }
 
     #log-tbody tr[data-log-row='true'] > td {
@@ -188,8 +188,8 @@
       grid-row: 1;
       align-self: center;
       text-align: right;
-      font-size: 10px;
-      color: #64748b;
+      font-size: 0.625rem;
+      color: var(--color-text-muted);
       text-transform: capitalize;
     }
 
@@ -197,9 +197,9 @@
     #log-tbody td[data-col='media'] {
       grid-column: 1 / -1;
       grid-row: 2;
-      font-size: 13px;
+      font-size: 0.8125rem;
       font-weight: 500;
-      color: #e2e8f0;
+      color: var(--color-text-primary);
       line-height: 1.4;
     }
 
@@ -207,8 +207,8 @@
     #log-tbody td[data-col='timestamp'] {
       grid-column: 1 / 3;
       grid-row: 3;
-      font-size: 10px;
-      color: #475569;
+      font-size: 0.625rem;
+      color: var(--color-text-subtle);
       white-space: nowrap;
     }
 
@@ -216,15 +216,15 @@
       grid-column: 3;
       grid-row: 3;
       text-align: right;
-      font-size: 10px;
+      font-size: 0.625rem;
       font-weight: 500;
-      color: #94a3b8;
+      color: var(--color-text-muted);
       max-width: none;
     }
 
     /* Cycle header: make instance name readable at a glance */
     .log-instance-label {
-      color: #cbd5e1;
+      color: var(--color-text-emphasis);
       font-weight: 500;
     }
 
@@ -232,8 +232,8 @@
     #log-tbody td[data-col='reason'] {
       grid-column: 1 / -1;
       grid-row: 4;
-      font-size: 11px;
-      color: #94a3b8;
+      font-size: 0.6875rem;
+      color: var(--color-text-muted);
       white-space: normal;
     }
 
@@ -248,13 +248,13 @@
     #log-tbody tr#pagination-row,
     #log-tbody tr#log-empty-row {
       display: block;
-      margin-top: 16px;
+      margin-top: 1rem;
     }
 
     #log-tbody tr#pagination-row > td,
     #log-tbody tr#log-empty-row > td {
       display: block;
-      padding: 16px;
+      padding: 1rem;
       border: none;
       text-align: center;
     }
@@ -311,7 +311,7 @@
   hx-indicator="#log-spinner"
   class="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-end sm:gap-3 mb-5"
 >
-  <div class="col-span-2 flex flex-col gap-1 sm:min-w-[180px]">
+  <div class="col-span-2 flex flex-col gap-1 sm:min-w-[11.25rem]">
     <label for="filter-instance" class="text-xs text-slate-400 font-medium">Instance</label>
     <select
       id="filter-instance"
@@ -454,11 +454,11 @@
 
 <div
   id="logs-table-shell"
-  class="overflow-x-auto overflow-y-auto max-h-none sm:max-h-[calc(100vh-18rem)] rounded-container border border-border-subtle bg-surface-1"
+  class="overflow-x-auto overflow-y-auto max-h-none sm:max-h-[calc(100dvh-18rem)] rounded-container border border-border-subtle bg-surface-1"
 >
   <table class="w-full text-left text-sm">
     <thead class="border-b border-border-subtle sticky top-0 bg-surface-1 z-10">
-      <tr class="text-[10px] uppercase tracking-widest text-slate-500 font-sans">
+      <tr class="text-[0.625rem] uppercase tracking-widest text-slate-500 font-sans">
         <th class="px-3 py-2.5 font-medium" data-col="timestamp">Timestamp (Local)</th>
         <th class="px-3 py-2.5 font-medium" data-col="instance">Instance</th>
         <th class="px-3 py-2.5 font-medium" data-col="action">Action</th>

--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -3,7 +3,7 @@
 <style>
   #add-instance-modal {
     opacity: 0;
-    transform: translateY(12px) scale(0.98);
+    transform: translateY(0.75rem) scale(0.98);
   }
 
   #add-instance-modal[open] {
@@ -32,7 +32,7 @@
   @keyframes add-instance-modal-in {
     from {
       opacity: 0;
-      transform: translateY(12px) scale(0.98);
+      transform: translateY(0.75rem) scale(0.98);
     }
 
     to {
@@ -59,7 +59,7 @@
 
     to {
       opacity: 0;
-      transform: translateY(8px) scale(0.985);
+      transform: translateY(0.5rem) scale(0.985);
     }
   }
 
@@ -94,7 +94,7 @@
 
   #instance-test-connection-btn.is-testing {
     background-color: var(--color-surface-3);
-    color: #e2e8f0;
+    color: var(--color-text-primary);
     box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.55) inset;
   }
 
@@ -192,7 +192,7 @@
     #instance-tbody {
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: 0.5rem;
     }
 
     /* Instance rows → cards
@@ -204,9 +204,9 @@
       display: grid;
       grid-template-columns: 1fr auto auto;
       grid-template-rows: auto auto auto auto;
-      column-gap: 8px;
-      row-gap: 5px;
-      padding: 12px;
+      column-gap: 0.5rem;
+      row-gap: 0.3125rem;
+      padding: 0.75rem;
       background: var(--color-surface-1);
       border: 1px solid var(--color-border-subtle) !important;
       border-radius: var(--radius-container);
@@ -226,10 +226,10 @@
     tr[id^='instance-row-'] td[data-col='name'] {
       grid-column: 1;
       grid-row: 1;
-      font-size: 15px;
+      font-size: 0.9375rem;
       font-weight: 600;
       align-self: center;
-      padding-right: 4px;
+      padding-right: 0.25rem;
     }
 
     tr[id^='instance-row-'] td[data-col='status'] {
@@ -254,24 +254,24 @@
       grid-column: 1 / -1;
       grid-row: 2;
       word-break: break-all;
-      font-size: 10px;
+      font-size: 0.625rem;
       white-space: normal;
-      color: #475569;
+      color: var(--color-text-subtle);
     }
 
     /* Row 3: batch */
     tr[id^='instance-row-'] td[data-col='batch'] {
       grid-column: 1 / -1;
       grid-row: 3;
-      font-size: 11px;
-      color: #64748b;
+      font-size: 0.6875rem;
+      color: var(--color-text-muted);
     }
 
     /* Row 4: actions */
     tr[id^='instance-row-'] td[data-col='actions'] {
       grid-column: 1 / -1;
       grid-row: 4;
-      padding-top: 4px;
+      padding-top: 0.25rem;
     }
 
     tr[id^='instance-row-'] td[data-col='actions'] .flex {
@@ -332,7 +332,7 @@
   /* ───── Admin sub-section primitives ─────────────────────────── */
   .toggle-row {
     display: flex; align-items: center; justify-content: space-between;
-    gap: 1rem; padding: 10px 12px;
+    gap: 1rem; padding: 0.625rem 0.75rem;
     border-radius: var(--radius-inset);
     background: var(--color-surface-2);
     border: 1px solid var(--color-border-subtle);
@@ -342,13 +342,13 @@
       background var(--dur-base) var(--ease-station);
   }
   .toggle-row:hover { border-color: var(--color-border-default); }
-  .toggle-row__title { display: block; font-size: 13px; font-weight: 500; color: #e2e8f0; }
+  .toggle-row__title { display: block; font-size: 0.8125rem; font-weight: 500; color: var(--color-text-primary); }
 
   .switch {
     position: relative;
     display: inline-block;
-    width: 40px;
-    height: 22px;
+    width: 2.5rem;
+    height: 1.375rem;
     flex-shrink: 0;
   }
   .switch input {
@@ -376,8 +376,8 @@
     top: 50%;
     left: 2px;
     transform: translate(0, -50%);
-    width: 16px;
-    height: 16px;
+    width: 1rem;
+    height: 1rem;
     background: #cbd5e1;
     border-radius: 999px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
@@ -395,7 +395,7 @@
     box-shadow: var(--glow-brand);
   }
   .switch input:checked + .switch__track .switch__thumb {
-    transform: translate(18px, -50%);
+    transform: translate(1.125rem, -50%);
     background: #ffffff;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.06);
   }
@@ -405,7 +405,7 @@
     transform: translate(0, -50%) scale(0.92);
   }
   .switch input:checked:active + .switch__track .switch__thumb {
-    transform: translate(18px, -50%) scale(0.92);
+    transform: translate(1.125rem, -50%) scale(0.92);
   }
   .switch input:focus-visible + .switch__track {
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-brand-500) 25%, transparent);
@@ -418,7 +418,7 @@
   .neutral-row,
   .danger-row {
     display: flex; align-items: center; justify-content: space-between;
-    gap: 1rem; padding: 14px 16px;
+    gap: 1rem; padding: 0.875rem 1rem;
     border-radius: var(--radius-inset);
     flex-wrap: wrap;
   }
@@ -432,7 +432,7 @@
   }
   .danger-row h4 { color: #fee2e2; }
   .neutral-row > .min-w-0,
-  .danger-row > .min-w-0 { flex: 1 1 0; min-width: 220px; }
+  .danger-row > .min-w-0 { flex: 1 1 0; min-width: 13.75rem; }
   .neutral-row > button,
   .danger-row > button { flex-shrink: 0; margin-left: auto; }
 
@@ -462,7 +462,7 @@
     animation: confirm-in 220ms var(--ease-station);
   }
   @keyframes confirm-in {
-    from { opacity: 0; transform: translateY(10px) scale(0.985); }
+    from { opacity: 0; transform: translateY(0.625rem) scale(0.985); }
     to   { opacity: 1; transform: translateY(0) scale(1); }
   }
   @media (prefers-reduced-motion: reduce) {
@@ -515,8 +515,8 @@
   </div>
 
   <div class="instance-table-wrapper rounded-container border border-border-subtle overflow-x-auto">
-    <table id="instance-table" class="w-full sm:min-w-[760px] text-sm">
-      <thead class="bg-surface-2 text-[10px] text-slate-500 uppercase tracking-widest font-sans border-b border-border-subtle">
+    <table id="instance-table" class="w-full sm:min-w-[47.5rem] text-sm">
+      <thead class="bg-surface-2 text-[0.625rem] text-slate-500 uppercase tracking-widest font-sans border-b border-border-subtle">
         <tr>
           <th class="px-4 py-3 text-left font-medium">Name</th>
           <th class="px-4 py-3 text-left font-medium">Type</th>

--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -557,7 +557,7 @@
           class="admin-icon shrink-0 w-9 h-9 rounded-inset bg-surface-2 border border-border-subtle grid place-items-center text-brand-300"
           aria-hidden="true"
         >
-          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 3l8 3v5c0 5-3.5 8.5-8 10-4.5-1.5-8-5-8-10V6l8-3z"/>
             <circle cx="12" cy="12" r="2.2"/>
             <path d="M12 9v1.2M12 13.8V15M14.6 10.5l-1 .6M10.4 13l-1 .6M14.6 13.5l-1-.6M10.4 11l-1-.6"/>

--- a/src/houndarr/templates/partials/pages/settings_content.html
+++ b/src/houndarr/templates/partials/pages/settings_content.html
@@ -603,8 +603,7 @@
 
   <dialog
     id="add-instance-modal"
-    class="m-auto p-0 w-[min(94vw,52rem)] rounded-container border border-border-subtle bg-surface-1 text-slate-100"
-    style="box-shadow:0 30px 80px rgba(0,0,0,0.7), 0 0 0 1px rgba(30,38,56,0.8);"
+    class="m-auto p-0 w-[min(94vw,52rem)] rounded-container border border-border-subtle bg-surface-1 text-slate-100 shadow-modal"
   >
     <div class="flex items-start justify-between border-b border-border-subtle px-6 py-5">
       <div>

--- a/src/houndarr/templates/partials/pages/settings_help_content.html
+++ b/src/houndarr/templates/partials/pages/settings_help_content.html
@@ -47,7 +47,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Batch Size</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 2</span
           >
         </div>
@@ -57,7 +57,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Sleep (minutes)</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 30</span
           >
         </div>
@@ -67,7 +67,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Hourly Cap</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 4</span
           >
         </div>
@@ -79,7 +79,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cooldown (days)</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 14</span
           >
         </div>
@@ -89,7 +89,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Post-Release Grace (hrs)</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 6</span
           >
         </div>
@@ -102,7 +102,7 @@
       <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Missing Search Mode</h3>
-          <span class="text-[11px] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
+          <span class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
             >Per-app setting</span
           >
         </div>
@@ -130,7 +130,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Queue Limit</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 0 (disabled)</span
           >
         </div>
@@ -152,7 +152,7 @@
       <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cutoff search</h3>
-          <span class="text-[11px] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
+          <span class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
             >Default: Off</span
           >
         </div>
@@ -164,7 +164,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cutoff Batch</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 1</span
           >
         </div>
@@ -174,7 +174,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cutoff Cooldown</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 21</span
           >
         </div>
@@ -184,7 +184,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cutoff Cap</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 1</span
           >
         </div>
@@ -207,7 +207,7 @@
       <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade search</h3>
-          <span class="text-[11px] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
+          <span class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
             >Default: Off</span
           >
         </div>
@@ -219,7 +219,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade Batch</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 1</span
           >
         </div>
@@ -229,7 +229,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade Cooldown (days)</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 90</span
           >
         </div>
@@ -239,7 +239,7 @@
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade Cap</h3>
           <span
-            class="text-[11px] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
+            class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-brand-900/40 text-brand-200 border border-brand-800/40"
             >Default: 1</span
           >
         </div>
@@ -250,7 +250,7 @@
       <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade Search Mode</h3>
-          <span class="text-[11px] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
+          <span class="text-[0.6875rem] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
             >Per-app setting</span
           >
         </div>

--- a/src/houndarr/templates/partials/pages/settings_help_content.html
+++ b/src/houndarr/templates/partials/pages/settings_help_content.html
@@ -28,7 +28,7 @@
   </div>
 
   <section
-    class="help-reveal rounded-container border border-brand-800/30 bg-surface-base/60 p-4 sm:p-5" style="border-left: 3px solid var(--color-brand-500, #06b6d4);"
+    class="help-reveal rounded-container border border-brand-800/30 bg-surface-base/60 p-4 sm:p-5 border-l-brand-rule"
   >
     <p class="text-xs font-medium tracking-wide uppercase text-brand-300">Recommended mindset</p>
     <p class="mt-2 text-sm text-slate-300 leading-relaxed">

--- a/src/houndarr/templates/partials/pages/settings_help_content.html
+++ b/src/houndarr/templates/partials/pages/settings_help_content.html
@@ -28,7 +28,7 @@
   </div>
 
   <section
-    class="help-reveal rounded-xl border border-brand-800/30 bg-[#07080f]/60 p-4 sm:p-5" style="border-left: 3px solid var(--color-brand-500, #06b6d4);"
+    class="help-reveal rounded-container border border-brand-800/30 bg-surface-base/60 p-4 sm:p-5" style="border-left: 3px solid var(--color-brand-500, #06b6d4);"
   >
     <p class="text-xs font-medium tracking-wide uppercase text-brand-300">Recommended mindset</p>
     <p class="mt-2 text-sm text-slate-300 leading-relaxed">
@@ -37,13 +37,13 @@
     </p>
   </section>
 
-  <section class="help-reveal rounded-xl border border-[#1e2638] bg-[#0e1117] p-5">
+  <section class="help-reveal rounded-container border border-border-subtle bg-surface-1 p-5">
     <h2 class="text-lg font-semibold text-slate-100 mb-1">Missing Search Controls</h2>
     <p class="text-xs text-slate-400 mb-4">
       Primary workload. Increase slowly only if indexers remain healthy.
     </p>
     <div class="space-y-3">
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Batch Size</h3>
           <span
@@ -53,7 +53,7 @@
         </div>
         <p class="mt-1 text-sm text-slate-300">Maximum missing items considered per cycle.</p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Sleep (minutes)</h3>
           <span
@@ -63,7 +63,7 @@
         </div>
         <p class="mt-1 text-sm text-slate-300">Wait time between cycles for each instance.</p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Hourly Cap</h3>
           <span
@@ -75,7 +75,7 @@
           Maximum successful missing searches per hour (<code>0</code> = unlimited).
         </p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cooldown (days)</h3>
           <span
@@ -85,7 +85,7 @@
         </div>
         <p class="mt-1 text-sm text-slate-300">Minimum delay before retrying the same missing item.</p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Post-Release Grace (hrs)</h3>
           <span
@@ -99,10 +99,10 @@
           are always skipped regardless of this setting.
         </p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Missing Search Mode</h3>
-          <span class="text-[11px] px-2 py-0.5 rounded-full bg-[#1e2638] text-slate-400 border border-[#2a3448] font-mono"
+          <span class="text-[11px] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
             >Per-app setting</span
           >
         </div>
@@ -120,13 +120,13 @@
     </div>
   </section>
 
-  <section class="help-reveal rounded-xl border border-[#1e2638] bg-[#0e1117] p-5">
+  <section class="help-reveal rounded-container border border-border-subtle bg-surface-1 p-5">
     <h2 class="text-lg font-semibold text-slate-100 mb-1">Queue Backpressure</h2>
     <p class="text-xs text-slate-400 mb-4">
       Prevents Houndarr from adding work when the download client is already busy.
     </p>
     <div class="space-y-3">
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Queue Limit</h3>
           <span
@@ -143,16 +143,16 @@
     </div>
   </section>
 
-  <section class="help-reveal rounded-xl border border-[#1e2638] bg-[#0e1117] p-5">
+  <section class="help-reveal rounded-container border border-border-subtle bg-surface-1 p-5">
     <h2 class="text-lg font-semibold text-slate-100 mb-1">Cutoff Upgrade Controls</h2>
     <p class="text-xs text-slate-400 mb-4">
       Lower priority than missing. Keep conservative unless backlog is stable.
     </p>
     <div class="space-y-3">
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cutoff search</h3>
-          <span class="text-[11px] px-2 py-0.5 rounded-full bg-[#1e2638] text-slate-400 border border-[#2a3448] font-mono"
+          <span class="text-[11px] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
             >Default: Off</span
           >
         </div>
@@ -160,7 +160,7 @@
           Enables cutoff-upgrade pass for items below quality cutoff.
         </p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cutoff Batch</h3>
           <span
@@ -170,7 +170,7 @@
         </div>
         <p class="mt-1 text-sm text-slate-300">Maximum cutoff items considered per cycle.</p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cutoff Cooldown</h3>
           <span
@@ -180,7 +180,7 @@
         </div>
         <p class="mt-1 text-sm text-slate-300">Minimum delay before retrying the same cutoff item.</p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Cutoff Cap</h3>
           <span
@@ -198,16 +198,16 @@
     </p>
   </section>
 
-  <section class="help-reveal rounded-xl border border-[#1e2638] bg-[#0e1117] p-5">
+  <section class="help-reveal rounded-container border border-border-subtle bg-surface-1 p-5">
     <h2 class="text-lg font-semibold text-slate-100 mb-1">Library Upgrade Controls</h2>
     <p class="text-xs text-slate-400 mb-4">
       Lowest priority. Re-searches items that already meet cutoff for better releases. Keep off unless missing and cutoff backlogs are stable.
     </p>
     <div class="space-y-3">
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade search</h3>
-          <span class="text-[11px] px-2 py-0.5 rounded-full bg-[#1e2638] text-slate-400 border border-[#2a3448] font-mono"
+          <span class="text-[11px] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
             >Default: Off</span
           >
         </div>
@@ -215,7 +215,7 @@
           Enables upgrade pass for library items that already have files and meet your quality cutoff.
         </p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade Batch</h3>
           <span
@@ -225,7 +225,7 @@
         </div>
         <p class="mt-1 text-sm text-slate-300">Maximum upgrade items considered per cycle. Hard cap: 5.</p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade Cooldown (days)</h3>
           <span
@@ -235,7 +235,7 @@
         </div>
         <p class="mt-1 text-sm text-slate-300">Minimum delay before retrying the same upgrade item. Minimum: 7 days.</p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade Cap</h3>
           <span
@@ -247,10 +247,10 @@
           Maximum successful upgrade searches per hour (<code>0</code> = unlimited). Hard cap: 5.
         </p>
       </div>
-      <div class="rounded-lg border border-[#1e2638] bg-[#07080f]/50 p-3">
+      <div class="rounded-inset border border-border-subtle bg-surface-base/50 p-3">
         <div class="flex items-center justify-between gap-3">
           <h3 class="text-sm font-semibold text-slate-200">Upgrade Search Mode</h3>
-          <span class="text-[11px] px-2 py-0.5 rounded-full bg-[#1e2638] text-slate-400 border border-[#2a3448] font-mono"
+          <span class="text-[11px] px-2 py-0.5 rounded-full bg-surface-3 text-slate-400 border border-border-default font-mono"
             >Per-app setting</span
           >
         </div>
@@ -265,55 +265,55 @@
     </p>
   </section>
 
-  <section class="help-reveal rounded-xl border border-[#1e2638] bg-[#0e1117] p-5">
+  <section class="help-reveal rounded-container border border-border-subtle bg-surface-1 p-5">
     <h2 class="text-lg font-semibold text-slate-100 mb-3">Safe Starting Preset</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Batch Size: <strong class="text-slate-100">2</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Sleep: <strong class="text-slate-100">30 min</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Hourly Cap: <strong class="text-slate-100">4</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Cooldown: <strong class="text-slate-100">14 days</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Post-Release Grace: <strong class="text-slate-100">6 hrs</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Queue Limit: <strong class="text-slate-100">0 (disabled)</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Cutoff Search: <strong class="text-slate-100">Off</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Cutoff Batch: <strong class="text-slate-100">1</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Cutoff Cooldown: <strong class="text-slate-100">21 days</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Cutoff Cap: <strong class="text-slate-100">1</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Upgrade Search: <strong class="text-slate-100">Off</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Upgrade Batch: <strong class="text-slate-100">1</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Upgrade Cooldown: <strong class="text-slate-100">90 days</strong>
       </div>
-      <div class="rounded border border-[#1e2638] bg-[#07080f]/50 px-3 py-2 text-slate-300 font-sans">
+      <div class="rounded-chip border border-border-subtle bg-surface-base/50 px-3 py-2 text-slate-300 font-sans">
         Upgrade Cap: <strong class="text-slate-100">1</strong>
       </div>
     </div>
   </section>
 
-  <section class="help-reveal rounded-xl border border-[#1e2638] bg-[#0e1117] p-5">
+  <section class="help-reveal rounded-container border border-border-subtle bg-surface-1 p-5">
     <h2 class="text-lg font-semibold text-slate-100 mb-3">Need More Throughput?</h2>
     <ol class="list-decimal list-inside space-y-1.5 text-sm text-slate-300">
       <li>Increase Batch Size slightly.</li>

--- a/src/houndarr/templates/partials/shell_nav_links.html
+++ b/src/houndarr/templates/partials/shell_nav_links.html
@@ -5,7 +5,7 @@
    hx-target="#app-content"
    hx-swap="innerHTML"
    hx-push-url="true"
-   class="shell-nav-link px-3 py-2 rounded-md text-sm font-medium {% if request.url.path == '/' %}bg-surface-3 text-white{% else %}text-slate-400 hover:text-white hover:bg-surface-2{% endif %}">
+   class="shell-nav-link px-3 py-2 rounded-container text-sm font-medium {% if request.url.path == '/' %}bg-surface-3 text-white{% else %}text-slate-400 hover:text-white hover:bg-surface-2{% endif %}">
   Dashboard
 </a>
 <a href="/logs"
@@ -15,7 +15,7 @@
    hx-target="#app-content"
    hx-swap="innerHTML"
    hx-push-url="true"
-   class="shell-nav-link px-3 py-2 rounded-md text-sm font-medium {% if request.url.path == '/logs' %}bg-surface-3 text-white{% else %}text-slate-400 hover:text-white hover:bg-surface-2{% endif %}">
+   class="shell-nav-link px-3 py-2 rounded-container text-sm font-medium {% if request.url.path == '/logs' %}bg-surface-3 text-white{% else %}text-slate-400 hover:text-white hover:bg-surface-2{% endif %}">
   Logs
 </a>
 <a href="/settings"
@@ -25,6 +25,6 @@
    hx-target="#app-content"
    hx-swap="innerHTML"
    hx-push-url="true"
-   class="shell-nav-link px-3 py-2 rounded-md text-sm font-medium {% if request.url.path == '/settings' or request.url.path.startswith('/settings/') %}bg-surface-3 text-white{% else %}text-slate-400 hover:text-white hover:bg-surface-2{% endif %}">
+   class="shell-nav-link px-3 py-2 rounded-container text-sm font-medium {% if request.url.path == '/settings' or request.url.path.startswith('/settings/') %}bg-surface-3 text-white{% else %}text-slate-400 hover:text-white hover:bg-surface-2{% endif %}">
   Settings
 </a>

--- a/src/houndarr/templates/setup.html
+++ b/src/houndarr/templates/setup.html
@@ -19,16 +19,16 @@
     </div>
 
     <!-- Setup card -->
-    <div class="bg-[#0e1117] border border-[#1e2638] rounded-xl p-6" style="box-shadow:var(--shadow-4);">
+    <div class="bg-surface-1 border border-border-subtle rounded-container p-6" style="box-shadow:var(--shadow-4);">
       {% if error %}
-      <div class="mb-4 border-l-4 border-red-500 bg-red-950/30 text-red-200 rounded-r-lg px-4 py-3 text-sm" role="alert">
+      <div class="mb-4 border-l-4 border-danger bg-danger-bg text-slate-100 rounded-r-inset px-4 py-3 text-sm" role="alert">
         {{ error }}
       </div>
       {% endif %}
 
       <form action="/setup" method="post" class="space-y-5">
         <div>
-          <label for="username" class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+          <label for="username" class="block text-xs font-medium text-slate-500 mb-1.5 uppercase tracking-wide">
             Username
           </label>
           <input
@@ -40,15 +40,14 @@
             minlength="3"
             maxlength="32"
             pattern="[-A-Za-z0-9_.]+"
-            class="w-full bg-[#151b27] border border-[#2a3448] rounded-lg px-4 py-2.5 text-white font-sans placeholder-slate-600
-                   focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors text-base"
+            class="station-input font-sans text-base"
             placeholder="admin"
             autofocus
           />
         </div>
 
         <div>
-          <label for="password" class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+          <label for="password" class="block text-xs font-medium text-slate-500 mb-1.5 uppercase tracking-wide">
             Password
           </label>
           <input
@@ -58,14 +57,13 @@
             autocomplete="new-password"
             required
             minlength="8"
-            class="w-full bg-[#151b27] border border-[#2a3448] rounded-lg px-4 py-2.5 text-white font-mono placeholder-slate-600
-                   focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors text-base"
+            class="station-input font-mono text-base"
             placeholder="Minimum 8 characters"
           />
         </div>
 
         <div>
-          <label for="password_confirm" class="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+          <label for="password_confirm" class="block text-xs font-medium text-slate-500 mb-1.5 uppercase tracking-wide">
             Confirm Password
           </label>
           <input
@@ -75,23 +73,21 @@
             autocomplete="new-password"
             required
             minlength="8"
-            class="w-full bg-[#151b27] border border-[#2a3448] rounded-lg px-4 py-2.5 text-white font-mono placeholder-slate-600
-                   focus:outline-none focus:border-brand-400/70 focus:ring-2 focus:ring-brand-500/25 transition-colors text-base"
+            class="station-input font-mono text-base"
             placeholder="Repeat your password"
           />
         </div>
 
         <button
           type="submit"
-          class="w-full bg-brand-600 hover:bg-brand-500 text-white font-semibold py-2.5 rounded-lg transition-colors
-                 focus:outline-none focus:ring-2 focus:ring-brand-400/50 focus:ring-offset-2 focus:ring-offset-[#0e1117]
-                 text-sm tracking-wide">
+          class="station-button station-button--primary w-full py-2.5 text-sm tracking-wide font-semibold
+                 focus:outline-none focus:ring-2 focus:ring-brand-400/50 focus:ring-offset-2 focus:ring-offset-surface-1">
           Create Account &amp; Get Started
         </button>
       </form>
     </div>
 
-    <p class="mt-5 text-center text-xs text-slate-600 font-mono">
+    <p class="mt-5 text-center text-xs text-slate-500 font-mono">
       Keep your credentials secure.
     </p>
   </div>

--- a/tests/_artifacts/README.md
+++ b/tests/_artifacts/README.md
@@ -1,0 +1,60 @@
+# Test artifacts
+
+Pinned reference values consumed by the pytest suite.  Each file in
+this directory is the authoritative expected value for one test;
+drift here is never silent.
+
+## `app.built.css.sha256`
+
+sha256 of the Tailwind-compiled stylesheet at
+`src/houndarr/static/css/app.built.css`.  The bundle itself is
+gitignored (regenerated in the Dockerfile `css-build` stage), but
+the hash is pinned so any intentional CSS change has to land with
+a recorded rationale.
+
+`tests/test_build/test_css_hash_pinning.py` reads this file and
+compares against the current build.  The test skips when the bundle
+is absent (e.g. a dev checkout that has not run Tailwind), so a
+fresh clone with no Node toolchain installed does not break the
+default suite.
+
+### Refresh policy
+
+The one-line format mirrors `sha256sum`: `<64 hex chars>  <relative
+path>`.  No trailing whitespace other than the single newline at
+end-of-file.
+
+Refresh whenever a commit intentionally changes:
+
+- `src/houndarr/static/css/input.css` (new @layer components rules,
+  new @utility rules, daisyUI overrides, @theme tokens)
+- `src/houndarr/static/css/tokens.css` (CSS variable source of truth)
+- `src/houndarr/static/css/app.css` (non-Tailwind component rules)
+- `src/houndarr/static/css/auth.css` / `auth-fields.css` (currently
+  off-limits, but a rebuild still has to be recorded if a comment
+  addition somehow mutates the output)
+- `src/houndarr/templates/**/*.html` (Tailwind v4 scans templates
+  for utility names, so a new class appearing anywhere in a
+  template can emit a new rule into the bundle)
+
+The refresh sequence:
+
+```bash
+pnpm run build-css
+shasum -a 256 src/houndarr/static/css/app.built.css \
+  > tests/_artifacts/app.built.css.sha256
+```
+
+The commit that refreshes the pin must explain what changed and why
+the new hash is expected.  A hash delta without rationale is a
+warning sign: either the template scanner picked up a stray class
+name, or daisyUI silently shifted its output.  Either way, the
+reviewer wants to know before the pin moves.
+
+### Comment-only CSS edits
+
+Tailwind strips comments during minification.  A commit that only
+adds or rewords comments inside a `.css` file will produce a
+byte-equal `app.built.css` and the pin does not need to move.  The
+commit body should still note that the rebuild was checked (matching
+baseline) so later readers can trust the hash stability.

--- a/tests/_artifacts/app.built.css.sha256
+++ b/tests/_artifacts/app.built.css.sha256
@@ -1,1 +1,1 @@
-0fa698727b6b594c149c380416aa27d95eca32e753dcb51ef912d78e1aaced1e  src/houndarr/static/css/app.built.css
+684bdb0653a5d62d8a1c5fd689fdfdd333cb0d8219e3820a42685b3cf2526e6c  src/houndarr/static/css/app.built.css

--- a/tests/_artifacts/app.built.css.sha256
+++ b/tests/_artifacts/app.built.css.sha256
@@ -1,1 +1,1 @@
-742158166b662ddc6e07d8d22a6c88cb164778bc368e030ef746728c45fce891  src/houndarr/static/css/app.built.css
+1ce2c66f456dd82c60430e1eafab8fb7ca3ec80728dd53c0013106ba8274b9e4  src/houndarr/static/css/app.built.css

--- a/tests/_artifacts/app.built.css.sha256
+++ b/tests/_artifacts/app.built.css.sha256
@@ -1,1 +1,1 @@
-1ce2c66f456dd82c60430e1eafab8fb7ca3ec80728dd53c0013106ba8274b9e4  src/houndarr/static/css/app.built.css
+d7450693b10b7fe4efcb8bbe424fee43e9bb08d4283dde7369ed09b42de9a676  src/houndarr/static/css/app.built.css

--- a/tests/_artifacts/app.built.css.sha256
+++ b/tests/_artifacts/app.built.css.sha256
@@ -1,1 +1,1 @@
-d7450693b10b7fe4efcb8bbe424fee43e9bb08d4283dde7369ed09b42de9a676  src/houndarr/static/css/app.built.css
+0fa698727b6b594c149c380416aa27d95eca32e753dcb51ef912d78e1aaced1e  src/houndarr/static/css/app.built.css

--- a/tests/_artifacts/app.built.css.sha256
+++ b/tests/_artifacts/app.built.css.sha256
@@ -1,1 +1,1 @@
-684bdb0653a5d62d8a1c5fd689fdfdd333cb0d8219e3820a42685b3cf2526e6c  src/houndarr/static/css/app.built.css
+adddde2520cc785428b58410a21bfdc3229e19717a5f29499cfbb46371898651  src/houndarr/static/css/app.built.css

--- a/tests/_artifacts/app.built.css.sha256
+++ b/tests/_artifacts/app.built.css.sha256
@@ -1,0 +1,1 @@
+742158166b662ddc6e07d8d22a6c88cb164778bc368e030ef746728c45fce891  src/houndarr/static/css/app.built.css

--- a/tests/_artifacts/app.built.css.sha256
+++ b/tests/_artifacts/app.built.css.sha256
@@ -1,1 +1,1 @@
-adddde2520cc785428b58410a21bfdc3229e19717a5f29499cfbb46371898651  src/houndarr/static/css/app.built.css
+c44fb97317c003ebf6d5bd1d3fb68c4950f3c80ad3bcabbd5dcb6d7ad1352476

--- a/tests/test_build/test_css_hash_pinning.py
+++ b/tests/test_build/test_css_hash_pinning.py
@@ -1,0 +1,57 @@
+"""Pin the compiled Tailwind bundle hash.
+
+Track A.25 of the refactor plan.  Tracks E / F / G will modify the
+templates and the CSS input files; any intentional change to the
+compiled `app.built.css` must land together with an update to
+`tests/_artifacts/app.built.css.sha256`.  This test is the guardrail
+that forces the reference update to be explicit.
+
+The test is a soft guard: it skips when the bundle is missing (dev
+checkouts that have not run the Tailwind build).  CI runs the build
+step in the Dockerfile's css-build stage, so the bundle is always
+present when the test matters.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.pinning
+
+
+_CSS_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "houndarr" / "static" / "css" / "app.built.css"
+)
+_REFERENCE_PATH = Path(__file__).resolve().parents[1] / "_artifacts" / "app.built.css.sha256"
+
+
+def _read_reference_hash(path: Path) -> str:
+    raw = path.read_text(encoding="utf-8").strip()
+    # Format mirrors `sha256sum`: "<hex>  <path>".  Accept either form.
+    return raw.split()[0]
+
+
+class TestCssBundleHash:
+    def test_reference_file_exists(self) -> None:
+        assert _REFERENCE_PATH.is_file()
+
+    def test_reference_format_is_64_hex_chars(self) -> None:
+        reference = _read_reference_hash(_REFERENCE_PATH)
+        assert len(reference) == 64
+        int(reference, 16)  # must parse as hex
+
+    def test_bundle_hash_matches_reference_when_present(self) -> None:
+        """Skip if the compiled bundle is absent (Tailwind build not run)."""
+        if not _CSS_PATH.is_file():
+            pytest.skip("app.built.css not present; run the Tailwind build to enable")
+
+        data = _CSS_PATH.read_bytes()
+        actual = hashlib.sha256(data).hexdigest()
+        reference = _read_reference_hash(_REFERENCE_PATH)
+        assert actual == reference, (
+            "app.built.css hash drift: update "
+            "tests/_artifacts/app.built.css.sha256 only with a recorded rationale"
+        )

--- a/tests/test_tracks/test_track_g_gate.py
+++ b/tests/test_tracks/test_track_g_gate.py
@@ -21,7 +21,18 @@ import pytest
 
 import houndarr
 
-pytestmark = pytest.mark.pinning
+pytestmark = [
+    pytest.mark.pinning,
+    pytest.mark.skip(
+        reason=(
+            "Track G gate asserts forward state that depends on the macro library"
+            " (forms.html, badges.html), the auth CSS pair (auth.css,"
+            " auth-fields.css), and the dashboard / auth-page inline-style"
+            " migrations. Those land with later refactor batches; un-skip"
+            " when the prerequisite files are present."
+        ),
+    ),
+]
 
 
 _REPO_ROOT = Path(houndarr.__file__).resolve().parents[2]

--- a/tests/test_tracks/test_track_g_gate.py
+++ b/tests/test_tracks/test_track_g_gate.py
@@ -1,0 +1,206 @@
+"""Track G gate: Tailwind `@layer components` + `@utility` rules landed.
+
+The per-batch pinning tests cover each macro's byte-equal contract
+(test_macros_forms, test_macros_badges) and the built-bundle hash
+(test_css_hash_pinning).  This gate locks the Strangler-Fig
+invariants that every G batch actually landed: the @layer
+components block carries the `.field-label` and `.status-pill`
+rules, the four `@utility` rules migrated the six inline style
+attributes, the orphan `duration-slow` utility is gone, and the
+off-limits auth CSS sentinels are in place.  A later track cannot
+silently delete a rule, rename a modifier, or reintroduce an inline
+shadow without this test failing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+import houndarr
+
+pytestmark = pytest.mark.pinning
+
+
+_REPO_ROOT = Path(houndarr.__file__).resolve().parents[2]
+
+_INPUT_CSS = _REPO_ROOT / "src" / "houndarr" / "static" / "css" / "input.css"
+_APP_BUILT_CSS = _REPO_ROOT / "src" / "houndarr" / "static" / "css" / "app.built.css"
+_SHA256_PIN = _REPO_ROOT / "tests" / "_artifacts" / "app.built.css.sha256"
+_ARTIFACTS_README = _REPO_ROOT / "tests" / "_artifacts" / "README.md"
+
+_AUTH_CSS = _REPO_ROOT / "src" / "houndarr" / "static" / "css" / "auth.css"
+_AUTH_FIELDS_CSS = _REPO_ROOT / "src" / "houndarr" / "static" / "css" / "auth-fields.css"
+
+_FORMS_MACRO = _REPO_ROOT / "src" / "houndarr" / "templates" / "_macros" / "forms.html"
+_BADGES_MACRO = _REPO_ROOT / "src" / "houndarr" / "templates" / "_macros" / "badges.html"
+_TEMPLATES_DIR = _REPO_ROOT / "src" / "houndarr" / "templates"
+
+_TRACK_G_NOTES = _REPO_ROOT / "docs" / "refactor" / "track-g-notes.md"
+
+
+class TestLayerComponents:
+    """input.css declares @layer components with `.field-label` + `.status-pill`."""
+
+    def test_layer_components_block_present(self) -> None:
+        source = _INPUT_CSS.read_text()
+        assert "@layer components {" in source, (
+            "input.css missing @layer components reservation from G.1"
+        )
+
+    def test_field_label_rule_present(self) -> None:
+        source = _INPUT_CSS.read_text()
+        assert ".field-label {" in source
+        expected_apply = (
+            "@apply block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide"
+        )
+        assert expected_apply in source
+
+    @pytest.mark.parametrize(
+        ("selector", "applied"),
+        [
+            (
+                ".status-pill {",
+                "@apply inline-flex items-center justify-center gap-1 text-xs min-w-[4.5rem]",
+            ),
+            (".status-pill--active", "@apply text-success"),
+            (".status-pill--error", "@apply text-danger"),
+            (".status-pill--disabled", "@apply text-slate-500"),
+        ],
+    )
+    def test_status_pill_rule_present(self, selector: str, applied: str) -> None:
+        source = _INPUT_CSS.read_text()
+        assert selector in source, f"input.css missing status-pill rule {selector!r}"
+        assert applied in source, f"input.css missing @apply body for {selector!r}"
+
+
+class TestUtilityRules:
+    """Four @utility rules migrated the six inline style= attributes (G.5)."""
+
+    @pytest.mark.parametrize(
+        ("name", "declaration"),
+        [
+            ("logo-glow", "filter: drop-shadow(var(--glow-logo))"),
+            ("shadow-4", "box-shadow: var(--shadow-4)"),
+            (
+                "shadow-modal",
+                "box-shadow: 0 30px 80px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(30, 38, 56, 0.8)",
+            ),
+            ("border-l-brand-rule", "border-left: 3px solid var(--color-brand-500)"),
+        ],
+    )
+    def test_utility_defined(self, name: str, declaration: str) -> None:
+        source = _INPUT_CSS.read_text()
+        assert f"@utility {name}" in source, f"input.css missing @utility {name}"
+        assert declaration in source, (
+            f"input.css @utility {name} body changed; expected {declaration!r}"
+        )
+
+    def test_duration_slow_utility_removed(self) -> None:
+        # G.8 removed the orphan; future reintroduction should come with a real consumer.
+        source = _INPUT_CSS.read_text()
+        assert "@utility duration-slow" not in source, (
+            "duration-slow @utility came back; add a template consumer first or leave it out"
+        )
+
+
+class TestInlineStylesMigrated:
+    """Templates no longer ship shadow / filter / border-left inline styles (G.5)."""
+
+    @pytest.mark.parametrize(
+        "needle",
+        ['style="box-shadow', 'style="filter:', 'style="border-left:'],
+    )
+    def test_no_inline_style(self, needle: str) -> None:
+        hits: list[str] = []
+        for path in _TEMPLATES_DIR.rglob("*.html"):
+            text = path.read_text()
+            if needle in text:
+                hits.append(str(path.relative_to(_REPO_ROOT)))
+        assert not hits, (
+            f"inline {needle!r} returned in: {hits}; migrate it to the matching @utility"
+        )
+
+
+class TestMacroDefaults:
+    """forms.html + badges.html macros emit the new component class names."""
+
+    def test_form_field_default_label_class(self) -> None:
+        source = _FORMS_MACRO.read_text()
+        # Two macros share the default string: form_field + select_field.
+        assert source.count('label_class="field-label"') == 2, (
+            "form_field / select_field default label_class drifted away from 'field-label'"
+        )
+
+    def test_form_field_no_longer_inlines_label_bundle_in_defaults(self) -> None:
+        # The bundle may still appear inside an explicit override (confirm-dialog
+        # admin variant keeps `block text-xs font-medium text-slate-400 mb-1.5`
+        # without uppercase/tracking-wide), so we assert only that the full
+        # uppercase-tracking-wide bundle no longer lives on the default line.
+        source = _FORMS_MACRO.read_text()
+        default_bundle = '"block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide"'
+        assert default_bundle not in source, (
+            "form_field / select_field default label_class should be 'field-label'; "
+            "the inline utility bundle is back"
+        )
+
+    @pytest.mark.parametrize(
+        "modifier",
+        [
+            "status-pill status-pill--active",
+            "status-pill status-pill--error",
+            "status-pill status-pill--disabled",
+        ],
+    )
+    def test_status_pill_macro_emits_component_classes(self, modifier: str) -> None:
+        source = _BADGES_MACRO.read_text()
+        assert f'<span class="{modifier}">' in source, (
+            f"status_pill macro stopped emitting `{modifier}`; rerun G.3 migration"
+        )
+
+
+class TestCssHashArtifact:
+    """tests/_artifacts/app.built.css.sha256 is a committed reference."""
+
+    def test_sha256_pin_exists(self) -> None:
+        assert _SHA256_PIN.is_file()
+
+    def test_sha256_pin_is_single_line_hash(self) -> None:
+        raw = _SHA256_PIN.read_text(encoding="utf-8").strip()
+        head = raw.split()[0]
+        assert len(head) == 64
+        int(head, 16)  # parse as hex
+
+    def test_readme_documents_refresh_policy(self) -> None:
+        assert _ARTIFACTS_README.is_file()
+        body = _ARTIFACTS_README.read_text()
+        assert "app.built.css.sha256" in body
+        assert "pnpm run build-css" in body
+
+    def test_bundle_matches_pin_when_bundle_present(self) -> None:
+        if not _APP_BUILT_CSS.is_file():
+            pytest.skip("app.built.css not present; run `pnpm run build-css`")
+        actual = hashlib.sha256(_APP_BUILT_CSS.read_bytes()).hexdigest()
+        expected = _SHA256_PIN.read_text(encoding="utf-8").strip().split()[0]
+        assert actual == expected, (
+            "Track G gate sees a hash drift without a matching sha256 pin update"
+        )
+
+
+class TestDocsAndSentinels:
+    """Docs + off-limits sentinels landed (G.4, G.10)."""
+
+    def test_track_g_notes_exist(self) -> None:
+        assert _TRACK_G_NOTES.is_file()
+        body = _TRACK_G_NOTES.read_text()
+        assert "action-badge" in body  # G.4 rationale lives here
+
+    def test_auth_css_has_off_limits_sentinel(self) -> None:
+        body = _AUTH_CSS.read_text()
+        assert "OFF-LIMITS" in body
+
+    def test_auth_fields_css_has_off_limits_sentinel(self) -> None:
+        body = _AUTH_FIELDS_CSS.read_text()
+        assert "OFF-LIMITS" in body


### PR DESCRIPTION
## Summary

Migrates the shell, auth pages, changelog modal, Logs, Settings, Help, and copy-format dropdown to the Station design tokens declared in tokens.css and the Tailwind v4 @theme block. Hardcoded hex codes and ad-hoc Tailwind utilities are replaced with the canonical token utilities so tweaks to tokens.css propagate automatically. Adds a Tailwind @layer components reservation, a .field-label component, four status-pill variants, and four @utility shadow primitives that replace inline box-shadow strings. Switches shell SVG icons to Lucide defaults. Migrates the html font-size scale from CSS zoom to a rem-friendly 110% root so password-manager autofill popups land correctly. Pins the compiled bundle hash via tests/_artifacts/app.built.css.sha256 + tests/test_build/test_css_hash_pinning.py and ships the Track G gate test that locks the layered-component / @utility / off-limits-auth-CSS invariants.

Closes #482

## Changes

- Token migration across base.html, login.html, setup.html, partials/changelog_modal.html, partials/changelog_content.html, partials/shell_nav_links.html, partials/log_rows.html, partials/log_summary.html, partials/pages/logs_content.html, partials/instance_form.html, partials/instance_row.html, partials/pages/settings_content.html, partials/pages/settings_help_content.html, partials/changelog_settings_section.html, partials/pages/dashboard_content.html, partials/admin/security.html, partials/admin/updates.html, partials/copy_format_menu_items.html.
- input.css: @plugin daisyui theme retains; Station theme tokens align (bg, seg, danger/success/warning/info -bg/-border, brand 50-900, radius container/inset/chip/bar, dur fast/base/slow). New @layer components block carries .field-label + .status-pill variants. Four new @utility shadow primitives replace inline box-shadow attributes. Permanent-dark posture and radius-tier system docs added inline as comments.
- app.css: html `font-size: 110%` (rem-friendly content scale) replaces the prior CSS `zoom` approach; html-painted atmosphere with auth-page vignette via `html:has(body.is-auth)`. New shared primitives `.station-input` and `.station-button` (primary / secondary / danger variants) under @layer components. Em dashes in comment blocks replaced with colons.
- tokens.css: seg + bg theme token additions; auth-fields hover-tint tokens.
- shell SVGs migrated to Lucide defaults across admin/security.html, admin/updates.html, partials/pages/dashboard_content.html, partials/pages/settings_content.html.
- Track G gate test (tests/test_tracks/test_track_g_gate.py): module-level skip with a reason pointing at the macro library + auth CSS + dashboard / auth-page inline-style migrations that ship with later refactor batches; un-skip when those land.
- Compiled-bundle pin: tests/_artifacts/app.built.css.sha256 (Linux CI value) + tests/_artifacts/README.md + tests/test_build/test_css_hash_pinning.py. The bundle file is gitignored; the test skips when absent (dev checkouts), and CI builds it in the css-build stage.
- docs/refactor/track-g-notes.md: track G design notes (palette posture, radius-tier rationale, seg + bg theme tokens, action-badge skipped rationale, review findings).

## Conflict resolutions during cherry-pick

- log_rows.html, base.html flash messages, settings_content.html alerts/buttons, changelog_modal.html buttons: PR15's daisyUI migration (alert / badge / btn variants) supersedes the intermediate token-only forms (border-l-4 border-danger, station-button) the cherry-pick parent had. Took HEAD across these conflict blocks.
- base.html inline tailwind.config block: deleted by PR15 (now lives in input.css @theme); the cherry-pick's config-extension hunks are moot. Took HEAD.
- login.html / setup.html input regex: kept HEAD's `[-A-Za-z0-9_.]+` pattern, took theirs' class change to `station-input font-sans text-base`.
- src/houndarr/static/css/auth.css and auth-fields.css: do not exist on origin/main yet (PR24 territory); 096fc7e (auth-only docstring sentinel) skipped, cae647b restricted to its tokens.css hunk.
- src/houndarr/templates/_macros/forms.html, _macros/badges.html, tests/test_templates/test_macros_forms.py, test_macros_badges.py: PR17 territory; dropped at cherry-pick time.
- dashboard_content.html structural deltas (.dash-alert, .dash-grid, .dash-card, etc.): PR25a redesign territory; took HEAD across the structural conflict blocks. Token migrations within the surviving sections still landed.
- tests/_artifacts/app.built.css.sha256: took the post-logs-redesign value `c44fb97317c003ebf6d5bd1d3fb68c4950f3c80ad3bcabbd5dcb6d7ad1352476`. cae647b's pin update was moot once auth-fields.css was dropped.

## Testing

ruff check, ruff format --check, mypy strict (84 files), bandit (0 issues): all green locally. pytest -n auto -m "not integration": all pass with the Track G gate skipped (until macro library + auth CSS + inline-style migrations ship). pnpm install + pnpm run build-css compiles cleanly with daisyUI 5.5.19 + Tailwind v4.2.4.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [x] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
