### PR TITLE
fix: post-review cleanup (integration marker, website engines, docstring polish)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: website/pnpm-lock.yaml
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: website/pnpm-lock.yaml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,5 +141,6 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "-q --tb=short"
 markers = [
+    "integration: end-to-end tests (live mock *arr containers or Playwright browser driving)",
     "pinning: characterization tests that lock current behaviour (Track A; run via `just pin`)",
 ]

--- a/src/houndarr/errors.py
+++ b/src/houndarr/errors.py
@@ -139,15 +139,17 @@ class InstanceValidationError(ServiceError):
         Every raise site in this codebase constructs the exception with
         a single literal string argument (e.g. ``raise
         InstanceValidationError("Invalid instance type.")``).  Reading
-        ``args[0]`` returns that literal verbatim, never the chained
-        ``__cause__`` traceback that ``str(exc)`` could potentially
-        leak in some Python builds.  Routes use this accessor so the
-        guard banner cannot accidentally expose internal exception text
-        even if a future raise site forgets to pass a curated string.
+        ``args[0]`` returns that literal verbatim regardless of how
+        many positional args were passed; ``str(exc)`` only matches
+        ``args[0]`` for the single-arg case and otherwise coerces the
+        whole tuple to ``repr(args)`` (e.g. ``"('a', 'b')"``).  Routes
+        use this accessor so the guard banner shows the curated
+        message even if a future raise site forgets the convention
+        and passes multiple positional args.
 
         Returns:
-            ``str(args[0])`` when the exception was constructed with at
-            least one argument; the empty string otherwise.
+            ``str(args[0])`` when the exception was constructed with
+            at least one argument; the empty string otherwise.
         """
         if not self.args:
             return ""

--- a/tests/test_e2e/test_search_cycle.py
+++ b/tests/test_e2e/test_search_cycle.py
@@ -154,6 +154,7 @@ async def _cooldown_rows(instance_id: int) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_full_cycle_sonarr(sonarr_instance: Instance, master_key: bytes) -> None:
@@ -182,6 +183,7 @@ async def test_full_cycle_sonarr(sonarr_instance: Instance, master_key: bytes) -
     assert cds[0]["item_type"] == "episode"
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_full_cycle_radarr(radarr_instance: Instance, master_key: bytes) -> None:
@@ -213,6 +215,7 @@ async def test_full_cycle_radarr(radarr_instance: Instance, master_key: bytes) -
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_second_cycle_items_skipped_on_cooldown(
@@ -253,6 +256,7 @@ async def test_second_cycle_items_skipped_on_cooldown(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_hourly_cap_enforced(
@@ -306,6 +310,7 @@ async def test_hourly_cap_enforced(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_supervisor_graceful_shutdown(
@@ -329,6 +334,7 @@ async def test_supervisor_graceful_shutdown(
     assert sup._tasks == {}  # noqa: SLF001
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 async def test_supervisor_no_instances_starts_cleanly(db: None, master_key: bytes) -> None:
     """Supervisor with zero instances should start and stop without error."""
@@ -343,6 +349,7 @@ async def test_supervisor_no_instances_starts_cleanly(db: None, master_key: byte
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_supervisor_runs_both_instances(
@@ -386,6 +393,7 @@ async def test_supervisor_runs_both_instances(
     assert radarr_instance.id in instance_ids
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_missing_pass_reaches_deeper_page_when_top_items_are_ineligible(
@@ -424,6 +432,7 @@ async def test_missing_pass_reaches_deeper_page_when_top_items_are_ineligible(
     assert any(row["item_id"] == 602 and row["action"] == "searched" for row in logs)
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_missing_list_calls_are_bounded_per_cycle(
@@ -517,6 +526,7 @@ async def whisparr_v2_instance(db: None, master_key: bytes) -> Instance:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_full_cycle_lidarr(lidarr_instance: Instance, master_key: bytes) -> None:
@@ -549,6 +559,7 @@ async def test_full_cycle_lidarr(lidarr_instance: Instance, master_key: bytes) -
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_full_cycle_readarr(readarr_instance: Instance, master_key: bytes) -> None:
@@ -580,6 +591,7 @@ async def test_full_cycle_readarr(readarr_instance: Instance, master_key: bytes)
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio()
 @respx.mock
 async def test_full_cycle_whisparr_v2(whisparr_v2_instance: Instance, master_key: bytes) -> None:

--- a/website/package.json
+++ b/website/package.json
@@ -50,7 +50,7 @@
     ]
   },
   "engines": {
-    "node": ">=20.0"
+    "node": ">=22.12"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary

Address the medium-severity findings from the post-merge adversarial review of the security-fix batch (#517 / #519 / #521 / #523).

- Restore the `@pytest.mark.integration` decorator on the 12 end-to-end cycle tests in `tests/test_e2e/test_search_cycle.py` and re-register the marker in `pyproject.toml`.  Both were on the pre-rollout backup tag `backup/pre-reorg-20260427` but never made it through to `origin/main` during the rollout, so `just test-integration` was collecting zero tests and the `-m "not integration"` filter on `just test-quick` / `just test-one` was inert.
- Tighten `website/package.json` `engines.node` from `>=20.0` to `>=22.12` so the field reflects the real minimum required by the uuid 14 transitive override (uuid 14 is ESM-only, sockjs requires it via CommonJS, and `require(esm)` is default-on starting Node 22.12).
- Bump `node-version: "20"` to `"22"` in `.github/workflows/pages.yml` and `.github/workflows/test-deploy.yml` so the deploy and preview workflows match the engines field.
- Reframe the `InstanceValidationError.public_message` docstring rationale to match real Python semantics: `str(BaseException)` returns `args[0]` for single-arg construction or `repr(args)` for multi-arg, never the chained `__cause__` traceback.  The accessor's defensive value comes from the multi-arg coercion guarantee.

Closes #524

## Changes

- `tests/test_e2e/test_search_cycle.py`: 12 new `@pytest.mark.integration` decorators (one per existing `@pytest.mark.asyncio()` test).
- `pyproject.toml`: re-register the `integration` marker in the `[tool.pytest.ini_options].markers` list.
- `website/package.json`: `engines.node` `>=20.0` → `>=22.12`.
- `.github/workflows/pages.yml` and `.github/workflows/test-deploy.yml`: `node-version: "20"` → `"22"`.
- `src/houndarr/errors.py`: rewrite the `InstanceValidationError.public_message` docstring rationale around multi-arg coercion divergence rather than imaginary cause-chain leakage.

## Testing

`just check` green locally: ruff lint + format-check, mypy strict, bandit, full pytest (2142 passed, 5 skipped).

Verified the marker fix works end-to-end:

```
just test-integration   # 12 passed in 1.31s (was: 0 collected, exit 5)
just test-quick         # 2130 passed, 5 skipped (12 cycle tests deselected)
just test               # 2142 passed, 5 skipped (both selected)
```

`pnpm install --no-frozen-lockfile` on the website succeeds with the tightened engines field on the local Node 24 install.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
