### PR TITLE
feat(engine): stratified shuffle, partial-page fix, typed catches, throttles, log polish

### DIFF
--- a/src/houndarr/clients/readarr.py
+++ b/src/houndarr/clients/readarr.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import ClassVar
+from dataclasses import dataclass, replace
+from typing import Any, ClassVar, TypeVar
 
 from houndarr.clients._wire_models import (
     PaginatedResponse,
@@ -39,6 +39,9 @@ class MissingBook:
     release_date: str | None  # ISO-8601 nullable string
 
 
+_BookT = TypeVar("_BookT", "MissingBook", "LibraryBook")
+
+
 class ReadarrClient(ArrClient):
     """Async client for the Readarr v1 REST API."""
 
@@ -53,6 +56,56 @@ class ReadarrClient(ArrClient):
         ReadarrWantedBook
     ]
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Session-scoped author-name cache.  Readarr's
+        # /wanted/{missing,cutoff}?includeAuthor=true is inconsistent:
+        # some records return the nested author object, others return
+        # author=null even when /author/{id} knows the name.  On the
+        # first book with an empty author_name we fetch /api/v1/author
+        # once, build an id->name map, and use it to hydrate every
+        # affected book for the rest of the session.  None means
+        # not-yet-loaded; {} means loaded-but-empty.
+        self._author_name_cache: dict[int, str] | None = None
+
+    async def _load_author_cache(self) -> dict[int, str]:
+        """Fetch the full author list once per session and build id->name."""
+        if self._author_name_cache is not None:
+            return self._author_name_cache
+        try:
+            records = await self._get("/api/v1/author")
+        except Exception:  # noqa: BLE001
+            # Transport failure fall-through: leave books with empty
+            # author_name rather than bubbling a secondary failure that
+            # would mask the primary wanted-page success.
+            self._author_name_cache = {}
+            return self._author_name_cache
+        cache: dict[int, str] = {}
+        if isinstance(records, list):
+            for r in records:
+                if not isinstance(r, dict):
+                    continue
+                aid = r.get("id")
+                name = r.get("authorName")
+                if isinstance(aid, int) and isinstance(name, str) and name:
+                    cache[aid] = name
+        self._author_name_cache = cache
+        return cache
+
+    async def _hydrate_author_names(self, books: list[_BookT]) -> list[_BookT]:
+        """Fill empty ``author_name`` on books whose wanted-page author was null."""
+        if not any(b.author_id and not b.author_name for b in books):
+            return books
+        cache = await self._load_author_cache()
+        if not cache:
+            return books
+        return [
+            replace(b, author_name=cache[b.author_id])
+            if (not b.author_name and b.author_id in cache)
+            else b
+            for b in books
+        ]
+
     async def get_missing(
         self,
         *,
@@ -62,7 +115,10 @@ class ReadarrClient(ArrClient):
         """Return a page of monitored missing books.
 
         Calls ``GET /api/v1/wanted/missing`` with ``includeAuthor=true``
-        so that author metadata is embedded in each record.
+        so that author metadata is embedded in each record.  Readarr
+        sometimes returns ``author: null`` even with the include flag;
+        :meth:`_hydrate_author_names` fills those in from the bulk
+        ``/api/v1/author`` list on first miss.
 
         Args:
             page: 1-based page number.
@@ -72,7 +128,8 @@ class ReadarrClient(ArrClient):
             List of :class:`MissingBook` dataclasses.
         """
         envelope = await self._fetch_wanted_page("missing", page=page, page_size=page_size)
-        return [_parse_book(w) for w in envelope.records]
+        books = [_parse_book(w) for w in envelope.records]
+        return await self._hydrate_author_names(books)
 
     async def search(self, item_id: int) -> None:
         """Trigger an automatic book search in Readarr.
@@ -125,7 +182,8 @@ class ReadarrClient(ArrClient):
             page_size=page_size,
             include_sort=False,
         )
-        return [_parse_book(w) for w in envelope.records]
+        books = [_parse_book(w) for w in envelope.records]
+        return await self._hydrate_author_names(books)
 
     async def get_wanted_total(self, kind: WantedKind) -> int:
         """Return the totalRecords count for ``wanted/{kind}`` via a size-1 probe.
@@ -156,7 +214,8 @@ class ReadarrClient(ArrClient):
             "/api/v1/book",
             includeAuthor="true",
         )
-        return [_parse_library_book(ReadarrLibraryBook.model_validate(r)) for r in records]
+        books = [_parse_library_book(ReadarrLibraryBook.model_validate(r)) for r in records]
+        return await self._hydrate_author_names(books)
 
 
 # Parsing helpers

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -30,7 +30,7 @@ from houndarr.services.instances import Instance, LidarrSearchMode
 
 logger = logging.getLogger(__name__)
 
-_UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES = 10
+_UPGRADE_CUTOFF_EXCLUSION_HARD_CAP = 100
 
 # ---------------------------------------------------------------------------
 # Label builders
