### PR TITLE
test(mock-arr): seeded *arr mock server and chi-square probes

### DIFF
--- a/justfile
+++ b/justfile
@@ -77,6 +77,13 @@ fix:
 dev:
     {{python}} -m houndarr --data-dir ./data-dev --dev
 
+# Launch the seeded mock *arr server. Mounts all six apps under one process
+# at distinct path prefixes (e.g. http://127.0.0.1:9100/sonarr). `items`
+# controls the approximate leaf count per app; `seed` makes the data
+# deterministic so two runs produce identical IDs.
+mock-arr port='9100' items='500' seed='42':
+    {{python}} -m tests.mock_arr.server --port {{port}} --items {{items}} --seed {{seed}}
+
 # Browser e2e against a Docker-Compose stack. Assumes the image is built
 # and mock-sonarr / mock-radarr are reachable on the shared network.
 # Host env: HOUNDARR_URL, MOCK_SONARR_URL, MOCK_RADARR_URL, HOUNDARR_E2E_USER,

--- a/tests/mock_arr/README.md
+++ b/tests/mock_arr/README.md
@@ -1,0 +1,105 @@
+# Mock *arr Server
+
+A single-process FastAPI mock that pretends to be Sonarr, Radarr, Lidarr,
+Readarr, Whisparr v2, and Whisparr v3. Built for end-to-end testing of
+Houndarr's search engine: the response shapes match the live *arr APIs,
+seeded data is deterministic, and POSTed search commands are captured for
+later assertion.
+
+## Why
+
+The live test *arr instances at `10.0.10.106:*` only carry a handful of
+records. Houndarr's random search algorithm has different behaviour
+regimes depending on `total_pages` vs `_MAX_LIST_PAGES_PER_PASS = 5`,
+and the test instances are too small to exercise the regime that real
+users sit in. This mock fills the gap by giving every app hundreds of
+items at startup, configurable from the CLI.
+
+## Run
+
+```
+just mock-arr                              # default: 500 items per app, seed 42, port 9100
+just mock-arr port=9200 items=2000 seed=7  # heavier load, different seed
+.venv/bin/python -m tests.mock_arr.server --port 9100 --items 500
+```
+
+The root URL prints a summary of seeded counts:
+
+```
+curl -s http://127.0.0.1:9100/ | jq .
+```
+
+Each app is mounted at `/<app>/api/v{1,3}/...`:
+
+| App          | Base URL                              | API version |
+|--------------|---------------------------------------|-------------|
+| Sonarr       | `http://127.0.0.1:9100/sonarr`        | v3 |
+| Radarr       | `http://127.0.0.1:9100/radarr`        | v3 |
+| Lidarr       | `http://127.0.0.1:9100/lidarr`        | v1 |
+| Readarr      | `http://127.0.0.1:9100/readarr`       | v1 |
+| Whisparr v2  | `http://127.0.0.1:9100/whisparr_v2`   | v3 |
+| Whisparr v3  | `http://127.0.0.1:9100/whisparr_v3`   | v3 |
+
+Any `X-Api-Key` value (or none) is accepted.
+
+## Endpoints implemented
+
+Every app:
+- `GET  /api/v{N}/system/status`
+- `GET  /api/v{N}/queue/status`
+- `POST /api/v{N}/command`
+
+Sonarr / Whisparr v2:
+- `GET /api/v3/wanted/missing` (paginated, `monitored`, `sortKey`, `sortDirection`, `includeSeries`)
+- `GET /api/v3/wanted/cutoff`
+- `GET /api/v3/series`
+- `GET /api/v3/episode?seriesId={id}`
+
+Radarr:
+- `GET /api/v3/wanted/missing`
+- `GET /api/v3/wanted/cutoff`
+- `GET /api/v3/movie`
+
+Lidarr / Readarr (v1):
+- `GET /api/v1/wanted/missing` (with `includeArtist` / `includeAuthor`)
+- `GET /api/v1/wanted/cutoff`
+- `GET /api/v1/{artist,album}` or `/api/v1/{author,book}`
+
+Whisparr v3 (no `/wanted` endpoints):
+- `GET /api/v3/movie` (full library; Houndarr filters in memory)
+
+Debug:
+- `GET /__commands__/{sonarr|radarr|lidarr|readarr|whisparr_v2|whisparr_v3}` returns
+  every command POSTed to that app since launch. Useful for asserting
+  what the engine actually dispatched during a cycle.
+
+## Wiring it into Houndarr
+
+1. Start the mock: `just mock-arr items=500`
+2. Start a Houndarr dev instance: `just dev` (uses `./data-dev`)
+3. In the Houndarr UI, add six instances pointing at the mock URLs
+   above. Any string works as the API key.
+4. Enable random search order on whichever instance you want to study.
+5. Watch the search log via `sqlite3 data-dev/houndarr.db` or the
+   `/api/logs` route. Use the `/__commands__/{app}` debug endpoint to
+   cross-check actual dispatch against the search log.
+
+## Tuning record counts
+
+The CLI takes a single `--items` knob that fans out to every app. To
+study the small-library bias regime, drop `--items` low:
+
+```
+just mock-arr items=15  # forces N < 5 pages at pageSize=10
+just mock-arr items=20  # N = 2 pages at pageSize=10
+```
+
+For per-app overrides, import `SeedConfig` from `tests.mock_arr.server`
+and call `create_app(SeedConfig(...))` directly.
+
+## Determinism
+
+`--seed` controls every RNG draw: leaf-id assignment, parent partitioning,
+the missing/cutoff/upgrade split, and the within-leaves shuffle that
+decides which records end up in which bucket. Two runs with the same
+`--seed` and `--items` produce byte-identical responses.

--- a/tests/mock_arr/__init__.py
+++ b/tests/mock_arr/__init__.py
@@ -1,0 +1,3 @@
+"""Seeded mock *arr server for end-to-end testing of Houndarr's search engine."""
+
+from __future__ import annotations

