### PR TITLE
chore(refactor): reconcile new repository modules with backup tag (wave 2)

### DIFF
--- a/src/houndarr/repositories/__init__.py
+++ b/src/houndarr/repositories/__init__.py
@@ -1,29 +1,29 @@
 """Repository layer: module-per-aggregate SQL boundary.
 
-Track D.1 introduces this namespace.  Concrete modules land
-incrementally over the remaining D batches and implement the
-Protocols already declared in :mod:`houndarr.protocols`:
+Every module here implements one of the Protocols declared in
+:mod:`houndarr.protocols`:
 
-- ``settings.py`` (D.2): key-value reads and writes, replacing the
-  ``get_setting`` / ``set_setting`` helpers inside ``database.py``.
-- ``instances.py`` (D.3 reads, D.4 writes): ``instances`` table CRUD
-  with ``InstanceInsert`` + ``InstanceUpdate`` payload dataclasses.
-- ``cooldowns.py`` (D.5): ``cooldowns`` table SQL.  The LRU skip-log
-  sentinel stays in :mod:`houndarr.services.cooldown` and is not
-  part of this boundary.
-- ``search_log.py`` (D.6): insert, filtered page fetch, recent
-  searches counter, and per-instance delete for the ``search_log``
-  table; the engine's ``_write_log`` helper becomes a thin call into
-  ``insert_log_row``.
+- ``settings.py``: key-value reads and writes for the ``settings``
+  table.
+- ``instances.py``: ``instances`` table CRUD with
+  :class:`InstanceInsert` and :class:`InstanceUpdate` payload
+  dataclasses.
+- ``cooldowns.py``: per-item cooldown upsert, existence check, and
+  per-instance delete.  The LRU skip-log sentinel stays in
+  :mod:`houndarr.services.cooldown`; it is an in-process cache, not
+  a SQL boundary.
+- ``search_log.py``: insert, filtered page fetch, recent-searches
+  counter, per-instance delete, and retention purge for the
+  ``search_log`` table; the engine's ``_write_log`` helper is a thin
+  call into ``insert_log_row``.
 
-Per locked user decision #4, every module in this package is
-function-based (no classes) and scoped to a single aggregate.
-Callers depend on the structural :mod:`houndarr.protocols` shape,
-not on the concrete repository import, which keeps the boundary
+Every module is function-based (no classes) and scoped to a single
+aggregate.  Callers depend on the structural Protocol shape, not on
+the concrete repository import, which keeps the boundary
 test-swappable without subclass gymnastics.
 
-The migration helpers ``_migrate_to_v2`` through ``_migrate_to_v13``
-stay off-limits in :mod:`houndarr.database`; repository functions
-only wrap ``get_db()`` queries and never alter schema, PRAGMAs, or
-the WAL lifecycle.
+Schema migrations (``_migrate_to_v2`` through ``_migrate_to_v13``)
+stay in :mod:`houndarr.database` and are off-limits here; repository
+functions only wrap ``get_db()`` queries and never alter schema,
+PRAGMAs, or the WAL lifecycle.
 """

