### PR TITLE
ci(security): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,11 @@ on:
   schedule:
     # Every Monday at 09:00 UTC
     - cron: "0 9 * * 1"
+  # Manual re-scan handle for when a website-only fix lands and the
+  # next cron is too far out to clear stale alerts.  Most relevant
+  # for pnpm-lock.yaml CVE bumps where the fix PR's paths-ignore
+  # excludes website/** so the PR-time Trivy run is skipped.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #554

## Summary

- Add a bare `workflow_dispatch:` trigger to `.github/workflows/security.yml`.
- Lets the maintainer run `gh workflow run security.yml --ref main` (or the GitHub UI button) to re-scan `main` on demand. Useful when a website-only fix lands and the PR-time Trivy run was skipped by `paths-ignore`, leaving stale alerts open until the next Monday cron.
- Same pattern #539 adopted for `browser-e2e.yml`.

## Test plan

- [ ] Workflow file passes `actionlint` (CI runs it on `.github/workflows/**` changes).
- [ ] After merge, `gh workflow run security.yml --ref main` succeeds.
- [ ] The dispatched run uploads SARIF, and the existing stale alerts (#15, #16, #17) auto-close because the current lockfile already has the fixed `postcss@8.5.12` and `uuid@14.0.0`.