### PR TITLE
fix(ui): keep cycle left-edge accent visible on hovered log entries

### DIFF
--- a/src/houndarr/static/css/logs.css
+++ b/src/houndarr/static/css/logs.css
@@ -423,7 +423,11 @@
 }
 
 /* Instance accent bar on the left edge; colour comes from the inline
-   --cycle-accent custom property the template sets per article. */
+   --cycle-accent custom property the template sets per article.
+   z-index keeps the bar above .entry:hover's background, which is
+   painted by an inner block element that would otherwise paint over
+   the absolutely-positioned bar and visibly hide the accent on
+   hovered rows. */
 .cycle::before {
   content: "";
   position: absolute;
@@ -433,6 +437,7 @@
   width: 3px;
   background: var(--cycle-accent, var(--color-text-subtle));
   opacity: 0.8;
+  z-index: 1;
 }
 .cycle--system::before { opacity: 0.35; }
 


### PR DESCRIPTION
## Summary

`.cycle::before` paints the 3px instance-coloured bar on the left of every cycle card.  When a user hovers a `skipped` or `info` entry inside the expanded body, the hover background covers the bar because both elements sit at the auto z-layer with later DOM order winning.  Add `z-index: 1` to `.cycle::before` so the accent stays above the entry hover background.

Closes #546

## Changes

- `src/houndarr/static/css/logs.css`: one-line addition (`z-index: 1`) to the `.cycle::before` rule, with a comment line explaining why.

## Testing

`just check` green: 2590 passed, 2 skipped.  CSS source rebuild on next CI run; the bundled output picks up the change automatically.

## Type of Change

- [x] Bug fix (`fix:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has `type:*` and `priority:*` labels
- [x] Branch name matches issue scope
- [x] No secrets committed
- [x] **Scope check**: helps search for missing or cutoff-unmet media in a controlled way