--- a/tests/mock_arr/_common.py
+++ b/tests/mock_arr/_common.py
@@ -1,0 +1,116 @@
+"""Shared helpers used by every per-app router.
+
+The pagination envelope, ping/queue/command handlers, and the partition logic
+are identical across all six *arr types. Centralising them keeps each router
+file focused on the per-app record shape.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from fastapi import APIRouter, Body, Query
+
+from tests.mock_arr.store import AppData
+
+
+def paginate(
+    records: list[dict[str, Any]],
+    *,
+    page: int,
+    page_size: int,
+    sort_key: str,
+    sort_direction: str,
+) -> dict[str, Any]:
+    """Wrap a slice of ``records`` in the *arr pagination envelope.
+
+    Real *arr APIs sort server-side. The mock keeps records in a stable
+    seeded order so callers see deterministic pagination; we still echo
+    the requested ``sort_key`` / ``sort_direction`` to match the wire shape.
+    """
+    total = len(records)
+    start = max(0, (page - 1) * page_size)
+    end = start + page_size
+    return {
+        "page": page,
+        "pageSize": page_size,
+        "sortKey": sort_key,
+        "sortDirection": sort_direction,
+        "totalRecords": total,
+        "records": records[start:end],
+    }
+
+
+def partition_leaf_ids(
+    leaf_ids: list[int],
+    *,
+    seed: int,
+    missing_ratio: float,
+    cutoff_ratio: float,
+) -> tuple[set[int], set[int], set[int]]:
+    """Split a flat list of leaf ids into missing / cutoff / upgrade buckets.
+
+    The ratios apply in order: ``missing_ratio`` first, then ``cutoff_ratio``
+    of the remainder, then everything left becomes upgrade-eligible. The
+    partition is shuffled deterministically with ``seed`` so the same seed
+    always reproduces the same bucket assignment.
+    """
+    rng = random.Random(seed)
+    pool = list(leaf_ids)
+    rng.shuffle(pool)
+    n = len(pool)
+    n_missing = int(n * missing_ratio)
+    n_cutoff = int(n * cutoff_ratio)
+    missing = set(pool[:n_missing])
+    cutoff = set(pool[n_missing : n_missing + n_cutoff])
+    upgrade = set(pool[n_missing + n_cutoff :])
+    return missing, cutoff, upgrade
+
+
+def attach_common_routes(router: APIRouter, data: AppData) -> None:
+    """Wire ``/system/status``, ``/queue/status``, and ``POST /command``.
+
+    Every *arr app exposes these three endpoints with the same shape, so
+    each per-app router gets them via this helper rather than re-declaring.
+    The command handler stores every POST so tests can assert dispatch.
+    """
+
+    @router.get("/system/status")
+    async def system_status() -> dict[str, Any]:
+        return {"appName": data.app_name, "version": data.app_version}
+
+    @router.get("/queue/status")
+    async def queue_status() -> dict[str, Any]:
+        return {
+            "totalCount": 0,
+            "count": 0,
+            "unknownCount": 0,
+            "errors": False,
+            "warnings": False,
+        }
+
+    @router.post("/command")
+    async def post_command(
+        body: dict[str, Any] = Body(default_factory=dict),
+    ) -> dict[str, Any]:
+        data.command_log.entries.append(body)
+        return {
+            "id": len(data.command_log.entries),
+            "name": body.get("name", "Unknown"),
+            "status": "queued",
+            "queued": "2026-04-25T00:00:00Z",
+        }
+
+
+def standard_pagination_params() -> dict[str, Any]:
+    """Return the FastAPI ``Query`` defaults shared by every wanted handler.
+
+    Centralised so individual routers only declare per-app-specific params.
+    """
+    return {
+        "page": Query(1, ge=1),
+        "page_size": Query(10, ge=1, le=2000, alias="pageSize"),
+        "sort_key": Query(None, alias="sortKey"),
+        "sort_direction": Query("ascending", alias="sortDirection"),
+    }

--- a/tests/mock_arr/probe_context_mode.py
+++ b/tests/mock_arr/probe_context_mode.py
@@ -1,0 +1,445 @@
+"""Context-mode fairness probe.
+
+Sonarr / Whisparr v2 / Lidarr / Readarr each support a per-app context
+search mode that groups child items by their parent (season, artist,
+author).  In context mode the engine dispatches one search per parent
+group per cycle instead of one per child item, using a synthetic
+negative parent id as the dedup key.
+
+This probe verifies that under each app's context mode:
+
+1. Every monitored parent group eventually gets dispatched at least
+   once over enough cycles for full coverage.
+2. The dispatches are uniformly distributed across parent groups
+   (chi-square against the uniform expected count, with the same
+   thresholds as the per-item probe).
+3. The padding + position-cap fix from the earlier round still holds
+   when the dispatch unit is the synthetic parent rather than the
+   raw leaf.
+
+Run:
+
+    .venv/bin/python -m tests.mock_arr.probe_context_mode
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+import statistics
+import tempfile
+import threading
+import time
+from collections import Counter
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+
+import uvicorn
+from cryptography.fernet import Fernet
+
+import houndarr.engine.search_loop as _search_loop
+from houndarr.crypto import encrypt
+from houndarr.database import get_db, init_db, set_db_path
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import (
+    CutoffPolicy,
+    Instance,
+    InstanceCore,
+    InstanceTimestamps,
+    InstanceType,
+    LidarrSearchMode,
+    MissingPolicy,
+    ReadarrSearchMode,
+    RuntimeSnapshot,
+    SchedulePolicy,
+    SearchOrder,
+    SonarrSearchMode,
+    UpgradePolicy,
+    WhisparrV2SearchMode,
+)
+from tests.mock_arr.server import SeedConfig, create_app
+
+_search_loop._INTER_SEARCH_DELAY_SECONDS = 0.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass(slots=True)
+class _Server:
+    server: uvicorn.Server
+    thread: threading.Thread
+
+
+def _start_mock(seed_config: SeedConfig) -> tuple[_Server, str]:
+    port = _free_port()
+    app = create_app(seed_config)
+    uv_config = uvicorn.Config(
+        app=app, host="127.0.0.1", port=port, log_level="error", access_log=False
+    )
+    server = uvicorn.Server(uv_config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not server.started:
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("mock failed to start")
+    return _Server(server=server, thread=thread), f"http://127.0.0.1:{port}"
+
+
+def _stop_mock(handle: _Server) -> None:
+    handle.server.should_exit = True
+    handle.thread.join(timeout=5)
+
+
+def _build_instance_sonarr(*, base_url: str, batch_size: int, hourly_cap: int) -> Instance:
+    """Sonarr with season_context search mode."""
+    return Instance(
+        core=InstanceCore(
+            id=1,
+            name="Probe Sonarr ctx",
+            type=InstanceType.sonarr,
+            url=f"{base_url}/sonarr",
+            api_key="probe-key",
+            enabled=True,
+        ),
+        missing=MissingPolicy(
+            batch_size=batch_size,
+            sleep_interval_mins=15,
+            hourly_cap=hourly_cap,
+            cooldown_days=7,
+            post_release_grace_hrs=0,
+            queue_limit=0,
+            sonarr_search_mode=SonarrSearchMode.season_context,
+            lidarr_search_mode=LidarrSearchMode.album,
+            readarr_search_mode=ReadarrSearchMode.book,
+            whisparr_v2_search_mode=WhisparrV2SearchMode.episode,
+        ),
+        cutoff=CutoffPolicy(
+            cutoff_enabled=False,
+            cutoff_batch_size=5,
+            cutoff_cooldown_days=21,
+            cutoff_hourly_cap=1,
+        ),
+        upgrade=UpgradePolicy(),
+        schedule=SchedulePolicy(search_order=SearchOrder.random),
+        snapshot=RuntimeSnapshot(),
+        timestamps=InstanceTimestamps(
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        ),
+    )
+
+
+def _build_instance_whisparr_v2(*, base_url: str, batch_size: int, hourly_cap: int) -> Instance:
+    """Whisparr v2 with season_context search mode."""
+    return Instance(
+        core=InstanceCore(
+            id=1,
+            name="Probe Whisparr v2 ctx",
+            type=InstanceType.whisparr_v2,
+            url=f"{base_url}/whisparr_v2",
+            api_key="probe-key",
+            enabled=True,
+        ),
+        missing=MissingPolicy(
+            batch_size=batch_size,
+            sleep_interval_mins=15,
+            hourly_cap=hourly_cap,
+            cooldown_days=7,
+            post_release_grace_hrs=0,
+            queue_limit=0,
+            sonarr_search_mode=SonarrSearchMode.episode,
+            lidarr_search_mode=LidarrSearchMode.album,
+            readarr_search_mode=ReadarrSearchMode.book,
+            whisparr_v2_search_mode=WhisparrV2SearchMode.season_context,
+        ),
+        cutoff=CutoffPolicy(
+            cutoff_enabled=False,
+            cutoff_batch_size=5,
+            cutoff_cooldown_days=21,
+            cutoff_hourly_cap=1,
+        ),
+        upgrade=UpgradePolicy(),
+        schedule=SchedulePolicy(search_order=SearchOrder.random),
+        snapshot=RuntimeSnapshot(),
+        timestamps=InstanceTimestamps(
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        ),
+    )
+
+
+def _build_instance_lidarr(*, base_url: str, batch_size: int, hourly_cap: int) -> Instance:
+    """Lidarr with artist_context search mode."""
+    return Instance(
+        core=InstanceCore(
+            id=1,
+            name="Probe Lidarr ctx",
+            type=InstanceType.lidarr,
+            url=f"{base_url}/lidarr",
+            api_key="probe-key",
+            enabled=True,
+        ),
+        missing=MissingPolicy(
+            batch_size=batch_size,
+            sleep_interval_mins=15,
+            hourly_cap=hourly_cap,
+            cooldown_days=7,
+            post_release_grace_hrs=0,
+            queue_limit=0,
+            sonarr_search_mode=SonarrSearchMode.episode,
+            lidarr_search_mode=LidarrSearchMode.artist_context,
+            readarr_search_mode=ReadarrSearchMode.book,
+            whisparr_v2_search_mode=WhisparrV2SearchMode.episode,
+        ),
+        cutoff=CutoffPolicy(
+            cutoff_enabled=False,
+            cutoff_batch_size=5,
+            cutoff_cooldown_days=21,
+            cutoff_hourly_cap=1,
+        ),
+        upgrade=UpgradePolicy(),
+        schedule=SchedulePolicy(search_order=SearchOrder.random),
+        snapshot=RuntimeSnapshot(),
+        timestamps=InstanceTimestamps(
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        ),
+    )
+
+
+def _build_instance_readarr(*, base_url: str, batch_size: int, hourly_cap: int) -> Instance:
+    """Readarr with author_context search mode."""
+    return Instance(
+        core=InstanceCore(
+            id=1,
+            name="Probe Readarr ctx",
+            type=InstanceType.readarr,
+            url=f"{base_url}/readarr",
+            api_key="probe-key",
+            enabled=True,
+        ),
+        missing=MissingPolicy(
+            batch_size=batch_size,
+            sleep_interval_mins=15,
+            hourly_cap=hourly_cap,
+            cooldown_days=7,
+            post_release_grace_hrs=0,
+            queue_limit=0,
+            sonarr_search_mode=SonarrSearchMode.episode,
+            lidarr_search_mode=LidarrSearchMode.album,
+            readarr_search_mode=ReadarrSearchMode.author_context,
+            whisparr_v2_search_mode=WhisparrV2SearchMode.episode,
+        ),
+        cutoff=CutoffPolicy(
+            cutoff_enabled=False,
+            cutoff_batch_size=5,
+            cutoff_cooldown_days=21,
+            cutoff_hourly_cap=1,
+        ),
+        upgrade=UpgradePolicy(),
+        schedule=SchedulePolicy(search_order=SearchOrder.random),
+        snapshot=RuntimeSnapshot(),
+        timestamps=InstanceTimestamps(
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        ),
+    )
+
+
+@contextlib.asynccontextmanager
+async def _temp_db(master_key: bytes, instance_type_value: str) -> AsyncIterator[None]:
+    with tempfile.TemporaryDirectory() as data_dir:
+        db_path = os.path.join(data_dir, "probe.db")
+        set_db_path(db_path)
+        await init_db()
+        encrypted = encrypt("probe-key", master_key)
+        async with get_db() as conn:
+            await conn.execute(
+                "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (1, "Probe ctx", instance_type_value, "http://localhost", encrypted),
+            )
+            await conn.commit()
+        yield
+
+
+async def _read_dispatched_per_synthetic_parent() -> Counter[int]:
+    """Count successful dispatches grouped by item_id.
+
+    Context-mode candidates carry a synthetic negative parent id, so a
+    single dispatch in season-context mode covers all children of one
+    season at once.  Each row in search_log with action='searched'
+    represents one parent dispatch.
+    """
+    counts: Counter[int] = Counter()
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT item_id, COUNT(*) FROM search_log "
+            "WHERE action = 'searched' AND item_id IS NOT NULL GROUP BY item_id"
+        ) as cur:
+            async for row in cur:
+                counts[int(row[0])] = int(row[1])
+    return counts
+
+
+async def _run_one(
+    *,
+    label: str,
+    instance: Instance,
+    instance_type_value: str,
+    cycles: int,
+    cooldown_days: int,
+) -> dict[str, Any]:
+    master_key = Fernet.generate_key()
+    advance = timedelta(days=cooldown_days, hours=1)
+
+    fake_time = [datetime(2026, 1, 1, tzinfo=UTC)]
+
+    def _now() -> datetime:
+        return fake_time[0]
+
+    async with _temp_db(master_key, instance_type_value):
+        with patch("houndarr.repositories.cooldowns._now_utc", _now):
+            for _ in range(cycles):
+                await run_instance_search(instance, master_key)
+                fake_time[0] += advance
+        dispatched = await _read_dispatched_per_synthetic_parent()
+
+    counts = list(dispatched.values())
+    parent_count = len(counts)
+    total = sum(counts)
+    if parent_count == 0:
+        return {
+            "label": label,
+            "cycles": cycles,
+            "parents_touched": 0,
+            "total_dispatches": 0,
+            "verdict": "no dispatches recorded (check fixture)",
+        }
+    expected = total / parent_count
+    chi_square = sum(((c - expected) ** 2) / expected for c in counts)
+    df = max(1, parent_count - 1)
+    if df <= 30:
+        small_crit = {
+            1: 3.84,
+            2: 5.99,
+            3: 7.81,
+            4: 9.49,
+            5: 11.07,
+            6: 12.59,
+            7: 14.07,
+            8: 15.51,
+            9: 16.92,
+            10: 18.31,
+            15: 25.00,
+            20: 31.41,
+            25: 37.65,
+            30: 43.77,
+        }
+        crit = small_crit.get(df, 1.5 * df)
+    else:
+        import math as _math
+
+        crit = 0.5 * (_math.sqrt(2 * df - 1) + 1.645) ** 2
+
+    verdict = "uniform" if chi_square <= crit else f"BIASED (chi^2={chi_square:.1f} > {crit:.1f})"
+
+    return {
+        "label": label,
+        "cycles": cycles,
+        "parents_touched": parent_count,
+        "total_dispatches": total,
+        "expected_per_parent": expected,
+        "min_per_parent": min(counts),
+        "max_per_parent": max(counts),
+        "mean_per_parent": statistics.mean(counts),
+        "stdev_per_parent": statistics.stdev(counts) if parent_count > 1 else 0.0,
+        "chi_square": chi_square,
+        "chi_square_critical": crit,
+        "verdict": verdict,
+    }
+
+
+async def main() -> None:
+    print("Context-mode fairness probe")
+    print("Verifies synthetic-parent dispatch is uniform across groups for each context mode.\n")
+
+    rows: list[dict[str, Any]] = []
+
+    cases: list[tuple[str, str, str]] = [
+        ("Sonarr / season_context", "sonarr", "sonarr"),
+        ("Whisparr v2 / season_context", "whisparr_v2", "whisparr_v2"),
+        ("Lidarr / artist_context", "lidarr", "lidarr"),
+        ("Readarr / author_context", "readarr", "readarr"),
+    ]
+
+    for label, sub_path, instance_type_value in cases:
+        # Each app uses the standard SeedConfig (50 parents x 10 leaves = 500
+        # leaves total, 50% missing = 250 missing items).  Context mode
+        # collapses dispatches to one per parent, so we expect up to ~50
+        # distinct parent dispatches to be eligible.
+        seed = SeedConfig(seed=42)
+        handle, base_url = _start_mock(seed)
+        try:
+            if sub_path == "sonarr":
+                inst = _build_instance_sonarr(base_url=base_url, batch_size=1, hourly_cap=1000)
+            elif sub_path == "whisparr_v2":
+                inst = _build_instance_whisparr_v2(base_url=base_url, batch_size=1, hourly_cap=1000)
+            elif sub_path == "lidarr":
+                inst = _build_instance_lidarr(base_url=base_url, batch_size=1, hourly_cap=1000)
+            else:
+                inst = _build_instance_readarr(base_url=base_url, batch_size=1, hourly_cap=1000)
+
+            print(f"=== {label} ===")
+            result = await _run_one(
+                label=label,
+                instance=inst,
+                instance_type_value=instance_type_value,
+                cycles=300,
+                cooldown_days=7,
+            )
+            rows.append(result)
+            if result.get("verdict", "").startswith("no dispatches"):
+                print(f"  {result['verdict']}\n")
+                continue
+            print(
+                f"  parents_touched={result['parents_touched']}  "
+                f"dispatches={result['total_dispatches']}  "
+                f"E[per-parent]={result['expected_per_parent']:.2f}  "
+                f"min={result['min_per_parent']}  max={result['max_per_parent']}  "
+                f"mean={result['mean_per_parent']:.2f}  stdev={result['stdev_per_parent']:.2f}"
+            )
+            print(
+                f"  chi^2={result['chi_square']:.2f}  "
+                f"critical={result['chi_square_critical']:.2f}  "
+                f"verdict={result['verdict']}\n"
+            )
+        finally:
+            _stop_mock(handle)
+
+    print("\n=================  CONTEXT-MODE SUMMARY  =================")
+    print(f"{'app / mode':30s}  {'parents':>7}  {'min':>4}  {'max':>4}  {'chi^2':>8}  verdict")
+    for r in rows:
+        if r.get("parents_touched", 0) == 0:
+            print(f"{r['label']:30s}  {'-':>7}  {'-':>4}  {'-':>4}  {'-':>8}  {r['verdict']}")
+            continue
+        print(
+            f"{r['label']:30s}  {r['parents_touched']:>7}  "
+            f"{r['min_per_parent']:>4}  {r['max_per_parent']:>4}  "
+            f"{r['chi_square']:>8.2f}  {r['verdict']}"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/mock_arr/probe_context_mode.py
+++ b/tests/mock_arr/probe_context_mode.py
@@ -10,9 +10,15 @@ This probe verifies that under each app's context mode:
 
 1. Every monitored parent group eventually gets dispatched at least
    once over enough cycles for full coverage.
-2. The dispatches are uniformly distributed across parent groups
-   (chi-square against the uniform expected count, with the same
-   thresholds as the per-item probe).
+2. Each parent's dispatch share matches its **share of missing items**
+   in the wanted-list, not a uniform 1/N share.  The earlier version
+   of this probe ran a naive chi-square against equal expected counts
+   per parent; that test is conservative because the engine visits a
+   random page of items, not a random parent, so a parent with twice
+   as many missing leaves is *expected* to be dispatched roughly
+   twice as often.  The weighted chi-square below tests the property
+   that actually matters: do the dispatch counts track the per-parent
+   missing-item shares predicted by the algorithm?
 3. The padding + position-cap fix from the earlier round still holds
    when the dispatch unit is the synthetic parent rather than the
    raw leaf.
@@ -39,6 +45,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import patch
 
+import httpx
 import uvicorn
 from cryptography.fernet import Fernet
 
@@ -293,9 +300,105 @@ async def _read_dispatched_per_synthetic_parent() -> Counter[int]:
     return counts
 
 
+def _decode_synthetic_parent(synthetic_id: int, app: str) -> int:
+    """Recover the real parent id from a synthetic negative dispatch id.
+
+    Sonarr and Whisparr v2 encode ``-(series_id * 1000 + season_number)``
+    so the parent identity is ``positive // 1000``.  Lidarr and Readarr
+    encode ``-(parent_id * 1000)`` flat (no season axis), so the parent
+    identity is also ``positive // 1000``.  In every case dividing the
+    absolute value by 1000 returns the parent id the dispatch belongs
+    to, which is what the weighted-chi-square test needs to match the
+    per-parent missing-item shares.
+    """
+    positive = -synthetic_id if synthetic_id < 0 else synthetic_id
+    return positive // 1000
+
+
+async def _missing_items_per_parent(
+    client: httpx.AsyncClient, base_url: str, app: str
+) -> Counter[int]:
+    """Return ``parent_id -> count_of_missing_leaves`` from the live mock.
+
+    The probe pages through every record in ``/wanted/missing`` for the
+    target app and groups leaves by their parent id (``seriesId`` for
+    Sonarr / Whisparr v2, ``artistId`` for Lidarr, ``authorId`` for
+    Readarr).  The resulting per-parent counts feed the weighted chi-
+    square denominator: a parent with three times as many missing
+    leaves should land in the page-shuffled scan three times as often,
+    so its expected dispatch count is three times higher.
+    """
+    if app in ("sonarr", "whisparr_v2"):
+        endpoint = f"{base_url}/{app}/api/v3/wanted/missing"
+        parent_field = "seriesId"
+    elif app == "lidarr":
+        endpoint = f"{base_url}/lidarr/api/v1/wanted/missing"
+        parent_field = "artistId"
+    else:  # readarr
+        endpoint = f"{base_url}/readarr/api/v1/wanted/missing"
+        parent_field = "authorId"
+
+    counts: Counter[int] = Counter()
+    page = 1
+    page_size = 250
+    while True:
+        resp = await client.get(
+            endpoint,
+            params={"page": page, "pageSize": page_size, "monitored": "true"},
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        records = body.get("records", [])
+        if not records:
+            break
+        for r in records:
+            pid = r.get(parent_field)
+            if pid is not None:
+                counts[int(pid)] += 1
+        if len(records) < page_size:
+            break
+        page += 1
+    return counts
+
+
+def _chi_square_critical(df: int) -> float:
+    """Return the 5%-significance chi-square critical value for ``df``.
+
+    Hard-codes the small-df values where the table look-up beats any
+    closed-form approximation, then falls back to the Wilson-Hilferty
+    form for larger df.  Centralised so the weighted and naive chi-
+    square branches share the same threshold logic.
+    """
+    small_crit = {
+        1: 3.84,
+        2: 5.99,
+        3: 7.81,
+        4: 9.49,
+        5: 11.07,
+        6: 12.59,
+        7: 14.07,
+        8: 15.51,
+        9: 16.92,
+        10: 18.31,
+        15: 25.00,
+        20: 31.41,
+        25: 37.65,
+        30: 43.77,
+    }
+    if df in small_crit:
+        return small_crit[df]
+    if df < 30:
+        return 1.5 * df
+    import math as _math
+
+    return 0.5 * (_math.sqrt(2 * df - 1) + 1.645) ** 2
+
+
 async def _run_one(
     *,
     label: str,
+    base_url: str,
+    app: str,
     instance: Instance,
     instance_type_value: str,
     cycles: int,
@@ -309,6 +412,9 @@ async def _run_one(
     def _now() -> datetime:
         return fake_time[0]
 
+    async with httpx.AsyncClient(timeout=30) as client:
+        missing_per_parent = await _missing_items_per_parent(client, base_url, app)
+
     async with _temp_db(master_key, instance_type_value):
         with patch("houndarr.repositories.cooldowns._now_utc", _now):
             for _ in range(cycles):
@@ -316,10 +422,15 @@ async def _run_one(
                 fake_time[0] += advance
         dispatched = await _read_dispatched_per_synthetic_parent()
 
-    counts = list(dispatched.values())
-    parent_count = len(counts)
-    total = sum(counts)
-    if parent_count == 0:
+    # Roll synthetic-parent dispatches up to real parent ids so the
+    # weighted chi-square can compare them against missing-item shares.
+    real_parent_dispatches: Counter[int] = Counter()
+    for synthetic, count in dispatched.items():
+        real_parent_dispatches[_decode_synthetic_parent(synthetic, app)] += count
+
+    parent_count = len(real_parent_dispatches)
+    total = sum(real_parent_dispatches.values())
+    if parent_count == 0 or total == 0:
         return {
             "label": label,
             "cycles": cycles,
@@ -327,45 +438,45 @@ async def _run_one(
             "total_dispatches": 0,
             "verdict": "no dispatches recorded (check fixture)",
         }
-    expected = total / parent_count
-    chi_square = sum(((c - expected) ** 2) / expected for c in counts)
-    df = max(1, parent_count - 1)
-    if df <= 30:
-        small_crit = {
-            1: 3.84,
-            2: 5.99,
-            3: 7.81,
-            4: 9.49,
-            5: 11.07,
-            6: 12.59,
-            7: 14.07,
-            8: 15.51,
-            9: 16.92,
-            10: 18.31,
-            15: 25.00,
-            20: 31.41,
-            25: 37.65,
-            30: 43.77,
-        }
-        crit = small_crit.get(df, 1.5 * df)
-    else:
-        import math as _math
 
-        crit = 0.5 * (_math.sqrt(2 * df - 1) + 1.645) ** 2
+    # Weighted expected: each parent's share is its missing-items share
+    # of the total wanted-list, scaled to the observed dispatch total.
+    # Naive expected: total / parent_count, kept as a sanity-check
+    # comparison so a regression that breaks the weighting also visibly
+    # shifts the naive chi-square.
+    total_missing_leaves = sum(missing_per_parent.values())
+    weighted_chi_square = 0.0
+    for parent_id, observed in real_parent_dispatches.items():
+        share = missing_per_parent.get(parent_id, 0) / max(1, total_missing_leaves)
+        expected = share * total
+        if expected <= 0:
+            continue
+        weighted_chi_square += ((observed - expected) ** 2) / expected
+    naive_expected = total / parent_count
+    naive_chi_square = sum(
+        ((observed - naive_expected) ** 2) / naive_expected
+        for observed in real_parent_dispatches.values()
+    )
+    crit = _chi_square_critical(max(1, parent_count - 1))
 
-    verdict = "uniform" if chi_square <= crit else f"BIASED (chi^2={chi_square:.1f} > {crit:.1f})"
+    verdict = (
+        "uniform-by-share"
+        if weighted_chi_square <= crit
+        else f"BIASED (weighted chi^2={weighted_chi_square:.1f} > {crit:.1f})"
+    )
 
+    counts = list(real_parent_dispatches.values())
     return {
         "label": label,
         "cycles": cycles,
         "parents_touched": parent_count,
         "total_dispatches": total,
-        "expected_per_parent": expected,
         "min_per_parent": min(counts),
         "max_per_parent": max(counts),
         "mean_per_parent": statistics.mean(counts),
         "stdev_per_parent": statistics.stdev(counts) if parent_count > 1 else 0.0,
-        "chi_square": chi_square,
+        "weighted_chi_square": weighted_chi_square,
+        "naive_chi_square": naive_chi_square,
         "chi_square_critical": crit,
         "verdict": verdict,
     }
@@ -404,6 +515,8 @@ async def main() -> None:
             print(f"=== {label} ===")
             result = await _run_one(
                 label=label,
+                base_url=base_url,
+                app=sub_path,
                 instance=inst,
                 instance_type_value=instance_type_value,
                 cycles=300,
@@ -416,12 +529,12 @@ async def main() -> None:
             print(
                 f"  parents_touched={result['parents_touched']}  "
                 f"dispatches={result['total_dispatches']}  "
-                f"E[per-parent]={result['expected_per_parent']:.2f}  "
                 f"min={result['min_per_parent']}  max={result['max_per_parent']}  "
                 f"mean={result['mean_per_parent']:.2f}  stdev={result['stdev_per_parent']:.2f}"
             )
             print(
-                f"  chi^2={result['chi_square']:.2f}  "
+                f"  weighted chi^2={result['weighted_chi_square']:.2f}  "
+                f"(naive chi^2={result['naive_chi_square']:.2f})  "
                 f"critical={result['chi_square_critical']:.2f}  "
                 f"verdict={result['verdict']}\n"
             )
@@ -429,15 +542,23 @@ async def main() -> None:
             _stop_mock(handle)
 
     print("\n=================  CONTEXT-MODE SUMMARY  =================")
-    print(f"{'app / mode':30s}  {'parents':>7}  {'min':>4}  {'max':>4}  {'chi^2':>8}  verdict")
+    print(
+        f"{'app / mode':30s}  {'parents':>7}  {'min':>4}  {'max':>4}  "
+        f"{'weighted':>9}  {'naive':>7}  {'crit':>5}  verdict"
+    )
     for r in rows:
         if r.get("parents_touched", 0) == 0:
-            print(f"{r['label']:30s}  {'-':>7}  {'-':>4}  {'-':>4}  {'-':>8}  {r['verdict']}")
+            print(
+                f"{r['label']:30s}  {'-':>7}  {'-':>4}  {'-':>4}  "
+                f"{'-':>9}  {'-':>7}  {'-':>5}  {r['verdict']}"
+            )
             continue
         print(
             f"{r['label']:30s}  {r['parents_touched']:>7}  "
             f"{r['min_per_parent']:>4}  {r['max_per_parent']:>4}  "
-            f"{r['chi_square']:>8.2f}  {r['verdict']}"
+            f"{r['weighted_chi_square']:>9.2f}  "
+            f"{r['naive_chi_square']:>7.2f}  "
+            f"{r['chi_square_critical']:>5.2f}  {r['verdict']}"
         )
 
 

--- a/tests/mock_arr/probe_cooldown.py
+++ b/tests/mock_arr/probe_cooldown.py
@@ -1,0 +1,382 @@
+"""Cooldown distribution probe.
+
+Drives the engine for many cycles without wiping the cooldown table and
+measures, for each item in the backlog, the distribution of times it
+gets searched. The promise being verified: cooldown plus the random
+search algorithm together produce roughly even attention across items
+once steady state is reached, with no item systematically stuck waiting
+indefinitely.
+
+Method:
+
+1. Monkey-patch ``houndarr.repositories.cooldowns._now_utc`` so each
+   cycle advances simulated time by ``cooldown_days + 1 hours``. This
+   keeps every item eligible at cycle start so the only thing that
+   decides which items get searched is the page-selection algorithm.
+2. Run N cycles against the mock with a known number of missing items
+   (e.g. 50 items / pageSize=10 = 5 pages).
+3. Read the search_log table, count "searched" rows per item_id, and
+   report the distribution.
+
+Key invariant: under stratified-shuffle + per-item cooldown, every
+missing item should be searched a comparable number of times across N
+cycles. Pages get visited uniformly per round, so items on each page
+should drain at the same rate.
+
+Run:
+
+    .venv/bin/python -m tests.mock_arr.probe_cooldown
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+import statistics
+import tempfile
+import threading
+import time
+from collections import Counter
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import uvicorn
+from cryptography.fernet import Fernet
+
+import houndarr.engine.search_loop as _search_loop
+from houndarr.crypto import encrypt
+from houndarr.database import get_db, init_db, set_db_path
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import (
+    CutoffPolicy,
+    Instance,
+    InstanceCore,
+    InstanceTimestamps,
+    InstanceType,
+    LidarrSearchMode,
+    MissingPolicy,
+    ReadarrSearchMode,
+    RuntimeSnapshot,
+    SchedulePolicy,
+    SearchOrder,
+    SonarrSearchMode,
+    UpgradePolicy,
+    WhisparrV2SearchMode,
+)
+from tests.mock_arr.server import SeedConfig, create_app
+
+_search_loop._INTER_SEARCH_DELAY_SECONDS = 0.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass(slots=True)
+class _Server:
+    server: uvicorn.Server
+    thread: threading.Thread
+
+
+def _start_mock(items: int, seed: int = 42) -> tuple[_Server, str]:
+    port = _free_port()
+    config = SeedConfig(
+        seed=seed,
+        sonarr_series=max(1, items // 10),
+        sonarr_episodes_per_series=max(1, items // max(1, items // 10)),
+    )
+    app = create_app(config)
+    uv_config = uvicorn.Config(
+        app=app, host="127.0.0.1", port=port, log_level="error", access_log=False
+    )
+    server = uvicorn.Server(uv_config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not server.started:
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("mock failed to start")
+    return _Server(server=server, thread=thread), f"http://127.0.0.1:{port}"
+
+
+def _stop_mock(handle: _Server) -> None:
+    handle.server.should_exit = True
+    handle.thread.join(timeout=5)
+
+
+def _build_instance(*, base_url: str, batch_size: int, hourly_cap: int) -> Instance:
+    return Instance(
+        core=InstanceCore(
+            id=1,
+            name="Probe Sonarr",
+            type=InstanceType.sonarr,
+            url=f"{base_url}/sonarr",
+            api_key="probe-key",
+            enabled=True,
+        ),
+        missing=MissingPolicy(
+            batch_size=batch_size,
+            sleep_interval_mins=15,
+            hourly_cap=hourly_cap,
+            cooldown_days=7,
+            post_release_grace_hrs=0,
+            queue_limit=0,
+            sonarr_search_mode=SonarrSearchMode.episode,
+            lidarr_search_mode=LidarrSearchMode.album,
+            readarr_search_mode=ReadarrSearchMode.book,
+            whisparr_v2_search_mode=WhisparrV2SearchMode.episode,
+        ),
+        cutoff=CutoffPolicy(
+            cutoff_enabled=False,
+            cutoff_batch_size=5,
+            cutoff_cooldown_days=21,
+            cutoff_hourly_cap=1,
+        ),
+        upgrade=UpgradePolicy(),
+        schedule=SchedulePolicy(search_order=SearchOrder.random),
+        snapshot=RuntimeSnapshot(),
+        timestamps=InstanceTimestamps(
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        ),
+    )
+
+
+@contextlib.asynccontextmanager
+async def _temp_db(master_key: bytes) -> AsyncIterator[None]:
+    with tempfile.TemporaryDirectory() as data_dir:
+        db_path = os.path.join(data_dir, "probe.db")
+        set_db_path(db_path)
+        await init_db()
+        encrypted = encrypt("probe-key", master_key)
+        async with get_db() as conn:
+            await conn.execute(
+                "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (1, "Probe Sonarr", "sonarr", "http://localhost/sonarr", encrypted),
+            )
+            await conn.commit()
+        yield
+
+
+async def _read_dispatched_per_item() -> Counter[int]:
+    """Count successful dispatches per item_id from the search_log."""
+    counts: Counter[int] = Counter()
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT item_id, COUNT(*) FROM search_log "
+            "WHERE action = 'searched' AND item_id IS NOT NULL GROUP BY item_id"
+        ) as cur:
+            async for row in cur:
+                counts[int(row[0])] = int(row[1])
+    return counts
+
+
+async def _missing_item_ids(client: httpx.AsyncClient, base_url: str) -> list[int]:
+    """Pull the full set of missing item IDs from the mock for ground-truth."""
+    resp = await client.get(
+        f"{base_url}/sonarr/api/v3/wanted/missing",
+        params={"page": 1, "pageSize": 2000, "monitored": "true"},
+    )
+    resp.raise_for_status()
+    return [r["id"] for r in resp.json()["records"]]
+
+
+async def _run_probe(
+    *, items: int, cycles: int, batch_size: int, hourly_cap: int
+) -> dict[str, Any]:
+    """Drive ``cycles`` cycles, advancing simulated time so cooldowns expire.
+
+    The clock advances ``cooldown_days + 1 hours`` per cycle so every item
+    is eligible at the start of every cycle. That isolates the page-and-item
+    selection algorithm from cooldown gating.
+    """
+    handle, base_url = _start_mock(items=items)
+    master_key = Fernet.generate_key()
+    cooldown_days = 7
+    advance = timedelta(days=cooldown_days, hours=1)
+
+    try:
+        async with _temp_db(master_key):
+            async with httpx.AsyncClient(timeout=30) as client:
+                missing_ids = await _missing_item_ids(client, base_url)
+
+                fake_time = [datetime(2026, 1, 1, tzinfo=UTC)]
+
+                def _now() -> datetime:
+                    return fake_time[0]
+
+                instance = _build_instance(
+                    base_url=base_url, batch_size=batch_size, hourly_cap=hourly_cap
+                )
+
+                with patch("houndarr.repositories.cooldowns._now_utc", _now):
+                    for _ in range(cycles):
+                        await run_instance_search(instance, master_key)
+                        fake_time[0] += advance
+
+                dispatched = await _read_dispatched_per_item()
+    finally:
+        _stop_mock(handle)
+
+    # Restrict to the actual missing-ID universe.
+    relevant = {item_id: dispatched.get(item_id, 0) for item_id in missing_ids}
+    counts = list(relevant.values())
+    n_missing = len(missing_ids)
+    n_searched_at_least_once = sum(1 for c in counts if c > 0)
+    n_never_searched = sum(1 for c in counts if c == 0)
+    total = sum(counts)
+
+    # Chi-square goodness-of-fit against uniform expected counts. This is
+    # the right test for "is each item being treated equally" rather than
+    # the naive max/min ratio, which collapses at small expected counts
+    # because Poisson noise dominates.
+    expected = total / n_missing if n_missing else 0
+    chi_square = sum(((c - expected) ** 2) / expected for c in counts) if expected > 0 else 0.0
+    # 5%-significance chi-square critical value at df = n_missing - 1.
+    # For df > 30 the value is closely approximated by
+    # 0.5 * (sqrt(2*df - 1) + 1.645) ** 2, the Wilson-Hilferty form.
+    df = max(1, n_missing - 1)
+    if df <= 30:
+        # Hard-coded critical values for small df.
+        small_crit = {
+            1: 3.84,
+            2: 5.99,
+            3: 7.81,
+            4: 9.49,
+            5: 11.07,
+            6: 12.59,
+            7: 14.07,
+            8: 15.51,
+            9: 16.92,
+            10: 18.31,
+            15: 25.00,
+            20: 31.41,
+            25: 37.65,
+            30: 43.77,
+        }
+        crit = small_crit.get(df, 1.5 * df)
+    else:
+        import math as _math
+
+        crit = 0.5 * (_math.sqrt(2 * df - 1) + 1.645) ** 2
+
+    # Coupon-collector reference: expected cycles to touch every item once.
+    coupon_expected = sum(n_missing / k for k in range(1, n_missing + 1)) if n_missing else 0.0
+
+    return {
+        "items": items,
+        "missing_count": n_missing,
+        "cycles": cycles,
+        "batch_size": batch_size,
+        "hourly_cap": hourly_cap,
+        "total_dispatches": total,
+        "expected_per_item": expected,
+        "items_touched": n_searched_at_least_once,
+        "items_never_touched": n_never_searched,
+        "min_per_item": min(counts) if counts else 0,
+        "max_per_item": max(counts) if counts else 0,
+        "mean_per_item": statistics.mean(counts) if counts else 0,
+        "stdev_per_item": statistics.stdev(counts) if len(counts) > 1 else 0.0,
+        "chi_square": chi_square,
+        "chi_square_critical": crit,
+        "coupon_expected_cycles": coupon_expected,
+    }
+
+
+def _verdict(result: dict[str, Any]) -> str:
+    """Verdict based on chi-square test against uniform.
+
+    Naive max/min ratios are misleading at small expected counts because
+    Poisson noise dominates: with mean=2, observing some 0s and some 6s
+    is consistent with uniformity, not bias. Chi-square correctly
+    accounts for the expected variance.
+    """
+    if result["chi_square"] > result["chi_square_critical"]:
+        return f"BIASED (chi^2={result['chi_square']:.1f} > {result['chi_square_critical']:.1f})"
+    if result["expected_per_item"] < 5 and result["items_never_touched"] > 0:
+        # Statistically uniform but the sample is too thin to actually
+        # cover every item; flag it so the reader knows coverage is
+        # incomplete even though no item is being algorithmically starved.
+        return (
+            "uniform-distribution (incomplete coverage at this sample size; "
+            f"E[per-item]={result['expected_per_item']:.1f}, "
+            f"need ~{result['coupon_expected_cycles']:.0f} cycles for full coverage)"
+        )
+    return "uniform"
+
+
+async def main() -> None:
+    """Run the probe at a few interesting library sizes and print summary."""
+    print("Cooldown distribution probe")
+    print("Time advances cooldown_days+1h per cycle, every item eligible each cycle.")
+    print("Verifies stratified-shuffle delivers fair per-item attention.\n")
+
+    # The selection algorithm visits pages uniformly (per the stratified-shuffle
+    # probe) and dispatches up to ``batch_size`` items from each page.  When
+    # the missing-item count divides evenly into the engine's page_size, every
+    # page has the same number of items and every item has the same hit rate
+    # per visit.  When it does not, the last (short) page over-selects its
+    # items because the engine drains all of them per visit.  The configs
+    # below demonstrate both regimes:
+    #
+    #   - items=200 / 100 missing / pageSize=10 -> 10 full pages of 10 items
+    #     each. Expected: uniform.
+    #   - items=400 / 200 missing / pageSize=10 -> 20 full pages.  Expected:
+    #     uniform.
+    #   - items=50 / 25 missing / pageSize=10 -> pages of 10, 10, 5 items.
+    #     The 5-item page over-selects.
+    #   - items=50 / 25 missing / batch=5 / pageSize=20 -> pages of 20 + 5.
+    #     The 5-item page over-selects much more dramatically.
+    configs = [
+        # (items, cycles, batch_size, hourly_cap, label)
+        (200, 400, 1, 1000, "100 missing / 10 full pages"),
+        (400, 600, 1, 1000, "200 missing / 20 full pages"),
+        (50, 200, 1, 1000, "25 missing / 3 pages (last has 5)"),
+        (50, 200, 5, 1000, "25 missing / batch=5 / pageSize=20 (last has 5)"),
+    ]
+    rows: list[dict[str, Any]] = []
+    for items, cycles, bs, cap, label in configs:
+        print(f"=== items={items} cycles={cycles} batch={bs} cap={cap}  ({label}) ===")
+        result = await _run_probe(items=items, cycles=cycles, batch_size=bs, hourly_cap=cap)
+        rows.append(result)
+        print(
+            f"  missing={result['missing_count']:4d}  "
+            f"dispatches={result['total_dispatches']:5d}  "
+            f"E[per-item]={result['expected_per_item']:5.2f}  "
+            f"touched={result['items_touched']:4d}  "
+            f"never={result['items_never_touched']:4d}  "
+            f"min={result['min_per_item']:3d}  max={result['max_per_item']:3d}  "
+            f"mean={result['mean_per_item']:5.2f}  stdev={result['stdev_per_item']:5.2f}"
+        )
+        print(
+            f"  chi^2={result['chi_square']:7.2f}  "
+            f"critical={result['chi_square_critical']:7.2f}  "
+            f"verdict={_verdict(result)}"
+        )
+
+    print("\n=================  COOLDOWN FAIRNESS SUMMARY  =================")
+    print(
+        f"{'items':>6}  {'cycles':>6}  {'bs':>3}  {'E[i]':>6}  "
+        f"{'min':>4}  {'max':>4}  {'chi^2':>8}  {'crit':>8}  verdict"
+    )
+    for r in rows:
+        print(
+            f"{r['items']:>6}  {r['cycles']:>6}  {r['batch_size']:>3}  "
+            f"{r['expected_per_item']:>6.2f}  "
+            f"{r['min_per_item']:>4}  {r['max_per_item']:>4}  "
+            f"{r['chi_square']:>8.2f}  {r['chi_square_critical']:>8.2f}  {_verdict(r)}"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/mock_arr/probe_distribution.py
+++ b/tests/mock_arr/probe_distribution.py
@@ -1,0 +1,446 @@
+"""Programmatic distribution probe for Houndarr's search algorithm.
+
+Boots the seeded mock *arr server in-process, drives the real search
+engine (``run_instance_search``) against it for many cycles at multiple
+library sizes, and reports the per-page hit distribution captured from
+the mock's ``/__page_log__`` endpoint.
+
+Runs both ``random`` and ``chronological`` search orders so the two can
+be compared directly. The mock is the source of truth for which pages
+the engine actually fetched; the engine is the real production code
+path, not a respx mock.
+
+Run:
+
+    .venv/bin/python -m tests.mock_arr.probe_distribution
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import math
+import os
+import socket
+import statistics
+import tempfile
+import threading
+import time
+from collections import Counter
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import uvicorn
+from cryptography.fernet import Fernet
+
+import houndarr.engine.search_loop as _search_loop
+from houndarr.crypto import encrypt
+from houndarr.database import get_db, init_db, set_db_path
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import (
+    CutoffPolicy,
+    Instance,
+    InstanceCore,
+    InstanceTimestamps,
+    InstanceType,
+    LidarrSearchMode,
+    MissingPolicy,
+    ReadarrSearchMode,
+    RuntimeSnapshot,
+    SchedulePolicy,
+    SearchOrder,
+    SonarrSearchMode,
+    UpgradePolicy,
+    WhisparrV2SearchMode,
+)
+from tests.mock_arr.server import SeedConfig, create_app
+
+# Zero the production inter-search delay so the probe runs at full speed.
+# The 3-second default exists to spread indexer fan-out, which the mock
+# does not care about.
+_search_loop._INTER_SEARCH_DELAY_SECONDS = 0.0
+
+
+def _free_port() -> int:
+    """Return an unused TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass(slots=True)
+class _Server:
+    """Wrap ``uvicorn.Server`` so we can boot+stop it from a thread."""
+
+    server: uvicorn.Server
+    thread: threading.Thread
+
+
+def _start_mock(items: int, seed: int = 42) -> tuple[_Server, str]:
+    """Boot the mock on a free port. Returns the running server + base URL."""
+    port = _free_port()
+    config = SeedConfig(
+        seed=seed,
+        sonarr_series=max(1, items // 10),
+        sonarr_episodes_per_series=max(1, items // max(1, items // 10)),
+        radarr_movies=items,
+        lidarr_artists=max(1, items // 10),
+        lidarr_albums_per_artist=max(1, items // max(1, items // 10)),
+        readarr_authors=max(1, items // 10),
+        readarr_books_per_author=max(1, items // max(1, items // 10)),
+        whisparr_v2_series=max(1, items // 10),
+        whisparr_v2_episodes_per_series=max(1, items // max(1, items // 10)),
+        whisparr_v3_movies=items,
+    )
+    app = create_app(config)
+    uv_config = uvicorn.Config(
+        app=app,
+        host="127.0.0.1",
+        port=port,
+        log_level="error",
+        access_log=False,
+    )
+    server = uvicorn.Server(uv_config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if server.started:
+            break
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("mock server failed to start within 5s")
+    return _Server(server=server, thread=thread), f"http://127.0.0.1:{port}"
+
+
+def _stop_mock(handle: _Server) -> None:
+    """Signal the uvicorn server to exit and wait for the thread to join."""
+    handle.server.should_exit = True
+    handle.thread.join(timeout=5)
+
+
+def _build_instance(
+    *,
+    base_url: str,
+    instance_id: int,
+    search_order: SearchOrder,
+    batch_size: int,
+    hourly_cap: int,
+) -> Instance:
+    """Construct an in-memory Instance pointing at the mock."""
+    return Instance(
+        core=InstanceCore(
+            id=instance_id,
+            name=f"Probe Sonarr {instance_id}",
+            type=InstanceType.sonarr,
+            url=f"{base_url}/sonarr",
+            api_key="probe-key",
+            enabled=True,
+        ),
+        missing=MissingPolicy(
+            batch_size=batch_size,
+            sleep_interval_mins=15,
+            hourly_cap=hourly_cap,
+            cooldown_days=7,
+            post_release_grace_hrs=0,
+            queue_limit=0,
+            sonarr_search_mode=SonarrSearchMode.episode,
+            lidarr_search_mode=LidarrSearchMode.album,
+            readarr_search_mode=ReadarrSearchMode.book,
+            whisparr_v2_search_mode=WhisparrV2SearchMode.episode,
+        ),
+        cutoff=CutoffPolicy(
+            cutoff_enabled=False,
+            cutoff_batch_size=5,
+            cutoff_cooldown_days=21,
+            cutoff_hourly_cap=1,
+        ),
+        upgrade=UpgradePolicy(),
+        schedule=SchedulePolicy(search_order=search_order),
+        snapshot=RuntimeSnapshot(),
+        timestamps=InstanceTimestamps(
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        ),
+    )
+
+
+@contextlib.asynccontextmanager
+async def _temp_db(master_key: bytes) -> AsyncIterator[None]:
+    """Create a fresh SQLite DB + insert a Sonarr instance row for FKs."""
+    with tempfile.TemporaryDirectory() as data_dir:
+        db_path = os.path.join(data_dir, "probe.db")
+        set_db_path(db_path)
+        await init_db()
+        encrypted = encrypt("probe-key", master_key)
+        async with get_db() as conn:
+            await conn.execute(
+                "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (1, "Probe Sonarr 1", "sonarr", "http://localhost/sonarr", encrypted),
+            )
+            await conn.commit()
+        yield
+
+
+async def _wipe_cooldowns_and_log() -> None:
+    """Clear cooldown + search_log rows so each cycle sees a fresh backlog.
+
+    Without this the engine would hit cooldown on previously-searched items
+    and skip them, contaminating the page-distribution measurement.
+    """
+    async with get_db() as conn:
+        await conn.execute("DELETE FROM cooldowns")
+        await conn.execute("DELETE FROM search_log")
+        await conn.commit()
+
+
+async def _reset_mock(client: httpx.AsyncClient, base_url: str) -> None:
+    """Wipe the mock's per-app logs."""
+    await client.post(f"{base_url}/__reset__/sonarr")
+
+
+async def _read_page_log(client: httpx.AsyncClient, base_url: str) -> list[tuple[str, int, int]]:
+    """Pull the mock's page-request log."""
+    resp = await client.get(f"{base_url}/__page_log__/sonarr")
+    resp.raise_for_status()
+    body = resp.json()
+    return [(kind, page, ps) for kind, page, ps in body["entries"]]
+
+
+@dataclass(slots=True)
+class _CycleStats:
+    """Aggregated page hits across many cycles, plus per-cycle start pages.
+
+    ``start_page_hits`` measures the algorithm's randint pick directly.
+    ``page_hits`` aggregates every visited page so we can see the wrap
+    pattern when the engine walks multiple pages.
+    """
+
+    start_page_hits: Counter[int]
+    page_hits: Counter[int]
+    total_cycles: int
+
+
+async def _run_cycles(
+    *,
+    base_url: str,
+    cycles: int,
+    instance: Instance,
+    master_key: bytes,
+    client: httpx.AsyncClient,
+) -> _CycleStats:
+    """Run ``cycles`` of ``run_instance_search`` and return distribution stats.
+
+    Cooldowns are wiped between cycles so the engine sees a fresh backlog
+    every time. Without this, a 7-day cooldown would mark every item
+    searched in cycle N ineligible for cycles N+1...N+M, biasing the
+    page-fetch measurement away from the underlying algorithm.
+
+    Two histograms are returned. ``start_page_hits`` records the FIRST
+    real-pageSize fetch of each cycle, which is the page the algorithm
+    picked via ``random.randint``. ``page_hits`` records every visited
+    page so we can also see how the wrap-once walk distributes hits.
+    """
+    start_page_hits: Counter[int] = Counter()
+    page_hits: Counter[int] = Counter()
+    for _ in range(cycles):
+        await _wipe_cooldowns_and_log()
+        await _reset_mock(client, base_url)
+        await run_instance_search(instance, master_key)
+        log = await _read_page_log(client, base_url)
+        first_seen = False
+        for kind, page, page_size_entry in log:
+            # Filter out the random-mode probe call (always page=1 page_size=1)
+            # so it does not bias the histogram toward page 1.
+            if kind != "missing" or page_size_entry <= 1:
+                continue
+            page_hits[page] += 1
+            if not first_seen:
+                start_page_hits[page] += 1
+                first_seen = True
+    return _CycleStats(
+        start_page_hits=start_page_hits,
+        page_hits=page_hits,
+        total_cycles=cycles,
+    )
+
+
+def _max_min_ratio(hits: Counter[int]) -> float:
+    """Ratio of the most-hit page count to the least-hit page count.
+
+    A perfectly uniform distribution returns 1.0. Larger means more bias.
+    """
+    if not hits:
+        return 0.0
+    counts = list(hits.values())
+    if min(counts) == 0:
+        return float("inf")
+    return max(counts) / min(counts)
+
+
+def _chi_square(hits: Counter[int], n_pages: int) -> float:
+    """Pearson chi-square against the uniform distribution.
+
+    Lower means closer to uniform. The page-set is the keys of ``hits``,
+    padded out to ``n_pages`` so missing pages count as zero hits.
+    """
+    total = sum(hits.values())
+    if total == 0 or n_pages == 0:
+        return 0.0
+    expected = total / n_pages
+    return sum(((hits.get(p, 0) - expected) ** 2) / expected for p in range(1, n_pages + 1))
+
+
+def _format_histogram(hits: Counter[int], n_pages: int) -> str:
+    """Render a compact ASCII histogram of page hits."""
+    if not hits:
+        return "(no data)"
+    counts = [hits.get(p, 0) for p in range(1, n_pages + 1)]
+    peak = max(counts) if counts else 0
+    if peak == 0:
+        return "(all zero)"
+    rows = []
+    for page, count in enumerate(counts, start=1):
+        bar = "#" * int(20 * count / peak)
+        rows.append(f"  page {page:2d}: {count:4d}  {bar}")
+    return "\n".join(rows)
+
+
+async def _probe_one(
+    *,
+    base_url: str,
+    client: httpx.AsyncClient,
+    items: int,
+    cycles: int,
+    search_order: SearchOrder,
+    master_key: bytes,
+    page_size: int,
+    batch_size: int,
+) -> dict[str, Any]:
+    """Run one (items, mode) configuration and return its summary stats."""
+    n_missing = items // 2
+    n_pages = max(1, math.ceil(n_missing / page_size))
+    instance = _build_instance(
+        base_url=base_url,
+        instance_id=1,
+        search_order=search_order,
+        batch_size=batch_size,
+        hourly_cap=batch_size * cycles + 1000,
+    )
+    stats = await _run_cycles(
+        base_url=base_url,
+        cycles=cycles,
+        instance=instance,
+        master_key=master_key,
+        client=client,
+    )
+    start_counts = [stats.start_page_hits.get(p, 0) for p in range(1, n_pages + 1)]
+    return {
+        "items": items,
+        "missing": n_missing,
+        "page_size": page_size,
+        "n_pages": n_pages,
+        "mode": search_order.value,
+        "cycles": cycles,
+        "total_starts": sum(stats.start_page_hits.values()),
+        "min_starts": min(start_counts) if start_counts else 0,
+        "max_starts": max(start_counts) if start_counts else 0,
+        "mean_starts": statistics.mean(start_counts) if start_counts else 0,
+        "stdev_starts": statistics.stdev(start_counts) if len(start_counts) > 1 else 0,
+        "max_min_ratio": _max_min_ratio(stats.start_page_hits),
+        "chi_square": _chi_square(stats.start_page_hits, n_pages),
+        "histogram": _format_histogram(stats.start_page_hits, n_pages),
+        "all_hits": dict(sorted(stats.page_hits.items())),
+    }
+
+
+async def main() -> None:
+    """Run every (items, mode) configuration and print the summary table.
+
+    The configurations span the four behaviour regimes:
+    - small library where ``N < K`` and the wrap-once rule biases vs page 1
+    - boundary where ``N == K``
+    - mid-size library where ``N`` is just above ``K``
+    - large library where ``N >> K``
+    """
+    master_key = Fernet.generate_key()
+    cycles = 400
+    batch_size = 1
+    page_size = 10
+
+    configs: list[tuple[int, str]] = [
+        (8, "N=1 (degenerate)"),
+        (20, "N=1 (boundary, all on one page)"),
+        (40, "N=2 (small, biased per the math)"),
+        (60, "N=3 (small, biased)"),
+        (80, "N=4 (small, biased)"),
+        (100, "N=5 (boundary, expected uniform)"),
+        (120, "N=6 (just above K, expected uniform)"),
+        (200, "N=10 (mid, expected uniform)"),
+        (1000, "N=50 (large, expected uniform)"),
+    ]
+
+    rows: list[dict[str, Any]] = []
+    for items, label in configs:
+        print(f"\n=== probing items={items} ({label}) ===")
+        handle, base_url = _start_mock(items=items)
+        try:
+            async with _temp_db(master_key):
+                async with httpx.AsyncClient(timeout=30) as client:
+                    for search_order in (
+                        SearchOrder.random,
+                        SearchOrder.chronological,
+                    ):
+                        result = await _probe_one(
+                            base_url=base_url,
+                            client=client,
+                            items=items,
+                            cycles=cycles,
+                            search_order=search_order,
+                            master_key=master_key,
+                            page_size=page_size,
+                            batch_size=batch_size,
+                        )
+                        result["label"] = label
+                        rows.append(result)
+                        print(
+                            f"  mode={result['mode']:14s}  "
+                            f"N={result['n_pages']:2d}  "
+                            f"starts={result['total_starts']:5d}  "
+                            f"min={result['min_starts']:4d}  "
+                            f"max={result['max_starts']:4d}  "
+                            f"max/min={result['max_min_ratio']:6.2f}  "
+                            f"chi^2={result['chi_square']:7.2f}"
+                        )
+                        if result["n_pages"] <= 12:
+                            print(result["histogram"])
+                        print(f"    all-page hits: {result['all_hits']}")
+        finally:
+            _stop_mock(handle)
+
+    print("\n\n=========================  START-PAGE SUMMARY  =========================")
+    print(
+        f"{'items':>6}  {'N':>3}  {'mode':14s}  "
+        f"{'min':>4}  {'max':>4}  {'max/min':>8}  {'chi^2':>8}  verdict"
+    )
+    for r in rows:
+        if r["n_pages"] == 1:
+            verdict = "trivial (single page)"
+        elif r["mode"] == "chronological":
+            verdict = "expected: always page 1 (state wiped between cycles)"
+        else:
+            ratio = r["max_min_ratio"]
+            chi2 = r["chi_square"]
+            verdict = "uniform" if ratio < 1.5 and chi2 < 3 * r["n_pages"] else "BIASED"
+        print(
+            f"{r['items']:>6}  {r['n_pages']:>3}  {r['mode']:14s}  "
+            f"{r['min_starts']:>4}  {r['max_starts']:>4}  "
+            f"{r['max_min_ratio']:>8.2f}  {r['chi_square']:>8.2f}  {verdict}"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/mock_arr/probe_hourly_cap.py
+++ b/tests/mock_arr/probe_hourly_cap.py
@@ -1,0 +1,357 @@
+"""Hourly-cap fairness probe.
+
+Drives multiple Houndarr instances against the mock and verifies that:
+
+1. Each instance respects its own ``hourly_cap`` (no instance ever
+   dispatches more than its cap within a 60-minute simulated window).
+2. Caps for different (instance, kind) pairs do not interfere: an
+   instance's missing cap does not affect its cutoff cap or another
+   instance's caps.
+3. With multiple instances at the same cap, none is systematically
+   starved by scheduling order or supervisor task interleaving.
+
+Method:
+
+The hourly counter is a SQL ``COUNT(*)`` over ``search_log`` with
+``timestamp > now - 3600s`` (the column has a SQLite default of
+``CURRENT_TIMESTAMP``, so timestamps reflect real wallclock time).
+Cooldown days are zeroed via the ``_now_utc`` patch so cooldown does
+not interfere with cap measurement; advancing simulated time also
+keeps every item eligible.
+
+We run ``cycles`` cycles per instance back-to-back (the supervisor's
+``sleep_interval_mins`` does not apply because we drive
+``run_instance_search`` directly) and confirm that:
+
+- per-instance dispatch counts respect the configured ``hourly_cap``
+- per (instance, kind) totals are independent
+- across multiple instances with identical caps, all reach within a
+  small tolerance of the cap (no starvation)
+
+Run:
+
+    .venv/bin/python -m tests.mock_arr.probe_hourly_cap
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import socket
+import tempfile
+import threading
+import time
+from collections import Counter
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+
+import uvicorn
+from cryptography.fernet import Fernet
+
+import houndarr.engine.search_loop as _search_loop
+from houndarr.crypto import encrypt
+from houndarr.database import get_db, init_db, set_db_path
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import (
+    CutoffPolicy,
+    Instance,
+    InstanceCore,
+    InstanceTimestamps,
+    InstanceType,
+    LidarrSearchMode,
+    MissingPolicy,
+    ReadarrSearchMode,
+    RuntimeSnapshot,
+    SchedulePolicy,
+    SearchOrder,
+    SonarrSearchMode,
+    UpgradePolicy,
+    WhisparrV2SearchMode,
+)
+from tests.mock_arr.server import SeedConfig, create_app
+
+_search_loop._INTER_SEARCH_DELAY_SECONDS = 0.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass(slots=True)
+class _Server:
+    server: uvicorn.Server
+    thread: threading.Thread
+
+
+def _start_mock(items_per_instance: int = 200, seed: int = 42) -> tuple[_Server, str]:
+    port = _free_port()
+    config = SeedConfig(
+        seed=seed,
+        sonarr_series=20,
+        sonarr_episodes_per_series=10,
+        radarr_movies=items_per_instance,
+        lidarr_artists=20,
+        lidarr_albums_per_artist=10,
+        readarr_authors=20,
+        readarr_books_per_author=10,
+        whisparr_v2_series=10,
+        whisparr_v2_episodes_per_series=10,
+        whisparr_v3_movies=items_per_instance,
+    )
+    app = create_app(config)
+    uv_config = uvicorn.Config(
+        app=app, host="127.0.0.1", port=port, log_level="error", access_log=False
+    )
+    server = uvicorn.Server(uv_config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not server.started:
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("mock failed to start")
+    return _Server(server=server, thread=thread), f"http://127.0.0.1:{port}"
+
+
+def _stop_mock(handle: _Server) -> None:
+    handle.server.should_exit = True
+    handle.thread.join(timeout=5)
+
+
+def _build_instance(
+    *,
+    instance_id: int,
+    base_url: str,
+    sub_path: str,
+    instance_type: InstanceType,
+    missing_cap: int,
+    cutoff_cap: int,
+    cutoff_enabled: bool = False,
+) -> Instance:
+    return Instance(
+        core=InstanceCore(
+            id=instance_id,
+            name=f"Probe {instance_type.value} {instance_id}",
+            type=instance_type,
+            url=f"{base_url}/{sub_path}",
+            api_key="probe-key",
+            enabled=True,
+        ),
+        missing=MissingPolicy(
+            batch_size=10,
+            sleep_interval_mins=15,
+            hourly_cap=missing_cap,
+            cooldown_days=7,
+            post_release_grace_hrs=0,
+            queue_limit=0,
+            sonarr_search_mode=SonarrSearchMode.episode,
+            lidarr_search_mode=LidarrSearchMode.album,
+            readarr_search_mode=ReadarrSearchMode.book,
+            whisparr_v2_search_mode=WhisparrV2SearchMode.episode,
+        ),
+        cutoff=CutoffPolicy(
+            cutoff_enabled=cutoff_enabled,
+            cutoff_batch_size=10,
+            cutoff_cooldown_days=21,
+            cutoff_hourly_cap=cutoff_cap,
+        ),
+        upgrade=UpgradePolicy(),
+        schedule=SchedulePolicy(search_order=SearchOrder.random),
+        snapshot=RuntimeSnapshot(),
+        timestamps=InstanceTimestamps(
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        ),
+    )
+
+
+@contextlib.asynccontextmanager
+async def _temp_db(master_key: bytes, instances: list[Instance]) -> AsyncIterator[None]:
+    with tempfile.TemporaryDirectory() as data_dir:
+        db_path = os.path.join(data_dir, "probe.db")
+        set_db_path(db_path)
+        await init_db()
+        encrypted = encrypt("probe-key", master_key)
+        async with get_db() as conn:
+            for inst in instances:
+                await conn.execute(
+                    "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+                    " VALUES (?, ?, ?, ?, ?)",
+                    (
+                        inst.core.id,
+                        inst.core.name,
+                        inst.core.type.value,
+                        inst.core.url,
+                        encrypted,
+                    ),
+                )
+            await conn.commit()
+        yield
+
+
+async def _dispatches_per_instance_kind() -> dict[tuple[int, str], int]:
+    """Count successful dispatches grouped by (instance_id, search_kind)."""
+    out: dict[tuple[int, str], int] = {}
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT instance_id, search_kind, COUNT(*) FROM search_log "
+            "WHERE action = 'searched' GROUP BY instance_id, search_kind"
+        ) as cur:
+            async for row in cur:
+                out[(int(row[0]), str(row[1]))] = int(row[2])
+    return out
+
+
+async def _run_probe(
+    *,
+    instance_specs: list[tuple[int, int]],
+    cycles_per_instance: int,
+    missing_cap: int,
+) -> dict[str, Any]:
+    """Drive ``cycles_per_instance`` cycles for each instance interleaved.
+
+    ``instance_specs`` is ``(instance_id, missing_cap)``. The probe builds
+    the Instance objects against the live mock's URL inside this function
+    so the URL never goes stale.
+
+    All cycles run within a single real-time-second window, so the SQL
+    ``timestamp > now - 3600s`` cap counter sees every dispatch. The
+    expected behaviour: each instance hits its cap once and then logs
+    'skipped' for the rest of its cycles.
+    """
+    handle, base_url = _start_mock()
+    master_key = Fernet.generate_key()
+    advance = timedelta(days=8)
+    fake_time = [datetime(2026, 1, 1, tzinfo=UTC)]
+
+    def _now() -> datetime:
+        return fake_time[0]
+
+    instances = [
+        _build_instance(
+            instance_id=iid,
+            base_url=base_url,
+            sub_path="sonarr",
+            instance_type=InstanceType.sonarr,
+            missing_cap=cap,
+            cutoff_cap=0,
+        )
+        for iid, cap in instance_specs
+    ]
+
+    try:
+        async with _temp_db(master_key, instances):
+            with patch("houndarr.repositories.cooldowns._now_utc", _now):
+                # Interleave cycles across instances so no instance gets a
+                # privileged head-start; a real supervisor would also run
+                # them concurrently in separate tasks.
+                for _cycle_idx in range(cycles_per_instance):
+                    for inst in instances:
+                        await run_instance_search(inst, master_key)
+                    fake_time[0] += advance
+
+            counts = await _dispatches_per_instance_kind()
+    finally:
+        _stop_mock(handle)
+
+    per_instance_total = Counter[int]()
+    for (iid, _kind), n in counts.items():
+        per_instance_total[iid] += n
+
+    spec_cap = dict(instance_specs)
+    cap_violations: list[tuple[int, str, int, int]] = []
+    underutilised: list[tuple[int, int, int]] = []
+    for (iid, kind), n in counts.items():
+        cap = spec_cap.get(iid, missing_cap)
+        if n > cap and kind == "missing":
+            cap_violations.append((iid, kind, n, cap))
+    for iid, cap in spec_cap.items():
+        actual = per_instance_total.get(iid, 0)
+        # Underutilised means the instance dispatched fewer than its cap
+        # despite being able to (mock returns plenty of items, no cooldown).
+        # We tolerate one short of the cap (sometimes the engine breaks
+        # mid-page); anything more is a real starvation signal.
+        if actual < cap - 1:
+            underutilised.append((iid, actual, cap))
+
+    return {
+        "n_instances": len(instances),
+        "cycles_per_instance": cycles_per_instance,
+        "missing_cap": missing_cap,
+        "per_pair": dict(counts),
+        "per_instance_total": dict(per_instance_total),
+        "cap_violations": cap_violations,
+        "underutilised": underutilised,
+        "spec_cap": spec_cap,
+    }
+
+
+def _verdict(result: dict[str, Any]) -> str:
+    if result["cap_violations"]:
+        viols = "; ".join(
+            f"i{iid}/{kind} {n} > cap {cap}" for iid, kind, n, cap in result["cap_violations"]
+        )
+        return f"CAP VIOLATED: {viols}"
+    if result["underutilised"]:
+        starved = "; ".join(
+            f"i{iid} got {actual}/{cap}" for iid, actual, cap in result["underutilised"]
+        )
+        return f"UNDERUTILISED: {starved}"
+    return "fair (each instance hit its configured cap)"
+
+
+async def main() -> None:
+    print("Hourly-cap fairness probe")
+    print("Drives multiple instances and verifies cap is respected and no instance starves.\n")
+
+    # Test A: three Sonarr instances at identical caps. Expect each to hit
+    # exactly its cap and none to violate.
+    print("=== three Sonarr instances, missing_cap=5 each, 1 cycle each ===")
+    result_a = await _run_probe(
+        instance_specs=[(1, 5), (2, 5), (3, 5)],
+        cycles_per_instance=1,
+        missing_cap=5,
+    )
+    print(f"  per (instance, kind): {result_a['per_pair']}")
+    print(f"  per instance total: {result_a['per_instance_total']}")
+    print(f"  verdict: {_verdict(result_a)}\n")
+
+    # Test B: same setup, three cycles each. The cap should bite in
+    # cycle 2 and 3 because the 1-hour rolling window covers them all.
+    print("=== three Sonarr instances, missing_cap=5, 3 cycles each ===")
+    result_b = await _run_probe(
+        instance_specs=[(1, 5), (2, 5), (3, 5)],
+        cycles_per_instance=3,
+        missing_cap=5,
+    )
+    print(f"  per (instance, kind): {result_b['per_pair']}")
+    print(f"  per instance total: {result_b['per_instance_total']}")
+    print(f"  verdict: {_verdict(result_b)}\n")
+
+    # Test C: heterogeneous caps. Expect each instance to hit its own cap
+    # independently, with no cross-instance interference.
+    print("=== three Sonarr instances, caps=[2, 10, 5], 2 cycles each ===")
+    result_c = await _run_probe(
+        instance_specs=[(1, 2), (2, 10), (3, 5)],
+        cycles_per_instance=2,
+        missing_cap=10,
+    )
+    cap_per_instance = {1: 2, 2: 10, 3: 5}
+    print(f"  per (instance, kind): {result_c['per_pair']}")
+    print(f"  per instance total: {result_c['per_instance_total']}")
+    print(f"  expected caps: {cap_per_instance}")
+    cap_check = []
+    for iid, n in sorted(result_c["per_instance_total"].items()):
+        cap_check.append(f"i{iid}:{n}/{cap_per_instance.get(iid)}")
+    print(f"  observed vs cap: {', '.join(cap_check)}")
+    print(f"  verdict: {_verdict(result_c)}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/mock_arr/probe_upgrade_coverage.py
+++ b/tests/mock_arr/probe_upgrade_coverage.py
@@ -1,0 +1,451 @@
+"""Upgrade-pass coverage probe.
+
+Drives many upgrade-only cycles against the mock and verifies that every
+monitored, has-file, cutoff-met item in the library gets searched within
+the predicted coverage window.
+
+Coverage promises by app type:
+
+- Radarr / Whisparr v3: full-library fetch every cycle. With chronological
+  order, ``upgrade_item_offset`` rotates so every item is touched within
+  ``ceil(library_size / batch_size)`` cycles. With random order, a fresh
+  shuffle every cycle yields probabilistic coverage that converges.
+- Sonarr / Whisparr v2: a sliding window of 5 series per cycle (the
+  ``_UPGRADE_MAX_SERIES_PER_CYCLE`` constant). ``upgrade_series_offset``
+  advances by 5 every cycle, so all monitored series are sampled within
+  ``ceil(monitored_series / 5)`` cycles.
+- Lidarr / Readarr: paginated cutoff exclusion (max 10 pages * 250 records)
+  followed by a full library fetch. The exclusion set is capped, so very
+  large cutoff backlogs may not fully filter the upgrade pool.
+
+The probe only verifies the simplest path: full coverage of a moderate-
+sized library by running enough cycles for the formula to predict
+complete coverage, then asserting every eligible item appeared in
+``search_log`` at least once.
+
+Run:
+
+    .venv/bin/python -m tests.mock_arr.probe_upgrade_coverage
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import math
+import os
+import socket
+import tempfile
+import threading
+import time
+from collections import Counter
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import uvicorn
+from cryptography.fernet import Fernet
+
+import houndarr.engine.search_loop as _search_loop
+from houndarr.crypto import encrypt
+from houndarr.database import get_db, init_db, set_db_path
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import (
+    CutoffPolicy,
+    Instance,
+    InstanceCore,
+    InstanceTimestamps,
+    InstanceType,
+    LidarrSearchMode,
+    MissingPolicy,
+    ReadarrSearchMode,
+    RuntimeSnapshot,
+    SchedulePolicy,
+    SearchOrder,
+    SonarrSearchMode,
+    UpgradePolicy,
+    WhisparrV2SearchMode,
+)
+from tests.mock_arr.server import SeedConfig, create_app
+
+_search_loop._INTER_SEARCH_DELAY_SECONDS = 0.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass(slots=True)
+class _Server:
+    server: uvicorn.Server
+    thread: threading.Thread
+
+
+def _start_mock(seed_config: SeedConfig) -> tuple[_Server, str]:
+    port = _free_port()
+    app = create_app(seed_config)
+    uv_config = uvicorn.Config(
+        app=app, host="127.0.0.1", port=port, log_level="error", access_log=False
+    )
+    server = uvicorn.Server(uv_config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not server.started:
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("mock failed to start")
+    return _Server(server=server, thread=thread), f"http://127.0.0.1:{port}"
+
+
+def _stop_mock(handle: _Server) -> None:
+    handle.server.should_exit = True
+    handle.thread.join(timeout=5)
+
+
+def _build_instance(
+    *,
+    base_url: str,
+    sub_path: str,
+    instance_type: InstanceType,
+    upgrade_batch_size: int,
+    search_order: SearchOrder,
+) -> Instance:
+    return Instance(
+        core=InstanceCore(
+            id=1,
+            name=f"Probe {instance_type.value}",
+            type=instance_type,
+            url=f"{base_url}/{sub_path}",
+            api_key="probe-key",
+            enabled=True,
+        ),
+        # Disable missing/cutoff: we only want the upgrade pass to fire.
+        missing=MissingPolicy(
+            batch_size=0,
+            sleep_interval_mins=15,
+            hourly_cap=0,
+            cooldown_days=7,
+            post_release_grace_hrs=0,
+            queue_limit=0,
+            sonarr_search_mode=SonarrSearchMode.episode,
+            lidarr_search_mode=LidarrSearchMode.album,
+            readarr_search_mode=ReadarrSearchMode.book,
+            whisparr_v2_search_mode=WhisparrV2SearchMode.episode,
+        ),
+        cutoff=CutoffPolicy(
+            cutoff_enabled=False,
+            cutoff_batch_size=0,
+            cutoff_cooldown_days=21,
+            cutoff_hourly_cap=0,
+        ),
+        upgrade=UpgradePolicy(
+            upgrade_enabled=True,
+            upgrade_batch_size=upgrade_batch_size,
+            upgrade_cooldown_days=7,
+            upgrade_hourly_cap=upgrade_batch_size * 100,
+        ),
+        schedule=SchedulePolicy(search_order=search_order),
+        snapshot=RuntimeSnapshot(),
+        timestamps=InstanceTimestamps(
+            created_at="2026-01-01T00:00:00Z",
+            updated_at="2026-01-01T00:00:00Z",
+        ),
+    )
+
+
+@contextlib.asynccontextmanager
+async def _temp_db(master_key: bytes, instance: Instance) -> AsyncIterator[None]:
+    with tempfile.TemporaryDirectory() as data_dir:
+        db_path = os.path.join(data_dir, "probe.db")
+        set_db_path(db_path)
+        await init_db()
+        encrypted = encrypt("probe-key", master_key)
+        async with get_db() as conn:
+            await conn.execute(
+                "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (
+                    instance.core.id,
+                    instance.core.name,
+                    instance.core.type.value,
+                    instance.core.url,
+                    encrypted,
+                ),
+            )
+            await conn.commit()
+        yield
+
+
+async def _read_dispatched_per_item() -> Counter[int]:
+    counts: Counter[int] = Counter()
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT item_id, COUNT(*) FROM search_log "
+            "WHERE action = 'searched' AND search_kind = 'upgrade' "
+            "AND item_id IS NOT NULL GROUP BY item_id"
+        ) as cur:
+            async for row in cur:
+                counts[int(row[0])] = int(row[1])
+    return counts
+
+
+async def _upgrade_eligible_movie_ids(
+    client: httpx.AsyncClient, base_url: str, sub_path: str
+) -> set[int]:
+    """For Radarr-shaped apps, pull the library and filter cutoff-met items."""
+    resp = await client.get(f"{base_url}/{sub_path}/api/v3/movie")
+    resp.raise_for_status()
+    return {
+        m["id"]
+        for m in resp.json()
+        if m.get("monitored")
+        and m.get("hasFile")
+        and m.get("movieFile") is not None
+        and not m["movieFile"].get("qualityCutoffNotMet", False)
+    }
+
+
+async def _upgrade_eligible_sonarr_episode_ids(
+    client: httpx.AsyncClient, base_url: str, sub_path: str
+) -> set[int]:
+    """For Sonarr-shaped apps, walk every series and collect upgrade items."""
+    series = (await client.get(f"{base_url}/{sub_path}/api/v3/series")).json()
+    eligible: set[int] = set()
+    for s in series:
+        eps = (
+            await client.get(
+                f"{base_url}/{sub_path}/api/v3/episode",
+                params={"seriesId": s["id"]},
+            )
+        ).json()
+        for ep in eps:
+            ef = ep.get("episodeFile")
+            if (
+                ep.get("monitored")
+                and ep.get("hasFile")
+                and ef is not None
+                and not ef.get("qualityCutoffNotMet", False)
+            ):
+                eligible.add(ep["id"])
+    return eligible
+
+
+async def _run_probe(
+    *,
+    instance_type: InstanceType,
+    sub_path: str,
+    seed_config: SeedConfig,
+    cycles: int,
+    upgrade_batch_size: int,
+    search_order: SearchOrder,
+) -> dict[str, Any]:
+    handle, base_url = _start_mock(seed_config)
+    master_key = Fernet.generate_key()
+    advance = timedelta(days=8)
+    fake_time = [datetime(2026, 1, 1, tzinfo=UTC)]
+
+    def _now() -> datetime:
+        return fake_time[0]
+
+    instance = _build_instance(
+        base_url=base_url,
+        sub_path=sub_path,
+        instance_type=instance_type,
+        upgrade_batch_size=upgrade_batch_size,
+        search_order=search_order,
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            if instance_type in (InstanceType.sonarr, InstanceType.whisparr_v2):
+                eligible_ids = await _upgrade_eligible_sonarr_episode_ids(
+                    client, base_url, sub_path
+                )
+            else:
+                eligible_ids = await _upgrade_eligible_movie_ids(client, base_url, sub_path)
+
+            async with _temp_db(master_key, instance):
+                # The hourly-cap counter is a SQL count over search_log
+                # within real-wallclock 3600s.  In a probe that runs all
+                # cycles in sub-second wallclock time, that cap saturates
+                # and starves every cycle after the first.  Patch it to
+                # always return zero so the cap never triggers; we are
+                # measuring rotation, not throttling.
+                async def _zero_hourly(*_args: object, **_kwargs: object) -> int:
+                    return 0
+
+                with (
+                    patch("houndarr.repositories.cooldowns._now_utc", _now),
+                    patch(
+                        "houndarr.engine.search_loop._count_searches_last_hour",
+                        _zero_hourly,
+                    ),
+                ):
+                    current = instance
+                    for _ in range(cycles):
+                        await run_instance_search(current, master_key)
+                        # Re-read the instance to pick up any persisted
+                        # series_offset / item_offset updates the engine
+                        # writes back during chronological mode.
+                        async with get_db() as conn:
+                            async with conn.execute(
+                                "SELECT upgrade_series_offset, upgrade_item_offset"
+                                " FROM instances WHERE id = ?",
+                                (instance.core.id,),
+                            ) as cur:
+                                row = await cur.fetchone()
+                        if row is not None:
+                            new_upgrade = UpgradePolicy(
+                                upgrade_enabled=current.upgrade.upgrade_enabled,
+                                upgrade_batch_size=current.upgrade.upgrade_batch_size,
+                                upgrade_cooldown_days=current.upgrade.upgrade_cooldown_days,
+                                upgrade_hourly_cap=current.upgrade.upgrade_hourly_cap,
+                                upgrade_sonarr_search_mode=current.upgrade.upgrade_sonarr_search_mode,
+                                upgrade_lidarr_search_mode=current.upgrade.upgrade_lidarr_search_mode,
+                                upgrade_readarr_search_mode=current.upgrade.upgrade_readarr_search_mode,
+                                upgrade_whisparr_v2_search_mode=current.upgrade.upgrade_whisparr_v2_search_mode,
+                                upgrade_item_offset=int(row[1] or 0),
+                                upgrade_series_offset=int(row[0] or 0),
+                            )
+                            current = Instance(
+                                core=current.core,
+                                missing=current.missing,
+                                cutoff=current.cutoff,
+                                upgrade=new_upgrade,
+                                schedule=current.schedule,
+                                snapshot=current.snapshot,
+                                timestamps=current.timestamps,
+                            )
+                        fake_time[0] += advance
+
+                dispatched = await _read_dispatched_per_item()
+    finally:
+        _stop_mock(handle)
+
+    relevant = {iid: dispatched.get(iid, 0) for iid in eligible_ids}
+    counts = list(relevant.values())
+    n_eligible = len(eligible_ids)
+    n_touched = sum(1 for c in counts if c > 0)
+    n_never = n_eligible - n_touched
+
+    return {
+        "type": instance_type.value,
+        "search_order": search_order.value,
+        "cycles": cycles,
+        "upgrade_batch_size": upgrade_batch_size,
+        "eligible": n_eligible,
+        "touched": n_touched,
+        "never_touched": n_never,
+        "total_dispatches": sum(counts),
+        "min_per_item": min(counts) if counts else 0,
+        "max_per_item": max(counts) if counts else 0,
+        "first_few_never": [iid for iid, n in relevant.items() if n == 0][:10],
+    }
+
+
+def _verdict(result: dict[str, Any], *, expected_full_coverage: bool) -> str:
+    if expected_full_coverage and result["never_touched"] > 0:
+        return (
+            f"INCOMPLETE COVERAGE: {result['never_touched']} of {result['eligible']} "
+            f"items never searched (first few: {result['first_few_never']})"
+        )
+    if result["never_touched"] > 0:
+        return (
+            f"partial coverage: {result['never_touched']} of {result['eligible']} "
+            "items not yet touched"
+        )
+    return "full coverage"
+
+
+async def main() -> None:
+    print("Upgrade-pass coverage probe\n")
+
+    # 1. Radarr chronological: full library every cycle, offset rotates by
+    #    upgrade_batch_size per cycle. With 100 movies in upgrade-eligible
+    #    state and batch=5, full coverage in ~20 cycles.
+    print("=== Radarr chronological, library=200, upgrade-eligible=60, batch=5 ===")
+    seed = SeedConfig(seed=42, radarr_movies=200)
+    cycles = math.ceil(60 / 5) + 5  # +5 padding
+    result = await _run_probe(
+        instance_type=InstanceType.radarr,
+        sub_path="radarr",
+        seed_config=seed,
+        cycles=cycles,
+        upgrade_batch_size=5,
+        search_order=SearchOrder.chronological,
+    )
+    print(
+        f"  eligible={result['eligible']}  touched={result['touched']}  "
+        f"never={result['never_touched']}  cycles={cycles}"
+    )
+    print(f"  verdict: {_verdict(result, expected_full_coverage=True)}\n")
+
+    # 2. Radarr random: same setup but random order. Expect probabilistic
+    #    coverage; over enough cycles every item is touched.
+    print("=== Radarr random, library=200, upgrade-eligible=60, batch=5 ===")
+    cycles = 60  # 5 * 60 = 300 dispatches, expected coverage E ~ N * H_N
+    result = await _run_probe(
+        instance_type=InstanceType.radarr,
+        sub_path="radarr",
+        seed_config=seed,
+        cycles=cycles,
+        upgrade_batch_size=5,
+        search_order=SearchOrder.random,
+    )
+    print(
+        f"  eligible={result['eligible']}  touched={result['touched']}  "
+        f"never={result['never_touched']}  cycles={cycles}  "
+        f"dispatches={result['total_dispatches']}"
+    )
+    print(f"  verdict: {_verdict(result, expected_full_coverage=False)}\n")
+
+    # 3. Sonarr chronological: 50 series x 10 episodes = 500 episodes total.
+    #    Window is 5 series per cycle. To touch every series at least once:
+    #    50/5 = 10 cycles. Each series fetch produces all its episodes; with
+    #    batch=5 we dispatch 5 per cycle. Full coverage of upgrade-eligible
+    #    episodes can take longer than the series rotation due to the
+    #    item-batch limit.
+    print("=== Sonarr chronological, 50 series x 10 episodes, batch=5 ===")
+    seed = SeedConfig(seed=42, sonarr_series=50, sonarr_episodes_per_series=10)
+    cycles = 60
+    result = await _run_probe(
+        instance_type=InstanceType.sonarr,
+        sub_path="sonarr",
+        seed_config=seed,
+        cycles=cycles,
+        upgrade_batch_size=5,
+        search_order=SearchOrder.chronological,
+    )
+    print(
+        f"  eligible={result['eligible']}  touched={result['touched']}  "
+        f"never={result['never_touched']}  cycles={cycles}  "
+        f"dispatches={result['total_dispatches']}"
+    )
+    print(f"  verdict: {_verdict(result, expected_full_coverage=False)}\n")
+
+    # 4. Sonarr random: random shuffles within the rotated window each cycle.
+    print("=== Sonarr random, 50 series x 10 episodes, batch=5 ===")
+    result = await _run_probe(
+        instance_type=InstanceType.sonarr,
+        sub_path="sonarr",
+        seed_config=seed,
+        cycles=cycles,
+        upgrade_batch_size=5,
+        search_order=SearchOrder.random,
+    )
+    print(
+        f"  eligible={result['eligible']}  touched={result['touched']}  "
+        f"never={result['never_touched']}  cycles={cycles}  "
+        f"dispatches={result['total_dispatches']}"
+    )
+    print(f"  verdict: {_verdict(result, expected_full_coverage=False)}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/mock_arr/routers/__init__.py
+++ b/tests/mock_arr/routers/__init__.py
@@ -1,0 +1,3 @@
+"""Per-app FastAPI routers for the mock *arr server."""
+
+from __future__ import annotations

--- a/tests/mock_arr/routers/lidarr.py
+++ b/tests/mock_arr/routers/lidarr.py
@@ -124,6 +124,7 @@ def make_lidarr_router(data: AppData) -> APIRouter:
         monitored: bool = Query(True),
         include_artist: bool = Query(False, alias="includeArtist"),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("missing", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
         return paginate(
             records,
@@ -142,6 +143,7 @@ def make_lidarr_router(data: AppData) -> APIRouter:
         monitored: bool = Query(True),
         include_artist: bool = Query(False, alias="includeArtist"),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("cutoff", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
         return paginate(
             records,

--- a/tests/mock_arr/routers/lidarr.py
+++ b/tests/mock_arr/routers/lidarr.py
@@ -1,0 +1,168 @@
+"""Lidarr mock router.
+
+Parent aggregate is the artist; leaves are albums. Houndarr's upgrade pass
+paginates ``/wanted/cutoff`` to build an exclusion set, then walks the
+flat ``/album`` library and keeps everything that has a file but is not
+cutoff-unmet. The seeder mirrors that contract.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+from tests.mock_arr._common import (
+    attach_common_routes,
+    paginate,
+    partition_leaf_ids,
+)
+from tests.mock_arr.store import AppData
+
+
+def make_lidarr_data(
+    *,
+    seed: int = 42,
+    artist_count: int = 50,
+    albums_per_artist: int = 10,
+    missing_ratio: float = 0.5,
+    cutoff_ratio: float = 0.2,
+) -> AppData:
+    rng = random.Random(seed)
+    parents: list[dict[str, Any]] = []
+    leaves: list[dict[str, Any]] = []
+    leaf_id = 4000
+    base_date = datetime(2005, 1, 1, tzinfo=UTC)
+    for artist_id in range(1, artist_count + 1):
+        artist_name = f"Mock Lidarr Artist {artist_id:03d}"
+        parents.append(
+            {
+                "id": artist_id,
+                "artistName": artist_name,
+                "sortName": artist_name.lower(),
+                "monitored": True,
+                "foreignArtistId": f"mb-artist-{artist_id:06d}",
+                "status": "active",
+            }
+        )
+        for album_index in range(1, albums_per_artist + 1):
+            release_date = base_date + timedelta(days=leaf_id - 4000)
+            album_title = f"Album {album_index:02d}"
+            leaves.append(
+                {
+                    "id": leaf_id,
+                    "artistId": artist_id,
+                    "title": album_title,
+                    "disambiguation": "",
+                    "albumType": "Album",
+                    "foreignAlbumId": f"mb-album-{leaf_id:06d}",
+                    "monitored": True,
+                    "releaseDate": release_date.isoformat().replace("+00:00", "Z"),
+                    "duration": 2_400_000,
+                    "artist": {
+                        "id": artist_id,
+                        "artistName": artist_name,
+                        "monitored": True,
+                    },
+                }
+            )
+            leaf_id += 1
+
+    rng.shuffle(leaves)
+    leaves.sort(key=lambda x: x["id"])
+
+    leaf_ids = [leaf["id"] for leaf in leaves]
+    missing_ids, cutoff_ids, upgrade_ids = partition_leaf_ids(
+        leaf_ids,
+        seed=seed,
+        missing_ratio=missing_ratio,
+        cutoff_ratio=cutoff_ratio,
+    )
+
+    return AppData(
+        app_name="Lidarr",
+        app_version="3.1.0.4875",
+        api_prefix="/lidarr/api/v1",
+        api_version="v1",
+        sort_key_default="releaseDate",
+        sort_direction_default="ascending",
+        parents=parents,
+        leaves=leaves,
+        missing_ids=missing_ids,
+        cutoff_ids=cutoff_ids,
+        upgrade_ids=upgrade_ids,
+    )
+
+
+def _library_shape(record: dict[str, Any], data: AppData) -> dict[str, Any]:
+    leaf_id = record["id"]
+    has_file = leaf_id not in data.missing_ids
+    track_file_count = 12 if has_file else 0
+    return {
+        **record,
+        "statistics": {
+            "trackFileCount": track_file_count,
+            "trackCount": 12,
+            "totalTrackCount": 12,
+            "sizeOnDisk": 12 * 5_000_000 if has_file else 0,
+        },
+    }
+
+
+def make_lidarr_router(data: AppData) -> APIRouter:
+    router = APIRouter(prefix=data.api_prefix)
+    attach_common_routes(router, data)
+
+    @router.get("/wanted/missing")
+    async def wanted_missing(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("releaseDate", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+        include_artist: bool = Query(False, alias="includeArtist"),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/wanted/cutoff")
+    async def wanted_cutoff(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("releaseDate", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+        include_artist: bool = Query(False, alias="includeArtist"),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/artist")
+    async def get_artists() -> list[dict[str, Any]]:
+        return data.parents
+
+    @router.get("/album")
+    async def get_albums(
+        include_artist: bool = Query(False, alias="includeArtist"),
+        artist_id: int | None = Query(None, alias="artistId"),
+    ) -> list[dict[str, Any]]:
+        records = data.leaves
+        if artist_id is not None:
+            records = [leaf for leaf in records if leaf["artistId"] == artist_id]
+        return [_library_shape(leaf, data) for leaf in records]
+
+    return router

--- a/tests/mock_arr/routers/radarr.py
+++ b/tests/mock_arr/routers/radarr.py
@@ -111,6 +111,7 @@ def make_radarr_router(data: AppData) -> APIRouter:
         sort_direction: str = Query("ascending", alias="sortDirection"),
         monitored: bool = Query(True),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("missing", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
         return paginate(
             records,
@@ -128,6 +129,7 @@ def make_radarr_router(data: AppData) -> APIRouter:
         sort_direction: str = Query("ascending", alias="sortDirection"),
         monitored: bool = Query(True),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("cutoff", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
         return paginate(
             records,

--- a/tests/mock_arr/routers/radarr.py
+++ b/tests/mock_arr/routers/radarr.py
@@ -1,0 +1,144 @@
+"""Radarr mock router.
+
+Radarr has no parent aggregate: every movie is a top-level record. The
+seeder produces a flat list of monitored movies; the partition decides
+which are missing (no file), cutoff-unmet, or upgrade-eligible.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+from tests.mock_arr._common import (
+    attach_common_routes,
+    paginate,
+    partition_leaf_ids,
+)
+from tests.mock_arr.store import AppData
+
+
+def make_radarr_data(
+    *,
+    seed: int = 42,
+    movie_count: int = 500,
+    missing_ratio: float = 0.5,
+    cutoff_ratio: float = 0.2,
+) -> AppData:
+    """Build the seeded Radarr-shaped record set."""
+    rng = random.Random(seed)
+    base_date = datetime(2010, 1, 1, tzinfo=UTC)
+    leaves: list[dict[str, Any]] = []
+    for movie_id in range(1, movie_count + 1):
+        title = f"Mock Radarr Movie {movie_id:03d}"
+        in_cinemas = base_date + timedelta(days=movie_id * 3)
+        physical = in_cinemas + timedelta(days=120)
+        digital = in_cinemas + timedelta(days=60)
+        leaves.append(
+            {
+                "id": movie_id,
+                "title": title,
+                "originalTitle": title,
+                "sortTitle": title.lower(),
+                "year": 2010 + (movie_id // 100),
+                "tmdbId": 3_000_000 + movie_id,
+                "imdbId": f"tt{7_000_000 + movie_id}",
+                "titleSlug": f"mock-radarr-movie-{movie_id:03d}",
+                "status": "released",
+                "minimumAvailability": "released",
+                "isAvailable": True,
+                "inCinemas": in_cinemas.isoformat().replace("+00:00", "Z"),
+                "physicalRelease": physical.isoformat().replace("+00:00", "Z"),
+                "digitalRelease": digital.isoformat().replace("+00:00", "Z"),
+                "releaseDate": digital.isoformat().replace("+00:00", "Z"),
+            }
+        )
+
+    rng.shuffle(leaves)
+    leaves.sort(key=lambda x: x["id"])
+
+    leaf_ids = [leaf["id"] for leaf in leaves]
+    missing_ids, cutoff_ids, upgrade_ids = partition_leaf_ids(
+        leaf_ids,
+        seed=seed,
+        missing_ratio=missing_ratio,
+        cutoff_ratio=cutoff_ratio,
+    )
+
+    return AppData(
+        app_name="Radarr",
+        app_version="6.1.1.10360",
+        api_prefix="/radarr/api/v3",
+        api_version="v3",
+        sort_key_default="movieMetadata.sortTitle",
+        sort_direction_default="ascending",
+        parents=[],
+        leaves=leaves,
+        missing_ids=missing_ids,
+        cutoff_ids=cutoff_ids,
+        upgrade_ids=upgrade_ids,
+    )
+
+
+def _library_shape(record: dict[str, Any], data: AppData) -> dict[str, Any]:
+    """Return a movie in the ``/movie`` library shape with file metadata."""
+    movie_id = record["id"]
+    has_file = movie_id not in data.missing_ids
+    cutoff_not_met = movie_id in data.cutoff_ids
+    payload = {
+        **record,
+        "monitored": True,
+        "hasFile": has_file,
+    }
+    payload["movieFile"] = (
+        {"id": movie_id, "qualityCutoffNotMet": cutoff_not_met} if has_file else None
+    )
+    return payload
+
+
+def make_radarr_router(data: AppData) -> APIRouter:
+    router = APIRouter(prefix=data.api_prefix)
+    attach_common_routes(router, data)
+
+    @router.get("/wanted/missing")
+    async def wanted_missing(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("inCinemas", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/wanted/cutoff")
+    async def wanted_cutoff(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("inCinemas", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/movie")
+    async def get_movies() -> list[dict[str, Any]]:
+        return [_library_shape(leaf, data) for leaf in data.leaves]
+
+    return router

--- a/tests/mock_arr/routers/readarr.py
+++ b/tests/mock_arr/routers/readarr.py
@@ -123,6 +123,7 @@ def make_readarr_router(data: AppData) -> APIRouter:
         monitored: bool = Query(True),
         include_author: bool = Query(False, alias="includeAuthor"),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("missing", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
         return paginate(
             records,
@@ -141,6 +142,7 @@ def make_readarr_router(data: AppData) -> APIRouter:
         monitored: bool = Query(True),
         include_author: bool = Query(False, alias="includeAuthor"),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("cutoff", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
         return paginate(
             records,

--- a/tests/mock_arr/routers/readarr.py
+++ b/tests/mock_arr/routers/readarr.py
@@ -1,0 +1,167 @@
+"""Readarr mock router.
+
+Parent aggregate is the author; leaves are books. Mirrors Lidarr's contract
+(paginated wanted + flat library walk for upgrades) but uses the v1 API
+path with ``includeAuthor`` instead of ``includeArtist``.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+from tests.mock_arr._common import (
+    attach_common_routes,
+    paginate,
+    partition_leaf_ids,
+)
+from tests.mock_arr.store import AppData
+
+
+def make_readarr_data(
+    *,
+    seed: int = 42,
+    author_count: int = 50,
+    books_per_author: int = 10,
+    missing_ratio: float = 0.5,
+    cutoff_ratio: float = 0.2,
+) -> AppData:
+    rng = random.Random(seed)
+    parents: list[dict[str, Any]] = []
+    leaves: list[dict[str, Any]] = []
+    leaf_id = 5000
+    base_date = datetime(2000, 1, 1, tzinfo=UTC)
+    for author_id in range(1, author_count + 1):
+        author_name = f"Mock Readarr Author {author_id:03d}"
+        parents.append(
+            {
+                "id": author_id,
+                "authorName": author_name,
+                "sortName": author_name.lower(),
+                "monitored": True,
+                "foreignAuthorId": f"gr-author-{author_id:06d}",
+                "status": "continuing",
+            }
+        )
+        for book_index in range(1, books_per_author + 1):
+            release_date = base_date + timedelta(days=leaf_id - 5000)
+            book_title = f"Book {book_index:02d}"
+            leaves.append(
+                {
+                    "id": leaf_id,
+                    "authorId": author_id,
+                    "title": book_title,
+                    "authorTitle": author_name,
+                    "disambiguation": "",
+                    "foreignBookId": f"gr-book-{leaf_id:06d}",
+                    "monitored": True,
+                    "pageCount": 320,
+                    "releaseDate": release_date.isoformat().replace("+00:00", "Z"),
+                    "author": {
+                        "id": author_id,
+                        "authorName": author_name,
+                        "monitored": True,
+                    },
+                }
+            )
+            leaf_id += 1
+
+    rng.shuffle(leaves)
+    leaves.sort(key=lambda x: x["id"])
+
+    leaf_ids = [leaf["id"] for leaf in leaves]
+    missing_ids, cutoff_ids, upgrade_ids = partition_leaf_ids(
+        leaf_ids,
+        seed=seed,
+        missing_ratio=missing_ratio,
+        cutoff_ratio=cutoff_ratio,
+    )
+
+    return AppData(
+        app_name="Readarr",
+        app_version="0.4.20.129",
+        api_prefix="/readarr/api/v1",
+        api_version="v1",
+        sort_key_default="releaseDate",
+        sort_direction_default="ascending",
+        parents=parents,
+        leaves=leaves,
+        missing_ids=missing_ids,
+        cutoff_ids=cutoff_ids,
+        upgrade_ids=upgrade_ids,
+    )
+
+
+def _library_shape(record: dict[str, Any], data: AppData) -> dict[str, Any]:
+    leaf_id = record["id"]
+    has_file = leaf_id not in data.missing_ids
+    book_file_count = 1 if has_file else 0
+    return {
+        **record,
+        "statistics": {
+            "bookFileCount": book_file_count,
+            "bookCount": 1,
+            "totalBookCount": 1,
+            "sizeOnDisk": 4_000_000 if has_file else 0,
+        },
+    }
+
+
+def make_readarr_router(data: AppData) -> APIRouter:
+    router = APIRouter(prefix=data.api_prefix)
+    attach_common_routes(router, data)
+
+    @router.get("/wanted/missing")
+    async def wanted_missing(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("releaseDate", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+        include_author: bool = Query(False, alias="includeAuthor"),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/wanted/cutoff")
+    async def wanted_cutoff(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("releaseDate", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+        include_author: bool = Query(False, alias="includeAuthor"),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/author")
+    async def get_authors() -> list[dict[str, Any]]:
+        return data.parents
+
+    @router.get("/book")
+    async def get_books(
+        include_author: bool = Query(False, alias="includeAuthor"),
+        author_id: int | None = Query(None, alias="authorId"),
+    ) -> list[dict[str, Any]]:
+        records = data.leaves
+        if author_id is not None:
+            records = [leaf for leaf in records if leaf["authorId"] == author_id]
+        return [_library_shape(leaf, data) for leaf in records]
+
+    return router

--- a/tests/mock_arr/routers/sonarr.py
+++ b/tests/mock_arr/routers/sonarr.py
@@ -1,0 +1,177 @@
+"""Sonarr mock router.
+
+Exposes ``/api/v3/{system/status, queue/status, command, wanted/missing,
+wanted/cutoff, series, episode}`` shaped to match a real Sonarr v4 instance.
+The seeder builds a parent/leaf tree (series -> episodes) where every leaf
+falls into exactly one of the three engine passes.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+from tests.mock_arr._common import (
+    attach_common_routes,
+    paginate,
+    partition_leaf_ids,
+)
+from tests.mock_arr.store import AppData
+
+
+def make_sonarr_data(
+    *,
+    seed: int = 42,
+    series_count: int = 50,
+    episodes_per_series: int = 10,
+    missing_ratio: float = 0.5,
+    cutoff_ratio: float = 0.2,
+) -> AppData:
+    """Build the seeded Sonarr-shaped record set.
+
+    With the defaults this yields 50 series * 10 episodes = 500 leaves,
+    partitioned 50% missing / 20% cutoff-unmet / 30% upgrade-eligible.
+    """
+    rng = random.Random(seed)
+    parents: list[dict[str, Any]] = []
+    leaves: list[dict[str, Any]] = []
+    leaf_id = 1000
+    base_date = datetime(2020, 1, 1, tzinfo=UTC)
+    for series_id in range(1, series_count + 1):
+        title = f"Mock Sonarr Series {series_id:03d}"
+        parents.append(
+            {
+                "id": series_id,
+                "title": title,
+                "sortTitle": title.lower(),
+                "monitored": True,
+                "tvdbId": 1_000_000 + series_id,
+                "status": "continuing",
+            }
+        )
+        for ep_num in range(1, episodes_per_series + 1):
+            air_date = base_date + timedelta(days=leaf_id - 1000)
+            leaves.append(
+                {
+                    "id": leaf_id,
+                    "seriesId": series_id,
+                    "tvdbId": 2_000_000 + leaf_id,
+                    "seriesTitle": title,
+                    "title": f"Episode {ep_num:02d}",
+                    "seasonNumber": 1,
+                    "episodeNumber": ep_num,
+                    "absoluteEpisodeNumber": ep_num,
+                    "airDate": air_date.date().isoformat(),
+                    "airDateUtc": air_date.isoformat().replace("+00:00", "Z"),
+                    "series": {
+                        "id": series_id,
+                        "title": title,
+                        "monitored": True,
+                    },
+                }
+            )
+            leaf_id += 1
+
+    rng.shuffle(leaves)
+    leaves.sort(key=lambda x: x["id"])
+
+    leaf_ids = [leaf["id"] for leaf in leaves]
+    missing_ids, cutoff_ids, upgrade_ids = partition_leaf_ids(
+        leaf_ids,
+        seed=seed,
+        missing_ratio=missing_ratio,
+        cutoff_ratio=cutoff_ratio,
+    )
+
+    return AppData(
+        app_name="Sonarr",
+        app_version="4.0.17.2952",
+        api_prefix="/sonarr/api/v3",
+        api_version="v3",
+        sort_key_default="episodes.airDateUtc",
+        sort_direction_default="ascending",
+        parents=parents,
+        leaves=leaves,
+        missing_ids=missing_ids,
+        cutoff_ids=cutoff_ids,
+        upgrade_ids=upgrade_ids,
+    )
+
+
+def _library_shape(record: dict[str, Any], data: AppData) -> dict[str, Any]:
+    """Return a leaf in the ``/episode`` library shape.
+
+    Real Sonarr returns each episode with ``monitored``, ``hasFile``, and
+    a nested ``episodeFile.qualityCutoffNotMet`` flag the engine reads
+    during the upgrade pass.
+    """
+    leaf_id = record["id"]
+    has_file = leaf_id not in data.missing_ids
+    cutoff_not_met = leaf_id in data.cutoff_ids
+    payload = {
+        **record,
+        "monitored": True,
+        "hasFile": has_file,
+    }
+    payload["episodeFile"] = (
+        {"id": leaf_id, "qualityCutoffNotMet": cutoff_not_met} if has_file else None
+    )
+    return payload
+
+
+def make_sonarr_router(data: AppData) -> APIRouter:
+    router = APIRouter(prefix=data.api_prefix)
+    attach_common_routes(router, data)
+
+    @router.get("/wanted/missing")
+    async def wanted_missing(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("airDateUtc", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+        include_series: bool = Query(False, alias="includeSeries"),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/wanted/cutoff")
+    async def wanted_cutoff(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("airDateUtc", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+        include_series: bool = Query(False, alias="includeSeries"),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/series")
+    async def get_series() -> list[dict[str, Any]]:
+        return data.parents
+
+    @router.get("/episode")
+    async def get_episodes(
+        series_id: int = Query(..., alias="seriesId"),
+        include_episode_file: bool = Query(False, alias="includeEpisodeFile"),
+        include_series: bool = Query(False, alias="includeSeries"),
+    ) -> list[dict[str, Any]]:
+        return [_library_shape(leaf, data) for leaf in data.leaves if leaf["seriesId"] == series_id]
+
+    return router

--- a/tests/mock_arr/routers/sonarr.py
+++ b/tests/mock_arr/routers/sonarr.py
@@ -135,6 +135,7 @@ def make_sonarr_router(data: AppData) -> APIRouter:
         monitored: bool = Query(True),
         include_series: bool = Query(False, alias="includeSeries"),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("missing", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
         return paginate(
             records,
@@ -153,6 +154,7 @@ def make_sonarr_router(data: AppData) -> APIRouter:
         monitored: bool = Query(True),
         include_series: bool = Query(False, alias="includeSeries"),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("cutoff", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
         return paginate(
             records,

--- a/tests/mock_arr/routers/whisparr_v2.py
+++ b/tests/mock_arr/routers/whisparr_v2.py
@@ -123,6 +123,7 @@ def make_whisparr_v2_router(data: AppData) -> APIRouter:
         monitored: bool = Query(True),
         include_series: bool = Query(False, alias="includeSeries"),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("missing", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
         return paginate(
             records,
@@ -141,6 +142,7 @@ def make_whisparr_v2_router(data: AppData) -> APIRouter:
         monitored: bool = Query(True),
         include_series: bool = Query(False, alias="includeSeries"),
     ) -> dict[str, Any]:
+        data.page_log.entries.append(("cutoff", page, page_size))
         records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
         return paginate(
             records,

--- a/tests/mock_arr/routers/whisparr_v2.py
+++ b/tests/mock_arr/routers/whisparr_v2.py
@@ -1,0 +1,165 @@
+"""Whisparr v2 mock router.
+
+Whisparr v2 is Sonarr-derived: same series + episode shape, same v3 API
+path, but defaults to ``releaseDate`` sort instead of ``airDateUtc``. The
+seeded data uses the same parent/leaf scheme as Sonarr with adjusted
+titles to keep the two apps distinguishable in the search log.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Query
+
+from tests.mock_arr._common import (
+    attach_common_routes,
+    paginate,
+    partition_leaf_ids,
+)
+from tests.mock_arr.store import AppData
+
+
+def make_whisparr_v2_data(
+    *,
+    seed: int = 42,
+    series_count: int = 30,
+    episodes_per_series: int = 10,
+    missing_ratio: float = 0.5,
+    cutoff_ratio: float = 0.2,
+) -> AppData:
+    rng = random.Random(seed)
+    parents: list[dict[str, Any]] = []
+    leaves: list[dict[str, Any]] = []
+    leaf_id = 6000
+    base_date = datetime(2018, 1, 1, tzinfo=UTC)
+    for series_id in range(1, series_count + 1):
+        title = f"Mock WhisparrV2 Studio {series_id:03d}"
+        parents.append(
+            {
+                "id": series_id,
+                "title": title,
+                "sortTitle": title.lower(),
+                "monitored": True,
+                "tvdbId": 4_000_000 + series_id,
+                "status": "continuing",
+            }
+        )
+        for ep_num in range(1, episodes_per_series + 1):
+            release_date = base_date + timedelta(days=leaf_id - 6000)
+            leaves.append(
+                {
+                    "id": leaf_id,
+                    "seriesId": series_id,
+                    "tvdbId": 5_000_000 + leaf_id,
+                    "seriesTitle": title,
+                    "title": f"Scene {ep_num:02d}",
+                    "seasonNumber": 1,
+                    "episodeNumber": ep_num,
+                    "absoluteEpisodeNumber": ep_num,
+                    "releaseDate": release_date.isoformat().replace("+00:00", "Z"),
+                    "series": {
+                        "id": series_id,
+                        "title": title,
+                        "monitored": True,
+                    },
+                }
+            )
+            leaf_id += 1
+
+    rng.shuffle(leaves)
+    leaves.sort(key=lambda x: x["id"])
+
+    leaf_ids = [leaf["id"] for leaf in leaves]
+    missing_ids, cutoff_ids, upgrade_ids = partition_leaf_ids(
+        leaf_ids,
+        seed=seed,
+        missing_ratio=missing_ratio,
+        cutoff_ratio=cutoff_ratio,
+    )
+
+    return AppData(
+        app_name="Whisparr",
+        app_version="2.2.0.108",
+        api_prefix="/whisparr_v2/api/v3",
+        api_version="v3",
+        sort_key_default="releaseDate",
+        sort_direction_default="ascending",
+        parents=parents,
+        leaves=leaves,
+        missing_ids=missing_ids,
+        cutoff_ids=cutoff_ids,
+        upgrade_ids=upgrade_ids,
+    )
+
+
+def _library_shape(record: dict[str, Any], data: AppData) -> dict[str, Any]:
+    leaf_id = record["id"]
+    has_file = leaf_id not in data.missing_ids
+    cutoff_not_met = leaf_id in data.cutoff_ids
+    payload = {
+        **record,
+        "monitored": True,
+        "hasFile": has_file,
+    }
+    payload["episodeFile"] = (
+        {"id": leaf_id, "qualityCutoffNotMet": cutoff_not_met} if has_file else None
+    )
+    return payload
+
+
+def make_whisparr_v2_router(data: AppData) -> APIRouter:
+    router = APIRouter(prefix=data.api_prefix)
+    attach_common_routes(router, data)
+
+    @router.get("/wanted/missing")
+    async def wanted_missing(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("releaseDate", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+        include_series: bool = Query(False, alias="includeSeries"),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.missing_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/wanted/cutoff")
+    async def wanted_cutoff(
+        page: int = Query(1, ge=1),
+        page_size: int = Query(10, ge=1, le=2000, alias="pageSize"),
+        sort_key: str = Query("releaseDate", alias="sortKey"),
+        sort_direction: str = Query("ascending", alias="sortDirection"),
+        monitored: bool = Query(True),
+        include_series: bool = Query(False, alias="includeSeries"),
+    ) -> dict[str, Any]:
+        records = [leaf for leaf in data.leaves if leaf["id"] in data.cutoff_ids]
+        return paginate(
+            records,
+            page=page,
+            page_size=page_size,
+            sort_key=sort_key,
+            sort_direction=sort_direction,
+        )
+
+    @router.get("/series")
+    async def get_series() -> list[dict[str, Any]]:
+        return data.parents
+
+    @router.get("/episode")
+    async def get_episodes(
+        series_id: int = Query(..., alias="seriesId"),
+        include_episode_file: bool = Query(False, alias="includeEpisodeFile"),
+        include_series: bool = Query(False, alias="includeSeries"),
+    ) -> list[dict[str, Any]]:
+        return [_library_shape(leaf, data) for leaf in data.leaves if leaf["seriesId"] == series_id]
+
+    return router

--- a/tests/mock_arr/routers/whisparr_v3.py
+++ b/tests/mock_arr/routers/whisparr_v3.py
@@ -1,0 +1,104 @@
+"""Whisparr v3 mock router.
+
+Whisparr v3 has no ``/wanted`` endpoints. Houndarr's client fetches the
+full ``/api/v3/movie`` library once per probe and computes the missing
+and cutoff partitions in memory. The mock therefore only needs to expose
+``/movie`` plus the common status / queue / command routes.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter
+
+from tests.mock_arr._common import attach_common_routes, partition_leaf_ids
+from tests.mock_arr.store import AppData
+
+
+def make_whisparr_v3_data(
+    *,
+    seed: int = 42,
+    movie_count: int = 500,
+    missing_ratio: float = 0.5,
+    cutoff_ratio: float = 0.2,
+) -> AppData:
+    rng = random.Random(seed)
+    leaves: list[dict[str, Any]] = []
+    base_date = datetime(2020, 1, 1, tzinfo=UTC)
+    for movie_id in range(1, movie_count + 1):
+        title = f"Mock WhisparrV3 Scene {movie_id:03d}"
+        release_date = base_date + timedelta(days=movie_id)
+        leaves.append(
+            {
+                "id": movie_id,
+                "title": title,
+                "code": f"SCN-{movie_id:05d}",
+                "sortTitle": title.lower(),
+                "year": 2020 + (movie_id // 200),
+                "studioTitle": f"Mock Studio {1 + (movie_id % 25):02d}",
+                "studioForeignId": f"st-{1 + (movie_id % 25):04d}",
+                "foreignId": f"sc-{movie_id:08d}",
+                "stashId": f"stash-{movie_id:08d}",
+                "performerNames": [f"Performer {(movie_id % 30) + 1:02d}"],
+                "performerForeignIds": [f"pf-{(movie_id % 30) + 1:04d}"],
+                "status": "released",
+                "minimumAvailability": "released",
+                "isAvailable": True,
+                "itemType": "scene",
+                "releaseDate": release_date.isoformat().replace("+00:00", "Z"),
+            }
+        )
+
+    rng.shuffle(leaves)
+    leaves.sort(key=lambda x: x["id"])
+
+    leaf_ids = [leaf["id"] for leaf in leaves]
+    missing_ids, cutoff_ids, upgrade_ids = partition_leaf_ids(
+        leaf_ids,
+        seed=seed,
+        missing_ratio=missing_ratio,
+        cutoff_ratio=cutoff_ratio,
+    )
+
+    return AppData(
+        app_name="Whisparr",
+        app_version="3.3.3.683",
+        api_prefix="/whisparr_v3/api/v3",
+        api_version="v3",
+        sort_key_default="movieMetadata.sortTitle",
+        sort_direction_default="ascending",
+        parents=[],
+        leaves=leaves,
+        missing_ids=missing_ids,
+        cutoff_ids=cutoff_ids,
+        upgrade_ids=upgrade_ids,
+    )
+
+
+def _library_shape(record: dict[str, Any], data: AppData) -> dict[str, Any]:
+    leaf_id = record["id"]
+    has_file = leaf_id not in data.missing_ids
+    cutoff_not_met = leaf_id in data.cutoff_ids
+    payload = {
+        **record,
+        "monitored": True,
+        "hasFile": has_file,
+    }
+    payload["movieFile"] = (
+        {"id": leaf_id, "qualityCutoffNotMet": cutoff_not_met} if has_file else None
+    )
+    return payload
+
+
+def make_whisparr_v3_router(data: AppData) -> APIRouter:
+    router = APIRouter(prefix=data.api_prefix)
+    attach_common_routes(router, data)
+
+    @router.get("/movie")
+    async def get_movies() -> list[dict[str, Any]]:
+        return [_library_shape(leaf, data) for leaf in data.leaves]
+
+    return router

--- a/tests/mock_arr/server.py
+++ b/tests/mock_arr/server.py
@@ -1,0 +1,225 @@
+"""Entry point for the mock *arr server.
+
+Run with ``python -m tests.mock_arr.server --port 9100 --items 500``. The
+server mounts six routers under distinct path prefixes so a single uvicorn
+process can pretend to be every supported *arr type. Houndarr instances
+are configured with URLs of the form ``http://localhost:9100/<app>``.
+
+The mock accepts any (or no) API key. Authentication is intentionally
+out of scope: the goal is to exercise Houndarr's pagination and search
+dispatch logic, not to model *arr auth.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import click
+import uvicorn
+from fastapi import FastAPI
+
+from tests.mock_arr.routers.lidarr import make_lidarr_data, make_lidarr_router
+from tests.mock_arr.routers.radarr import make_radarr_data, make_radarr_router
+from tests.mock_arr.routers.readarr import make_readarr_data, make_readarr_router
+from tests.mock_arr.routers.sonarr import make_sonarr_data, make_sonarr_router
+from tests.mock_arr.routers.whisparr_v2 import (
+    make_whisparr_v2_data,
+    make_whisparr_v2_router,
+)
+from tests.mock_arr.routers.whisparr_v3 import (
+    make_whisparr_v3_data,
+    make_whisparr_v3_router,
+)
+from tests.mock_arr.store import MockState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SeedConfig:
+    """Per-app record counts for ``create_app``.
+
+    Defaults give every app a comfortably large library so the random
+    search algorithm runs in the ``N >= K`` regime where it is uniform.
+    Lower the counts to reproduce the small-library bias.
+    """
+
+    seed: int = 42
+    sonarr_series: int = 50
+    sonarr_episodes_per_series: int = 10
+    radarr_movies: int = 500
+    lidarr_artists: int = 50
+    lidarr_albums_per_artist: int = 10
+    readarr_authors: int = 50
+    readarr_books_per_author: int = 10
+    whisparr_v2_series: int = 30
+    whisparr_v2_episodes_per_series: int = 10
+    whisparr_v3_movies: int = 500
+    missing_ratio: float = 0.5
+    cutoff_ratio: float = 0.2
+
+
+def build_state(config: SeedConfig) -> MockState:
+    """Seed every app's data using the same master seed."""
+    return MockState(
+        sonarr=make_sonarr_data(
+            seed=config.seed,
+            series_count=config.sonarr_series,
+            episodes_per_series=config.sonarr_episodes_per_series,
+            missing_ratio=config.missing_ratio,
+            cutoff_ratio=config.cutoff_ratio,
+        ),
+        radarr=make_radarr_data(
+            seed=config.seed,
+            movie_count=config.radarr_movies,
+            missing_ratio=config.missing_ratio,
+            cutoff_ratio=config.cutoff_ratio,
+        ),
+        lidarr=make_lidarr_data(
+            seed=config.seed,
+            artist_count=config.lidarr_artists,
+            albums_per_artist=config.lidarr_albums_per_artist,
+            missing_ratio=config.missing_ratio,
+            cutoff_ratio=config.cutoff_ratio,
+        ),
+        readarr=make_readarr_data(
+            seed=config.seed,
+            author_count=config.readarr_authors,
+            books_per_author=config.readarr_books_per_author,
+            missing_ratio=config.missing_ratio,
+            cutoff_ratio=config.cutoff_ratio,
+        ),
+        whisparr_v2=make_whisparr_v2_data(
+            seed=config.seed,
+            series_count=config.whisparr_v2_series,
+            episodes_per_series=config.whisparr_v2_episodes_per_series,
+            missing_ratio=config.missing_ratio,
+            cutoff_ratio=config.cutoff_ratio,
+        ),
+        whisparr_v3=make_whisparr_v3_data(
+            seed=config.seed,
+            movie_count=config.whisparr_v3_movies,
+            missing_ratio=config.missing_ratio,
+            cutoff_ratio=config.cutoff_ratio,
+        ),
+    )
+
+
+def create_app(config: SeedConfig | None = None) -> FastAPI:
+    """Build the FastAPI app with all six routers mounted."""
+    cfg = config or SeedConfig()
+    state = build_state(cfg)
+    app = FastAPI(
+        title="Houndarr Mock *arr Server",
+        description="Seeded multi-app mock for testing Houndarr's search engine.",
+    )
+
+    app.include_router(make_sonarr_router(state.sonarr))
+    app.include_router(make_radarr_router(state.radarr))
+    app.include_router(make_lidarr_router(state.lidarr))
+    app.include_router(make_readarr_router(state.readarr))
+    app.include_router(make_whisparr_v2_router(state.whisparr_v2))
+    app.include_router(make_whisparr_v3_router(state.whisparr_v3))
+
+    @app.get("/")
+    async def root() -> dict[str, Any]:
+        return {
+            "name": "Houndarr Mock *arr Server",
+            "endpoints": {
+                "sonarr": "http://HOST:PORT/sonarr",
+                "radarr": "http://HOST:PORT/radarr",
+                "lidarr": "http://HOST:PORT/lidarr",
+                "readarr": "http://HOST:PORT/readarr",
+                "whisparr_v2": "http://HOST:PORT/whisparr_v2",
+                "whisparr_v3": "http://HOST:PORT/whisparr_v3",
+            },
+            "totals": {
+                "sonarr": _summary(state.sonarr),
+                "radarr": _summary(state.radarr),
+                "lidarr": _summary(state.lidarr),
+                "readarr": _summary(state.readarr),
+                "whisparr_v2": _summary(state.whisparr_v2),
+                "whisparr_v3": _summary(state.whisparr_v3),
+            },
+        }
+
+    @app.get("/__commands__/{app_name}")
+    async def get_commands(app_name: str) -> dict[str, Any]:
+        """Return every POSTed command captured for one app.
+
+        Useful for tests that want to assert which leaves the engine
+        actually dispatched a search for during a cycle.
+        """
+        store = getattr(state, app_name, None)
+        if store is None:
+            return {"error": f"unknown app: {app_name}"}
+        return {"commands": store.command_log.entries}
+
+    app.state.mock_state = state
+    return app
+
+
+def _summary(data: object) -> dict[str, int]:
+    leaves: list[Any] = getattr(data, "leaves", [])
+    missing: set[int] = getattr(data, "missing_ids", set())
+    cutoff: set[int] = getattr(data, "cutoff_ids", set())
+    upgrade: set[int] = getattr(data, "upgrade_ids", set())
+    return {
+        "total": len(leaves),
+        "missing": len(missing),
+        "cutoff": len(cutoff),
+        "upgrade": len(upgrade),
+    }
+
+
+@click.command()
+@click.option("--port", default=9100, show_default=True, help="Port to bind.")
+@click.option("--host", default="127.0.0.1", show_default=True, help="Host to bind.")
+@click.option("--seed", default=42, show_default=True, help="Master RNG seed.")
+@click.option(
+    "--items",
+    default=500,
+    show_default=True,
+    help="Approximate leaf count per *arr app (overrides per-app counts).",
+)
+@click.option("--missing-ratio", default=0.5, show_default=True)
+@click.option("--cutoff-ratio", default=0.2, show_default=True)
+@click.option("--log-level", default="info", show_default=True)
+def main(
+    port: int,
+    host: str,
+    seed: int,
+    items: int,
+    missing_ratio: float,
+    cutoff_ratio: float,
+    log_level: str,
+) -> None:
+    """Launch the mock server."""
+    parents = max(10, items // 10)
+    leaves_per_parent = max(1, items // parents)
+    config = SeedConfig(
+        seed=seed,
+        sonarr_series=parents,
+        sonarr_episodes_per_series=leaves_per_parent,
+        radarr_movies=items,
+        lidarr_artists=parents,
+        lidarr_albums_per_artist=leaves_per_parent,
+        readarr_authors=parents,
+        readarr_books_per_author=leaves_per_parent,
+        whisparr_v2_series=max(10, parents // 2),
+        whisparr_v2_episodes_per_series=leaves_per_parent,
+        whisparr_v3_movies=items,
+        missing_ratio=missing_ratio,
+        cutoff_ratio=cutoff_ratio,
+    )
+    app = create_app(config)
+    uvicorn.run(app, host=host, port=port, log_level=log_level)
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mock_arr/server.py
+++ b/tests/mock_arr/server.py
@@ -157,6 +157,30 @@ def create_app(config: SeedConfig | None = None) -> FastAPI:
             return {"error": f"unknown app: {app_name}"}
         return {"commands": store.command_log.entries}
 
+    @app.get("/__page_log__/{app_name}")
+    async def get_page_log(app_name: str) -> dict[str, Any]:
+        """Return every paginated wanted request captured for one app.
+
+        Each entry is ``[kind, page, page_size]`` where kind is one of
+        ``"missing"`` or ``"cutoff"``. This is the ground-truth log for
+        verifying the random search algorithm's page-distribution
+        fairness.
+        """
+        store = getattr(state, app_name, None)
+        if store is None:
+            return {"error": f"unknown app: {app_name}"}
+        return {"entries": list(store.page_log.entries)}
+
+    @app.post("/__reset__/{app_name}")
+    async def reset_app(app_name: str) -> dict[str, Any]:
+        """Wipe command and page logs for one app, leaving seed data intact."""
+        store = getattr(state, app_name, None)
+        if store is None:
+            return {"error": f"unknown app: {app_name}"}
+        store.command_log.entries.clear()
+        store.page_log.entries.clear()
+        return {"reset": app_name}
+
     app.state.mock_state = state
     return app
 

--- a/tests/mock_arr/store.py
+++ b/tests/mock_arr/store.py
@@ -1,0 +1,55 @@
+"""In-memory state container for the mock *arr server.
+
+The mock holds one ``AppData`` per *arr type. Each ``AppData`` carries the
+seeded record set plus a partition into missing / cutoff-unmet / upgrade
+buckets, so the routers can answer ``/wanted/missing``, ``/wanted/cutoff``,
+and library scans from the same source of truth without re-randomising.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class CommandLog:
+    """Captures POSTed search commands so tests can assert dispatch behaviour."""
+
+    entries: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class AppData:
+    """Per-app mock state.
+
+    ``parents`` holds the optional parent aggregate (series, artist, author).
+    Radarr and Whisparr v3 leave it empty because their leaves are top-level.
+    ``leaves`` is the searchable record set; the three id sets partition the
+    leaves into the three engine passes.
+    """
+
+    app_name: str
+    app_version: str
+    api_prefix: str
+    api_version: str
+    sort_key_default: str
+    sort_direction_default: str
+    parents: list[dict[str, Any]]
+    leaves: list[dict[str, Any]]
+    missing_ids: set[int]
+    cutoff_ids: set[int]
+    upgrade_ids: set[int]
+    command_log: CommandLog = field(default_factory=CommandLog)
+
+
+@dataclass(slots=True)
+class MockState:
+    """Aggregate state across all six mocked *arr apps."""
+
+    sonarr: AppData
+    radarr: AppData
+    lidarr: AppData
+    readarr: AppData
+    whisparr_v2: AppData
+    whisparr_v3: AppData

--- a/tests/mock_arr/store.py
+++ b/tests/mock_arr/store.py
@@ -20,6 +20,18 @@ class CommandLog:
 
 
 @dataclass(slots=True)
+class PageLog:
+    """Records every paginated wanted request so tests can measure distribution.
+
+    Each entry is ``(kind, page, page_size)`` where kind is ``"missing"`` or
+    ``"cutoff"``. This is the ground truth for verifying the random search
+    algorithm's page-selection fairness.
+    """
+
+    entries: list[tuple[str, int, int]] = field(default_factory=list)
+
+
+@dataclass(slots=True)
 class AppData:
     """Per-app mock state.
 
@@ -41,6 +53,7 @@ class AppData:
     cutoff_ids: set[int]
     upgrade_ids: set[int]
     command_log: CommandLog = field(default_factory=CommandLog)
+    page_log: PageLog = field(default_factory=PageLog)
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary

Adds a seeded multi-app *arr mock server (Sonarr, Radarr, Lidarr, Readarr, Whisparr v2, Whisparr v3 mounted under one FastAPI process at distinct path prefixes) plus five programmatic probes that drive the production engine against the mock and verify Tier-1 algorithm fairness invariants. Adds a `just mock-arr` recipe and a README documenting how the mock is seeded and how to run the probes.

Closes #488

## Changes

- `tests/mock_arr/server.py`: single FastAPI process mounting six routers under per-app path prefixes; `__page_log__` and `__commands__` introspection endpoints; `__reset__` to clear logs between runs.
- `tests/mock_arr/_common.py`, `tests/mock_arr/store.py`: shared per-app store (deterministic seed, CLI-tunable item count) and pagination helpers.
- `tests/mock_arr/routers/{sonarr,radarr,lidarr,readarr,whisparr_v2,whisparr_v3}.py`: per-app routers with `/wanted/missing`, `/wanted/cutoff`, library, parent-aggregate, and command endpoints.
- `tests/mock_arr/probe_distribution.py`: drives `run_instance_search()` against the mock for many cycles at multiple library sizes; reports per-cycle start-page distribution.
- `tests/mock_arr/probe_cooldown.py`: advances simulated time so cooldowns expire each cycle; measures per-item dispatch counts via chi-square against uniform.
- `tests/mock_arr/probe_hourly_cap.py`: three concurrent instances with heterogeneous caps; checks no instance exceeds its cap and no instance is starved.
- `tests/mock_arr/probe_upgrade_coverage.py`: many upgrade-only cycles; verifies Radarr full-library 100% coverage in `ceil(eligible/batch)` cycles and Sonarr windowed-rotation coverage matching `1 - ((W-B)/W)^R`.
- `tests/mock_arr/probe_context_mode.py`: synthetic-parent dispatch fairness for Sonarr / Whisparr v2 season_context, Lidarr artist_context, Readarr author_context. Weighted chi-square scales expected counts by per-parent missing share so a parent with three times the missing leaves gets three times the expected dispatches; the naive equal-expected variant is reported alongside so a regression that breaks weighting also visibly shifts the naive number.
- `justfile`: adds `mock-arr port=PORT items=N seed=S` recipe.
- `tests/mock_arr/README.md`: documents how the mock is seeded, how to run the probes, and what each one measures.

## Conflict resolutions during cherry-pick

- `e778827` carries dashboard mobile polish, logs auto-refresh, and upgrade-window UI alongside `tests/mock_arr/probe_context_mode.py`. Sliced the cherry-pick: `git cherry-pick -n e778827`, reverted the seven non-probe files to HEAD, `git rm` on `static/js/logs.js` (the cherry-pick brought a modify-vs-deleted-on-HEAD shape; the file does not exist on origin/main yet), then `git commit -C e778827` and amended the message to reflect the slice. The other slices ride PR22 (upgrade window UI), PR25b (dashboard mobile polish), and PR26 (logs auto-refresh).
- Cherry-picks ran in author-date order: `ebe278b`, `acaacc5`, `22a52d9`, `e778827` (slice), `356eaa5`. No textual conflicts on the four pure-probe commits.

## Notes for review

The probes import `WhisparrV2SearchMode` and use the `whisparr_v2_search_mode` field on `MissingPolicy` / `UpgradePolicy`; both are introduced by PR21 (Whisparr v2 disambiguation). The probes also build Instance values via the seven sub-struct kwargs (`Instance(core=..., missing=..., ...)`); PR11's facade kept the flat-kwargs `__init__` per the rollout's facade-only ship of PR11. Until PR21 lands and the PR11 facade-unwrap follow-up lands after PR20, manual probe invocation fails at import / construction time.

The mock server itself (`tests.mock_arr.server` and the six routers) imports cleanly on origin/main today; `just mock-arr` boots it. Pytest does not collect any file under `tests/mock_arr/` (probes use the `probe_*` prefix, not `test_*`).

## Testing

ruff check, ruff format --check, mypy strict (84 src/ files), bandit (0 issues): all green locally. pytest -n auto -m "not integration": 1882 passed, 29 skipped. `pytest --collect-only tests/mock_arr/` collects zero tests. Mock server modules import cleanly (`tests.mock_arr.server`, `tests.mock_arr._common`, `tests.mock_arr.store`, all six routers).

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
