### PR TITLE
ci(browser-e2e): add workflow_dispatch baseline-capture trigger

### DIFF
--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -7,6 +7,12 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+  workflow_dispatch:
+    inputs:
+      update_baselines:
+        description: "Re-capture login + setup visual baselines and upload them as an artifact (chromium only)."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -128,6 +134,7 @@ jobs:
             -o /dev/null
 
       - name: Run browser e2e suite
+        if: github.event_name != 'workflow_dispatch' || inputs.update_baselines != true
         env:
           HOUNDARR_URL: http://localhost:8877
           MOCK_SONARR_URL: http://mock-sonarr:8989
@@ -147,6 +154,35 @@ jobs:
             --junitxml=test-results/junit.xml \
             --reruns 2 \
             -v
+
+      - name: Capture login + setup visual baselines (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.update_baselines == true && matrix.browser == 'chromium'
+        env:
+          HOUNDARR_URL: http://localhost:8877
+          MOCK_SONARR_URL: http://mock-sonarr:8989
+          MOCK_RADARR_URL: http://mock-radarr:7878
+          HOUNDARR_E2E_USER: admin
+          HOUNDARR_E2E_PASS: CITestPass1!
+          HOUNDARR_E2E_CAPTURE: "1"
+        run: |
+          # The visual baseline tests honour HOUNDARR_E2E_CAPTURE=1 by
+          # writing the rendered screenshot to disk instead of asserting
+          # against the committed PNG.  Run only the two visual tests so
+          # nothing else writes into _screenshots/.
+          pytest tests/e2e_browser/test_flows.py \
+            --confcutdir tests/e2e_browser \
+            --browser chromium \
+            --full-page-screenshot \
+            -k "test_login_page_visual or test_setup_page_visual" \
+            -v
+
+      - name: Upload re-captured baselines (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.update_baselines == true && matrix.browser == 'chromium'
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-baselines-chromium
+          path: tests/e2e_browser/_screenshots/*.png
+          retention-days: 30
 
       - name: Dump container logs on failure
         if: failure()


### PR DESCRIPTION
## Summary

Add a `workflow_dispatch` trigger to `browser-e2e.yml` so the maintainer can re-capture login + setup visual baselines from inside CI itself.  When dispatched with `update_baselines = true`, the chromium job runs only the two visual tests with `HOUNDARR_E2E_CAPTURE=1` (writes rendered screenshots to disk instead of asserting) and uploads the resulting PNGs as a `visual-baselines-chromium` artifact.

The maintainer downloads the artifact, commits the PNGs to `tests/e2e_browser/_screenshots/`, and pushes.  Next PR Browser E2E run verifies byte-equal against CI render.

Local `just capture-baselines` runs Playwright inside `mcr.microsoft.com/playwright/python:v1.58.0-jammy`.  That container's font subpixel rendering does not byte-match GitHub's ubuntu-latest runner with `playwright install --with-deps`, so locally-captured PNGs reliably fail CI's strict byte compare.  Capturing on CI is the only path to baselines that survive CI verification.

Closes #538

## Changes

- `.github/workflows/browser-e2e.yml`: add `workflow_dispatch` input `update_baselines`, gate the existing test step on `event_name != workflow_dispatch || input != true`, add capture step + upload-artifact step (chromium only) gated on the dispatch + input.

## Testing

PR-event behaviour is unchanged.  Workflow_dispatch surface verified locally via `actionlint` (no syntax errors).

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has `type:*` and `priority:*` labels
- [x] Branch name matches issue scope
- [x] No secrets committed
- [x] **Scope check**: helps search for missing or cutoff-unmet media in a controlled way
