### PR TITLE
chore(refactor): reconcile foundation files with backup tag (wave 1)

### DIFF
--- a/src/houndarr/bootstrap.py
+++ b/src/houndarr/bootstrap.py
@@ -51,6 +51,7 @@ class AppSettingsOverrides(TypedDict, total=False):
     trusted_proxies: str
     auth_mode: str
     auth_proxy_header: str
+    update_check_repo: str
 
 
 def bootstrap_non_web(
@@ -68,7 +69,7 @@ def bootstrap_non_web(
         **overrides: Additional :class:`AppSettings` field values (``host``,
             ``port``, ``dev``, ``log_level``, ``secure_cookies``,
             ``cookie_samesite``, ``trusted_proxies``, ``auth_mode``,
-            ``auth_proxy_header``). When any
+            ``auth_proxy_header``, ``update_check_repo``). When any
             override is supplied, :class:`AppSettings` is constructed
             directly and pinned into the runtime singleton so the whole
             process agrees on the overridden values. When no overrides

--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -162,9 +162,15 @@ def _parse_update_check_repo(raw: str) -> str:
 
     The value is interpolated into ``https://api.github.com/repos/{repo}/...``
     so the GitHub URL parser already keeps the host pinned. This guard is
-    defence in depth: catch typos (missing slash, accidental query strings)
-    at startup and log a warning instead of letting a garbled request hit
-    the GitHub API.
+    defence in depth: every :func:`get_settings` call that reads env
+    (the no-pin fallback, including the no-override branch of
+    :func:`bootstrap_settings`) flows through here, so a typo (missing
+    slash, accidental query string, absolute URL) is caught before a
+    garbled request hits the GitHub API. CLI overrides bypass this path
+    entirely because :func:`bootstrap_settings` constructs ``AppSettings``
+    from kwargs directly; ``HOUNDARR_UPDATE_CHECK_REPO`` only affects
+    the env-fallback callers (scripts, tests, and any caller that
+    invokes :func:`bootstrap_settings` with no overrides).
     """
     value = raw.strip()
     if not value:
@@ -220,6 +226,7 @@ class BootstrapOverrides(TypedDict, total=False):
     trusted_proxies: str
     auth_mode: str
     auth_proxy_header: str
+    update_check_repo: str
 
 
 def bootstrap_settings(**overrides: Unpack[BootstrapOverrides]) -> AppSettings:
@@ -235,9 +242,8 @@ def bootstrap_settings(**overrides: Unpack[BootstrapOverrides]) -> AppSettings:
     :func:`get_settings` calls return the same instance until the next
     ``bootstrap_settings`` call (or process restart). Any prior pin is
     replaced; any env var for an *unsupplied* key is ignored (the kwarg
-    path matches the pre-refactor ``AppSettings(data_dir=..., **overrides)``
-    shape, where missing fields take the dataclass default rather than the
-    env value).
+    path builds :class:`AppSettings` from overrides alone, so missing
+    fields take the dataclass default rather than the env value).
 
     With no overrides supplied, any prior pin is cleared and the result of
     :func:`get_settings` (env-var resolved) is returned *without* pinning.

--- a/src/houndarr/errors.py
+++ b/src/houndarr/errors.py
@@ -1,14 +1,11 @@
 """Houndarr's exception hierarchy.
 
-Previously the codebase had zero custom exceptions; error handling
-relied on ``except Exception  # noqa: BLE001`` at 12+ sites.  This
-module introduces a single root (``HoundarrError``) plus four layer-
-specific branches so call sites can switch to named exceptions
-incrementally in Tracks B.11-B.17.
-
-The hierarchy is declaration-only in this batch; no raise site is
-migrated yet.  Each concrete class documents which existing
-``except Exception`` block it will eventually replace.
+A single root (:class:`HoundarrError`) plus four layer-specific
+branches (:class:`ClientError`, :class:`EngineError`,
+:class:`ServiceError`, :class:`RouteError`) let call sites catch
+Houndarr-originated failures by layer without rewrapping third-party
+exceptions.  Each concrete subclass documents the surface it covers so
+callers pick the narrowest useful base.
 """
 
 from __future__ import annotations
@@ -23,9 +20,7 @@ class HoundarrError(Exception):
     """
 
 
-# ---------------------------------------------------------------------------
 # Client-layer errors (clients/*.py)
-# ---------------------------------------------------------------------------
 
 
 class ClientError(HoundarrError):
@@ -79,9 +74,7 @@ class ClientUnreachableError(ClientError):
     """
 
 
-# ---------------------------------------------------------------------------
 # Engine-layer errors (engine/*.py)
-# ---------------------------------------------------------------------------
 
 
 class EngineError(HoundarrError):
@@ -115,9 +108,7 @@ class EngineQueueProbeError(EngineError):
     """The queue-backpressure probe (``get_queue_status``) failed."""
 
 
-# ---------------------------------------------------------------------------
 # Service-layer errors (services/*.py, routes/admin.py)
-# ---------------------------------------------------------------------------
 
 
 class ServiceError(HoundarrError):
@@ -159,8 +150,9 @@ class InstanceValidationError(ServiceError):
 class CooldownStateError(ServiceError):
     """Cooldown state is inconsistent (e.g. negative days).
 
-    Defensive: the service should never raise this today, but adding
-    it gives Track B.17 a target for the ``except Exception`` guard.
+    Defensive: the service should never raise this today.  Keeping
+    the class lets the service-wide ``except Exception`` guard narrow
+    to a named subclass without losing coverage.
     """
 
 
@@ -173,9 +165,7 @@ class TimeWindowSpecError(ServiceError):
     """
 
 
-# ---------------------------------------------------------------------------
 # Route-layer errors (routes/*.py, auth.py)
-# ---------------------------------------------------------------------------
 
 
 class RouteError(HoundarrError):

--- a/src/houndarr/protocols.py
+++ b/src/houndarr/protocols.py
@@ -1,29 +1,23 @@
 """Structural Protocols for Houndarr's repository and factory seams.
 
-Track B.20 declaration.  These Protocols advertise the repository
-shape that Track D.3-D.6 will implement concretely in
-``src/houndarr/repositories/``; this module lands the declarations
-first so service-layer callers can depend on the shape instead of
-the eventual SQL-executing module.  A similar story holds for
-:class:`ClientFactory`: today every :class:`ArrClient` is constructed
-inline via an adapter's ``make_client``; Track C will introduce a
-registered factory that satisfies this Protocol.
+Each Protocol advertises the shape of a repository or factory
+boundary so service-layer callers depend on the structural contract
+rather than the concrete SQL-executing module.  The concrete
+implementations live in :mod:`houndarr.repositories`.
 
 Every declaration is ``@runtime_checkable`` so tests can assert
-conformance with ``isinstance(instance, InstanceRepository)`` once
-a concrete implementation lands.  The signatures are deliberately
-minimal: Track D refines them as each repository boundary solidifies.
-Until then this module is the single source of truth for the seam.
+conformance with ``isinstance(instance, InstanceRepository)``.
+Signatures are deliberately minimal: each method covers one call
+site the service layer uses today, and nothing more.
 """
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable
 from typing import Any, Literal, Protocol, runtime_checkable
 
 from houndarr.clients.base import ArrClient
-from houndarr.enums import ItemType
-from houndarr.services.instances import Instance, InstanceType
+from houndarr.services.instances import Instance
 from houndarr.value_objects import ItemRef
 
 # ``RunNowStatus`` is duplicated here (rather than imported from
@@ -55,15 +49,14 @@ class SettingsRepository(Protocol):
 class InstanceRepository(Protocol):
     """Instance CRUD boundary backing the ``instances`` table.
 
-    Track D.3 lands the read half under ``repositories/instances.py``;
-    Track D.4 lands the write half, including the concrete
+    Read methods take the Fernet ``master_key`` so the concrete
+    repository can decrypt ``encrypted_api_key`` before returning an
+    :class:`Instance`.  Write methods accept
     :class:`~houndarr.repositories.instances.InstanceInsert` and
     :class:`~houndarr.repositories.instances.InstanceUpdate` payload
-    dataclasses the Protocol references below.  The read methods take
-    the Fernet ``master_key`` so the repository can decrypt
-    ``encrypted_api_key`` before returning an :class:`Instance`; the
-    service layer in ``services/instances.py`` becomes a facade over
-    this boundary.
+    dataclasses; those types are structurally typed as :class:`Any`
+    on the Protocol so consumers do not have to import the concrete
+    repository module just to satisfy the Protocol.
     """
 
     def list_instances(self, *, master_key: bytes) -> Awaitable[list[Instance]]:
@@ -119,8 +112,8 @@ class CooldownRepository(Protocol):
     """Cooldown SQL boundary backing the ``cooldowns`` table.
 
     The LRU skip-log sentinel (``should_log_skip``) stays in the
-    service layer; this Protocol only covers the SQL write paths
-    that Track D.5 will migrate to ``repositories/cooldowns.py``.
+    service layer; this Protocol covers the three SQL methods the
+    concrete repository exposes.
     """
 
     def exists_active_cooldown(self, ref: ItemRef, cooldown_days: int) -> Awaitable[bool]:
@@ -137,9 +130,9 @@ class CooldownRepository(Protocol):
 class SearchLogRepository(Protocol):
     """``search_log`` SQL boundary.
 
-    Track D.6 will land ``repositories/search_log.py``; the engine's
-    :func:`_write_log` helper becomes a thin call to
-    :meth:`insert_log_row`.
+    The engine's :func:`_write_log` helper is a thin call to
+    :meth:`insert_log_row`; the log-query service composes
+    :meth:`fetch_log_rows` for the ``/api/logs`` route.
     """
 
     def insert_log_row(
@@ -190,16 +183,12 @@ class SearchLogRepository(Protocol):
 class SupervisorProto(Protocol):
     """Route-facing view of the engine supervisor.
 
-    Track B.21 introduces this Protocol so FastAPI routes can depend
-    on the structural contract instead of the concrete
-    :class:`~houndarr.engine.supervisor.Supervisor` class.  Only the
-    methods route handlers invoke are declared; internal task
-    bookkeeping and lifecycle helpers stay on the concrete type.
-
-    Wired through :func:`get_supervisor` in ``routes/api/status.py``
-    today; Track D.12 + D.26 will move it into a shared
-    :mod:`houndarr.deps` module and migrate the remaining
-    ``settings/instances`` callers.
+    FastAPI routes depend on this structural contract instead of the
+    concrete :class:`~houndarr.engine.supervisor.Supervisor` class.
+    Only the methods route handlers invoke are declared; internal
+    task bookkeeping and lifecycle helpers stay on the concrete
+    type.  The shim in :mod:`houndarr.deps` wires the concrete
+    instance into this Protocol for every route that depends on it.
     """
 
     async def trigger_run_now(self, instance_id: int) -> RunNowStatus:
@@ -219,13 +208,13 @@ class SupervisorProto(Protocol):
 class ClientFactory(Protocol):
     """Construct an :class:`ArrClient` for a given :class:`Instance`.
 
-    Today every adapter exposes its own ``make_client`` function; the
+    Each adapter exposes its own ``make_client`` function; the
     supervisor and search loop receive adapters via
     :func:`houndarr.engine.adapters.get_adapter` and call
-    ``adapter.make_client(instance)`` inline.  Track C will introduce
-    a registered factory seam so tests can swap client construction
-    without monkeypatching.  Implementations must return an unopened
-    client; callers open it via ``async with``.
+    ``adapter.make_client(instance)`` directly.  The Protocol
+    captures that signature so tests and future factory seams can
+    depend on the structural contract.  Implementations must return
+    an unopened client; callers open it via ``async with``.
     """
 
     def __call__(self, instance: Instance) -> ArrClient:
@@ -244,7 +233,3 @@ __all__ = [
     "SettingsRepository",
     "SupervisorProto",
 ]
-
-
-# Silence "unused" hints on passthrough imports used by ``@runtime_checkable``
-_TYPE_HINTS: tuple[Any, ...] = (Callable, Iterable, ItemType, InstanceType)


### PR DESCRIPTION
## Summary

Reconciliation Wave 1 of seven.  Bring four foundation source files (`errors.py`, `config.py`, `bootstrap.py`, `protocols.py`) from `backup/pre-reorg-20260427` onto `origin/main`.  No intra-codebase coupling; safe to land first.  Preserves the `InstanceValidationError.public_message` accessor added in #517.

Closes #528

## Changes

- `src/houndarr/errors.py`: backup version + retained `public_message` property.
- `src/houndarr/config.py`, `src/houndarr/bootstrap.py`, `src/houndarr/protocols.py`: backup versions verbatim.

## Testing

`just check` green locally: ruff lint + format-check, mypy strict, bandit, full pytest (2142 passed, 5 skipped).

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Branch name matches issue scope
- [x] Tests added/updated for all changes
- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
