### PR TITLE
ci: restore wave-4 reverts + add marketing skip

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -13,6 +13,7 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+      - "scripts/marketing/**"
 
 permissions:
   checks: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,7 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+      - "scripts/marketing/**"
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,12 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+      - "scripts/marketing/**"
+  schedule:
+    # Weekly arm64 canary every Sunday at 06:00 UTC.  PR builds skip arm64
+    # for speed, so this run is the regular safety net for arm64 regressions
+    # outside the release path.  Not a required check.
+    - cron: "0 6 * * 0"
 
 # Permissions set at job level for least-privilege.
 permissions: {}
@@ -23,16 +29,26 @@ env:
 jobs:
   build:
     name: Build ${{ startsWith(github.ref, 'refs/tags/v') && '+ Push' || '(no push)' }}
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       contents: read
       packages: write
+    env:
+      # Avoid the post-build summary upload that has caused workflow hangs.
+      # See docker/build-push-action#1156.
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # QEMU is only needed when an arm64 build will actually run.
+      # Regular PRs are amd64 native; bump PRs (chore/bump-*) and tag pushes
+      # build the full multi-arch image and need emulation.
       - name: Set up QEMU
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'chore/bump-')
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -59,12 +75,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Regular PRs: amd64 only, no attestations (fast feedback; Trivy still scans).
+      # Bump PRs (chore/bump-*): full multi-arch + provenance/sbom so any arm64
+      # break is caught before the tag push (the actual release).
+      # Tag pushes: same as bump PRs, plus push to GHCR.
       - name: Build (and push on tag)
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'chore/bump-')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
+          provenance: ${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'chore/bump-')) && 'mode=max' || 'false' }}
+          sbom: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.head_ref, 'chore/bump-') }}
           build-args: |
             HOUNDARR_VERSION=${{ steps.meta.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -72,8 +94,42 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  arm64-canary:
+    name: arm64 canary build
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build linux/arm64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/arm64
+          push: false
+          provenance: false
+          sbom: false
+          build-args: |
+            HOUNDARR_VERSION=arm64-canary
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   scan:
     name: Trivy image scan
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build
@@ -100,7 +156,7 @@ jobs:
           cache-from: type=gha
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: houndarr:scan
           format: table
@@ -112,7 +168,7 @@ jobs:
       # Fork PRs lack security-events: write so this step is skipped.
       - name: Run Trivy (SARIF for GitHub Security tab)
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: houndarr:scan
           format: sarif

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,6 +7,7 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+      - "scripts/marketing/**"
 
 permissions:
   contents: read

--- a/.github/workflows/security-smoke-test.yml
+++ b/.github/workflows/security-smoke-test.yml
@@ -7,6 +7,7 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+      - "scripts/marketing/**"
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,7 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+      - "scripts/marketing/**"
   schedule:
     # Every Monday at 09:00 UTC
     - cron: "0 9 * * 1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
       - "**/*.md"
       - "website/**"
       - ".claude/**"
+      - "scripts/marketing/**"
 
 permissions:
   contents: read
@@ -41,8 +42,11 @@ jobs:
           pip install -r requirements-dev.txt
           pip install -e .
 
+      # Run pytest under xdist with worker-per-CPU.  Each test gets its own
+      # tmp_data_dir + per-call respx mocks, so worker isolation holds.
+      # The browser e2e suite is excluded by `norecursedirs` in pyproject.toml.
       - name: Run tests
-        run: python -m pytest -q --tb=short
+        run: python -m pytest -q --tb=short -n auto
 
       - name: Sanity checks
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,6 +567,31 @@ explain what the original observation was actually picking up
 noise), and close the discussion. A correct "no change required" is a
 successful task, not a non-result.
 
+### Known emergent behaviours (already measured)
+
+These are real but minor effects that have been verified by probe and
+deliberately left alone. Do not re-investigate them unless the
+operating point changes or a user reports a concrete regression.
+
+- Partial-last-page over-selection on missing/cutoff under random
+  search order. When the engine's `page_size` does not divide
+  `totalRecords` evenly, items on the (short) last page are drained
+  every visit because the engine dispatches up to `batch_size` items
+  per page. Measured at most 2x attention skew for the 1-9 items on
+  the last page at default settings (batch=1, pageSize=10) and 4x in
+  contrived configurations (batch=5, pageSize=20). Affects a small
+  slice of the backlog; the only clean fix is a virtual flat-index
+  draw which is a substantial redesign of `_run_search_pass`. Probe:
+  `tests/mock_arr/probe_cooldown.py`.
+- Sonarr / Whisparr v2 windowed-rotation coverage time. The upgrade
+  pass visits 5 series per cycle; full-library coverage takes
+  approximately `ceil(eligible_episodes * H / batch)` cycles where H
+  is the harmonic-coverage factor. Measured 91% theoretical and
+  85-89% empirical coverage at 60 cycles with batch=5 on 50 series.
+  This is the intentional trade-off versus hammering one series with
+  a single huge *arr fetch. Probe:
+  `tests/mock_arr/probe_upgrade_coverage.py`.
+
 ---
 
 ## Git & GitHub Workflow

--- a/justfile
+++ b/justfile
@@ -54,6 +54,18 @@ test:
 test-quick:
     {{pytest}} -n {{workers}} -m "not integration"
 
+# Run a filtered subset (single file, single test, keyword, etc.) under
+# the same parallelism + non-integration marker that test-quick uses.
+# Forwards every remaining positional argument straight to pytest.
+# When the first forwarded argument starts with a dash, prefix the
+# command with `just --` so just does not interpret the dash as one of
+# its own options:
+#     just test-one tests/test_errors.py
+#     just test-one tests/test_errors.py::TestInstanceValidationPublicMessage
+#     just -- test-one -k csrf -v
+test-one *ARGS:
+    {{pytest}} -n {{workers}} -m "not integration" {{ARGS}}
+
 test-integration:
     {{pytest}} -n {{workers}} -m integration tests/test_e2e/
 

--- a/scripts/security_smoke_test.sh
+++ b/scripts/security_smoke_test.sh
@@ -270,9 +270,12 @@ if [[ "$AUTHENTICATED" == "1" ]]; then
         fi
     done
 
-    # factory-reset with valid session + CSRF but wrong password must 422
-    # (the endpoint should never redirect unauthenticated, but verify that
-    # the dangerous path is password-gated in builtin mode).
+    # factory-reset with valid session + CSRF but wrong password must reject.
+    # Section 5 just maxed the IP-scoped rate-limit bucket with 7 failed
+    # logins; factory-reset shares that same bucket (security fix #496),
+    # so the first attempt here returns 429 instead of the 422 a fresh-IP
+    # call would get.  Both responses prove the endpoint refused the
+    # destructive action; either is acceptable as a security-gate signal.
     SC=$(curl -s -o "$BODY" -w "%{http_code}" \
         -X POST \
         --max-redirs 0 \
@@ -281,13 +284,13 @@ if [[ "$AUTHENTICATED" == "1" ]]; then
         -H "X-CSRF-Token: ${CSRF_TOKEN}" \
         -d "confirm_phrase=RESET&current_password=definitely-not-the-password" \
         "$HOST/settings/admin/factory-reset" || true)
-    if [[ "$SC" == "422" ]]; then
-        _pass "POST /settings/admin/factory-reset with wrong password -> 422"
+    if [[ "$SC" == "422" || "$SC" == "429" ]]; then
+        _pass "POST /settings/admin/factory-reset with wrong password -> $SC (rejected)"
     else
-        _fail "POST /settings/admin/factory-reset with wrong password -> $SC (expected 422)"
+        _fail "POST /settings/admin/factory-reset with wrong password -> $SC (expected 422 or 429)"
     fi
 
-    # factory-reset with wrong phrase + right password must still 422.
+    # factory-reset with wrong phrase + right password must still reject.
     SC=$(curl -s -o "$BODY" -w "%{http_code}" \
         -X POST \
         --max-redirs 0 \
@@ -296,10 +299,10 @@ if [[ "$AUTHENTICATED" == "1" ]]; then
         -H "X-CSRF-Token: ${CSRF_TOKEN}" \
         -d "confirm_phrase=nope&current_password=${PASSWORD}" \
         "$HOST/settings/admin/factory-reset" || true)
-    if [[ "$SC" == "422" ]]; then
-        _pass "POST /settings/admin/factory-reset with wrong phrase -> 422"
+    if [[ "$SC" == "422" || "$SC" == "429" ]]; then
+        _pass "POST /settings/admin/factory-reset with wrong phrase -> $SC (rejected)"
     else
-        _fail "POST /settings/admin/factory-reset with wrong phrase -> $SC (expected 422)"
+        _fail "POST /settings/admin/factory-reset with wrong phrase -> $SC (expected 422 or 429)"
     fi
 
     # /settings/changelog/full was retired in favour of the GitHub link


### PR DESCRIPTION
Closes #552

## Summary

- Restore `tests.yml` `-n auto` (#451) and `docker.yml` PR-time optimizations (#444): amd64-only on regular PRs, conditional provenance/sbom, QEMU skip, weekly arm64 canary cron, `DOCKER_BUILD_SUMMARY` env vars.
- Restore `AGENTS.md` "Known emergent behaviours" subsection, `justfile` `test-one` recipe, and `scripts/security_smoke_test.sh` rate-limit-tolerant factory-reset assertions (422 or 429).
- Add `scripts/marketing/**` to `paths-ignore` across the six required workflows and the inverse `paths:` filter in `ci-skip.yml` so demo-tool changes do not pull the full pipeline.

## Test plan

- [ ] CI on this PR uses the docs-only / amd64-only fast paths once branch protection settles.
- [ ] `just --list` shows `test-one`.
- [ ] `just test-one tests/test_auth.py` runs the file under `-n auto -m "not integration"`.
- [ ] `grep -n "Known emergent" AGENTS.md` finds the subsection.
- [ ] `grep -n '"429"' scripts/security_smoke_test.sh` shows the rate-limit-tolerant branches.
- [ ] On the marketing-style follow-up, only `CI Skip (docs-only)` reports on the required-check rollup.