@@ -205,6 +205,14 @@ async def fetch_upgrade_pool(
     Builds a cutoff-unmet exclusion set by paginating ``wanted/cutoff``, then
     returns monitored albums with files that are NOT in the exclusion set.
 
+    The cutoff pagination stops naturally when a short page is returned
+    (fewer records than the requested page_size).  A safety bound of
+    ``_UPGRADE_CUTOFF_EXCLUSION_HARD_CAP`` pages prevents an unbounded
+    walk if a misconfigured *arr instance returns full pages indefinitely;
+    that bound is sized to cover libraries up to roughly
+    ``hard_cap * 250`` cutoff-unmet albums (default 25000), which is well
+    above any real Lidarr deployment we have observed.
+
     Args:
         client: An open :class:`LidarrClient` context.
         instance: The configured Lidarr instance.
@@ -213,7 +221,8 @@ async def fetch_upgrade_pool(
         List of upgrade-eligible :class:`LibraryAlbum` items.
     """
     exclusion: set[int] = set()
-    for page in range(1, _UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES + 1):
+    page = 1
+    while page <= _UPGRADE_CUTOFF_EXCLUSION_HARD_CAP:
         try:
             cutoff_items = await client.get_cutoff_unmet(page=page, page_size=250)
         except (httpx.HTTPError, httpx.InvalidURL, ValidationError):
@@ -227,6 +236,16 @@ async def fetch_upgrade_pool(
             exclusion.add(item.album_id)
         if len(cutoff_items) < 250:
             break
+        page += 1
+    if page > _UPGRADE_CUTOFF_EXCLUSION_HARD_CAP:
+        logger.warning(
+            "[%s] cutoff exclusion walk hit safety cap of %d pages; "
+            "library has more than %d cutoff-unmet albums and the "
+            "upgrade pool may include some that are still cutoff-unmet",
+            instance.core.name,
+            _UPGRADE_CUTOFF_EXCLUSION_HARD_CAP,
+            _UPGRADE_CUTOFF_EXCLUSION_HARD_CAP * 250,
+        )
 
     library = await client.get_albums()
     return [a for a in library if a.monitored and a.has_file and a.album_id not in exclusion]

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import logging
 
+import httpx
+from pydantic import ValidationError
+
 from houndarr.clients.base import InstanceSnapshot, ReconcileSets
 from houndarr.clients.lidarr import LibraryAlbum, LidarrClient, MissingAlbum
 from houndarr.engine.adapters._common import (
@@ -213,7 +216,7 @@ async def fetch_upgrade_pool(
     for page in range(1, _UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES + 1):
         try:
             cutoff_items = await client.get_cutoff_unmet(page=page, page_size=250)
-        except Exception:  # noqa: BLE001
+        except (httpx.HTTPError, httpx.InvalidURL, ValidationError):
             logger.warning(
                 "[%s] failed to fetch cutoff page %d for exclusion set",
                 instance.core.name,

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -30,7 +30,7 @@ from houndarr.services.instances import Instance, ReadarrSearchMode
 
 logger = logging.getLogger(__name__)
 
-_UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES = 10
+_UPGRADE_CUTOFF_EXCLUSION_HARD_CAP = 100
 
 # ---------------------------------------------------------------------------
 # Label builders
@@ -204,6 +204,14 @@ async def fetch_upgrade_pool(
     Builds a cutoff-unmet exclusion set by paginating ``wanted/cutoff``, then
     returns monitored books with files that are NOT in the exclusion set.
 
+    The cutoff pagination stops naturally when a short page is returned
+    (fewer records than the requested page_size).  A safety bound of
+    ``_UPGRADE_CUTOFF_EXCLUSION_HARD_CAP`` pages prevents an unbounded
+    walk if a misconfigured *arr instance returns full pages indefinitely;
+    that bound is sized to cover libraries up to roughly
+    ``hard_cap * 250`` cutoff-unmet books (default 25000), which is well
+    above any real Readarr deployment we have observed.
+
     Args:
         client: An open :class:`ReadarrClient` context.
         instance: The configured Readarr instance.
@@ -212,7 +220,8 @@ async def fetch_upgrade_pool(
         List of upgrade-eligible :class:`LibraryBook` items.
     """
     exclusion: set[int] = set()
-    for page in range(1, _UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES + 1):
+    page = 1
+    while page <= _UPGRADE_CUTOFF_EXCLUSION_HARD_CAP:
         try:
             cutoff_items = await client.get_cutoff_unmet(page=page, page_size=250)
         except (httpx.HTTPError, httpx.InvalidURL, ValidationError):
@@ -226,6 +235,16 @@ async def fetch_upgrade_pool(
             exclusion.add(item.book_id)
         if len(cutoff_items) < 250:
             break
+        page += 1
+    if page > _UPGRADE_CUTOFF_EXCLUSION_HARD_CAP:
+        logger.warning(
+            "[%s] cutoff exclusion walk hit safety cap of %d pages; "
+            "library has more than %d cutoff-unmet books and the "
+            "upgrade pool may include some that are still cutoff-unmet",
+            instance.core.name,
+            _UPGRADE_CUTOFF_EXCLUSION_HARD_CAP,
+            _UPGRADE_CUTOFF_EXCLUSION_HARD_CAP * 250,
+        )
 
     library = await client.get_books()
     return [b for b in library if b.monitored and b.has_file and b.book_id not in exclusion]

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import logging
 
+import httpx
+from pydantic import ValidationError
+
 from houndarr.clients.base import InstanceSnapshot, ReconcileSets
 from houndarr.clients.readarr import LibraryBook, MissingBook, ReadarrClient
 from houndarr.engine.adapters._common import (
@@ -212,7 +215,7 @@ async def fetch_upgrade_pool(
     for page in range(1, _UPGRADE_CUTOFF_EXCLUSION_MAX_PAGES + 1):
         try:
             cutoff_items = await client.get_cutoff_unmet(page=page, page_size=250)
-        except Exception:  # noqa: BLE001
+        except (httpx.HTTPError, httpx.InvalidURL, ValidationError):
             logger.warning(
                 "[%s] failed to fetch cutoff page %d for exclusion set",
                 instance.core.name,

--- a/src/houndarr/engine/retry.py
+++ b/src/houndarr/engine/retry.py
@@ -17,6 +17,7 @@ helper.
 from __future__ import annotations
 
 import logging
+import secrets
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
@@ -24,6 +25,23 @@ from houndarr.enums import CycleTrigger, SearchAction
 from houndarr.services.instances import Instance
 
 logger = logging.getLogger(__name__)
+
+
+def _apply_jitter(secs: int, jitter_secs: float | None) -> float:
+    """Return ``secs`` with up to ``jitter_secs`` seconds of symmetric jitter.
+
+    Uses :mod:`secrets` so there is no seeded reproducibility footgun;
+    tests that need determinism pass ``jitter_secs=None`` (the
+    default) to keep the returned value exactly equal to ``secs``.
+    Negative results are clamped to ``0.0`` so a large jitter band
+    never pushes the sleep below zero.
+    """
+    if jitter_secs is None or jitter_secs <= 0.0:
+        return float(secs)
+    # ``secrets.SystemRandom().uniform`` is the documented unseeded
+    # spelling; ``secrets.randbelow`` is integer-only.
+    delta = secrets.SystemRandom().uniform(-jitter_secs, jitter_secs)
+    return max(0.0, float(secs) + delta)
 
 
 @dataclass
@@ -51,7 +69,8 @@ async def run_with_reconnect(
     error_retry_secs: int,
     success_sleep_secs: int,
     write_log: Callable[..., Awaitable[None]],
-) -> int:
+    jitter_secs: float | None = None,
+) -> float:
     """Run *cycle* and apply per-instance reconnect-state transitions.
 
     *cycle* is a zero-arg awaitable that runs one search cycle and
@@ -93,9 +112,19 @@ async def run_with_reconnect(
             writer in keeps this module free of any direct dependency
             on ``engine.search_loop`` and lets tests substitute a
             spy.
+        jitter_secs: Optional symmetric jitter window in seconds
+            applied to the returned sleep duration (uniform random
+            in ``[-jitter_secs, +jitter_secs]``, clamped to ``>= 0``).
+            ``None`` (the default) keeps the sleep exactly equal to
+            the nominal value so the supervisor's pre-jitter
+            behaviour is preserved.  Opt-in jitter de-synchronises
+            re-ping storms when several instances come back online
+            at the same moment.
 
     Returns:
-        Number of seconds to sleep before the next cycle.
+        Number of seconds to sleep before the next cycle.  ``float``
+        even when ``jitter_secs`` is ``None`` so the return shape is
+        stable across both call modes.
     """
     got_connect_error = await cycle()
 
@@ -110,7 +139,7 @@ async def run_with_reconnect(
                 message=f"Could not reach {instance.url}",
             )
         state.in_retry = True
-        return error_retry_secs
+        return _apply_jitter(error_retry_secs, jitter_secs)
 
     if state.in_retry:
         logger.info(
@@ -127,4 +156,4 @@ async def run_with_reconnect(
             message=f"{instance.name!r} ({instance.url}) is reachable again",
         )
         state.in_retry = False
-    return success_sleep_secs
+    return _apply_jitter(success_sleep_secs, jitter_secs)

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -774,16 +774,24 @@ async def _run_upgrade_pass(
 
     if not pool:
         logger.info("[%s] upgrade pool empty, nothing to upgrade", instance.name)
-        await _write_log(
-            instance.id,
-            None,
-            None,
-            SearchAction.info.value,
-            search_kind="upgrade",
-            cycle_id=cycle_id,
-            cycle_trigger=cycle_trigger,
-            message="upgrade pool empty",
-        )
+        # Suppress identical info rows on every cycle for an instance
+        # that has nothing to upgrade.  One row per 6 hours per
+        # instance keeps the logs feed calm while still proving the
+        # pass ran periodically.  See `services/cooldown.py::
+        # should_log_info` for the LRU + TTL contract.
+        from houndarr.services.cooldown import should_log_info
+
+        if await should_log_info((instance.id, "upgrade_pool_empty"), 6 * 3600):
+            await _write_log(
+                instance.id,
+                None,
+                None,
+                SearchAction.info.value,
+                search_kind="upgrade",
+                cycle_id=cycle_id,
+                cycle_trigger=cycle_trigger,
+                message="nothing to upgrade right now",
+            )
         return 0
 
     # Random mode shuffles the pool and bypasses id-sort + offset-rotation.

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -25,6 +25,7 @@ from houndarr.engine.adapters import get_adapter
 from houndarr.engine.adapters.protocols import AppAdapterProto
 from houndarr.engine.candidates import SearchCandidate
 from houndarr.enums import CycleTrigger, ItemType, SearchAction, SearchKind
+from houndarr.errors import ClientError, EngineError
 from houndarr.services.cooldown import (
     is_on_cooldown_ref,
     record_search_ref,
@@ -819,6 +820,16 @@ async def run_instance_search(
     3. Optionally run the cutoff pass via :func:`_run_search_pass`.
     4. Return the total number of items searched.
 
+    Error surface (Track B.13):
+    Typed Houndarr errors (:class:`~houndarr.errors.EngineError` and
+    :class:`~houndarr.errors.ClientError` subclasses) and
+    :class:`httpx.TransportError` propagate unchanged; the supervisor's
+    reconnect loop inspects ``httpx.TransportError`` specifically, and
+    its typed catch consumes the two Houndarr bases.  Any other
+    exception escaping the internal handlers is wrapped in a fresh
+    :class:`EngineError` with the original on ``__cause__`` so callers
+    only ever see a Houndarr-specific surface.
+
     Args:
         instance: Fully-populated (decrypted) instance.
         master_key: Unused here but kept in signature for symmetry with
@@ -826,6 +837,36 @@ async def run_instance_search(
 
     Returns:
         Count of items searched in this cycle.
+    """
+    try:
+        return await _run_instance_search_impl(
+            instance,
+            master_key,
+            cycle_id=cycle_id,
+            cycle_trigger=cycle_trigger,
+        )
+    except httpx.TransportError:
+        raise
+    except (EngineError, ClientError):
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise EngineError(
+            f"unhandled error in search cycle for {instance.name!r}: {exc}"
+        ) from exc
+
+
+async def _run_instance_search_impl(
+    instance: Instance,
+    master_key: bytes,
+    *,
+    cycle_id: str | None = None,
+    cycle_trigger: CycleTrigger | str = CycleTrigger.scheduled,
+) -> int:
+    """Cycle body; wrapped by :func:`run_instance_search` for typed errors.
+
+    Kept as a private implementation so the public entrypoint can own
+    the error-surface contract without indenting a 200-line try block.
+    Callers outside this module should use :func:`run_instance_search`.
     """
     logger.info(
         "[%s] starting search cycle (batch_size=%d)",

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -28,6 +28,7 @@ from houndarr.enums import CycleTrigger, SearchAction, SearchKind
 from houndarr.services.cooldown import (
     is_on_cooldown,
     record_search,
+    should_log_skip,
 )
 from houndarr.services.instances import Instance, InstanceType, SearchOrder, update_instance
 from houndarr.services.time_window import (
@@ -444,18 +445,27 @@ async def _run_search_pass(  # noqa: C901
                     if is_cutoff
                     else f"on cooldown ({cooldown_days}d)"
                 )
-                logger.debug("[%s] %s%s: %s", instance.name, log_prefix, candidate.item_id, reason)
-                await _write_log(
-                    instance.id,
-                    candidate.item_id,
-                    candidate.item_type,
-                    SearchAction.skipped.value,
-                    search_kind=search_kind,
-                    cycle_id=cycle_id,
-                    cycle_trigger=cycle_trigger,
-                    item_label=candidate.label,
-                    reason=reason,
-                )
+                bucket = "cutoff_cd" if is_cutoff else "cooldown"
+                skip_key = (instance.id, candidate.item_id, search_kind, bucket)
+                if await should_log_skip(skip_key):
+                    logger.debug(
+                        "[%s] %s%s: %s",
+                        instance.name,
+                        log_prefix,
+                        candidate.item_id,
+                        reason,
+                    )
+                    await _write_log(
+                        instance.id,
+                        candidate.item_id,
+                        candidate.item_type,
+                        SearchAction.skipped.value,
+                        search_kind=search_kind,
+                        cycle_id=cycle_id,
+                        cycle_trigger=cycle_trigger,
+                        item_label=candidate.label,
+                        reason=reason,
+                    )
                 continue
 
             # Count only eligible (non-skipped) candidates against scan budget.
@@ -681,18 +691,20 @@ async def _run_upgrade_pass(
         # Cooldown
         if await is_on_cooldown(instance.id, candidate.item_id, candidate.item_type, cooldown_days):
             reason = f"on upgrade cooldown ({cooldown_days}d)"
-            logger.debug("[%s] upgrade %s: %s", instance.name, candidate.item_id, reason)
-            await _write_log(
-                instance.id,
-                candidate.item_id,
-                candidate.item_type,
-                SearchAction.skipped.value,
-                search_kind="upgrade",
-                cycle_id=cycle_id,
-                cycle_trigger=cycle_trigger,
-                item_label=candidate.label,
-                reason=reason,
-            )
+            skip_key = (instance.id, candidate.item_id, "upgrade", "upgrade_cd")
+            if await should_log_skip(skip_key):
+                logger.debug("[%s] upgrade %s: %s", instance.name, candidate.item_id, reason)
+                await _write_log(
+                    instance.id,
+                    candidate.item_id,
+                    candidate.item_type,
+                    SearchAction.skipped.value,
+                    search_kind="upgrade",
+                    cycle_id=cycle_id,
+                    cycle_trigger=cycle_trigger,
+                    item_label=candidate.label,
+                    reason=reason,
+                )
             new_offset = (offset + scanned + 1) % len(pool)
             scanned += 1
             continue

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -13,6 +13,7 @@ import logging
 import math
 import random
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
@@ -70,6 +71,76 @@ _UPGRADE_SCAN_BUDGET_MAX = 40
 _UPGRADE_BATCH_HARD_CAP = 5
 _UPGRADE_HOURLY_CAP_HARD_CAP = 5
 _UPGRADE_MIN_COOLDOWN_DAYS = 7
+
+
+# ---------------------------------------------------------------------------
+# Random search order: stratified-shuffle deck
+# ---------------------------------------------------------------------------
+#
+# When ``SearchOrder.random`` is active, ``_run_search_pass`` picks page
+# numbers from a shuffled permutation of ``[1, max_page]`` rather than a
+# fresh ``random.randint`` each cycle plus a forward walk with wrap-once.
+# The deck is held in this module-level cache, keyed by
+# ``(instance_id, search_kind)`` so each (instance, missing/cutoff) pair
+# tracks its own progress through the current round.
+#
+# Two properties this design buys over the old algorithm:
+#
+#   1. Bounded short-term variance.  Every page is visited exactly once
+#      per round (one round == ``max_page`` page-draws). The worst-case
+#      wait for a given page is therefore ``ceil(max_page / K)`` cycles,
+#      where K = ``_MAX_LIST_PAGES_PER_PASS``.  The previous algorithm
+#      could skip a page for arbitrarily many cycles in a row by chance.
+#
+#   2. No wrap-once asymmetry.  The original walk visited
+#      ``{start, start+1, ..., max_page, 1, 2, ...}`` which favoured
+#      pages near the end of the list when start>1 (a 1.25x-1.5x bias
+#      under multi-page-walk conditions; see AGENTS.md "Verifying
+#      Claims About Algorithms").  Pulling from a fresh shuffle has
+#      no positional asymmetry.
+#
+# The deck is rebuilt whenever ``max_page`` changes (the wanted-list
+# grew or shrank since the last cycle) or whenever the previous round
+# is exhausted.  Stale entries for deleted instances stay in the dict
+# but cost only a small list of integers per (instance, kind) pair.
+
+
+@dataclass(slots=True)
+class _RandomDeckState:
+    """Per-(instance, kind) deck of remaining page numbers for random mode."""
+
+    max_page: int
+    remaining: list[int]
+
+
+_random_decks: dict[tuple[int, str], _RandomDeckState] = {}
+
+
+def _draw_next_random_page(instance_id: int, search_kind: SearchKind | str, max_page: int) -> int:
+    """Pop the next page from this (instance, kind)'s shuffled deck.
+
+    Refreshes the deck when it is empty or when ``max_page`` differs from
+    the value the deck was built against (which happens when the user has
+    added or removed wanted items in the *arr instance since the last
+    cycle).
+    """
+    key = (instance_id, str(search_kind))
+    state = _random_decks.get(key)
+    if state is None or state.max_page != max_page or not state.remaining:
+        deck = list(range(1, max_page + 1))
+        random.shuffle(deck)  # noqa: S311  # nosec B311
+        state = _RandomDeckState(max_page=max_page, remaining=deck)
+        _random_decks[key] = state
+    return state.remaining.pop()
+
+
+def _reset_random_deck(instance_id: int, search_kind: SearchKind | str) -> None:
+    """Drop the cached deck for one (instance, kind) pair.
+
+    Test helper.  Production code does not need to call this because the
+    deck self-refreshes on ``max_page`` mismatch and on exhaustion.
+    """
+    _random_decks.pop((instance_id, str(search_kind)), None)
 
 
 # ---------------------------------------------------------------------------
@@ -450,6 +521,8 @@ async def _run_search_pass(  # noqa: C901
     scanned = 0
     page = max(1, start_page)
     wrapped = False
+    random_max_page = 0
+    use_random_deck = False
 
     if instance.search_order == SearchOrder.random and total_fn is not None:
         try:
@@ -464,8 +537,9 @@ async def _run_search_pass(  # noqa: C901
             )
         else:
             if total > 0:
-                max_page = max(1, math.ceil(total / page_size))
-                page = random.randint(1, max_page)  # noqa: S311  # nosec B311
+                random_max_page = max(1, math.ceil(total / page_size))
+                use_random_deck = True
+                page = _draw_next_random_page(instance.core.id, search_kind, random_max_page)
 
     for _ in range(_MAX_LIST_PAGES_PER_PASS):
         if searched >= target or scanned >= scan_budget:
@@ -482,9 +556,17 @@ async def _run_search_pass(  # noqa: C901
             page,
         )
         if not items:
-            # Paged past available data; wrap to page 1 once per pass so
-            # items at the start of the list (which may have come off
-            # cooldown) still get evaluated.
+            # Random mode draws every page from a pre-shuffled deck of
+            # ``[1, max_page]``, so an empty response means the deck is
+            # carrying a stale page number from before the wanted-list
+            # shrank.  Skip to the next deck entry; the deck will refresh
+            # itself when exhausted or when ``max_page`` no longer matches.
+            if use_random_deck:
+                page = _draw_next_random_page(instance.core.id, search_kind, random_max_page)
+                continue
+            # Chronological mode: paged past available data; wrap to page
+            # 1 once per pass so items at the start of the list (which may
+            # have come off cooldown) still get evaluated.
             if start_page > 1 and not wrapped:
                 page = 1
                 wrapped = True
@@ -695,7 +777,10 @@ async def _run_search_pass(  # noqa: C901
         # consumed.  When the batch fills or scan budget is reached
         # mid-page, the remaining items should be re-evaluated next cycle.
         if page_fully_consumed:
-            page += 1
+            if use_random_deck:
+                page = _draw_next_random_page(instance.core.id, search_kind, random_max_page)
+            else:
+                page += 1
 
     return searched, page
 

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -73,8 +73,21 @@ _UPGRADE_MIN_COOLDOWN_DAYS = 7
 
 
 # ---------------------------------------------------------------------------
-# search_log helper
+# search_log helpers
 # ---------------------------------------------------------------------------
+
+
+def _format_hourly_limit_reason(kind: SearchKind | str, cap: int) -> str:
+    """Return the skip-reason string for a cap-exhausted pass.
+
+    Centralises the phrasing used at the three hourly-cap gate sites
+    (missing / cutoff / upgrade) so they cannot drift apart.  The
+    parameter shape ``(N/hr)`` reads as "N per hour" to a user, where
+    the older ``(N)`` form read as an error code, a repeat finding
+    in post-Huntarr self-hoster research.
+    """
+    prefix = "" if kind == "missing" else f"{kind} "
+    return f"{prefix}hourly limit reached ({cap}/hr)"
 
 
 async def _write_log(
@@ -531,10 +544,8 @@ async def _run_search_pass(  # noqa: C901
 
             # Hourly cap.
             if hourly_cap > 0 and searches_this_hour >= hourly_cap:
-                reason = (
-                    f"cutoff hourly cap reached ({hourly_cap})"
-                    if is_cutoff
-                    else f"hourly cap reached ({hourly_cap})"
+                reason = _format_hourly_limit_reason(
+                    "cutoff" if is_cutoff else "missing", hourly_cap
                 )
                 logger.info("[%s] %s%s: %s", instance.name, log_prefix, candidate.item_id, reason)
                 await _write_item_log(
@@ -830,7 +841,7 @@ async def _run_upgrade_pass(
 
         # Hourly cap
         if hourly_cap > 0 and searches_this_hour >= hourly_cap:
-            reason = f"upgrade hourly cap reached ({hourly_cap})"
+            reason = _format_hourly_limit_reason("upgrade", hourly_cap)
             logger.info("[%s] upgrade %s: %s", instance.name, candidate.item_id, reason)
             await _write_item_log(
                 ref,

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -29,6 +29,7 @@ from houndarr.errors import (
     ClientError,
     EngineDispatchError,
     EngineError,
+    EngineOffsetPersistError,
     EnginePoolFetchError,
 )
 from houndarr.services.cooldown import (
@@ -291,6 +292,45 @@ async def _dispatch_with_typed_wrap(
         raise
     except Exception as exc:  # noqa: BLE001
         raise EngineDispatchError(str(exc)) from exc
+
+
+async def _persist_offset_with_typed_wrap(
+    instance_id: int,
+    *,
+    master_key: bytes,
+    **offsets: int,
+) -> None:
+    """Call :func:`update_instance` with offset kwargs, typing failures.
+
+    Track B.15 introduces this helper so the four offset-persist call
+    sites (upgrade series offset + upgrade item offset in
+    :func:`_run_upgrade_pass`; missing page offset + cutoff page offset
+    in :func:`_run_instance_search_impl`) can narrow their
+    ``except Exception`` to :class:`EngineOffsetPersistError`.
+
+    These writes are non-fatal by design: callers swallow the typed
+    error and the next cycle retries the persist.  The wrap keeps the
+    log line identical (``"failed to persist ..."``) while giving
+    observability a typed surface to key on.
+
+    Args:
+        instance_id: Primary key of the row being updated.
+        master_key: Fernet key required by :func:`update_instance`.
+        **offsets: Integer columns to update, e.g.
+            ``missing_page_offset=7``.  Non-integer columns are not a
+            valid shape for this helper; callers should use
+            :func:`update_instance` directly for those.
+
+    Raises:
+        EngineOffsetPersistError: Any non-typed ``Exception``; the
+            original is preserved on ``__cause__``.
+    """
+    try:
+        await update_instance(instance_id, master_key=master_key, **offsets)
+    except (EngineError, ClientError):
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise EngineOffsetPersistError(str(exc)) from exc
 
 
 async def _fetch_pool_with_typed_wrap(
@@ -713,12 +753,12 @@ async def _run_upgrade_pass(
     if instance.type in (InstanceType.sonarr, InstanceType.whisparr_v2):
         new_series_offset = instance.upgrade_series_offset + 5
         try:
-            await update_instance(
+            await _persist_offset_with_typed_wrap(
                 instance.id,
                 master_key=master_key,
                 upgrade_series_offset=new_series_offset,
             )
-        except Exception:  # noqa: BLE001
+        except EngineOffsetPersistError:
             logger.warning("[%s] failed to persist upgrade_series_offset", instance.name)
 
     if not pool:
@@ -872,12 +912,12 @@ async def _run_upgrade_pass(
     # keep the column meaningful and avoid per-cycle row churn.
     if instance.search_order == SearchOrder.chronological:
         try:
-            await update_instance(
+            await _persist_offset_with_typed_wrap(
                 instance.id,
                 master_key=master_key,
                 upgrade_item_offset=new_offset,
             )
-        except Exception:  # noqa: BLE001
+        except EngineOffsetPersistError:
             logger.warning("[%s] failed to persist upgrade_item_offset", instance.name)
 
     return searched
@@ -1067,12 +1107,12 @@ async def _run_instance_search_impl(
         # Only advance the offset in chronological mode.
         if instance.search_order == SearchOrder.chronological:
             try:
-                await update_instance(
+                await _persist_offset_with_typed_wrap(
                     instance.id,
                     master_key=master_key,
                     missing_page_offset=next_missing_page,
                 )
-            except Exception:  # noqa: BLE001
+            except EngineOffsetPersistError:
                 logger.warning("[%s] failed to persist missing_page_offset", instance.name)
 
     logger.info("[%s] cycle complete: %d searched", instance.name, searched)
@@ -1110,12 +1150,12 @@ async def _run_instance_search_impl(
             # chronological mode.  See the missing pass for rationale.
             if instance.search_order == SearchOrder.chronological:
                 try:
-                    await update_instance(
+                    await _persist_offset_with_typed_wrap(
                         instance.id,
                         master_key=master_key,
                         cutoff_page_offset=next_cutoff_page,
                     )
-                except Exception:  # noqa: BLE001
+                except EngineOffsetPersistError:
                     logger.warning("[%s] failed to persist cutoff_page_offset", instance.name)
             searched += cutoff_searched
 

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -143,6 +143,17 @@ def _reset_random_deck(instance_id: int, search_kind: SearchKind | str) -> None:
     _random_decks.pop((instance_id, str(search_kind)), None)
 
 
+# Sentinel used to pad partial last pages out to ``page_size`` in random mode
+# so the within-page selection probability is the same on partial and full
+# pages.  Without this padding, items on a short last page would be drained
+# every visit (``actual_items < page_size`` means each item has higher than
+# ``batch_size / page_size`` per-visit dispatch probability), accumulating a
+# small but persistent over-selection of the last 1-9 items in any backlog
+# whose ``totalRecords`` is not a multiple of ``page_size``.  Identity
+# comparison (``item is _SHUFFLE_PAD``) is the cheap and unambiguous gate.
+_SHUFFLE_PAD: object = object()
+
+
 # ---------------------------------------------------------------------------
 # search_log helpers
 # ---------------------------------------------------------------------------
@@ -546,6 +557,20 @@ async def _run_search_pass(  # noqa: C901
             break
 
         items = await fetch_fn(page=page, page_size=page_size)
+        # Pad partial pages out to page_size with sentinels in random mode so
+        # the per-item probability of being in the first batch_size positions
+        # of the shuffle is exactly batch_size / page_size on every page.  We
+        # only pad when there is more than one page in the wanted-list: with
+        # max_page == 1 the partial page is the entire backlog and there is
+        # no other page to compete with, so padding would only reduce
+        # throughput without affecting fairness.  See the cooldown probe and
+        # the AGENTS.md "Verifying Claims About Algorithms" section for the
+        # bias derivation this guards against.
+        pad_partial = use_random_deck and random_max_page > 1 and items and len(items) < page_size
+        if pad_partial:
+            items = list(items)
+            while len(items) < page_size:
+                items.append(_SHUFFLE_PAD)
         if instance.search_order == SearchOrder.random and items:
             random.shuffle(items)  # noqa: S311  # nosec B311
         logger.debug(
@@ -575,10 +600,30 @@ async def _run_search_pass(  # noqa: C901
 
         stop_pass = False
         page_fully_consumed = True
+        positions_consumed = 0
+        # In random mode each page visit consumes exactly ``batch_size``
+        # shuffled positions: padding sentinels count toward the position
+        # quota but produce no dispatch, so partial pages dispatch fewer
+        # real items per visit, equalising per-item attention across the
+        # backlog.  Hitting the cap is treated as "page work done" so the
+        # outer loop advances to the next deck page instead of re-fetching
+        # this one.  In chronological mode there is no per-page position
+        # cap; the existing ``searched >= target`` gate is the only break.
+        position_cap = batch_size if pad_partial else None
         for item in items:
             if searched >= target or scanned >= scan_budget:
                 page_fully_consumed = False
                 break
+            if position_cap is not None and positions_consumed >= position_cap:
+                break
+            positions_consumed += 1
+
+            if item is _SHUFFLE_PAD:
+                # Sentinel from partial-page padding: no real item to dispatch.
+                # Counts as scanned (consumes scan budget) so the engine still
+                # bounds its outbound work, but contributes zero dispatches.
+                scanned += 1
+                continue
 
             candidate = adapt_fn(item, instance)
             ref = ItemRef(

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -203,12 +203,15 @@ async def _count_searches_last_hour(instance_id: int, search_kind: SearchKind | 
     return int(row[0]) if row else 0
 
 
-async def _latest_missing_reason(
-    instance_id: int,
-    item_id: int,
-    item_type: str,
-) -> str | None:
-    """Return the latest logged missing-pass reason for one item, if any."""
+async def _latest_missing_reason_ref(ref: ItemRef) -> str | None:
+    """Return the latest logged missing-pass reason for *ref*, if any.
+
+    Used by the release-timing retry branch in :func:`_run_search_pass`
+    to decide whether an item that is currently on cooldown should be
+    retried (because the last logged reason was a pre-release or
+    post-release-grace skip that has since elapsed) or left on
+    cooldown.
+    """
     async with get_db() as db:
         async with db.execute(
             """
@@ -221,26 +224,11 @@ async def _latest_missing_reason(
             ORDER BY timestamp DESC, id DESC
             LIMIT 1
             """,
-            (instance_id, item_id, item_type),
+            (ref.instance_id, ref.item_id, ref.item_type.value),
         ) as cur:
             row = await cur.fetchone()
 
     return str(row[0]) if row and row[0] is not None else None
-
-
-async def _latest_missing_reason_ref(ref: ItemRef) -> str | None:
-    """Return the latest logged missing-pass reason for *ref*, if any.
-
-    ItemRef-accepting variant of :func:`_latest_missing_reason`.  Used
-    by the release-timing retry branch in :func:`_run_search_pass` so
-    the call site stays symmetric with the adjacent cooldown-service
-    ``is_on_cooldown_ref`` call.
-    """
-    return await _latest_missing_reason(
-        ref.instance_id,
-        ref.item_id,
-        ref.item_type.value,
-    )
 
 
 def _is_release_timing_reason(reason: str | None) -> bool:

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -24,10 +24,10 @@ from houndarr.database import get_db
 from houndarr.engine.adapters import get_adapter
 from houndarr.engine.adapters.protocols import AppAdapterProto
 from houndarr.engine.candidates import SearchCandidate
-from houndarr.enums import CycleTrigger, SearchAction, SearchKind
+from houndarr.enums import CycleTrigger, ItemType, SearchAction, SearchKind
 from houndarr.services.cooldown import (
-    is_on_cooldown,
-    record_search,
+    is_on_cooldown_ref,
+    record_search_ref,
     should_log_skip,
 )
 from houndarr.services.instances import Instance, InstanceType, SearchOrder, update_instance
@@ -36,6 +36,7 @@ from houndarr.services.time_window import (
     is_within_window,
     parse_time_window,
 )
+from houndarr.value_objects import ItemRef
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,52 @@ async def _write_log(
         search_kind=str(search_kind) if search_kind is not None else None,
         cycle_id=cycle_id,
         cycle_trigger=str(cycle_trigger) if cycle_trigger is not None else None,
+        item_label=item_label,
+        reason=reason,
+        message=message,
+    )
+
+
+async def _write_item_log(
+    ref: ItemRef,
+    action: str,
+    *,
+    search_kind: SearchKind | str | None = None,
+    cycle_id: str | None = None,
+    cycle_trigger: CycleTrigger | str | None = None,
+    item_label: str | None = None,
+    reason: str | None = None,
+    message: str | None = None,
+) -> None:
+    """Write one ``search_log`` row tied to a specific item reference.
+
+    Thin wrapper over :func:`_write_log` that accepts :class:`ItemRef`
+    in place of the three positional ``(instance_id, item_id, item_type)``
+    arguments.  Used by the hot loops in :func:`_run_search_pass` and
+    :func:`_run_upgrade_pass` where every persisted row is tied to an
+    identified candidate.  Cycle-scope info / error rows (queue gate,
+    window gate, upgrade pool fetch failure, upgrade pool empty) have no
+    ``ItemRef`` and continue to call :func:`_write_log` directly with
+    ``None`` for ``item_id`` and ``item_type``.
+
+    Args:
+        ref: The item this log row pertains to.
+        action: One of the :class:`SearchAction` values (as ``str``).
+        search_kind: ``"missing"`` / ``"cutoff"`` / ``"upgrade"``.
+        cycle_id: Shared cycle identifier for all rows in one cycle.
+        cycle_trigger: ``"scheduled"`` / ``"run_now"`` / ``"system"``.
+        item_label: Human-readable label for the item.
+        reason: Structured skip reason for ``skipped`` rows.
+        message: Free-form detail for ``error`` / ``info`` rows.
+    """
+    await _write_log(
+        ref.instance_id,
+        ref.item_id,
+        ref.item_type.value,
+        action,
+        search_kind=search_kind,
+        cycle_id=cycle_id,
+        cycle_trigger=cycle_trigger,
         item_label=item_label,
         reason=reason,
         message=message,
@@ -179,6 +226,21 @@ async def _latest_missing_reason(
             row = await cur.fetchone()
 
     return str(row[0]) if row and row[0] is not None else None
+
+
+async def _latest_missing_reason_ref(ref: ItemRef) -> str | None:
+    """Return the latest logged missing-pass reason for *ref*, if any.
+
+    ItemRef-accepting variant of :func:`_latest_missing_reason`.  Used
+    by the release-timing retry branch in :func:`_run_search_pass` so
+    the call site stays symmetric with the adjacent cooldown-service
+    ``is_on_cooldown_ref`` call.
+    """
+    return await _latest_missing_reason(
+        ref.instance_id,
+        ref.item_id,
+        ref.item_type.value,
+    )
 
 
 def _is_release_timing_reason(reason: str | None) -> bool:
@@ -310,6 +372,11 @@ async def _run_search_pass(  # noqa: C901
                 break
 
             candidate = adapt_fn(item, instance)
+            ref = ItemRef(
+                instance.id,
+                candidate.item_id,
+                ItemType(candidate.item_type),
+            )
 
             # Item-level modes can dedup immediately. Context modes defer dedup
             # until after release-timing checks so a temporarily blocked record
@@ -325,10 +392,8 @@ async def _run_search_pass(  # noqa: C901
             if candidate.unreleased_reason is not None:
                 is_grace = candidate.unreleased_reason.startswith("post-release grace")
                 if not (is_grace and cycle_trigger == "run_now"):
-                    await _write_log(
-                        instance.id,
-                        candidate.item_id,
-                        candidate.item_type,
+                    await _write_item_log(
+                        ref,
                         SearchAction.skipped.value,
                         search_kind=search_kind,
                         cycle_id=cycle_id,
@@ -358,10 +423,8 @@ async def _run_search_pass(  # noqa: C901
                     else f"hourly cap reached ({hourly_cap})"
                 )
                 logger.info("[%s] %s%s: %s", instance.name, log_prefix, candidate.item_id, reason)
-                await _write_log(
-                    instance.id,
-                    candidate.item_id,
-                    candidate.item_type,
+                await _write_item_log(
+                    ref,
                     SearchAction.skipped.value,
                     search_kind=search_kind,
                     cycle_id=cycle_id,
@@ -373,13 +436,9 @@ async def _run_search_pass(  # noqa: C901
                 break
 
             # Cooldown.
-            if await is_on_cooldown(
-                instance.id, candidate.item_id, candidate.item_type, cooldown_days
-            ):
+            if await is_on_cooldown_ref(ref, cooldown_days):
                 if search_kind == "missing":
-                    latest_reason = await _latest_missing_reason(
-                        instance.id, candidate.item_id, candidate.item_type
-                    )
+                    latest_reason = await _latest_missing_reason_ref(ref)
                     if _is_release_timing_reason(latest_reason):
                         logger.info(
                             "[%s] allowing missing retry for %s after release-timing block",
@@ -399,10 +458,8 @@ async def _run_search_pass(  # noqa: C901
                                 candidate.item_id,
                                 msg,
                             )
-                            await _write_log(
-                                instance.id,
-                                candidate.item_id,
-                                candidate.item_type,
+                            await _write_item_log(
+                                ref,
                                 SearchAction.error.value,
                                 search_kind=search_kind,
                                 cycle_id=cycle_id,
@@ -412,16 +469,9 @@ async def _run_search_pass(  # noqa: C901
                             )
                             continue
 
-                        await record_search(
-                            instance.id,
-                            candidate.item_id,
-                            candidate.item_type,
-                            search_kind,
-                        )
-                        await _write_log(
-                            instance.id,
-                            candidate.item_id,
-                            candidate.item_type,
+                        await record_search_ref(ref, search_kind)
+                        await _write_item_log(
+                            ref,
                             SearchAction.searched.value,
                             search_kind=search_kind,
                             cycle_id=cycle_id,
@@ -455,10 +505,8 @@ async def _run_search_pass(  # noqa: C901
                         candidate.item_id,
                         reason,
                     )
-                    await _write_log(
-                        instance.id,
-                        candidate.item_id,
-                        candidate.item_type,
+                    await _write_item_log(
+                        ref,
                         SearchAction.skipped.value,
                         search_kind=search_kind,
                         cycle_id=cycle_id,
@@ -484,10 +532,8 @@ async def _run_search_pass(  # noqa: C901
                     candidate.item_id,
                     msg,
                 )
-                await _write_log(
-                    instance.id,
-                    candidate.item_id,
-                    candidate.item_type,
+                await _write_item_log(
+                    ref,
                     SearchAction.error.value,
                     search_kind=search_kind,
                     cycle_id=cycle_id,
@@ -497,16 +543,9 @@ async def _run_search_pass(  # noqa: C901
                 )
                 continue
 
-            await record_search(
-                instance.id,
-                candidate.item_id,
-                candidate.item_type,
-                search_kind,
-            )
-            await _write_log(
-                instance.id,
-                candidate.item_id,
-                candidate.item_type,
+            await record_search_ref(ref, search_kind)
+            await _write_item_log(
+                ref,
                 SearchAction.searched.value,
                 search_kind=search_kind,
                 cycle_id=cycle_id,
@@ -657,6 +696,11 @@ async def _run_upgrade_pass(
             break
 
         candidate = adapter.adapt_upgrade(item, instance)
+        ref = ItemRef(
+            instance.id,
+            candidate.item_id,
+            ItemType(candidate.item_type),
+        )
 
         # Dedup
         if candidate.group_key is None:
@@ -675,10 +719,8 @@ async def _run_upgrade_pass(
         if hourly_cap > 0 and searches_this_hour >= hourly_cap:
             reason = f"upgrade hourly cap reached ({hourly_cap})"
             logger.info("[%s] upgrade %s: %s", instance.name, candidate.item_id, reason)
-            await _write_log(
-                instance.id,
-                candidate.item_id,
-                candidate.item_type,
+            await _write_item_log(
+                ref,
                 SearchAction.skipped.value,
                 search_kind="upgrade",
                 cycle_id=cycle_id,
@@ -689,15 +731,13 @@ async def _run_upgrade_pass(
             break
 
         # Cooldown
-        if await is_on_cooldown(instance.id, candidate.item_id, candidate.item_type, cooldown_days):
+        if await is_on_cooldown_ref(ref, cooldown_days):
             reason = f"on upgrade cooldown ({cooldown_days}d)"
             skip_key = (instance.id, candidate.item_id, "upgrade", "upgrade_cd")
             if await should_log_skip(skip_key):
                 logger.debug("[%s] upgrade %s: %s", instance.name, candidate.item_id, reason)
-                await _write_log(
-                    instance.id,
-                    candidate.item_id,
-                    candidate.item_type,
+                await _write_item_log(
+                    ref,
                     SearchAction.skipped.value,
                     search_kind="upgrade",
                     cycle_id=cycle_id,
@@ -723,10 +763,8 @@ async def _run_upgrade_pass(
                 candidate.item_id,
                 msg,
             )
-            await _write_log(
-                instance.id,
-                candidate.item_id,
-                candidate.item_type,
+            await _write_item_log(
+                ref,
                 SearchAction.error.value,
                 search_kind="upgrade",
                 cycle_id=cycle_id,
@@ -737,16 +775,9 @@ async def _run_upgrade_pass(
             new_offset = (offset + scanned) % len(pool)
             continue
 
-        await record_search(
-            instance.id,
-            candidate.item_id,
-            candidate.item_type,
-            "upgrade",
-        )
-        await _write_log(
-            instance.id,
-            candidate.item_id,
-            candidate.item_type,
+        await record_search_ref(ref, "upgrade")
+        await _write_item_log(
+            ref,
             SearchAction.searched.value,
             search_kind="upgrade",
             cycle_id=cycle_id,

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -612,7 +612,7 @@ async def _run_search_pass(  # noqa: C901
                 )
                 bucket = "cutoff_cd" if is_cutoff else "cooldown"
                 skip_key = (instance.id, candidate.item_id, search_kind, bucket)
-                if await should_log_skip(skip_key):
+                if cycle_trigger == "run_now" or await should_log_skip(skip_key):
                     logger.debug(
                         "[%s] %s%s: %s",
                         instance.name,
@@ -847,7 +847,7 @@ async def _run_upgrade_pass(
         if await is_on_cooldown_ref(ref, cooldown_days):
             reason = f"on upgrade cooldown ({cooldown_days}d)"
             skip_key = (instance.id, candidate.item_id, "upgrade", "upgrade_cd")
-            if await should_log_skip(skip_key):
+            if cycle_trigger == "run_now" or await should_log_skip(skip_key):
                 logger.debug("[%s] upgrade %s: %s", instance.name, candidate.item_id, reason)
                 await _write_item_log(
                     ref,

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -25,7 +25,12 @@ from houndarr.engine.adapters import get_adapter
 from houndarr.engine.adapters.protocols import AppAdapterProto
 from houndarr.engine.candidates import SearchCandidate
 from houndarr.enums import CycleTrigger, ItemType, SearchAction, SearchKind
-from houndarr.errors import ClientError, EngineError
+from houndarr.errors import (
+    ClientError,
+    EngineDispatchError,
+    EngineError,
+    EnginePoolFetchError,
+)
 from houndarr.services.cooldown import (
     is_on_cooldown_ref,
     record_search_ref,
@@ -239,6 +244,86 @@ def _is_release_timing_reason(reason: str | None) -> bool:
     )
 
 
+# Typed wrap helpers for adapter calls
+
+
+async def _dispatch_with_typed_wrap(
+    adapter: AppAdapterProto,
+    instance: Instance,
+    dispatch_fn: Callable[..., Awaitable[None]],
+    candidate: SearchCandidate,
+) -> None:
+    """Open a client, call *dispatch_fn*, and surface failures typed.
+
+    Track B.14 introduces this helper so the three dispatch call sites
+    in :func:`_run_search_pass` and :func:`_run_upgrade_pass` can each
+    narrow their ``except Exception`` to :class:`EngineDispatchError`.
+    The helper owns the whole ``adapter.make_client -> dispatch``
+    attempt boundary: client construction (``httpx.InvalidURL``),
+    context-manager entry / exit, and the dispatch call itself all
+    get typed into one surface.
+
+    Already-typed :class:`EngineError` and :class:`ClientError`
+    subclasses propagate unchanged so richer context from the client
+    layer (Track B.11 / B.12) is not flattened.  Track B.16 will
+    move the wrap into the adapter implementations; at that point
+    this helper becomes a thin passthrough.
+
+    The typed error message is ``str(exc)`` verbatim, which keeps the
+    ``search_log.message`` field byte-equal to the pre-refactor
+    ``message=str(exc)`` write and preserves the golden log shape.
+
+    Args:
+        adapter: The :class:`AppAdapterProto` for the instance.
+        instance: Fully-populated instance.
+        dispatch_fn: Adapter dispatch callable; takes ``(client,
+            candidate)`` and sends the search command.
+        candidate: Item to dispatch.
+
+    Raises:
+        EngineDispatchError: Any non-typed ``Exception``; the original
+            is preserved on ``__cause__``.
+    """
+    try:
+        async with adapter.make_client(instance) as client:
+            await dispatch_fn(client, candidate)
+    except (EngineError, ClientError):
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise EngineDispatchError(str(exc)) from exc
+
+
+async def _fetch_pool_with_typed_wrap(
+    adapter: AppAdapterProto,
+    instance: Instance,
+) -> list[Any]:
+    """Open a client, call ``adapter.fetch_upgrade_pool``, surface typed.
+
+    Sibling of :func:`_dispatch_with_typed_wrap` for the upgrade-pool
+    build path.  Owns the ``adapter.make_client -> fetch`` boundary so
+    construction + context entry + pool fetch all land in the same
+    :class:`EnginePoolFetchError` surface.
+
+    Args:
+        adapter: The :class:`AppAdapterProto` for the instance.
+        instance: Fully-populated instance.
+
+    Returns:
+        The raw upgrade-pool list produced by the adapter.
+
+    Raises:
+        EnginePoolFetchError: Any non-typed ``Exception``; the original
+            is preserved on ``__cause__``.
+    """
+    try:
+        async with adapter.make_client(instance) as client:
+            return await adapter.fetch_upgrade_pool(client, instance)
+    except (EngineError, ClientError):
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise EnginePoolFetchError(str(exc)) from exc
+
+
 # ---------------------------------------------------------------------------
 # Unified search pass
 # ---------------------------------------------------------------------------
@@ -436,9 +521,10 @@ async def _run_search_pass(  # noqa: C901
                         )
                         scanned += 1
                         try:
-                            async with adapter.make_client(instance) as dispatch_client:
-                                await dispatch_fn(dispatch_client, candidate)
-                        except Exception as exc:  # noqa: BLE001
+                            await _dispatch_with_typed_wrap(
+                                adapter, instance, dispatch_fn, candidate
+                            )
+                        except EngineDispatchError as exc:
                             msg = str(exc)
                             logger.warning(
                                 "[%s] %ssearch failed for %s: %s",
@@ -510,9 +596,8 @@ async def _run_search_pass(  # noqa: C901
 
             # Dispatch search via a fresh client context.
             try:
-                async with adapter.make_client(instance) as dispatch_client:
-                    await dispatch_fn(dispatch_client, candidate)
-            except Exception as exc:  # noqa: BLE001
+                await _dispatch_with_typed_wrap(adapter, instance, dispatch_fn, candidate)
+            except EngineDispatchError as exc:
                 msg = str(exc)
                 logger.warning(
                     "[%s] %ssearch failed for %s: %s",
@@ -603,9 +688,8 @@ async def _run_upgrade_pass(
 
     # Fetch upgrade-eligible pool via the adapter
     try:
-        async with adapter.make_client(instance) as client:
-            pool = await adapter.fetch_upgrade_pool(client, instance)
-    except Exception as exc:  # noqa: BLE001
+        pool = await _fetch_pool_with_typed_wrap(adapter, instance)
+    except EnginePoolFetchError as exc:
         msg = str(exc)
         logger.warning("[%s] upgrade pool fetch failed: %s", instance.name, msg)
         await _write_log(
@@ -742,9 +826,8 @@ async def _run_upgrade_pass(
 
         # Dispatch search
         try:
-            async with adapter.make_client(instance) as dispatch_client:
-                await adapter.dispatch_search(dispatch_client, candidate)
-        except Exception as exc:  # noqa: BLE001
+            await _dispatch_with_typed_wrap(adapter, instance, adapter.dispatch_search, candidate)
+        except EngineDispatchError as exc:
             msg = str(exc)
             logger.warning(
                 "[%s] upgrade search failed for %s: %s",
@@ -850,9 +933,7 @@ async def run_instance_search(
     except (EngineError, ClientError):
         raise
     except Exception as exc:  # noqa: BLE001
-        raise EngineError(
-            f"unhandled error in search cycle for {instance.name!r}: {exc}"
-        ) from exc
+        raise EngineError(f"unhandled error in search cycle for {instance.name!r}: {exc}") from exc
 
 
 async def _run_instance_search_impl(

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -24,6 +24,7 @@ from houndarr.engine.adapters.protocols import AppAdapterProto
 from houndarr.engine.retry import ReconnectState, run_with_reconnect
 from houndarr.engine.search_loop import _write_log, run_instance_search
 from houndarr.enums import CycleTrigger, SearchAction
+from houndarr.errors import ClientError, EngineError
 from houndarr.services.cooldown_reconcile import reconcile_cooldowns
 from houndarr.services.instances import (
     Instance,
@@ -360,7 +361,13 @@ class Supervisor:
                     _CONNECT_RETRY_SECS,
                 )
                 return True
-            except Exception as exc:  # noqa: BLE001
+            except (EngineError, ClientError) as exc:
+                # Track B.13: run_instance_search now wraps every
+                # non-typed escape into EngineError before it reaches
+                # this handler, and the client layer (Track B.11/B.12)
+                # raises ClientError subclasses.  Both branches land
+                # here and produce the same search_log row shape the
+                # pre-refactor `except Exception` produced.
                 logger.error(
                     "Supervisor: unhandled error in search loop for %r: %s",
                     instance.core.name,

--- a/tests/test_e2e/test_search_cycle.py
+++ b/tests/test_e2e/test_search_cycle.py
@@ -298,7 +298,7 @@ async def test_hourly_cap_enforced(
     assert actions.count("searched") == 1
     assert actions.count("skipped") == 1
     skipped = next(r for r in logs if r["action"] == "skipped")
-    assert "hourly cap" in (skipped["reason"] or "")
+    assert "hourly limit" in (skipped["reason"] or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engine/conftest.py
+++ b/tests/test_engine/conftest.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterator
 from typing import Any
 
+import pytest
 import pytest_asyncio
 from cryptography.fernet import Fernet
 
 from houndarr.database import get_db
 from houndarr.engine.candidates import ItemType
+from houndarr.services.cooldown import _reset_skip_log_cache
 from houndarr.services.instances import (
     Instance,
     InstanceType,
@@ -19,6 +21,20 @@ from houndarr.services.instances import (
     SonarrSearchMode,
     WhisparrSearchMode,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_skip_log_sentinel() -> Iterator[None]:
+    """Clear the in-memory cooldown-skip sentinel between engine tests.
+
+    Without this, a test that triggers ``should_log_skip`` leaves cache
+    entries that suppress skip writes in the next test, producing
+    order-dependent test failures.
+    """
+    _reset_skip_log_cache()
+    yield
+    _reset_skip_log_cache()
+
 
 # ---------------------------------------------------------------------------
 # Shared constants

--- a/tests/test_engine/test_adapter_narrow_catch_pinning.py
+++ b/tests/test_engine/test_adapter_narrow_catch_pinning.py
@@ -1,0 +1,248 @@
+"""Pin the narrow adapter fallback catches introduced in Track B.16.
+
+Each of Sonarr, Lidarr, Readarr, and Whisparr v2 has a per-iteration
+``try`` inside ``fetch_upgrade_pool`` that swallows transient client
+failures so pool building can continue:
+
+* Sonarr / Whisparr v2 iterate monitored series and catch
+  ``client.get_episodes(series_id)`` failures.
+* Lidarr / Readarr iterate cutoff pages and catch
+  ``client.get_cutoff_unmet(page, page_size)`` failures while
+  building the exclusion set.
+
+Track B.16 narrows each of these from ``except Exception`` to
+``except (httpx.HTTPError, httpx.InvalidURL, ValidationError)``.  The
+catch still logs + continues for the three expected failure shapes
+so pool building stays resilient to transient network or wire-
+validation noise, but anything else (KeyError, RuntimeError,
+AttributeError, etc.) now propagates to the search_loop wrap
+(``_fetch_pool_with_typed_wrap`` from B.14) which converts it to
+:class:`~houndarr.errors.EnginePoolFetchError`.
+
+These tests lock both sides of the narrow-catch contract per
+adapter.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from houndarr.engine.adapters import lidarr, readarr, sonarr, whisparr_v2
+from houndarr.services.instances import InstanceType
+from tests.test_engine.conftest import make_instance
+
+pytestmark = pytest.mark.pinning
+
+
+def _series(series_id: int) -> MagicMock:
+    """Shorthand for a monitored series with the given id."""
+    obj = MagicMock()
+    obj.id = series_id
+    obj.monitored = True
+    return obj
+
+
+def _validation_error() -> ValidationError:
+    """Build a real :class:`ValidationError` via a trivial Pydantic failure."""
+    from pydantic import BaseModel
+
+    class _M(BaseModel):
+        x: int
+
+    try:
+        _M.model_validate({"x": "not-an-int"})
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("ValidationError factory failed to raise")
+
+
+# Sonarr (series-rotation per-iteration catch)
+
+
+class TestSonarrAdapterNarrowCatch:
+    """Pin sonarr.fetch_upgrade_pool's per-series narrow catch."""
+
+    @pytest.mark.asyncio()
+    async def test_http_error_per_series_skips_and_continues(self) -> None:
+        """httpx.ConnectError on get_episodes is swallowed; pool builds."""
+        client = MagicMock()
+        client.get_series = AsyncMock(return_value=[_series(1)])
+        client.get_episodes = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await sonarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.sonarr))
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_validation_error_per_series_skips_and_continues(self) -> None:
+        """pydantic.ValidationError on get_episodes is swallowed; pool builds."""
+        client = MagicMock()
+        client.get_series = AsyncMock(return_value=[_series(1)])
+        client.get_episodes = AsyncMock(side_effect=_validation_error())
+        result = await sonarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.sonarr))
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_non_http_exception_propagates(self) -> None:
+        """RuntimeError escapes so search_loop's pool wrap can type it."""
+        client = MagicMock()
+        client.get_series = AsyncMock(return_value=[_series(1)])
+        client.get_episodes = AsyncMock(side_effect=RuntimeError("bug"))
+        with pytest.raises(RuntimeError):
+            await sonarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.sonarr))
+
+
+# Whisparr v2 (mirrors Sonarr: series rotation + per-series catch)
+
+
+class TestWhisparrV2AdapterNarrowCatch:
+    """Pin whisparr_v2.fetch_upgrade_pool's per-series narrow catch."""
+
+    @pytest.mark.asyncio()
+    async def test_http_error_per_series_skips_and_continues(self) -> None:
+        """httpx.ReadTimeout on get_episodes is swallowed; pool builds."""
+        client = MagicMock()
+        client.get_series = AsyncMock(return_value=[_series(1)])
+        client.get_episodes = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+        result = await whisparr_v2.fetch_upgrade_pool(
+            client, make_instance(itype=InstanceType.whisparr_v2)
+        )
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_validation_error_per_series_skips_and_continues(self) -> None:
+        """pydantic.ValidationError on get_episodes is swallowed."""
+        client = MagicMock()
+        client.get_series = AsyncMock(return_value=[_series(1)])
+        client.get_episodes = AsyncMock(side_effect=_validation_error())
+        result = await whisparr_v2.fetch_upgrade_pool(
+            client, make_instance(itype=InstanceType.whisparr_v2)
+        )
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_non_http_exception_propagates(self) -> None:
+        """KeyError escapes so the outer wrap can type it."""
+        client = MagicMock()
+        client.get_series = AsyncMock(return_value=[_series(1)])
+        client.get_episodes = AsyncMock(side_effect=KeyError("bug"))
+        with pytest.raises(KeyError):
+            await whisparr_v2.fetch_upgrade_pool(
+                client, make_instance(itype=InstanceType.whisparr_v2)
+            )
+
+
+# Lidarr (cutoff-exclusion page loop)
+
+
+class TestLidarrAdapterNarrowCatch:
+    """Pin lidarr.fetch_upgrade_pool's cutoff-exclusion narrow catch."""
+
+    @pytest.mark.asyncio()
+    async def test_http_error_on_cutoff_page_breaks_exclusion_loop(self) -> None:
+        """httpx.ConnectError on get_cutoff_unmet is swallowed; exclusion stays empty."""
+        client = MagicMock()
+        client.get_cutoff_unmet = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        client.get_albums = AsyncMock(return_value=[])
+        result = await lidarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.lidarr))
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_validation_error_on_cutoff_page_breaks_exclusion_loop(self) -> None:
+        """pydantic.ValidationError on get_cutoff_unmet is swallowed."""
+        client = MagicMock()
+        client.get_cutoff_unmet = AsyncMock(side_effect=_validation_error())
+        client.get_albums = AsyncMock(return_value=[])
+        result = await lidarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.lidarr))
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_non_http_exception_propagates(self) -> None:
+        """RuntimeError escapes so the outer wrap can type it."""
+        client = MagicMock()
+        client.get_cutoff_unmet = AsyncMock(side_effect=RuntimeError("bug"))
+        client.get_albums = AsyncMock(return_value=[])
+        with pytest.raises(RuntimeError):
+            await lidarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.lidarr))
+
+
+# Readarr (mirrors Lidarr)
+
+
+class TestReadarrAdapterNarrowCatch:
+    """Pin readarr.fetch_upgrade_pool's cutoff-exclusion narrow catch."""
+
+    @pytest.mark.asyncio()
+    async def test_http_error_on_cutoff_page_breaks_exclusion_loop(self) -> None:
+        """httpx.ReadTimeout on get_cutoff_unmet is swallowed; exclusion stays empty."""
+        client = MagicMock()
+        client.get_cutoff_unmet = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+        client.get_books = AsyncMock(return_value=[])
+        result = await readarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.readarr))
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_validation_error_on_cutoff_page_breaks_exclusion_loop(self) -> None:
+        """pydantic.ValidationError on get_cutoff_unmet is swallowed."""
+        client = MagicMock()
+        client.get_cutoff_unmet = AsyncMock(side_effect=_validation_error())
+        client.get_books = AsyncMock(return_value=[])
+        result = await readarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.readarr))
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_non_http_exception_propagates(self) -> None:
+        """AttributeError escapes so the outer wrap can type it."""
+        client = MagicMock()
+        client.get_cutoff_unmet = AsyncMock(side_effect=AttributeError("bug"))
+        client.get_books = AsyncMock(return_value=[])
+        with pytest.raises(AttributeError):
+            await readarr.fetch_upgrade_pool(client, make_instance(itype=InstanceType.readarr))
+
+
+# Shape check: confirm the four fallback catches are indeed narrowed
+
+
+@pytest.mark.asyncio()
+async def test_narrow_catch_tuple_is_consistent_across_adapters() -> None:
+    """Every narrowed except clause contains the same 3-class tuple.
+
+    This is a weak structural check against future edits that drift
+    the catch shape between adapters.  It reads the source of each
+    adapter module and asserts the tuple token appears verbatim,
+    once per adapter.
+    """
+    import pathlib
+
+    src_root = pathlib.Path(sonarr.__file__).parent
+    expected = "except (httpx.HTTPError, httpx.InvalidURL, ValidationError):"
+    for adapter_name in ("sonarr.py", "lidarr.py", "readarr.py", "whisparr_v2.py"):
+        source = (src_root / adapter_name).read_text()
+        count = source.count(expected)
+        assert count == 1, f"{adapter_name}: expected 1 narrow catch, found {count}"
+
+
+@pytest.mark.asyncio()
+async def test_no_broad_bare_exception_left_in_adapters() -> None:
+    """Four adapters must no longer carry ``except Exception  # noqa: BLE001``.
+
+    Defensive: if a future edit reintroduces the broad catch in one of
+    the four narrowed adapters, this assertion catches it.  Whisparr
+    v3 is deliberately excluded: its fetch_upgrade_pool does not have
+    a per-iteration catch today.
+    """
+    import pathlib
+
+    src_root = pathlib.Path(sonarr.__file__).parent
+    for adapter_name in ("sonarr.py", "lidarr.py", "readarr.py", "whisparr_v2.py"):
+        source = (src_root / adapter_name).read_text()
+        assert "except Exception" not in source, (
+            f"{adapter_name} still contains a broad `except Exception` catch"
+        )
+
+
+# mypy-silencing: suppress the unused-variable hint on Any/Callable imports.
+_UNUSED: Any = None