--- a/src/houndarr/repositories/search_log.py
+++ b/src/houndarr/repositories/search_log.py
@@ -1,19 +1,15 @@
 """Search-log aggregate: SQL boundary for the ``search_log`` table.
 
-Track D.6 lands the insert path and a minimal fetch surface matching
-the :class:`houndarr.protocols.SearchLogRepository` Protocol.  The
-engine's ``_write_log`` helper in :mod:`houndarr.engine.search_loop`
-delegates to :func:`insert_log_row`; the golden-log characterisation
-test in ``tests/test_engine/test_golden_search_log.py`` pins the
-column ordering and NULL-vs-value handling so the byte-equal
-invariant survives the migration.
-
-Track D.9 extracts a log-query service that will consume
-:func:`fetch_log_rows` for the ``/api/logs`` route; until then the
-route keeps its own dynamic SQL.  D.27 sweeps the remaining engine
-call sites for ``_write_log`` (the specialised ``fetch_recent_searches``
-and ``fetch_latest_missing_reason`` lookups currently living in
-:mod:`houndarr.engine.search_loop`) through the repository.
+Implements the :class:`houndarr.protocols.SearchLogRepository`
+contract plus the retention purge.  The engine's ``_write_log``
+helper in :mod:`houndarr.engine.search_loop` delegates to
+:func:`insert_log_row`; the golden-log characterisation test in
+``tests/test_engine/test_golden_search_log.py`` pins the column
+ordering and NULL-vs-value handling so the insert shape stays
+byte-equal.  The ``/api/logs`` route is backed by
+:mod:`houndarr.services.log_query`, which composes
+:func:`fetch_log_rows` with the filter and pagination logic the
+route needs.
 
 Timestamps: the ``search_log.timestamp`` column is a ``DEFAULT
 strftime(...)`` at the schema level, so inserts leave it untouched
@@ -230,6 +226,91 @@ async def fetch_recent_searches(
     return int(row[0]) if row else 0
 
 
+async def fetch_latest_missing_reason(
+    instance_id: int,
+    item_id: int,
+    item_type: str,
+) -> str | None:
+    """Return the ``reason`` from the most recent missing-pass log for *ref*.
+
+    Used by the release-timing retry branch in the engine search loop
+    to decide whether an item currently on cooldown should be retried
+    (because the last logged skip reason was pre-release or
+    post-release-grace, both of which can now have elapsed) or left
+    alone.
+
+    Args:
+        instance_id: Owning instance primary key.
+        item_id: *arr per-type item identifier.
+        item_type: ``ItemType`` string value (``"episode"``,
+            ``"season"``, ``"movie"``, ``"album"``, ``"book"``,
+            ``"author"``, ``"series"``, ``"artist"``).
+
+    Returns:
+        The ``reason`` column value from the newest matching row, or
+        ``None`` when no missing-pass row exists or the row's reason
+        is NULL.
+    """
+    async with get_db() as db:
+        async with db.execute(
+            """
+            SELECT reason
+            FROM search_log
+            WHERE instance_id = ?
+              AND item_id = ?
+              AND item_type = ?
+              AND search_kind = 'missing'
+            ORDER BY timestamp DESC, id DESC
+            LIMIT 1
+            """,
+            (instance_id, item_id, item_type),
+        ) as cur:
+            row = await cur.fetchone()
+    return str(row[0]) if row and row[0] is not None else None
+
+
+async def fetch_active_error_instance_ids() -> set[int]:
+    """Return the set of instance IDs whose newest log row is an error.
+
+    Used by the settings page to paint the per-row status dot red and
+    by the dashboard banner to flag active failures.  The window is
+    narrowed to the last 48 hours so the ``ROW_NUMBER()`` partition
+    only scans recent rows: an error that has not re-surfaced in two
+    days is stale for the "is this instance healthy right now?"
+    question, and a genuinely stuck instance writes fresh error rows
+    well inside that window.
+
+    The cutoff uses ``strftime('%Y-%m-%dT%H:%M:%fZ', ...)`` so the
+    boundary matches the stored column format exactly.  SQLite
+    compares TEXT lexicographically, and ``datetime('now',
+    '-2 days')`` returns a space-separated value; at position 10 of
+    the comparison that space (0x20) sorts below the stored value's
+    ``T`` (0x54), which would let same-calendar-day rows older than
+    48 hours slip through.  Matching formats makes the comparison a
+    pure ISO-8601 string compare and restores the advertised window.
+
+    Returns:
+        Set of instance IDs whose newest ``search_log`` row (within
+        the 48h window) has ``action='error'``.  Empty set when no
+        instance is currently failing.
+    """
+    sql = """
+    SELECT instance_id FROM (
+        SELECT instance_id, action,
+               ROW_NUMBER() OVER (
+                   PARTITION BY instance_id ORDER BY timestamp DESC, id DESC
+               ) AS rn
+        FROM search_log
+        WHERE timestamp >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-2 days')
+    )
+    WHERE rn = 1 AND action = 'error'
+    """
+    async with get_db() as db:
+        async with db.execute(sql) as cur:
+            rows = await cur.fetchall()
+    return {int(row["instance_id"]) for row in rows}
+
+
 async def delete_logs_for_instance(instance_id: int) -> int:
     """Delete every ``search_log`` row for *instance_id*.
 
@@ -254,6 +335,51 @@ async def delete_logs_for_instance(instance_id: int) -> int:
         )
         await db.commit()
         return cur.rowcount or 0
