### PR TITLE
chore(devx): add test-one recipe and align AGENTS.md filtered runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ just check      # all five gates, CI order
 just quick      # lint + type + non-integration pytest (fast feedback loop)
 just fix        # ruff check --fix + ruff format, in place
 just test-quick # pytest -m "not integration"
+just test-one tests/foo.py # filtered run (single file, single test, -k pattern)
 just test-integration  # pytest -m integration tests/test_e2e/
 just test-browser chromium  # Playwright e2e against a live stack
 just dev        # python -m houndarr --data-dir ./data-dev --dev
@@ -121,33 +122,23 @@ just capture-baselines   # produce + commit new PNG baselines
 just verify-baselines    # check committed baselines without re-capturing
 ```
 
-For one-off invocations that don't have a `just` recipe (single test
-file, keyword filter, coverage report) call `pytest` directly:
+Filtered runs (single file, single test, keyword expression, single
+directory) go through `just test-one`, which forwards every remaining
+argument to pytest under the same xdist parallelism + non-integration
+marker filter that `just test-quick` uses:
 
 ```bash
-# Single file
-.venv/bin/pytest tests/test_auth.py
-
-# Single test by name
-.venv/bin/pytest tests/test_auth.py::test_check_password_valid -v
-
-# Tests matching a keyword expression
-.venv/bin/pytest -k "csrf" -v
-
-# Single directory
-.venv/bin/pytest tests/test_services/
-
-# With coverage
-.venv/bin/pytest --cov=houndarr --cov-report=term-missing
+just test-one tests/test_auth.py                                       # single file
+just test-one tests/test_auth.py::test_verify_password_correct         # single test
+just test-one tests/test_services/                                     # single directory
+just -- test-one -k csrf -v                                            # keyword filter (pass -- when the first forwarded arg is a flag)
 ```
 
-For one-off invocations without a `just` recipe:
+Drop to `.venv/bin/pytest` directly only for invocations the
+recipes do not cover, e.g. coverage reports:
 
 ```bash
-.venv/bin/pytest tests/test_auth.py                                    # single file
-.venv/bin/pytest tests/test_auth.py::test_check_password_valid -v      # single test
-.venv/bin/pytest -k "csrf" -v                                          # keyword filter
-.venv/bin/pytest --cov=houndarr --cov-report=term-missing              # coverage
+.venv/bin/pytest --cov=houndarr --cov-report=term-missing
 ```
 
 ### Markers

--- a/justfile
+++ b/justfile
@@ -54,6 +54,18 @@ test:
 test-quick:
     {{pytest}} -n {{workers}} -m "not integration"
 
+# Run a filtered subset (single file, single test, keyword, etc.) under
+# the same parallelism + non-integration marker that test-quick uses.
+# Forwards every remaining positional argument straight to pytest.
+# When the first forwarded argument starts with a dash, prefix the
+# command with `just --` so just does not interpret the dash as one of
+# its own options:
+#     just test-one tests/test_errors.py
+#     just test-one tests/test_errors.py::TestInstanceValidationPublicMessage
+#     just -- test-one -k csrf -v
+test-one *ARGS:
+    {{pytest}} -n {{workers}} -m "not integration" {{ARGS}}
+
 test-integration:
     {{pytest}} -n {{workers}} -m integration tests/test_e2e/
 

--- a/src/houndarr/errors.py
+++ b/src/houndarr/errors.py
@@ -134,7 +134,7 @@ class InstanceValidationError(ServiceError):
 
     @property
     def public_message(self) -> str:
-        """Curated user-facing message safe to surface in HTTP responses.
+        """Return the curated user-facing string safe to surface in HTTP responses.
 
         Every raise site in this codebase constructs the exception with
         a single literal string argument (e.g. ``raise
@@ -144,6 +144,10 @@ class InstanceValidationError(ServiceError):
         leak in some Python builds.  Routes use this accessor so the
         guard banner cannot accidentally expose internal exception text
         even if a future raise site forgets to pass a curated string.
+
+        Returns:
+            ``str(args[0])`` when the exception was constructed with at
+            least one argument; the empty string otherwise.
         """
         if not self.args:
             return ""


### PR DESCRIPTION
## Summary

Add a `test-one *ARGS` recipe to the justfile so filtered pytest runs (single file, single test, keyword expression) go through `just` like every other quality gate.  Update AGENTS.md so contributors and agents reach for `just test-one tests/path` instead of dropping to `.venv/bin/pytest`, and polish the `InstanceValidationError.public_message` docstring landed in #517 to imperative mood per the project's commenting standard.

Closes #522

## Changes

- `justfile`: new `test-one *ARGS` recipe that runs `{{pytest}} -n {{workers}} -m "not integration" {{ARGS}}`, with a comment block explaining when to prefix the call with `just --` (only when the first forwarded argument starts with a dash, per just's documented variadic-arg limitation).
- `AGENTS.md` Recipe index: add a `just test-one tests/foo.py` entry next to `just test-quick`.
- `AGENTS.md` Running Tests: replace the duplicated "for one-off invocations" blocks with a single example block showing `just test-one` for file / test / directory / keyword runs.  The raw `pytest` example is retained only for invocations the recipes do not cover (e.g. coverage reports).
- `src/houndarr/errors.py`: rewrite the `public_message` docstring summary line in imperative mood ("Return the curated user-facing string...") and add a `Returns:` section per the project's Python commenting standard.

## Testing

`just check` green locally: ruff lint + format-check, mypy strict, bandit, full pytest (2142 passed, 5 skipped).

Verified the new recipe end-to-end:

```
just test-one tests/test_errors.py                                      # 24 passed in 1.10s
just test-one tests/test_auth.py::test_verify_password_correct          # 1 passed in 1.40s
just -- test-one -k csrf -v                                             # 42 passed in 3.44s
```

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