--- a/tests/test_engine/test_dispatch_pool_wrap_pinning.py
+++ b/tests/test_engine/test_dispatch_pool_wrap_pinning.py
@@ -1,0 +1,243 @@
+"""Pin the typed-error wrap helpers for dispatch + upgrade pool fetch.
+
+Track B.14 replaces search_loop's broad ``except Exception`` branches
+around ``dispatch_fn`` (3 sites) and ``adapter.fetch_upgrade_pool`` (1
+site) with narrow catches on the typed
+:class:`~houndarr.errors.EngineDispatchError` /
+:class:`~houndarr.errors.EnginePoolFetchError` surface.  The wrap
+itself lives in two small helpers in :mod:`houndarr.engine.search_loop`:
+
+* :func:`_dispatch_with_typed_wrap`: owns the
+  ``adapter.make_client`` -> dispatch attempt boundary.
+* :func:`_fetch_pool_with_typed_wrap`: owns the
+  ``adapter.make_client`` -> fetch_upgrade_pool boundary.
+
+These tests lock the wrap contract end-to-end: message preservation,
+``__cause__`` chain, and passthrough of already-typed errors.  Track
+B.16 will eventually move the wrap into each adapter; at that point
+the helpers become thin passthroughs and these tests continue to
+pass.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from houndarr.engine.adapters import AppAdapter
+from houndarr.engine.candidates import SearchCandidate
+from houndarr.engine.search_loop import (
+    _dispatch_with_typed_wrap,
+    _fetch_pool_with_typed_wrap,
+)
+from houndarr.enums import ItemType
+from houndarr.errors import (
+    ClientHTTPError,
+    ClientTransportError,
+    ClientValidationError,
+    EngineDispatchError,
+    EngineError,
+    EnginePoolFetchError,
+)
+from tests.test_engine.conftest import make_instance
+
+pytestmark = pytest.mark.pinning
+
+
+def _fake_candidate() -> SearchCandidate:
+    """Build a minimal SearchCandidate for dispatch-wrap tests."""
+    return SearchCandidate(
+        item_id=101,
+        item_type=ItemType.episode,
+        label="Test / S01E01",
+        unreleased_reason=None,
+        group_key=None,
+        search_payload={},
+    )
+
+
+def _adapter_with_fake_client(side_effect: Any = None, return_value: Any = None) -> AppAdapter:
+    """Build an AppAdapter whose make_client yields a mocked context.
+
+    The make_client callable returns an async context manager; entering
+    it yields a stub client.  dispatch_fn / fetch_upgrade_pool are
+    attached with the requested side_effect or return_value so each
+    wrap path can be exercised independently.
+    """
+
+    stub_client = MagicMock()
+
+    class _CtxManager:
+        async def __aenter__(self) -> Any:
+            return stub_client
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    adapter = MagicMock(spec=AppAdapter)
+    adapter.make_client = MagicMock(return_value=_CtxManager())
+    if side_effect is not None:
+        adapter.fetch_upgrade_pool = AsyncMock(side_effect=side_effect)
+    else:
+        adapter.fetch_upgrade_pool = AsyncMock(return_value=return_value or [])
+    return adapter
+
+
+# _dispatch_with_typed_wrap
+
+
+class TestDispatchTypedWrap:
+    """Pin the dispatch-side wrap helper (Track B.14)."""
+
+    @pytest.mark.asyncio()
+    async def test_http_status_error_wraps_to_engine_dispatch_error(self) -> None:
+        """A raw httpx.HTTPStatusError becomes EngineDispatchError."""
+        adapter = _adapter_with_fake_client()
+        request = httpx.Request("POST", "http://sonarr:8989/api/v3/command")
+        response = httpx.Response(500, request=request)
+        original = httpx.HTTPStatusError("server error", request=request, response=response)
+        dispatch_fn = AsyncMock(side_effect=original)
+
+        with pytest.raises(EngineDispatchError) as exc_info:
+            await _dispatch_with_typed_wrap(
+                adapter, make_instance(), dispatch_fn, _fake_candidate()
+            )
+
+        assert exc_info.value.__cause__ is original
+        # Message preservation: str(typed) == str(original) keeps the
+        # golden search_log.message byte-equal.
+        assert str(exc_info.value) == str(original)
+
+    @pytest.mark.asyncio()
+    async def test_key_error_wraps_to_engine_dispatch_error(self) -> None:
+        """An unrelated Exception (e.g. KeyError) also wraps."""
+        adapter = _adapter_with_fake_client()
+        original = KeyError("boom")
+        dispatch_fn = AsyncMock(side_effect=original)
+
+        with pytest.raises(EngineDispatchError) as exc_info:
+            await _dispatch_with_typed_wrap(
+                adapter, make_instance(), dispatch_fn, _fake_candidate()
+            )
+
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio()
+    @pytest.mark.parametrize(
+        "cls",
+        [ClientHTTPError, ClientTransportError, ClientValidationError],
+    )
+    async def test_client_error_subclasses_propagate_unchanged(
+        self, cls: type[EngineError]
+    ) -> None:
+        """ClientError subclasses pass through unchanged (not re-wrapped)."""
+        adapter = _adapter_with_fake_client()
+        original = cls("client layer failure")
+        dispatch_fn = AsyncMock(side_effect=original)
+
+        with pytest.raises(cls) as exc_info:
+            await _dispatch_with_typed_wrap(
+                adapter, make_instance(), dispatch_fn, _fake_candidate()
+            )
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    async def test_engine_error_propagates_unchanged(self) -> None:
+        """An already-typed EngineError is not re-wrapped."""
+        adapter = _adapter_with_fake_client()
+        original = EngineError("inner engine error")
+        dispatch_fn = AsyncMock(side_effect=original)
+
+        with pytest.raises(EngineError) as exc_info:
+            await _dispatch_with_typed_wrap(
+                adapter, make_instance(), dispatch_fn, _fake_candidate()
+            )
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    async def test_success_returns_none(self) -> None:
+        """Happy path: the helper returns None and dispatch_fn is awaited."""
+        adapter = _adapter_with_fake_client()
+        dispatch_fn = AsyncMock(return_value=None)
+
+        result = await _dispatch_with_typed_wrap(
+            adapter, make_instance(), dispatch_fn, _fake_candidate()
+        )
+
+        assert result is None
+        dispatch_fn.assert_awaited_once()
+
+
+# _fetch_pool_with_typed_wrap
+
+
+class TestFetchPoolTypedWrap:
+    """Pin the upgrade-pool-fetch-side wrap helper (Track B.14)."""
+
+    @pytest.mark.asyncio()
+    async def test_http_status_error_wraps_to_engine_pool_fetch_error(self) -> None:
+        """A raw httpx.HTTPStatusError becomes EnginePoolFetchError."""
+        request = httpx.Request("GET", "http://radarr:7878/api/v3/movie")
+        response = httpx.Response(500, request=request)
+        original = httpx.HTTPStatusError("server error", request=request, response=response)
+        adapter = _adapter_with_fake_client(side_effect=original)
+
+        with pytest.raises(EnginePoolFetchError) as exc_info:
+            await _fetch_pool_with_typed_wrap(adapter, make_instance())
+
+        assert exc_info.value.__cause__ is original
+        assert str(exc_info.value) == str(original)
+
+    @pytest.mark.asyncio()
+    async def test_runtime_error_wraps(self) -> None:
+        """Any Exception (not just httpx) is wrapped."""
+        original = RuntimeError("pool builder crashed")
+        adapter = _adapter_with_fake_client(side_effect=original)
+
+        with pytest.raises(EnginePoolFetchError) as exc_info:
+            await _fetch_pool_with_typed_wrap(adapter, make_instance())
+
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio()
+    @pytest.mark.parametrize(
+        "cls",
+        [ClientHTTPError, ClientTransportError, ClientValidationError],
+    )
+    async def test_client_error_subclasses_propagate_unchanged(
+        self, cls: type[EngineError]
+    ) -> None:
+        """ClientError subclasses pass through; the wrap does not re-type them."""
+        original = cls("client layer failure")
+        adapter = _adapter_with_fake_client(side_effect=original)
+
+        with pytest.raises(cls) as exc_info:
+            await _fetch_pool_with_typed_wrap(adapter, make_instance())
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    async def test_engine_error_propagates_unchanged(self) -> None:
+        """Already-typed EngineError passes through."""
+        original = EngineError("inner engine error")
+        adapter = _adapter_with_fake_client(side_effect=original)
+
+        with pytest.raises(EngineError) as exc_info:
+            await _fetch_pool_with_typed_wrap(adapter, make_instance())
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    async def test_success_returns_adapter_pool_verbatim(self) -> None:
+        """Happy path: return whatever fetch_upgrade_pool produced."""
+        pool_items = [object(), object(), object()]
+        adapter = _adapter_with_fake_client(return_value=pool_items)
+
+        result = await _fetch_pool_with_typed_wrap(adapter, make_instance())
+
+        assert result == pool_items

--- a/tests/test_engine/test_golden_search_log.py
+++ b/tests/test_engine/test_golden_search_log.py
@@ -431,14 +431,14 @@ async def test_golden_mixed_eligibility(seeded_instances: None) -> None:
       - ep 102: unreleased (future air date → skipped before cap check)
       - ep 103: on cooldown (passes unreleased + cap, hits cooldown)
       - ep 104: eligible (searched - uses 2 of 2 cap slots)
-      - ep 105: hourly cap reached (cap=2 exhausted → skipped, stop_pass)
+      - ep 105: hourly limit reached (cap=2 exhausted → skipped, stop_pass)
 
     Expected sequence:
       1. searched - ep 101
       2. skipped  - ep 102, "not yet released"
       3. skipped  - ep 103, "on cooldown (7d)"
       4. searched - ep 104
-      5. skipped  - ep 105, "hourly cap reached (2)"
+      5. skipped  - ep 105, "hourly limit reached (2/hr)"
     """
     from houndarr.services.cooldown import record_search
 