+
+
+async def delete_all_logs() -> int:
+    """Truncate the ``search_log`` table and return the removed row count.
+
+    Backs the Admin > Maintenance > Clear all logs action.  The audit
+    breadcrumb row ("Audit log cleared by admin ...") is written by
+    :func:`insert_admin_audit` after this returns, so the DELETE and
+    the follow-up INSERT are two separate statements against two
+    separate connections; that keeps the truncate a pure wipe and
+    lets concurrent supervisor writes interleave without corrupting
+    the breadcrumb row.
+
+    Returns:
+        Number of rows that were removed (excluding the breadcrumb,
+        which is written by the caller afterwards).
+    """
+    async with get_db() as db:
+        cur = await db.execute("DELETE FROM search_log")
+        await db.commit()
+        return cur.rowcount or 0
+
+
+async def insert_admin_audit(message: str) -> None:
+    """Insert a single system-audit row into ``search_log``.
+
+    Used by admin operations (policy reset, log clear, factory reset)
+    to leave a breadcrumb on the Activity logs page
+    (e.g. "Policy settings reset to defaults by admin").  The row is
+    attributed to ``cycle_trigger='system'`` and ``action='info'`` so
+    it sorts alongside the scheduler's lifecycle events rather than a
+    real search result.  ``instance_id`` is NULL because these are
+    library-wide operations, not per-instance.
+
+    Args:
+        message: Free-text audit message written to the ``message``
+            column verbatim.
+    """
+    async with get_db() as db:
+        await db.execute(
+            "INSERT INTO search_log (instance_id, cycle_trigger, action, message)"
+            " VALUES (NULL, 'system', 'info', ?)",
+            (message,),
+        )
+        await db.commit()
 
 
 async def purge_old_logs(retention_days: int) -> int:

--- a/src/houndarr/repositories/settings.py
+++ b/src/houndarr/repositories/settings.py
@@ -1,19 +1,15 @@
 """Key-value settings aggregate: SQL boundary for the ``settings`` table.
 
-Track D.2 introduced this module.  The previous incarnation lived as
-two helpers (``get_setting`` / ``set_setting``) inside
-:mod:`houndarr.database`; the final refactor wave's Phase 6a removed
-those delegators outright and migrated every caller to import from
-here directly.  ``delete_setting`` rounds out the full
-:class:`houndarr.protocols.SettingsRepository` contract; the previous
-code path had no delete at all because removing a setting was never
-required by any caller, but the contract calls for the symmetry.
-
-Function shape matches the Protocol (no ``default`` argument on
-``get_setting``).  Callers that need a default fall back at their own
-call site: ``(await get_setting(key)) or "default"`` for the truthy
-case, or ``(await get_setting(key)) if value is not None else default``
-for the strict ``None``-only fallback.
+Implements the :class:`houndarr.protocols.SettingsRepository`
+contract with three functions: :func:`get_setting`,
+:func:`set_setting`, :func:`delete_setting`.  ``get_setting`` has no
+``default`` argument; callers that need a default fall back at their
+own call site (``(await get_setting(key)) or "default"`` for the
+truthy case, or ``(await get_setting(key)) if value is not None else
+default`` for the strict ``None``-only fallback).  The symmetry of a
+dedicated delete entry point (versus calling ``set_setting`` with
+``""``) keeps the semantics of "absent" distinct from "empty string"
+for callers that rely on that difference.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Wave 2 of seven reconciliation PRs.  Bring three additive repository modules forward from `backup/pre-reorg-20260427`: `__init__.py`, `search_log.py`, `settings.py`.  No callers regress; new APIs sit on the shelf for the next wave to wire up.

Closes #530

## Changes

- `src/houndarr/repositories/__init__.py`: backup version (public surface re-exports).
- `src/houndarr/repositories/search_log.py`: backup version (audit-log helpers + query builders).
- `src/houndarr/repositories/settings.py`: backup version (full repo implementation of `get_setting` / `set_setting`).

## Testing

`just check` green: 2142 passed, 5 skipped.

## Type of Change

- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has `type:*` and `priority:*` labels
- [x] Branch name matches issue scope
- [x] Type check passes
- [x] Lint passes
- [x] Format passes
- [x] No secrets committed
- [x] **Scope check**: helps search for missing or cutoff-unmet media in a controlled way
