### PR TITLE
fix(ui): top-anchor cooldown schedule entries on dashboard cards

### DIFF
--- a/src/houndarr/templates/partials/pages/dashboard_content.html
+++ b/src/houndarr/templates/partials/pages/dashboard_content.html
@@ -532,11 +532,19 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    /* Centre a short list vertically in the expanded cooldown box so
-       a 1- or 2-item card doesn't cluster at the top like the empty
-       state used to. 3+ items fill naturally (auto margins collapse
-       to 0 when there's no slack). */
-    margin: auto 0;
+    /* Top-anchored: the outer .dash-unlocks absorbs any vertical
+       slack the grid hands the card so siblings stay height-aligned,
+       but the entries themselves pin to the top of the box.  An
+       earlier rule used `margin: auto 0` to centre short lists, but
+       that produced visible empty rows above and below the entries
+       whenever a neighbour card in the same row was tall enough to
+       stretch this one (long titles, more chips, an error banner).
+       Reads as randomness because the spacing depends on which cards
+       happen to be adjacent in the grid.  Top-anchored avoids that:
+       any extra height shows as space at the bottom only, which the
+       eye reads as "room for more cooldowns" instead of floating
+       entries. */
+    margin: 0;
   }
   .dash-unlocks__row {
     display: grid;


### PR DESCRIPTION
## Summary

`.dash-unlocks__list` previously used `margin: auto 0` to vertically centre the cooldown entries inside the box.  Combined with the outer `.dash-unlocks { flex: 1 1 auto }` (which keeps cards in a grid row at equal height), this pushed the entries to the middle of the box whenever a neighbour card was taller, producing visible empty rows above and below them.  The effect varied card-to-card and refresh-to-refresh because spacing depended on adjacent-card content.

Switch to `margin: 0` so entries pin to the top.  Card-height alignment is preserved by the outer flex; any slack now shows as space at the bottom only.

Closes #548

## Changes

- `src/houndarr/templates/partials/pages/dashboard_content.html`: `.dash-unlocks__list { margin: auto 0 }` → `margin: 0`, plus a comment block explaining the trade-off.

## Testing

`just check` green: 2590 passed, 2 skipped.  Verified locally on the marketing demo seed (six instances; both Sonarr and Radarr cards now show their three cooldown entries flush at the top of the box).

## Type of Change

- [x] Bug fix (`fix:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has `type:*` and `priority:*` labels
- [x] Branch name matches issue scope
- [x] No secrets committed
- [x] **Scope check**: helps search for missing or cutoff-unmet media in a controlled way