@@ -537,7 +537,7 @@ async def test_golden_mixed_eligibility(seeded_instances: None) -> None:
     assert rows[4]["item_type"] == "episode"
     assert rows[4]["item_label"] == "My Show - S01E05 - Capped"
     assert rows[4]["search_kind"] == "missing"
-    assert rows[4]["reason"] == "hourly cap reached (2)"
+    assert rows[4]["reason"] == "hourly limit reached (2/hr)"
     assert rows[4]["cycle_id"] == "golden-g4"
 
 

--- a/tests/test_engine/test_offset_persist_wrap_pinning.py
+++ b/tests/test_engine/test_offset_persist_wrap_pinning.py
@@ -1,0 +1,168 @@
+"""Pin the typed-error wrap on :func:`_persist_offset_with_typed_wrap`.
+
+Track B.15 replaces the four broad ``except Exception`` branches
+around ``update_instance(...)`` in the engine's offset-persist paths
+with narrow catches on the typed
+:class:`~houndarr.errors.EngineOffsetPersistError` surface.  The
+wrap itself lives in :func:`_persist_offset_with_typed_wrap` in
+:mod:`houndarr.engine.search_loop`.
+
+These tests lock:
+
+* arbitrary ``Exception`` from ``update_instance`` wraps to
+  :class:`EngineOffsetPersistError` with ``__cause__`` preserved and
+  the original ``str`` kept verbatim.
+* already-typed Houndarr errors (:class:`EngineError`,
+  :class:`ClientError`) propagate unchanged.
+* the happy path forwards the kwargs to ``update_instance`` without
+  raising.
+
+Non-fatal by design: the four search-loop call sites swallow the
+typed error and log; the next cycle retries the persist.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from houndarr.engine import search_loop as search_loop_module
+from houndarr.engine.search_loop import _persist_offset_with_typed_wrap
+from houndarr.errors import (
+    ClientHTTPError,
+    ClientTransportError,
+    ClientValidationError,
+    EngineError,
+    EngineOffsetPersistError,
+)
+
+pytestmark = pytest.mark.pinning
+
+
+_MASTER_KEY = b"0123456789abcdef0123456789abcdef_"
+
+
+class TestPersistOffsetTypedWrap:
+    """Pin the offset-persist wrap helper (Track B.15)."""
+
+    @pytest.mark.asyncio()
+    async def test_arbitrary_exception_wraps_to_engine_offset_persist_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A RuntimeError from update_instance wraps to EngineOffsetPersistError."""
+        original = RuntimeError("db write failed")
+        monkeypatch.setattr(
+            search_loop_module,
+            "update_instance",
+            AsyncMock(side_effect=original),
+        )
+
+        with pytest.raises(EngineOffsetPersistError) as exc_info:
+            await _persist_offset_with_typed_wrap(
+                1,
+                master_key=_MASTER_KEY,
+                missing_page_offset=3,
+            )
+
+        assert exc_info.value.__cause__ is original
+        assert str(exc_info.value) == str(original)
+
+    @pytest.mark.asyncio()
+    async def test_operational_error_wraps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An aiosqlite-style OperationalError also wraps."""
+
+        class OperationalError(Exception):
+            """Stand-in for aiosqlite.OperationalError."""
+
+        original = OperationalError("database locked")
+        monkeypatch.setattr(
+            search_loop_module,
+            "update_instance",
+            AsyncMock(side_effect=original),
+        )
+
+        with pytest.raises(EngineOffsetPersistError) as exc_info:
+            await _persist_offset_with_typed_wrap(
+                1,
+                master_key=_MASTER_KEY,
+                upgrade_item_offset=2,
+            )
+
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio()
+    @pytest.mark.parametrize(
+        "cls",
+        [ClientHTTPError, ClientTransportError, ClientValidationError],
+    )
+    async def test_client_error_subclasses_propagate_unchanged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        cls: type[EngineError],
+    ) -> None:
+        """ClientError subclasses pass through unchanged (no re-wrap)."""
+        original = cls("client layer")
+        monkeypatch.setattr(
+            search_loop_module,
+            "update_instance",
+            AsyncMock(side_effect=original),
+        )
+
+        with pytest.raises(cls) as exc_info:
+            await _persist_offset_with_typed_wrap(
+                1,
+                master_key=_MASTER_KEY,
+                cutoff_page_offset=4,
+            )
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    async def test_engine_error_propagates_unchanged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An already-typed EngineError is not re-wrapped."""
+        original = EngineError("inner engine error")
+        monkeypatch.setattr(
+            search_loop_module,
+            "update_instance",
+            AsyncMock(side_effect=original),
+        )
+
+        with pytest.raises(EngineError) as exc_info:
+            await _persist_offset_with_typed_wrap(
+                1,
+                master_key=_MASTER_KEY,
+                upgrade_series_offset=5,
+            )
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    async def test_success_forwards_kwargs_to_update_instance(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Happy path forwards every kwarg to update_instance verbatim."""
+        mock_update = AsyncMock(return_value=None)
+        monkeypatch.setattr(search_loop_module, "update_instance", mock_update)
+
+        await _persist_offset_with_typed_wrap(
+            7,
+            master_key=_MASTER_KEY,
+            missing_page_offset=11,
+            upgrade_item_offset=13,
+        )
+
+        mock_update.assert_awaited_once_with(
+            7,
+            master_key=_MASTER_KEY,
+            missing_page_offset=11,
+            upgrade_item_offset=13,
+        )

--- a/tests/test_engine/test_random_deck.py
+++ b/tests/test_engine/test_random_deck.py
@@ -1,0 +1,108 @@
+"""Pin the stratified-shuffle invariants for ``SearchOrder.random``.
+
+The engine draws each cycle's start page (and any subsequent walk pages)
+from a per-(instance, kind) deck of all pages ``[1, max_page]``.  These
+tests pin the four properties the design buys:
+
+1. Within a round the deck contains every page exactly once: no page is
+   skipped and no page is visited twice before the round ends.
+2. When the deck is exhausted the engine reshuffles automatically so
+   long-run behaviour stays uniformly random.
+3. When ``max_page`` changes (the wanted-list grew or shrank) the deck
+   rebuilds against the new size on the very next draw.
+4. The per-(instance, kind) keying isolates Sonarr-missing from
+   Sonarr-cutoff and from a second Sonarr instance: one's progress
+   does not leak into another's.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.engine.search_loop import (
+    _draw_next_random_page,
+    _random_decks,
+    _reset_random_deck,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_decks() -> None:
+    """Wipe the module-level deck cache before every test in this file."""
+    _random_decks.clear()
+
+
+def test_round_permutes_every_page_exactly_once() -> None:
+    """One round of draws produces a permutation of [1..max_page]."""
+    max_page = 10
+    drawn = [_draw_next_random_page(1, "missing", max_page) for _ in range(max_page)]
+    assert sorted(drawn) == list(range(1, max_page + 1))
+    assert len(set(drawn)) == max_page
+
+
+def test_consecutive_draws_do_not_repeat_within_a_round() -> None:
+    """No page appears twice in the same round, even at small max_page."""
+    max_page = 3
+    seen: set[int] = set()
+    for _ in range(max_page):
+        page = _draw_next_random_page(1, "missing", max_page)
+        assert page not in seen, f"page {page} repeated within one round"
+        seen.add(page)
+
+
+def test_deck_reshuffles_when_exhausted() -> None:
+    """After ``max_page`` draws the next call kicks off a fresh round."""
+    max_page = 4
+    first_round = [_draw_next_random_page(1, "missing", max_page) for _ in range(max_page)]
+    second_round = [_draw_next_random_page(1, "missing", max_page) for _ in range(max_page)]
+    assert sorted(first_round) == list(range(1, max_page + 1))
+    assert sorted(second_round) == list(range(1, max_page + 1))
+
+
+def test_max_page_change_rebuilds_deck() -> None:
+    """Growing or shrinking the wanted-list invalidates any partial round."""
+    # Draw three pages out of a five-page round.
+    for _ in range(3):
+        _draw_next_random_page(1, "missing", 5)
+    assert len(_random_decks[(1, "missing")].remaining) == 2
+    # Now the wanted-list grew to 8 pages.  The next draw must come from
+    # a fresh shuffle of [1..8], not from the leftover [1..5] tail.
+    page = _draw_next_random_page(1, "missing", 8)
+    assert 1 <= page <= 8
+    assert _random_decks[(1, "missing")].max_page == 8
+    assert len(_random_decks[(1, "missing")].remaining) == 7
+
+
+def test_decks_are_isolated_per_instance_and_kind() -> None:
+    """Three deck keys carry independent state and never share draws."""
+    # Drain instance 1's missing deck completely.
+    drained = sorted(_draw_next_random_page(1, "missing", 4) for _ in range(4))
+    assert drained == [1, 2, 3, 4]
+    assert len(_random_decks[(1, "missing")].remaining) == 0
+    # Instance 1's cutoff deck is untouched: starts a fresh round on first draw.
+    cutoff_first = _draw_next_random_page(1, "cutoff", 4)
+    assert 1 <= cutoff_first <= 4
+    assert len(_random_decks[(1, "cutoff")].remaining) == 3
+    # Instance 2's missing deck is also independent.
+    other_first = _draw_next_random_page(2, "missing", 4)
+    assert 1 <= other_first <= 4
+    assert len(_random_decks[(2, "missing")].remaining) == 3
+    # Instance 1's exhausted missing deck reshuffles on the next draw.
+    next_round_first = _draw_next_random_page(1, "missing", 4)
+    assert 1 <= next_round_first <= 4
+    assert len(_random_decks[(1, "missing")].remaining) == 3
+
+
+def test_reset_clears_one_key_only() -> None:
+    """``_reset_random_deck`` drops one (instance, kind) pair, no others."""
+    _draw_next_random_page(1, "missing", 5)
+    _draw_next_random_page(1, "cutoff", 5)
+    _reset_random_deck(1, "missing")
+    assert (1, "missing") not in _random_decks
+    assert (1, "cutoff") in _random_decks
+
+
+def test_max_page_one_repeats_page_one_every_draw() -> None:
+    """Single-page wanted lists draw page 1 forever; no degenerate crashes."""
+    for _ in range(10):
+        assert _draw_next_random_page(1, "missing", 1) == 1

--- a/tests/test_engine/test_release_timing.py
+++ b/tests/test_engine/test_release_timing.py
@@ -12,6 +12,7 @@ from houndarr.engine.search_loop import (
     _is_release_timing_reason,
     run_instance_search,
 )
+from houndarr.services.cooldown import should_log_skip
 from houndarr.services.instances import InstanceType
 
 from .conftest import (
@@ -439,3 +440,45 @@ async def test_release_timing_retry_increments_count(
     count = await run_instance_search(inst, MASTER_KEY)
 
     assert count == 1
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_release_timing_retry_fires_when_sentinel_primed(
+    seeded_instances: None,
+) -> None:
+    """Skip-log sentinel must not suppress the release-timing retry.
+
+    Simulates a prior cycle that already logged a cooldown skip (the
+    sentinel holds an entry for ``(instance, item, missing, cooldown)``).
+    The retry path lives above the sentinel-gated skip-write and must
+    still dispatch and record a ``searched`` row.
+    """
+    await seed_release_timing_retry(
+        instance_id=1,
+        item_id=101,
+        item_type="episode",
+        reason="not yet released",
+    )
+
+    # Prime the sentinel as if a previous cycle already logged the skip.
+    primed = await should_log_skip((1, 101, "missing", "cooldown"))
+    assert primed is True
+    second = await should_log_skip((1, 101, "missing", "cooldown"))
+    assert second is False  # sanity: second call is suppressed
+
+    ep = {**_EPISODE_RECORD, "airDateUtc": "2023-09-01T00:00:00Z"}
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_page([ep])),
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP),
+    )
+
+    inst = _sonarr_instance(post_release_grace_hrs=0, batch_size=1)
+    count = await run_instance_search(inst, MASTER_KEY)
+
+    assert count == 1
+    rows = await get_log_rows()
+    searched = [r for r in rows if r["action"] == "searched" and r["item_id"] == 101]
+    assert len(searched) == 1

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -2748,11 +2748,17 @@ async def test_missing_random_picks_random_start_page(seeded_instances: None) ->
         "totalRecords": 1000,
         "records": [_EPISODE_RECORD],
     }
+    # The probe and the start-page fetch consume the first two side effects.
+    # Padding partial pages in random mode can cause the engine to advance
+    # to the next deck-drawn page when a sentinel lands in position zero,
+    # so the test pre-stages enough empty responses to absorb any number
+    # of subsequent fetches; only the first two are asserted on.
+    empty_response = httpx.Response(200, json={"records": []})
     missing_route = respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
         side_effect=[
             httpx.Response(200, json=probe_response),
             httpx.Response(200, json=page_response),
-            httpx.Response(200, json={"records": []}),
+            *[empty_response] * 50,
         ]
     )
     respx.post(f"{SONARR_URL}/api/v3/command").mock(

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -1143,7 +1143,7 @@ async def test_hourly_cap_stops_searches(seeded_instances: None) -> None:
 
     rows = await _get_log_rows()
     assert rows[-1]["action"] == "skipped"
-    assert "hourly cap" in (rows[-1]["reason"] or "")
+    assert "hourly limit" in (rows[-1]["reason"] or "")
 
 
 @pytest.mark.asyncio()

--- a/tests/test_engine/test_search_pass_interactions.py
+++ b/tests/test_engine/test_search_pass_interactions.py
@@ -533,7 +533,10 @@ async def test_empty_upgrade_pool_logs_info(
     mock_update: AsyncMock,
     seeded_instances: None,
 ) -> None:
-    """Empty upgrade pool logs an info row with 'upgrade pool empty'."""
+    """Empty upgrade pool logs a user-facing info row once per TTL window."""
+    from houndarr.services.cooldown import _reset_info_log_cache
+
+    _reset_info_log_cache()
     _mock_radarr_missing(_EMPTY_PAGE)
     _mock_radarr_library([])
     _mock_radarr_command()
@@ -548,7 +551,7 @@ async def test_empty_upgrade_pool_logs_info(
     rows = await get_log_rows()
     info_rows = [r for r in rows if r["action"] == "info" and r["search_kind"] == "upgrade"]
     assert len(info_rows) == 1
-    assert "upgrade pool empty" in (info_rows[0].get("message") or "")
+    assert "nothing to upgrade right now" in (info_rows[0].get("message") or "")
 
 
 @pytest.mark.asyncio()

--- a/tests/test_engine/test_skip_throttle_concurrency.py
+++ b/tests/test_engine/test_skip_throttle_concurrency.py
@@ -1,0 +1,177 @@
+"""Concurrency check for the PR 0 skip-throttle sentinel.
+
+Context
+-------
+
+Plan PR 0 proposes denoising the engine's per-cycle cooldown-skip writes to at
+most one row per ``(instance_id, item_id, search_kind, reason-bucket)`` per
+24 hours.  This test verifies the *concurrency* behavior of that sentinel under
+the realistic case where two passes against the same instance run
+near-simultaneously against the same cooldown item.
+
+Chosen implementation
+---------------------
+
+**In-memory dict keyed by ``(instance_id, item_id, search_kind, reason_bucket)``
+with an ``asyncio.Lock`` held across check-then-write.**  The dict avoids a v13
+schema migration and keeps the de-noise purely an engine concern; the lock
+serializes the check-then-write so two concurrent passes inside the same
+process can't both bypass the sentinel.  Dict entries age out on a 24-hour TTL
+and are reset on process restart, which is fine because a cold start has no
+accumulated noise anyway.
+
+What this test does
+-------------------
+
+Seeds an item into ``cooldowns`` so it is on-cooldown for any missing pass,
+then fires two ``_run_search_pass`` invocations concurrently via
+``asyncio.gather`` against the same candidate.  Asserts the expected
+post-sentinel skip-row count in ``search_log``.
+
+Per the user instruction accompanying this test: engine code is NOT modified.
+The assertion reflects what the chosen sentinel design *should* produce.  A
+failure here against current (pre-sentinel) code documents the structural
+noise — it is the observation, not a bug to fix in this PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+from houndarr.database import get_db
+from houndarr.engine.adapters import get_adapter
+from houndarr.engine.candidates import SearchCandidate
+from houndarr.engine.search_loop import _run_search_pass
+from houndarr.services.cooldown import record_search
+from houndarr.services.instances import InstanceType
+from tests.test_engine.conftest import make_instance, seeded_instances  # noqa: F401
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_ITEM_ID = 101
+_ITEM_TYPE = "episode"
+_INSTANCE_ID = 1  # Sonarr (from seeded_instances)
+
+
+@pytest_asyncio.fixture()
+async def cooldowned_item(seeded_instances: None) -> AsyncGenerator[None, None]:  # noqa: F811
+    """Pre-seed a cooldowns row so ``is_on_cooldown`` returns True for the
+    canonical ``(instance_id=1, item_id=101, item_type='episode')`` tuple used
+    throughout this module.
+    """
+    await record_search(_INSTANCE_ID, _ITEM_ID, _ITEM_TYPE)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# The concurrency test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_concurrent_passes_produce_at_most_one_skip_row(
+    cooldowned_item: None,
+) -> None:
+    """Two near-simultaneous missing passes against the same cooldown item
+    should produce at most ONE ``action='skipped'`` row in ``search_log``.
+
+    Against current engine code (no sentinel) this asserts and will fail with
+    2 rows written — the structural noise PR 0 is intended to eliminate.
+    """
+    instance = make_instance(
+        instance_id=_INSTANCE_ID,
+        itype=InstanceType.sonarr,
+        batch_size=5,
+        hourly_cap=10,
+        cooldown_days=14,
+    )
+    adapter = get_adapter(instance.type)
+
+    # One pre-built candidate that matches the cooldowned item.  Both passes
+    # pull from the same fetch_fn and hit is_on_cooldown -> True, then fall
+    # through to the cooldown skip-write path at search_loop.py:443-459.
+    candidate = SearchCandidate(
+        item_id=_ITEM_ID,
+        item_type=_ITEM_TYPE,
+        label="Cooldowned Show S01E01",
+        unreleased_reason=None,
+        group_key=None,
+        search_payload={"seriesId": 1, "episodeIds": [_ITEM_ID]},
+    )
+
+    # Raw item is opaque here; adapt_fn ignores it and returns the pre-built
+    # candidate.  fetch_fn returns exactly one raw item per call.
+    _raw_item: dict[str, Any] = {"id": _ITEM_ID}
+
+    async def fetch_one(page: int, page_size: int) -> list[Any]:  # noqa: ARG001
+        return [_raw_item]
+
+    def adapt_passthrough(item: Any, instance: Any) -> SearchCandidate:  # noqa: ARG001
+        return candidate
+
+    # dispatch_fn must be awaitable; it should NEVER be called in this test
+    # because the item is on cooldown and the pass should skip-write instead
+    # of dispatching.  AsyncMock makes an accidental call visible.
+    dispatch_mock = AsyncMock(return_value=None)
+
+    async def run_one_pass(cycle_label: str) -> None:
+        await _run_search_pass(
+            instance,
+            adapter,
+            adapt_fn=adapt_passthrough,
+            dispatch_fn=dispatch_mock,
+            fetch_fn=fetch_one,
+            search_kind="missing",
+            batch_size=5,
+            hourly_cap=10,
+            cooldown_days=14,
+            page_size=10,
+            scan_budget=10,
+            cycle_id=f"cycle-{cycle_label}",
+            cycle_trigger="scheduled",
+            start_page=1,
+            total_fn=None,
+        )
+
+    # asyncio.gather schedules both coroutines on the same event loop; they
+    # interleave at every await point, which is the realistic race shape
+    # (two cycles from the same supervisor landing inside the same tick).
+    await asyncio.gather(run_one_pass("A"), run_one_pass("B"))
+
+    # Dispatch should not have fired — the item is on cooldown.
+    assert dispatch_mock.await_count == 0, (
+        "Cooldowned item was dispatched; engine cooldown check is broken or the test seed is wrong."
+    )
+
+    # Count cooldown-reason skip rows written for this item.
+    async with get_db() as conn:
+        async with conn.execute(
+            """
+            SELECT COUNT(*) FROM search_log
+            WHERE instance_id = ?
+              AND item_id     = ?
+              AND item_type   = ?
+              AND action      = 'skipped'
+              AND reason LIKE 'on cooldown (%'
+            """,
+            (_INSTANCE_ID, _ITEM_ID, _ITEM_TYPE),
+        ) as cur:
+            row = await cur.fetchone()
+
+    skip_count = int(row[0]) if row else 0
+
+    # POST-SENTINEL expectation.  Current (pre-sentinel) code writes 2.
+    assert skip_count <= 1, (
+        f"Expected at most 1 cooldown skip row after 2 concurrent passes "
+        f"against the same on-cooldown item; got {skip_count}. "
+        f"This documents the per-cycle duplication PR 0 is intended to fix."
+    )

--- a/tests/test_engine/test_typed_errors_pinning.py
+++ b/tests/test_engine/test_typed_errors_pinning.py
@@ -1,0 +1,308 @@
+"""Pin the typed-error surface on ``run_instance_search`` and the supervisor.
+
+Track B.13 installs a top-level wrap on :func:`run_instance_search`
+that re-raises typed errors unchanged and converts any other
+``Exception`` into a fresh :class:`EngineError` with the original
+cause preserved on ``__cause__``.  The supervisor's
+``_run_search_cycle`` migrates its ``except Exception`` branch to
+``except (EngineError, ClientError)`` to match.
+
+These tests lock both ends of that contract:
+
+* :func:`run_instance_search` wraps untyped exceptions and lets the
+  three escape types (``EngineError``, ``ClientError``,
+  ``httpx.TransportError``) propagate unchanged.
+* The supervisor's ``_run_search_cycle`` writes the same error row
+  for ``EngineError`` and ``ClientError`` that the pre-refactor
+  ``except Exception`` produced, and still returns ``True`` on
+  ``httpx.TransportError`` so the reconnect loop engages.
+
+Future batches (B.14-B.17 raising typed errors from internal
+handlers; C.11 extracting the supervisor's reconnect helper)
+cannot drift these behaviours without failing this file.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from cryptography.fernet import Fernet
+
+from houndarr.database import get_db
+from houndarr.engine import search_loop as search_loop_module
+from houndarr.engine import supervisor as supervisor_module
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.engine.supervisor import Supervisor
+from houndarr.errors import (
+    ClientError,
+    ClientHTTPError,
+    ClientTransportError,
+    ClientValidationError,
+    EngineError,
+)
+from houndarr.services.instances import InstanceType
+from tests.test_engine.conftest import SONARR_URL, make_instance
+
+pytestmark = pytest.mark.pinning
+
+
+_MASTER_KEY: bytes = Fernet.generate_key()
+
+
+def _encrypt_key(value: str) -> str:
+    """Return a Fernet token usable in the ``instances`` table seed rows."""
+    return Fernet(_MASTER_KEY).encrypt(value.encode()).decode()
+
+
+# run_instance_search wrap surface
+
+
+class TestRunInstanceSearchWrap:
+    """Pin the public entrypoint's typed-error surface (B.13)."""
+
+    @pytest.mark.asyncio()
+    async def test_unhandled_exception_wraps_to_engine_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A raw ``Exception`` escaping the cycle body is wrapped in EngineError."""
+        original = RuntimeError("boom")
+        monkeypatch.setattr(
+            search_loop_module,
+            "_run_instance_search_impl",
+            AsyncMock(side_effect=original),
+        )
+        instance = make_instance()
+        with pytest.raises(EngineError) as exc_info:
+            await run_instance_search(instance, _MASTER_KEY)
+        assert exc_info.value.__cause__ is original
+        assert instance.name in str(exc_info.value)
+
+    @pytest.mark.asyncio()
+    async def test_key_error_wraps_to_engine_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """KeyError (e.g. unknown instance type) also wraps to EngineError."""
+        original = KeyError("unknown-type")
+        monkeypatch.setattr(
+            search_loop_module,
+            "_run_instance_search_impl",
+            AsyncMock(side_effect=original),
+        )
+        instance = make_instance()
+        with pytest.raises(EngineError) as exc_info:
+            await run_instance_search(instance, _MASTER_KEY)
+        assert exc_info.value.__cause__ is original
+
+    @pytest.mark.asyncio()
+    async def test_engine_error_propagates_unchanged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An already-typed EngineError passes through the wrapper unchanged."""
+        original = EngineError("dispatch failed")
+        monkeypatch.setattr(
+            search_loop_module,
+            "_run_instance_search_impl",
+            AsyncMock(side_effect=original),
+        )
+        instance = make_instance()
+        with pytest.raises(EngineError) as exc_info:
+            await run_instance_search(instance, _MASTER_KEY)
+        # Same instance, not wrapped again.
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    @pytest.mark.parametrize(
+        "cls",
+        [ClientHTTPError, ClientTransportError, ClientValidationError],
+    )
+    async def test_client_error_subclasses_propagate_unchanged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        cls: type[ClientError],
+    ) -> None:
+        """All three ClientError subclasses propagate without re-wrap."""
+        original = cls("client layer failure")
+        monkeypatch.setattr(
+            search_loop_module,
+            "_run_instance_search_impl",
+            AsyncMock(side_effect=original),
+        )
+        instance = make_instance()
+        with pytest.raises(cls) as exc_info:
+            await run_instance_search(instance, _MASTER_KEY)
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    async def test_httpx_transport_error_propagates_unchanged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """httpx.TransportError bypasses the wrap so the supervisor sees it."""
+        original = httpx.ConnectError("connection refused")
+        monkeypatch.setattr(
+            search_loop_module,
+            "_run_instance_search_impl",
+            AsyncMock(side_effect=original),
+        )
+        instance = make_instance()
+        with pytest.raises(httpx.ConnectError) as exc_info:
+            await run_instance_search(instance, _MASTER_KEY)
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio()
+    async def test_successful_run_returns_impl_count(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Happy path: the wrapper returns whatever the impl returned."""
+        monkeypatch.setattr(
+            search_loop_module,
+            "_run_instance_search_impl",
+            AsyncMock(return_value=7),
+        )
+        instance = make_instance()
+        result = await run_instance_search(instance, _MASTER_KEY)
+        assert result == 7
+
+
+# Supervisor._run_search_cycle catch surface
+
+
+@pytest_asyncio.fixture()
+async def seeded_supervisor_instance(db: None) -> AsyncGenerator[None, None]:
+    """Seed one enabled Sonarr instance keyed by FK constraints on search_log."""
+    enc = _encrypt_key("test-api-key")
+    async with get_db() as conn:
+        await conn.execute(
+            """
+            INSERT INTO instances
+            (id, name, type, url, encrypted_api_key, enabled)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (1, "Sonarr Test", "sonarr", SONARR_URL, enc, 1),
+        )
+        await conn.commit()
+    yield
+
+
+async def _fetch_error_rows() -> list[dict[str, Any]]:
+    """Return every ``action='error'`` row in search_log ordered by id."""
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT * FROM search_log WHERE action = 'error' ORDER BY id ASC"
+        ) as cur:
+            rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+class TestSupervisorCycleCatchSurface:
+    """Pin ``Supervisor._run_search_cycle`` post-B.13 catch behaviour."""
+
+    @pytest.mark.asyncio()
+    async def test_engine_error_writes_row_and_returns_false(
+        self,
+        seeded_supervisor_instance: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """EngineError from run_instance_search produces one error row, returns False."""
+        monkeypatch.setattr(
+            supervisor_module,
+            "run_instance_search",
+            AsyncMock(side_effect=EngineError("bad cycle")),
+        )
+        sup = Supervisor(master_key=_MASTER_KEY)
+        instance = make_instance(instance_id=1)
+
+        result = await sup._run_search_cycle(instance, cycle_trigger="scheduled")
+
+        assert result is False
+        rows = await _fetch_error_rows()
+        assert len(rows) == 1
+        assert rows[0]["instance_id"] == 1
+        assert rows[0]["action"] == "error"
+        assert rows[0]["cycle_trigger"] == "scheduled"
+        assert rows[0]["message"] == "bad cycle"
+
+    @pytest.mark.asyncio()
+    @pytest.mark.parametrize(
+        "cls",
+        [ClientHTTPError, ClientTransportError, ClientValidationError],
+    )
+    async def test_client_error_writes_row_and_returns_false(
+        self,
+        seeded_supervisor_instance: None,
+        monkeypatch: pytest.MonkeyPatch,
+        cls: type[ClientError],
+    ) -> None:
+        """Every ClientError subclass lands on the same supervisor branch."""
+        monkeypatch.setattr(
+            supervisor_module,
+            "run_instance_search",
+            AsyncMock(side_effect=cls("client layer")),
+        )
+        sup = Supervisor(master_key=_MASTER_KEY)
+        instance = make_instance(instance_id=1)
+
+        result = await sup._run_search_cycle(instance, cycle_trigger="run_now")
+
+        assert result is False
+        rows = await _fetch_error_rows()
+        assert len(rows) == 1
+        assert rows[0]["instance_id"] == 1
+        assert rows[0]["cycle_trigger"] == "run_now"
+        assert rows[0]["message"] == "client layer"
+
+    @pytest.mark.asyncio()
+    async def test_transport_error_returns_true_and_writes_nothing(
+        self,
+        seeded_supervisor_instance: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """httpx.TransportError triggers the reconnect branch and skips the row.
+
+        Pinning: the row write happens in the outer reconnect loop the
+        FIRST time a connection error is seen, not here.  This branch
+        only signals the outer loop via the ``True`` return value.
+        """
+        monkeypatch.setattr(
+            supervisor_module,
+            "run_instance_search",
+            AsyncMock(side_effect=httpx.ConnectError("refused")),
+        )
+        sup = Supervisor(master_key=_MASTER_KEY)
+        instance = make_instance(instance_id=1)
+
+        result = await sup._run_search_cycle(instance, cycle_trigger="scheduled")
+
+        assert result is True
+        rows = await _fetch_error_rows()
+        assert rows == []
+
+    @pytest.mark.asyncio()
+    async def test_success_returns_false_and_writes_nothing(
+        self,
+        seeded_supervisor_instance: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Happy path: run_instance_search returns, cycle returns False, no row."""
+        monkeypatch.setattr(
+            supervisor_module,
+            "run_instance_search",
+            AsyncMock(return_value=3),
+        )
+        sup = Supervisor(master_key=_MASTER_KEY)
+        instance = make_instance(instance_id=1, itype=InstanceType.sonarr)
+
+        result = await sup._run_search_cycle(instance, cycle_trigger="scheduled")
+
+        assert result is False
+        rows = await _fetch_error_rows()
+        assert rows == []

--- a/tests/test_engine/test_upgrade_pass.py
+++ b/tests/test_engine/test_upgrade_pass.py
@@ -397,7 +397,10 @@ async def test_upgrade_empty_pool_logs_info(
     mock_update: AsyncMock,
     seeded_instances: None,
 ) -> None:
-    """Empty library logs 'upgrade pool empty'."""
+    """Empty library logs one info row with the user-facing phrasing."""
+    from houndarr.services.cooldown import _reset_info_log_cache
+
+    _reset_info_log_cache()
     _mock_radarr_empty_missing()
     _mock_radarr_library([])
     _mock_radarr_command()
@@ -408,7 +411,7 @@ async def test_upgrade_empty_pool_logs_info(
     rows = await get_log_rows()
     info_rows = [r for r in rows if r["action"] == "info" and r["search_kind"] == "upgrade"]
     assert len(info_rows) == 1
-    assert "upgrade pool empty" in (info_rows[0].get("message") or "")
+    assert "nothing to upgrade right now" in (info_rows[0].get("message") or "")
 
 
 @pytest.mark.asyncio()

--- a/tests/test_services/test_cooldown.py
+++ b/tests/test_services/test_cooldown.py
@@ -12,11 +12,13 @@ import pytest_asyncio
 from houndarr.database import get_db
 from houndarr.services import cooldown as cooldown_module
 from houndarr.services.cooldown import (
+    _reset_info_log_cache,
     _reset_skip_log_cache,
     clear_cooldowns,
     count_searches_last_hour,
     is_on_cooldown,
     record_search,
+    should_log_info,
     should_log_skip,
 )
 
@@ -306,5 +308,79 @@ async def test_should_log_skip_concurrent_calls_serialize() -> None:
     """Ten concurrent callers with the same key produce exactly one True."""
     key = (1, 101, "missing", "cooldown")
     results = await asyncio.gather(*(should_log_skip(key) for _ in range(10)))
+    assert sum(results) == 1
+    assert results.count(False) == 9
+
+
+# ---------------------------------------------------------------------------
+# should_log_info sentinel (caller-supplied TTL per key category)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_info_sentinel() -> Iterator[None]:
+    _reset_info_log_cache()
+    yield
+    _reset_info_log_cache()
+
+
+@pytest.mark.asyncio()
+async def test_should_log_info_first_call_returns_true() -> None:
+    assert await should_log_info((1, "upgrade_pool_empty"), 3600) is True
+
+
+@pytest.mark.asyncio()
+async def test_should_log_info_within_ttl_returns_false() -> None:
+    key = (1, "upgrade_pool_empty")
+    assert await should_log_info(key, 3600) is True
+    assert await should_log_info(key, 3600) is False
+    assert await should_log_info(key, 3600) is False
+
+
+@pytest.mark.asyncio()
+async def test_should_log_info_after_ttl_returns_true() -> None:
+    key = (1, "upgrade_pool_empty")
+    assert await should_log_info(key, 3600) is True
+    # Rewind the stored timestamp past the 1h TTL.
+    stale = datetime.now(UTC) - timedelta(seconds=3601)
+    cooldown_module._INFO_LOG_CACHE[key] = stale
+    assert await should_log_info(key, 3600) is True
+
+
+@pytest.mark.asyncio()
+async def test_should_log_info_distinct_instances_independent() -> None:
+    k_a = (1, "upgrade_pool_empty")
+    k_b = (2, "upgrade_pool_empty")
+    assert await should_log_info(k_a, 3600) is True
+    assert await should_log_info(k_b, 3600) is True
+    # Each instance's entry is throttled independently.
+    assert await should_log_info(k_a, 3600) is False
+    assert await should_log_info(k_b, 3600) is False
+
+
+@pytest.mark.asyncio()
+async def test_should_log_info_distinct_reason_keys_independent() -> None:
+    k_one = (1, "upgrade_pool_empty")
+    k_two = (1, "some_other_info")
+    assert await should_log_info(k_one, 3600) is True
+    assert await should_log_info(k_two, 3600) is True
+    assert await should_log_info(k_one, 3600) is False
+    assert await should_log_info(k_two, 3600) is False
+
+
+@pytest.mark.asyncio()
+async def test_should_log_info_caller_owns_ttl() -> None:
+    """Different callers can pass different TTLs on the same key; window of the last call wins."""
+    key = (1, "upgrade_pool_empty")
+    assert await should_log_info(key, 10) is True
+    # Inside the 10s window, subsequent calls are suppressed regardless of TTL.
+    assert await should_log_info(key, 60 * 60) is False
+    assert await should_log_info(key, 1) is False
+
+
+@pytest.mark.asyncio()
+async def test_should_log_info_concurrent_calls_serialize() -> None:
+    key = (1, "upgrade_pool_empty")
+    results = await asyncio.gather(*(should_log_info(key, 3600) for _ in range(10)))
     assert sum(results) == 1
     assert results.count(False) == 9

--- a/tests/test_services/test_cooldown.py
+++ b/tests/test_services/test_cooldown.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Iterator
 from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
 
 from houndarr.database import get_db
+from houndarr.services import cooldown as cooldown_module
 from houndarr.services.cooldown import (
+    _reset_skip_log_cache,
     clear_cooldowns,
     count_searches_last_hour,
     is_on_cooldown,
     record_search,
+    should_log_skip,
 )
 
 
@@ -213,3 +217,94 @@ async def test_clear_cooldowns_only_affects_given_instance(seeded_instances: Non
 async def test_clear_cooldowns_nonexistent_instance(seeded_instances: None) -> None:
     deleted = await clear_cooldowns(9999)
     assert deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# should_log_skip sentinel
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_sentinel() -> Iterator[None]:
+    """Clear the module-level skip-log cache between tests."""
+    _reset_skip_log_cache()
+    yield
+    _reset_skip_log_cache()
+
+
+@pytest.mark.asyncio()
+async def test_should_log_skip_first_call_returns_true() -> None:
+    key = (1, 101, "missing", "cooldown")
+    assert await should_log_skip(key) is True
+
+
+@pytest.mark.asyncio()
+async def test_should_log_skip_within_ttl_returns_false() -> None:
+    key = (1, 101, "missing", "cooldown")
+    assert await should_log_skip(key) is True
+    assert await should_log_skip(key) is False
+    assert await should_log_skip(key) is False
+
+
+@pytest.mark.asyncio()
+async def test_should_log_skip_after_ttl_returns_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = (1, 101, "missing", "cooldown")
+    assert await should_log_skip(key) is True
+
+    # Rewind the stored timestamp by 25 hours to simulate TTL expiry.
+    stale = datetime.now(UTC) - timedelta(hours=25)
+    cooldown_module._SKIP_LOG_CACHE[key] = stale
+
+    assert await should_log_skip(key) is True
+
+
+@pytest.mark.asyncio()
+async def test_should_log_skip_distinct_keys_independent() -> None:
+    k_missing = (1, 101, "missing", "cooldown")
+    k_cutoff = (1, 101, "cutoff", "cutoff_cd")
+    k_upgrade = (1, 101, "upgrade", "upgrade_cd")
+    k_other_item = (1, 102, "missing", "cooldown")
+    k_other_instance = (2, 101, "missing", "cooldown")
+
+    assert await should_log_skip(k_missing) is True
+    assert await should_log_skip(k_cutoff) is True
+    assert await should_log_skip(k_upgrade) is True
+    assert await should_log_skip(k_other_item) is True
+    assert await should_log_skip(k_other_instance) is True
+
+    # Repeats of each key are suppressed independently.
+    assert await should_log_skip(k_missing) is False
+    assert await should_log_skip(k_cutoff) is False
+    assert await should_log_skip(k_upgrade) is False
+
+
+@pytest.mark.asyncio()
+async def test_should_log_skip_lru_evicts_oldest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the cache hits its hard cap, the oldest entry is evicted."""
+    monkeypatch.setattr(cooldown_module, "_SKIP_LOG_MAX_ENTRIES", 3)
+
+    keys = [(1, i, "missing", "cooldown") for i in range(4)]
+    for key in keys[:3]:
+        assert await should_log_skip(key) is True
+
+    # Fourth insert evicts the oldest (first) entry.
+    assert await should_log_skip(keys[3]) is True
+    assert len(cooldown_module._SKIP_LOG_CACHE) == 3
+    assert keys[0] not in cooldown_module._SKIP_LOG_CACHE
+    # Remaining three stay cached, so should_log_skip returns False for them.
+    assert await should_log_skip(keys[1]) is False
+    assert await should_log_skip(keys[2]) is False
+    assert await should_log_skip(keys[3]) is False
+
+
+@pytest.mark.asyncio()
+async def test_should_log_skip_concurrent_calls_serialize() -> None:
+    """Ten concurrent callers with the same key produce exactly one True."""
+    key = (1, 101, "missing", "cooldown")
+    results = await asyncio.gather(*(should_log_skip(key) for _ in range(10)))
+    assert sum(results) == 1
+    assert results.count(False) == 9

--- a/website/docs/guides/troubleshoot-connection.md
+++ b/website/docs/guides/troubleshoot-connection.md
@@ -52,7 +52,7 @@ Checks:
    there is nothing for Houndarr to search.
 2. Check the Houndarr Logs page for the instance. When the most
    recent entries say `skipped` with reason
-   `hourly cap reached`, wait until the next hour window.
+   `hourly limit reached`, wait until the next hour window.
 3. Confirm the instance is enabled (green toggle in Settings).
 4. Check that the sleep interval has elapsed since the last
    cycle. With a 30-minute sleep, Houndarr runs roughly twice per

--- a/website/docs/reference/skip-reasons.md
+++ b/website/docs/reference/skip-reasons.md
@@ -19,9 +19,9 @@ reasons are normal scheduling behavior, not errors.
 | `on upgrade cooldown (Nd)` | per-item | Upgrade item was searched less than `Upgrade Cooldown (days)` ago. Default 90 days. |
 | `not yet released` | per-item | No release date, or the release date is in the future. |
 | `post-release grace (Nh)` | per-item | Release date passed but the grace window (default 6 hours) has not elapsed. |
-| `hourly cap reached (N)` | per-item | Missing pass hit `Hourly Cap` of `N` for the current hour. |
-| `cutoff hourly cap reached (N)` | per-item | Cutoff pass hit `Cutoff Cap` of `N`. |
-| `upgrade hourly cap reached (N)` | per-item | Upgrade pass hit `Upgrade Cap` of `N`. |
+| `hourly limit reached (N/hr)` | per-item | Missing pass hit `Hourly Cap` of `N` for the current hour. |
+| `cutoff hourly limit reached (N/hr)` | per-item | Cutoff pass hit `Cutoff Cap` of `N`. |
+| `upgrade hourly limit reached (N/hr)` | per-item | Upgrade pass hit `Upgrade Cap` of `N`. |
 | `queue backpressure (N/M)` | cycle-level | Download queue has `N` items, at or above `Queue Limit` of `M`. Entire cycle is skipped. |
 | `outside allowed time window` | cycle-level | Current time falls outside every window defined in `Allowed Search Window`. Entire cycle is skipped. |
 


### PR DESCRIPTION
## Summary

Engine fairness and noise-control wave: stratified-shuffle random page-pick deck plus partial-page sentinel padding so per-page and per-item probability stay uniform; typed exception wraps around dispatch / pool-fetch / offset-persist / supervisor boundaries; throttled cooldown skip rows and one-per-six-hour gating on `nothing to upgrade right now` info rows; Run Now cycles bypass the skip-row throttle; `hourly limit reached (N/hr)` phrasing across the three cap-exhausted sites; Lidarr/Readarr cutoff exclusion pagination cap raised; Readarr empty-author hydration; `_run_search_pass` and `_run_upgrade_pass` skip / dispatch / record-search call sites routed via ItemRef.

Closes #490

## Changes

- `src/houndarr/engine/search_loop.py`: stratified-shuffle deck (`_RandomDeckState`, `_draw_next_random_page`, `_reset_random_deck`), `_SHUFFLE_PAD` sentinel and partial-page padding logic; `_format_hourly_limit_reason(kind, cap)` helper; `_write_item_log(ref, action, ...)` wrapper over `_write_log`; ItemRef-routed `is_on_cooldown_ref` / `record_search_ref` calls; `_dispatch_with_typed_wrap`, `_persist_offset_with_typed_wrap`, `_fetch_pool_with_typed_wrap` typed boundaries; cooldown-skip blocks gated by `should_log_skip` (with `cycle_trigger == "run_now"` short-circuit); upgrade-pool-empty info row gated by `should_log_info((instance.id, "upgrade_pool_empty"), 6 * 3600)`.
- `src/houndarr/engine/supervisor.py`: typed `EngineError` / `ClientError` re-raise around the per-instance run.
- `src/houndarr/engine/retry.py`: `jitter_secs` kwarg + `_apply_jitter` helper. Inactive at supervisor call sites.
- `src/houndarr/engine/adapters/lidarr.py` and `readarr.py`: narrow `(httpx.HTTPError, httpx.InvalidURL, ValidationError)` catches plus raised `_UPGRADE_CUTOFF_EXCLUSION_HARD_CAP`.
- `src/houndarr/clients/readarr.py`: hydrate empty author names via session cache.
- New pinning suites: `tests/test_engine/test_random_deck.py`, `test_typed_errors_pinning.py`, `test_dispatch_pool_wrap_pinning.py`, `test_offset_persist_wrap_pinning.py`, `test_adapter_narrow_catch_pinning.py`, `test_skip_throttle_concurrency.py`.
- Existing suites updated for new phrasing, throttled skip-log shape, deck-driven page picks: `test_release_timing.py`, `test_search_loop.py`, `test_search_pass_interactions.py`, `test_upgrade_pass.py`, `test_golden_search_log.py`, `tests/test_e2e/test_search_cycle.py`, `tests/test_services/test_cooldown.py`.
- Docs: `website/docs/guides/troubleshoot-connection.md`, `website/docs/reference/skip-reasons.md` updated for `hourly limit reached (N/hr)`.

## Conflict resolutions during cherry-pick

- `src/houndarr/services/cooldown.py` for `d56a4fa`, `8059b3c`, `c193787`: origin/main already carries `should_log_skip`, `should_log_info`, `is_on_cooldown_ref` / `record_search_ref` because PR10's `f8da3fe` cooldown-SQL extraction pulled the post-PR20 service-module shape forward via the fold-up technique noted in §14.10. Took HEAD across all cooldown.py conflict blocks; the function bodies and `_ref` overloads were already present.
- `src/houndarr/engine/search_loop.py` cooldown call sites: HEAD called `record_search` with the post-PR7 `search_kind` positional argument; the PR5 deferral cherry-picks (`f771c30`, `8059b3c`) wanted `record_search_ref(ref)` on the older single-arg shape. Resolution: routed to `record_search_ref(ref, search_kind)` (and `"upgrade"` for the upgrade pass) so the v15 CHECK constraint stays satisfied.
- `src/houndarr/engine/search_loop.py` skip-log blocks for `d56a4fa`: combined HEAD's `SearchAction.skipped.value` enum form with the cherry-pick's `should_log_skip` wrap.
- `src/houndarr/engine/search_loop.py` typed-helper insertion for `cd8f93b`: cherry-pick used `AppAdapter` type; rewrote to `AppAdapterProto` to match the post-PR4 protocol shape.
- `src/houndarr/engine/search_loop.py` skip-log blocks for `a2f8cab`: HEAD uses flat `instance.id`; cherry-pick wanted sub-struct `instance.core.id`. Stayed with flat-attribute access throughout to keep the file consistent (post-PR11 facade allows both).
- `src/houndarr/engine/search_loop.py` upgrade-pool-empty block for `c193787`: combined HEAD's flat `instance.id` shape with the cherry-pick's `should_log_info` throttle and the new `nothing to upgrade right now` message.
- `src/houndarr/engine/search_loop.py` partial-page block for `f4c4baa`: combined HEAD's flat `instance.search_order` access with the cherry-pick's `_SHUFFLE_PAD` padding logic. The first cherry-pick run committed before the marker was resolved cleanly; amended the commit to drop the marker.
- `src/houndarr/engine/adapters/{lidarr,readarr,sonarr,whisparr_v2}.py` for `f084872`: HEAD already has the post-PR7 `_collect_upgrade_episodes` helper for sonarr / whisparr_v2 (which already uses the narrow catch); only lidarr / readarr genuinely needed the narrow-catch change. Sonarr / whisparr_v2 conflict blocks resolved by taking HEAD (helper-extracted); lidarr / readarr import lines extended with `import httpx` + `from pydantic import ValidationError`.
- `src/houndarr/engine/supervisor.py` for `6381068`: combined HEAD's `cooldown_reconcile` import (PR8) with the cherry-pick's `errors` import.
- `tests/test_engine/test_retry_jitter_pinning.py` for `6bc8ea0`: file does not exist on origin/main (introduced by `f1ad787` which is deferred from PR12). `git rm`'d at cherry-pick time; the new `test_reconnect_jitter_respects_bound` case lands when `f1ad787` ships.
- `tests/test_engine/test_search_loop_helpers_pinning.py` for `9b2527e`: file does not exist on origin/main (introduced by `77cbe78` on the rolled-back PR set). `git rm`'d; the `_format_hourly_limit_reason` pin case lands when the helpers pinning suite ships.

## Notes for review

This PR includes the two PR5 deferrals (`f771c30`, `8059b3c`) per §14.2: both ItemRef-routing commits depended on `should_log_skip` from `d56a4fa` which lands here. Author-date order kept the chain coherent.

## Testing

ruff check, ruff format --check, mypy strict (84 source files), bandit (0 issues): all green locally. pytest -n auto -m "not integration": 1953 passed, 29 skipped.

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
