### PR TITLE
fix(db): version-lock CHECK + close PRAGMA tx leak

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,6 +384,24 @@ src/houndarr/
 Full DDL and migrations live in `src/houndarr/database.py`. Bump
 `SCHEMA_VERSION` and add a `_migrate_to_vN` when changing schema.
 
+### Migration constants are version-locked
+
+Rebuild migrations (`CREATE TABLE foo_new ... INSERT INTO foo_new SELECT ...`)
+must reference a snapshot constant frozen at the introducing schema version,
+never the current `_ITEM_TYPES` / `_INSTANCE_TYPES` alias. The snapshots
+(`_ITEM_TYPES_V5`, `_ITEM_TYPES_V10`, `_ITEM_TYPES_V15`, `_ITEM_TYPES_V16`,
+`_INSTANCE_TYPES_V5`, `_INSTANCE_TYPES_V10`) live at the top of `database.py`
+and are immutable after their migration ships. Fresh-install DDL in
+`_SCHEMA_SQL` uses the latest snapshot via the `_ITEM_TYPES` /
+`_INSTANCE_TYPES` aliases.
+
+When adding a migration that renames a value: introduce a new
+`_FOO_TYPES_VN` constant, point the `_FOO_TYPES` alias at it, write the new
+migration with the new constant plus a CASE WHEN translation in its COPY,
+and leave the prior snapshot (and prior migrations) untouched. This prevents
+the class of bug where a later rename retroactively breaks an earlier
+rebuild migration's CHECK clause.
+
 ### *arr API reference (local)
 
 Full upstream OpenAPI specs vendored under `docs/api/` (one per app:

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -18,8 +18,28 @@ SCHEMA_VERSION = 17
 # ---------------------------------------------------------------------------
 # DDL
 # ---------------------------------------------------------------------------
-_INSTANCE_TYPES = "'radarr', 'sonarr', 'lidarr', 'readarr', 'whisparr_v2', 'whisparr_v3'"
-_ITEM_TYPES = "'episode', 'movie', 'album', 'book', 'whisparr_v2_episode', 'whisparr_v3_movie'"
+# Version-locked DDL constants.  Each rebuild migration references the snapshot
+# matching its own schema version so that future renames (e.g. PR #493 rotating
+# 'whisparr_episode' to 'whisparr_v2_episode') cannot retroactively invalidate
+# the CHECK clauses written by earlier migrations.  Never edit a snapshot once
+# its migration has shipped: add a new constant for the migration that performs
+# the rename instead, and update _ITEM_TYPES / _INSTANCE_TYPES below to point at
+# the latest snapshot for fresh-install DDL.
+
+_INSTANCE_TYPES_V5 = "'sonarr', 'radarr', 'lidarr', 'readarr', 'whisparr'"
+_INSTANCE_TYPES_V10 = "'radarr', 'sonarr', 'lidarr', 'readarr', 'whisparr_v2', 'whisparr_v3'"
+
+_ITEM_TYPES_V5 = "'episode', 'movie', 'album', 'book', 'whisparr_episode'"
+_ITEM_TYPES_V10 = "'episode', 'movie', 'album', 'book', 'whisparr_episode', 'whisparr_v3_movie'"
+# v15 rebuilt cooldowns to enforce search_kind CHECK; the item_type list was
+# unchanged, so v15 reuses the v10 snapshot.
+_ITEM_TYPES_V15 = _ITEM_TYPES_V10
+_ITEM_TYPES_V16 = "'episode', 'movie', 'album', 'book', 'whisparr_v2_episode', 'whisparr_v3_movie'"
+
+# Aliases used by _SCHEMA_SQL and the latest-shipped CHECK clauses.  Always
+# point at the most recent snapshot.
+_INSTANCE_TYPES = _INSTANCE_TYPES_V10
+_ITEM_TYPES = _ITEM_TYPES_V16
 
 _SCHEMA_SQL = f"""
 CREATE TABLE IF NOT EXISTS settings (
@@ -277,16 +297,24 @@ async def _migrate_to_v5(db: aiosqlite.Connection) -> None:
     New columns (lidarr/readarr/whisparr search modes) are added afterwards
     via ALTER TABLE since they have defaults.
     """
+    # Flush any pending transaction first.  PRAGMA foreign_keys is a no-op
+    # inside an open transaction (per SQLite docs), and earlier migrations
+    # may have left one open via DML statements.  Without this commit, FK
+    # enforcement stays ON and the DROP TABLE instances below would CASCADE
+    # delete every cooldowns row.
+    await db.commit()
     # Disable FK enforcement during table recreation to prevent CASCADE deletes
     await db.execute("PRAGMA foreign_keys=OFF")
 
     # -- 1) Recreate instances with expanded type CHECK ----------------------
+    # Use the v5 snapshot of _INSTANCE_TYPES so this rebuild stays correct even
+    # when the current alias rotates in a later migration.
     await db.execute(
         f"""
         CREATE TABLE instances_new (
             id                   INTEGER PRIMARY KEY AUTOINCREMENT,
             name                 TEXT    NOT NULL,
-            type                 TEXT    NOT NULL CHECK(type IN ({_INSTANCE_TYPES})),
+            type                 TEXT    NOT NULL CHECK(type IN ({_INSTANCE_TYPES_V5})),
             url                  TEXT    NOT NULL,
             encrypted_api_key    TEXT    NOT NULL DEFAULT '',
             batch_size           INTEGER NOT NULL DEFAULT 2,
@@ -328,13 +356,15 @@ async def _migrate_to_v5(db: aiosqlite.Connection) -> None:
     await db.execute("ALTER TABLE instances_new RENAME TO instances")
 
     # -- 2) Recreate cooldowns with expanded item_type CHECK -----------------
+    # v5 snapshot still allows 'whisparr_episode'; the rename to
+    # 'whisparr_v2_episode' belongs to v16, not here.
     await db.execute(
         f"""
         CREATE TABLE cooldowns_new (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
             instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
             item_id     INTEGER NOT NULL,
-            item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES})),
+            item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES_V5})),
             searched_at TEXT    NOT NULL,
             UNIQUE(instance_id, item_id, item_type)
         )
@@ -343,10 +373,7 @@ async def _migrate_to_v5(db: aiosqlite.Connection) -> None:
     await db.execute(
         """
         INSERT INTO cooldowns_new (id, instance_id, item_id, item_type, searched_at)
-        SELECT id, instance_id, item_id,
-               CASE WHEN item_type = 'whisparr_episode' THEN 'whisparr_v2_episode'
-                    ELSE item_type END,
-               searched_at
+        SELECT id, instance_id, item_id, item_type, searched_at
         FROM cooldowns
         """
     )
@@ -364,7 +391,7 @@ async def _migrate_to_v5(db: aiosqlite.Connection) -> None:
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
             instance_id INTEGER REFERENCES instances(id) ON DELETE SET NULL,
             item_id     INTEGER,
-            item_type   TEXT    CHECK(item_type IN ({_ITEM_TYPES})),
+            item_type   TEXT    CHECK(item_type IN ({_ITEM_TYPES_V5})),
             search_kind TEXT,
             cycle_id    TEXT,
             cycle_trigger TEXT CHECK(cycle_trigger IN ('scheduled', 'run_now', 'system')),
@@ -383,9 +410,7 @@ async def _migrate_to_v5(db: aiosqlite.Connection) -> None:
             cycle_id, cycle_trigger, item_label, action, reason, message, timestamp
         )
         SELECT
-            id, instance_id, item_id,
-            CASE WHEN item_type = 'whisparr_episode' THEN 'whisparr_v2_episode'
-                 ELSE item_type END,
+            id, instance_id, item_id, item_type,
             search_kind, cycle_id, cycle_trigger, item_label, action, reason, message, timestamp
         FROM search_log
         """
@@ -576,6 +601,11 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
         "upgrade_whisparr_v2_search_mode" if v16_already_applied else "upgrade_whisparr_search_mode"
     )
 
+    # Flush any pending transaction so PRAGMA foreign_keys=OFF actually takes
+    # effect.  Without this, v6's UPDATE keeps a transaction open through
+    # v7..v9, the PRAGMA below silently no-ops, and the DROP TABLE instances
+    # CASCADE-wipes every cooldowns row.
+    await db.commit()
     await db.execute("PRAGMA foreign_keys=OFF")
 
     # Guard: clean up any leftover temp tables from a partial previous run.
@@ -584,12 +614,14 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
     await db.execute("DROP TABLE IF EXISTS search_log_new")
 
     # -- 1) Recreate instances with expanded type CHECK + rename whisparr ------
+    # v10 snapshot of _INSTANCE_TYPES locks the CHECK clause to what this
+    # migration introduced; later renames live in their own migrations.
     await db.execute(
         f"""
         CREATE TABLE instances_new (
             id                   INTEGER PRIMARY KEY AUTOINCREMENT,
             name                 TEXT    NOT NULL,
-            type                 TEXT    NOT NULL CHECK(type IN ({_INSTANCE_TYPES})),
+            type                 TEXT    NOT NULL CHECK(type IN ({_INSTANCE_TYPES_V10})),
             url                  TEXT    NOT NULL,
             encrypted_api_key    TEXT    NOT NULL DEFAULT '',
             batch_size           INTEGER NOT NULL DEFAULT 2,
@@ -662,13 +694,16 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
     await db.execute("ALTER TABLE instances_new RENAME TO instances")
 
     # -- 2) Recreate cooldowns with expanded item_type CHECK -------------------
+    # v10 snapshot still allows 'whisparr_episode'; v16 is the migration that
+    # renames it.  Keeping that responsibility in one place keeps each
+    # migration's intent clear.
     await db.execute(
         f"""
         CREATE TABLE cooldowns_new (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
             instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
             item_id     INTEGER NOT NULL,
-            item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES})),
+            item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES_V10})),
             searched_at TEXT    NOT NULL,
             UNIQUE(instance_id, item_id, item_type)
         )
@@ -677,10 +712,7 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
     await db.execute(
         """
         INSERT INTO cooldowns_new (id, instance_id, item_id, item_type, searched_at)
-        SELECT id, instance_id, item_id,
-               CASE WHEN item_type = 'whisparr_episode' THEN 'whisparr_v2_episode'
-                    ELSE item_type END,
-               searched_at
+        SELECT id, instance_id, item_id, item_type, searched_at
         FROM cooldowns
         """
     )
@@ -698,7 +730,7 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
             instance_id INTEGER REFERENCES instances(id) ON DELETE SET NULL,
             item_id     INTEGER,
-            item_type   TEXT    CHECK(item_type IN ({_ITEM_TYPES})),
+            item_type   TEXT    CHECK(item_type IN ({_ITEM_TYPES_V10})),
             search_kind TEXT,
             cycle_id    TEXT,
             cycle_trigger TEXT CHECK(cycle_trigger IN ('scheduled', 'run_now', 'system')),
@@ -718,9 +750,7 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
             reason, message, timestamp
         )
         SELECT
-            id, instance_id, item_id,
-            CASE WHEN item_type = 'whisparr_episode' THEN 'whisparr_v2_episode'
-                 ELSE item_type END,
+            id, instance_id, item_id, item_type,
             search_kind, cycle_id, cycle_trigger, item_label, action,
             reason, message, timestamp
         FROM search_log
@@ -882,12 +912,30 @@ async def _migrate_to_v15(db: aiosqlite.Connection) -> None:
     not reject pre-existing data; such rows should not exist in
     practice (the app writes only valid kinds) but defence-in-depth
     keeps the migration from failing on a corrupted snapshot.
+
+    The item_type CHECK uses ``_ITEM_TYPES_V15``, the version-locked
+    snapshot of the item-type list at v15's introduction, which still
+    allows ``'whisparr_episode'``.  v16 is the migration that renames
+    that value to ``'whisparr_v2_episode'``; binding v15 to the
+    contemporaneous list means a later rename of ``_ITEM_TYPES``
+    cannot retroactively reject pre-rename rows during this rebuild.
     """
     if await _cooldowns_has_search_kind_check(db):
         return
 
+    # Flush any pending transaction so PRAGMA foreign_keys=OFF actually takes
+    # effect.  v14's UPDATE leaves an open transaction; without this commit
+    # the PRAGMA silently no-ops.  v15's DROP is on cooldowns (a child, not
+    # a parent) so CASCADE is not the immediate concern, but committing here
+    # also makes v11..v14's column adds durable on disk before the rebuild.
+    await db.commit()
     await db.execute("PRAGMA foreign_keys=OFF")
     try:
+        # Clean up any leftover temp table from a partial previous run.
+        # Mirrors the same defence in v16; a CHECK violation on the COPY
+        # below would otherwise leave cooldowns_new behind and break retry.
+        await db.execute("DROP TABLE IF EXISTS cooldowns_new")
+
         await db.execute(
             f"""
             CREATE TABLE cooldowns_new (
@@ -895,7 +943,7 @@ async def _migrate_to_v15(db: aiosqlite.Connection) -> None:
                 instance_id INTEGER NOT NULL
                                     REFERENCES instances(id) ON DELETE CASCADE,
                 item_id     INTEGER NOT NULL,
-                item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES})),
+                item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES_V15})),
                 search_kind TEXT    NOT NULL DEFAULT 'missing'
                                     CHECK(search_kind IN ('missing', 'cutoff', 'upgrade')),
                 searched_at TEXT    NOT NULL,
@@ -973,6 +1021,11 @@ async def _migrate_to_v16(db: aiosqlite.Connection) -> None:
     if await _cooldowns_has_v2_item_type_check(db):
         return
 
+    # Flush any pending transaction so PRAGMA foreign_keys=OFF actually takes
+    # effect (it is a no-op inside a transaction).  v15 above ran a rebuild
+    # in the same connection if v14 had pending DML; without this commit the
+    # PRAGMA below would silently no-op.
+    await db.commit()
     await db.execute("PRAGMA foreign_keys=OFF")
     try:
         # Clean up any leftover temp tables from a partial previous run.
@@ -980,6 +1033,9 @@ async def _migrate_to_v16(db: aiosqlite.Connection) -> None:
         await db.execute("DROP TABLE IF EXISTS search_log_new")
 
         # cooldowns rebuild with the v16 item_type CHECK + UPDATE rows.
+        # Use the v16 snapshot — this migration is the rename, so it pins
+        # the post-rename list and is unaffected by future changes to the
+        # current _ITEM_TYPES alias.
         await db.execute(
             f"""
             CREATE TABLE cooldowns_new (
@@ -987,7 +1043,7 @@ async def _migrate_to_v16(db: aiosqlite.Connection) -> None:
                 instance_id INTEGER NOT NULL
                                     REFERENCES instances(id) ON DELETE CASCADE,
                 item_id     INTEGER NOT NULL,
-                item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES})),
+                item_type   TEXT    NOT NULL CHECK(item_type IN ({_ITEM_TYPES_V16})),
                 search_kind TEXT    NOT NULL DEFAULT 'missing'
                                     CHECK(search_kind IN ('missing', 'cutoff', 'upgrade')),
                 searched_at TEXT    NOT NULL,
@@ -1025,7 +1081,7 @@ async def _migrate_to_v16(db: aiosqlite.Connection) -> None:
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
                 instance_id INTEGER REFERENCES instances(id) ON DELETE SET NULL,
                 item_id     INTEGER,
-                item_type   TEXT    CHECK(item_type IN ({_ITEM_TYPES})),
+                item_type   TEXT    CHECK(item_type IN ({_ITEM_TYPES_V16})),
                 search_kind TEXT,
                 cycle_id    TEXT,
                 cycle_trigger TEXT CHECK(cycle_trigger IN ('scheduled', 'run_now', 'system')),

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1070,6 +1070,732 @@ async def test_migrate_to_v15_coerces_invalid_search_kind(tmp_path: Path) -> Non
         ]
 
 
+# ---------------------------------------------------------------------------
+# Historical migration matrix
+# ---------------------------------------------------------------------------
+#
+# Every released schema version must migrate cleanly to current with realistic
+# data, including ``whisparr_episode`` cooldown rows from any v1.1.0+ install
+# that ever ran a Whisparr instance.  The fixtures below emit the
+# contemporaneous DDL for each schema version (literal SQL, no module
+# constants) so the tests are stable against future changes to
+# ``_ITEM_TYPES`` / ``_INSTANCE_TYPES``.
+
+
+def _seed_v4_shaped_db() -> str:
+    """v4-shaped DB (~v1.0.x): pre-Whisparr era.
+
+    Only ``sonarr`` and ``radarr`` instance types; only ``episode`` and
+    ``movie`` item_types.  Drives the longest possible migration chain
+    (v5 → v17) and verifies that v10's rebuild preserves every cooldown
+    row when no transaction-leak from v6 exists at v4 (since v6 has not
+    run yet at the start of this chain — but v6 will run mid-chain).
+    """
+    return """
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO settings (key, value) VALUES ('schema_version', '4');
+
+    CREATE TABLE instances (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL CHECK(type IN ('sonarr','radarr')),
+        url TEXT NOT NULL,
+        encrypted_api_key TEXT NOT NULL DEFAULT '',
+        batch_size INTEGER NOT NULL DEFAULT 2,
+        sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+        hourly_cap INTEGER NOT NULL DEFAULT 4,
+        cooldown_days INTEGER NOT NULL DEFAULT 14,
+        unreleased_delay_hrs INTEGER NOT NULL DEFAULT 36,
+        cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+        cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+        cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+        cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+        sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z',
+        updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+
+    CREATE TABLE cooldowns (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
+        item_id INTEGER NOT NULL,
+        item_type TEXT NOT NULL CHECK(item_type IN ('episode','movie')),
+        searched_at TEXT NOT NULL,
+        UNIQUE(instance_id, item_id, item_type)
+    );
+
+    CREATE TABLE search_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER REFERENCES instances(id) ON DELETE SET NULL,
+        item_id INTEGER,
+        item_type TEXT CHECK(item_type IN ('episode','movie')),
+        search_kind TEXT,
+        cycle_id TEXT,
+        cycle_trigger TEXT,
+        item_label TEXT,
+        action TEXT NOT NULL,
+        reason TEXT,
+        message TEXT,
+        timestamp TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+    """
+
+
+def _seed_v5_shaped_db() -> str:
+    """v5-shaped DB (~v1.1.x): the earliest version where ``whisparr_episode``
+    item_type values exist.  Drives the longest realistic migration chain
+    (v6 → v17) including v6's column drop, v10's rebuild, v15's rebuild,
+    and v16's rename.
+    """
+    return """
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO settings (key, value) VALUES ('schema_version', '5');
+
+    CREATE TABLE instances (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL CHECK(type IN (
+            'sonarr','radarr','lidarr','readarr','whisparr'
+        )),
+        url TEXT NOT NULL,
+        encrypted_api_key TEXT NOT NULL DEFAULT '',
+        batch_size INTEGER NOT NULL DEFAULT 2,
+        sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+        hourly_cap INTEGER NOT NULL DEFAULT 4,
+        cooldown_days INTEGER NOT NULL DEFAULT 14,
+        unreleased_delay_hrs INTEGER NOT NULL DEFAULT 36,
+        cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+        cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+        cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+        cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+        sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+        readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+        whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z',
+        updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+
+    CREATE TABLE cooldowns (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
+        item_id INTEGER NOT NULL,
+        item_type TEXT NOT NULL CHECK(item_type IN (
+            'episode','movie','album','book','whisparr_episode'
+        )),
+        searched_at TEXT NOT NULL,
+        UNIQUE(instance_id, item_id, item_type)
+    );
+
+    CREATE TABLE search_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER REFERENCES instances(id) ON DELETE SET NULL,
+        item_id INTEGER,
+        item_type TEXT CHECK(item_type IN (
+            'episode','movie','album','book','whisparr_episode'
+        )),
+        search_kind TEXT,
+        cycle_id TEXT,
+        cycle_trigger TEXT,
+        item_label TEXT,
+        action TEXT NOT NULL,
+        reason TEXT,
+        message TEXT,
+        timestamp TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+    """
+
+
+def _seed_v7_shaped_db() -> str:
+    """v7-shaped DB (~v1.2.x .. v1.5.0): v6 already ran (post_release_grace_hrs
+    in place of unreleased_delay_hrs) plus v7's ``queue_limit``.  No upgrade_*
+    columns yet (v8) and no page_offset (v9).
+    """
+    return """
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO settings (key, value) VALUES ('schema_version', '7');
+
+    CREATE TABLE instances (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL CHECK(type IN (
+            'sonarr','radarr','lidarr','readarr','whisparr'
+        )),
+        url TEXT NOT NULL,
+        encrypted_api_key TEXT NOT NULL DEFAULT '',
+        batch_size INTEGER NOT NULL DEFAULT 2,
+        sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+        hourly_cap INTEGER NOT NULL DEFAULT 4,
+        cooldown_days INTEGER NOT NULL DEFAULT 14,
+        post_release_grace_hrs INTEGER NOT NULL DEFAULT 6,
+        queue_limit INTEGER NOT NULL DEFAULT 0,
+        cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+        cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+        cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+        cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+        sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+        readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+        whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z',
+        updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+
+    CREATE TABLE cooldowns (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
+        item_id INTEGER NOT NULL,
+        item_type TEXT NOT NULL CHECK(item_type IN (
+            'episode','movie','album','book','whisparr_episode'
+        )),
+        searched_at TEXT NOT NULL,
+        UNIQUE(instance_id, item_id, item_type)
+    );
+
+    CREATE TABLE search_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER REFERENCES instances(id) ON DELETE SET NULL,
+        item_id INTEGER,
+        item_type TEXT CHECK(item_type IN (
+            'episode','movie','album','book','whisparr_episode'
+        )),
+        search_kind TEXT,
+        cycle_id TEXT,
+        cycle_trigger TEXT,
+        item_label TEXT,
+        action TEXT NOT NULL,
+        reason TEXT,
+        message TEXT,
+        timestamp TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+    """
+
+
+def _seed_v8_shaped_db() -> str:
+    """v8-shaped DB (~v1.6.0 .. v1.6.2): v7 plus the upgrade_* columns."""
+    return (
+        _seed_v7_shaped_db()
+        .replace(
+            "INSERT INTO settings (key, value) VALUES ('schema_version', '7');",
+            "INSERT INTO settings (key, value) VALUES ('schema_version', '8');",
+        )
+        .replace(
+            "whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',",
+            "whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',\n        "
+            "upgrade_enabled INTEGER NOT NULL DEFAULT 0,\n        "
+            "upgrade_batch_size INTEGER NOT NULL DEFAULT 1,\n        "
+            "upgrade_cooldown_days INTEGER NOT NULL DEFAULT 90,\n        "
+            "upgrade_hourly_cap INTEGER NOT NULL DEFAULT 1,\n        "
+            "upgrade_sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',\n        "
+            "upgrade_lidarr_search_mode TEXT NOT NULL DEFAULT 'album',\n        "
+            "upgrade_readarr_search_mode TEXT NOT NULL DEFAULT 'book',\n        "
+            "upgrade_whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',\n        "
+            "upgrade_item_offset INTEGER NOT NULL DEFAULT 0,\n        "
+            "upgrade_series_offset INTEGER NOT NULL DEFAULT 0,",
+        )
+    )
+
+
+def _seed_v9_shaped_db() -> str:
+    """Return the DDL for a v9-shaped database (~v1.6.x).
+
+    v9 still uses the v5 ``_INSTANCE_TYPES`` (singular ``whisparr``) and the
+    v5 ``_ITEM_TYPES`` (allows ``whisparr_episode``, no ``whisparr_v3_movie``).
+    Adds ``missing_page_offset`` / ``cutoff_page_offset`` from v9.
+    """
+    return """
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO settings (key, value) VALUES ('schema_version', '9');
+
+    CREATE TABLE instances (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL CHECK(type IN (
+            'sonarr','radarr','lidarr','readarr','whisparr'
+        )),
+        url TEXT NOT NULL,
+        encrypted_api_key TEXT NOT NULL DEFAULT '',
+        batch_size INTEGER NOT NULL DEFAULT 2,
+        sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+        hourly_cap INTEGER NOT NULL DEFAULT 4,
+        cooldown_days INTEGER NOT NULL DEFAULT 14,
+        post_release_grace_hrs INTEGER NOT NULL DEFAULT 6,
+        queue_limit INTEGER NOT NULL DEFAULT 0,
+        cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+        cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+        cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+        cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+        sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+        readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+        whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        upgrade_enabled INTEGER NOT NULL DEFAULT 0,
+        upgrade_batch_size INTEGER NOT NULL DEFAULT 1,
+        upgrade_cooldown_days INTEGER NOT NULL DEFAULT 90,
+        upgrade_hourly_cap INTEGER NOT NULL DEFAULT 1,
+        upgrade_sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        upgrade_lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+        upgrade_readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+        upgrade_whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        upgrade_item_offset INTEGER NOT NULL DEFAULT 0,
+        upgrade_series_offset INTEGER NOT NULL DEFAULT 0,
+        missing_page_offset INTEGER NOT NULL DEFAULT 1,
+        cutoff_page_offset INTEGER NOT NULL DEFAULT 1,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z',
+        updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+
+    CREATE TABLE cooldowns (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
+        item_id INTEGER NOT NULL,
+        item_type TEXT NOT NULL CHECK(item_type IN (
+            'episode','movie','album','book','whisparr_episode'
+        )),
+        searched_at TEXT NOT NULL,
+        UNIQUE(instance_id, item_id, item_type)
+    );
+
+    CREATE TABLE search_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER REFERENCES instances(id) ON DELETE SET NULL,
+        item_id INTEGER,
+        item_type TEXT CHECK(item_type IN (
+            'episode','movie','album','book','whisparr_episode'
+        )),
+        search_kind TEXT,
+        cycle_id TEXT,
+        cycle_trigger TEXT,
+        item_label TEXT,
+        action TEXT NOT NULL,
+        reason TEXT,
+        message TEXT,
+        timestamp TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+    """
+
+
+def _seed_v10_shaped_db() -> str:
+    """v10-shaped DB (~v1.7.0): type CHECK rebuilt to whisparr_v2/whisparr_v3."""
+    return """
+    CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO settings (key, value) VALUES ('schema_version', '10');
+
+    CREATE TABLE instances (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        type TEXT NOT NULL CHECK(type IN (
+            'radarr','sonarr','lidarr','readarr','whisparr_v2','whisparr_v3'
+        )),
+        url TEXT NOT NULL,
+        encrypted_api_key TEXT NOT NULL DEFAULT '',
+        batch_size INTEGER NOT NULL DEFAULT 2,
+        sleep_interval_mins INTEGER NOT NULL DEFAULT 30,
+        hourly_cap INTEGER NOT NULL DEFAULT 4,
+        cooldown_days INTEGER NOT NULL DEFAULT 14,
+        post_release_grace_hrs INTEGER NOT NULL DEFAULT 6,
+        queue_limit INTEGER NOT NULL DEFAULT 0,
+        cutoff_enabled INTEGER NOT NULL DEFAULT 0,
+        cutoff_batch_size INTEGER NOT NULL DEFAULT 1,
+        cutoff_cooldown_days INTEGER NOT NULL DEFAULT 21,
+        cutoff_hourly_cap INTEGER NOT NULL DEFAULT 1,
+        sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+        readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+        whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        upgrade_enabled INTEGER NOT NULL DEFAULT 0,
+        upgrade_batch_size INTEGER NOT NULL DEFAULT 1,
+        upgrade_cooldown_days INTEGER NOT NULL DEFAULT 90,
+        upgrade_hourly_cap INTEGER NOT NULL DEFAULT 1,
+        upgrade_sonarr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        upgrade_lidarr_search_mode TEXT NOT NULL DEFAULT 'album',
+        upgrade_readarr_search_mode TEXT NOT NULL DEFAULT 'book',
+        upgrade_whisparr_search_mode TEXT NOT NULL DEFAULT 'episode',
+        upgrade_item_offset INTEGER NOT NULL DEFAULT 0,
+        upgrade_series_offset INTEGER NOT NULL DEFAULT 0,
+        missing_page_offset INTEGER NOT NULL DEFAULT 1,
+        cutoff_page_offset INTEGER NOT NULL DEFAULT 1,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z',
+        updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+
+    CREATE TABLE cooldowns (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER NOT NULL REFERENCES instances(id) ON DELETE CASCADE,
+        item_id INTEGER NOT NULL,
+        item_type TEXT NOT NULL CHECK(item_type IN (
+            'episode','movie','album','book','whisparr_episode','whisparr_v3_movie'
+        )),
+        searched_at TEXT NOT NULL,
+        UNIQUE(instance_id, item_id, item_type)
+    );
+
+    CREATE TABLE search_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        instance_id INTEGER REFERENCES instances(id) ON DELETE SET NULL,
+        item_id INTEGER,
+        item_type TEXT CHECK(item_type IN (
+            'episode','movie','album','book','whisparr_episode','whisparr_v3_movie'
+        )),
+        search_kind TEXT,
+        cycle_id TEXT,
+        cycle_trigger TEXT,
+        item_label TEXT,
+        action TEXT NOT NULL,
+        reason TEXT,
+        message TEXT,
+        timestamp TEXT NOT NULL DEFAULT '2024-01-01T00:00:00.000Z'
+    );
+    """
+
+
+def _seed_v11_shaped_db() -> str:
+    """v11-shaped DB (~v1.8.0): adds allowed_time_window."""
+    return (
+        _seed_v10_shaped_db()
+        .replace(
+            "INSERT INTO settings (key, value) VALUES ('schema_version', '10');",
+            "INSERT INTO settings (key, value) VALUES ('schema_version', '11');",
+        )
+        .replace(
+            "missing_page_offset INTEGER NOT NULL DEFAULT 1,",
+            "missing_page_offset INTEGER NOT NULL DEFAULT 1,\n        "
+            "allowed_time_window TEXT NOT NULL DEFAULT '',",
+        )
+    )
+
+
+def _seed_v12_shaped_db() -> str:
+    """v12-shaped DB (~v1.9.0): adds search_order.
+
+    This is the regression-of-record fixture: a Whisparr v2 user on v1.9.0
+    upgrading to next-release hits ``_migrate_to_v15`` first, which used to
+    rebuild ``cooldowns`` with a CHECK that no longer allowed
+    ``whisparr_episode`` rows.
+    """
+    return (
+        _seed_v11_shaped_db()
+        .replace(
+            "INSERT INTO settings (key, value) VALUES ('schema_version', '11');",
+            "INSERT INTO settings (key, value) VALUES ('schema_version', '12');",
+        )
+        .replace(
+            "allowed_time_window TEXT NOT NULL DEFAULT '',",
+            "allowed_time_window TEXT NOT NULL DEFAULT '',\n        "
+            "search_order TEXT NOT NULL DEFAULT 'chronological',",
+        )
+    )
+
+
+def _whisparr_v2_seed_inserts(version: int) -> str:
+    """INSERTs that exercise the rename path: a Whisparr v2 instance plus
+    cooldowns/search_log rows carrying the pre-v16 ``whisparr_episode`` value.
+    """
+    instance_type = "whisparr" if version <= 9 else "whisparr_v2"
+    return f"""
+    INSERT INTO instances (id, name, type, url) VALUES
+        (1, 'Sonarr Test', 'sonarr', 'http://sonarr:8989'),
+        (2, 'Whisparr v2 Test', '{instance_type}', 'http://whisparr:6969');
+
+    INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at) VALUES
+        (1, 100, 'episode',          '2024-06-01T00:00:00.000Z'),
+        (2, 200, 'whisparr_episode', '2024-06-02T00:00:00.000Z'),
+        (2, 201, 'whisparr_episode', '2024-06-03T00:00:00.000Z'),
+        (2, 202, 'whisparr_episode', '2024-06-04T00:00:00.000Z');
+
+    INSERT INTO search_log
+        (instance_id, item_id, item_type, action, timestamp) VALUES
+        (1, 100, 'episode',          'searched', '2024-06-01T00:00:00.000Z'),
+        (2, 200, 'whisparr_episode', 'searched', '2024-06-02T00:00:00.000Z'),
+        (2, 201, 'whisparr_episode', 'skipped',  '2024-06-03T00:00:00.000Z');
+    """
+
+
+@pytest.mark.asyncio()
+@pytest.mark.parametrize(
+    ("source_version", "ddl_builder"),
+    [
+        (5, _seed_v5_shaped_db),
+        (7, _seed_v7_shaped_db),
+        (8, _seed_v8_shaped_db),
+        (9, _seed_v9_shaped_db),
+        (10, _seed_v10_shaped_db),
+        (11, _seed_v11_shaped_db),
+        (12, _seed_v12_shaped_db),
+    ],
+)
+async def test_init_db_migrates_whisparr_episode_rows_through_to_current(
+    tmp_path: Path,
+    source_version: int,
+    ddl_builder: object,
+) -> None:
+    """Every released schema version 9..12 must migrate to current cleanly,
+    even when ``cooldowns`` and ``search_log`` carry pre-v16 ``whisparr_episode``
+    rows.  Regression test for the bug where ``_migrate_to_v15`` used the
+    current ``_ITEM_TYPES`` (which no longer allows ``whisparr_episode``) for
+    its rebuild CHECK and crashed on the COPY before ``_migrate_to_v16`` could
+    do the rename.
+    """
+    db_path = tmp_path / f"v{source_version}.db"
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        # pyright doesn't understand the parametrize-supplied callable; we
+        # only ever pass the four module-level functions defined above.
+        await conn.executescript(ddl_builder())  # type: ignore[operator]
+        await conn.executescript(_whisparr_v2_seed_inserts(source_version))
+        await conn.commit()
+
+    set_db_path(str(db_path))
+    await init_db()
+
+    async with get_db() as conn:
+        # 1. Schema version landed at current.
+        async with conn.execute("SELECT value FROM settings WHERE key = 'schema_version'") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == "17"
+
+        # 2. The Whisparr v2 cooldown rows survived and were renamed.
+        async with conn.execute(
+            "SELECT item_id, item_type, search_kind FROM cooldowns"
+            " WHERE instance_id = 2 ORDER BY item_id"
+        ) as cur:
+            cooldown_rows = [(int(r[0]), str(r[1]), str(r[2])) async for r in cur]
+        assert cooldown_rows == [
+            (200, "whisparr_v2_episode", "missing"),
+            (201, "whisparr_v2_episode", "missing"),
+            (202, "whisparr_v2_episode", "missing"),
+        ]
+
+        # 3. search_log rows likewise renamed (v16 rebuilds search_log too).
+        async with conn.execute(
+            "SELECT item_id, item_type, action FROM search_log"
+            " WHERE instance_id = 2 ORDER BY item_id"
+        ) as cur:
+            log_rows = [(int(r[0]), str(r[1]), str(r[2])) async for r in cur]
+        assert log_rows == [
+            (200, "whisparr_v2_episode", "searched"),
+            (201, "whisparr_v2_episode", "skipped"),
+        ]
+
+        # 4. Both tables now carry the v16 CHECK clause.
+        async with conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table'"
+            " AND name IN ('cooldowns','search_log')"
+        ) as cur:
+            ddls = {str(r[0] or "") async for r in cur}
+        for ddl in ddls:
+            assert "whisparr_v2_episode" in ddl
+            assert "whisparr_episode'" not in ddl  # the trailing quote keeps
+            # 'whisparr_v2_episode' from satisfying the substring check
+
+        # 5. cooldowns also carries the v15 search_kind CHECK clause.
+        async with conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='cooldowns'"
+        ) as cur:
+            cooldowns_ddl = (await cur.fetchone())[0]  # type: ignore[index]
+        compact = "".join(str(cooldowns_ddl or "").split())
+        assert "CHECK(search_kindIN" in compact
+
+        # 6. The Whisparr v2 instance row was migrated and the column rename
+        #    landed (v10 + v16).
+        async with conn.execute("SELECT type FROM instances WHERE id = 2") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == "whisparr_v2"
+        async with conn.execute("PRAGMA table_info(instances)") as cur:
+            instance_columns = {r[1] async for r in cur}
+        assert "whisparr_v2_search_mode" in instance_columns
+        assert "upgrade_whisparr_v2_search_mode" in instance_columns
+        assert "upgrade_series_window_size" in instance_columns
+        assert "monitored_total" in instance_columns
+        assert "snapshot_refreshed_at" in instance_columns
+
+        # 7. No leftover *_new tables from rebuild migrations.
+        async with conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '%_new'"
+        ) as cur:
+            leftovers = [r[0] async for r in cur]
+        assert leftovers == []
+
+    # 8. Idempotency: running init_db a second time on the migrated DB must
+    #    be a clean no-op (the self-heal block runs every startup).
+    await init_db()
+    async with get_db() as conn:
+        async with conn.execute("SELECT COUNT(*) FROM cooldowns WHERE instance_id = 2") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 3
+
+
+@pytest.mark.asyncio()
+async def test_init_db_migrates_v4_preserves_cooldowns_through_v10_rebuild(
+    tmp_path: Path,
+) -> None:
+    """v4 (~v1.0.x) was the pre-Whisparr era: only sonarr/radarr instances and
+    only ``episode`` / ``movie`` cooldowns.  The v4 → v17 chain runs through
+    v6 (UPDATE leaves a transaction open) and v10 (rebuilds instances).
+    Without the commit added at the start of v10, ``PRAGMA foreign_keys=OFF``
+    silently no-ops inside the still-open transaction, FK enforcement stays
+    on, and the DROP TABLE instances CASCADE-wipes every cooldown row.
+    This test would have failed before the fix.
+    """
+    db_path = tmp_path / "v4.db"
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await conn.executescript(_seed_v4_shaped_db())
+        await conn.executescript(
+            """
+            INSERT INTO instances (id, name, type, url) VALUES
+                (1, 'Sonarr Test', 'sonarr', 'http://sonarr:8989'),
+                (2, 'Radarr Test', 'radarr', 'http://radarr:7878');
+
+            INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at) VALUES
+                (1, 100, 'episode', '2024-06-01T00:00:00.000Z'),
+                (1, 101, 'episode', '2024-06-02T00:00:00.000Z'),
+                (2, 200, 'movie',   '2024-06-03T00:00:00.000Z'),
+                (2, 201, 'movie',   '2024-06-04T00:00:00.000Z');
+
+            INSERT INTO search_log
+                (instance_id, item_id, item_type, action, timestamp) VALUES
+                (1, 100, 'episode', 'searched', '2024-06-01T00:00:00.000Z'),
+                (2, 200, 'movie',   'searched', '2024-06-03T00:00:00.000Z');
+            """
+        )
+        await conn.commit()
+
+    set_db_path(str(db_path))
+    await init_db()
+
+    async with get_db() as conn:
+        async with conn.execute("SELECT value FROM settings WHERE key = 'schema_version'") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == "17"
+
+        # All four cooldown rows must survive the v10 instances rebuild.
+        async with conn.execute(
+            "SELECT instance_id, item_id, item_type FROM cooldowns ORDER BY item_id"
+        ) as cur:
+            rows = [(int(r[0]), int(r[1]), str(r[2])) async for r in cur]
+        assert rows == [
+            (1, 100, "episode"),
+            (1, 101, "episode"),
+            (2, 200, "movie"),
+            (2, 201, "movie"),
+        ]
+
+        # search_log rows survive too (FK is ON DELETE SET NULL, so even
+        # without the commit fix the rows would survive — but instance_id
+        # would have been NULLed).  With the fix, the FK reference is
+        # preserved.
+        async with conn.execute(
+            "SELECT instance_id, item_id FROM search_log ORDER BY item_id"
+        ) as cur:
+            log_rows = [(r[0], int(r[1])) async for r in cur]
+        assert log_rows == [(1, 100), (2, 200)]
+
+
+@pytest.mark.asyncio()
+async def test_init_db_self_heals_v17_with_whisparr_v2_data(tmp_path: Path) -> None:
+    """An already-migrated v17 database with whisparr_v2_episode data must
+    pass through ``init_db`` unchanged: every self-heal migration's idempotency
+    guard fires and returns early.
+    """
+    db_path = tmp_path / "healthy-v17.db"
+
+    set_db_path(str(db_path))
+    await init_db()
+
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+            " VALUES (1, 'Whisparr v2', 'whisparr_v2', 'http://w:6969', 'fake')"
+        )
+        await conn.execute(
+            "INSERT INTO cooldowns (instance_id, item_id, item_type, search_kind, searched_at)"
+            " VALUES (1, 999, 'whisparr_v2_episode', 'missing', '2026-01-01T00:00:00.000Z')"
+        )
+        await conn.commit()
+
+    # Second init_db must be a no-op: no exception, data preserved.
+    await init_db()
+
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT item_type, search_kind FROM cooldowns WHERE item_id = 999"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == "whisparr_v2_episode"
+        assert row[1] == "missing"
+
+        async with conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '%_new'"
+        ) as cur:
+            leftovers = [r[0] async for r in cur]
+        assert leftovers == []
+
+
+@pytest.mark.asyncio()
+async def test_migrate_to_v15_recovers_from_partial_previous_run(
+    tmp_path: Path,
+) -> None:
+    """If a previous run of ``_migrate_to_v15`` crashed after CREATE TABLE
+    cooldowns_new but before DROP/RENAME, the next startup must recover by
+    dropping the leftover and retrying.  The fix adds DROP TABLE IF EXISTS at
+    the top of v15's body, mirroring v16.
+    """
+    db_path = tmp_path / "partial-v15.db"
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        # v14-shaped schema (so v15 will run) plus a dangling cooldowns_new.
+        await conn.executescript(_seed_v12_shaped_db())
+        await conn.executescript(_whisparr_v2_seed_inserts(12))
+        await conn.execute("UPDATE settings SET value = '14' WHERE key = 'schema_version'")
+        # Add the v14 search_kind column (NOT NULL DEFAULT 'missing') without
+        # the v15 CHECK so v15 will rebuild.
+        await conn.execute(
+            "ALTER TABLE cooldowns ADD COLUMN search_kind TEXT NOT NULL DEFAULT 'missing'"
+        )
+        # Simulate a leftover from a crashed previous v15 run.
+        await conn.executescript(
+            """
+            CREATE TABLE cooldowns_new (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                instance_id INTEGER NOT NULL,
+                item_id     INTEGER NOT NULL,
+                item_type   TEXT    NOT NULL,
+                search_kind TEXT    NOT NULL DEFAULT 'missing',
+                searched_at TEXT    NOT NULL,
+                UNIQUE(instance_id, item_id, item_type)
+            );
+            """
+        )
+        await conn.commit()
+
+    set_db_path(str(db_path))
+    await init_db()  # must not raise "table cooldowns_new already exists"
+
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '%_new'"
+        ) as cur:
+            leftovers = [r[0] async for r in cur]
+        assert leftovers == []
+        async with conn.execute(
+            "SELECT COUNT(*) FROM cooldowns WHERE item_type = 'whisparr_v2_episode'"
+        ) as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row[0] == 3
+
+
 @pytest.mark.asyncio()
 async def test_set_and_get_setting(db: None) -> None:
     """set_setting / get_setting round-trip."""


### PR DESCRIPTION
## Summary

Closes #558

Fixes two upgrade-time data-safety bugs in `database.py`:

1. `_migrate_to_v15` used the current `_ITEM_TYPES` alias for its rebuild CHECK, so any pre-v16 `whisparr_episode` cooldown row crashes `init_db` on the COPY before `_migrate_to_v16` can rename it. Affects every v1.7.0-v1.9.0 user with a Whisparr v2 instance.
2. `PRAGMA foreign_keys=OFF` is a no-op inside an open transaction. `_migrate_to_v6`'s `UPDATE` leaves one open through v7-v9, so `_migrate_to_v10`'s PRAGMA silently fails and `DROP TABLE instances` CASCADE-wipes every cooldowns row. Affects every v1.0.x / v1.1.x user who upgraded to v1.7.0+.

## Changes

- Introduce version-locked DDL snapshot constants (`_ITEM_TYPES_V5`, `_V10`, `_V15`, `_V16`, `_INSTANCE_TYPES_V5`, `_V10`). Each rebuild migration references the snapshot frozen at its own schema version. `_ITEM_TYPES` / `_INSTANCE_TYPES` remain as aliases that always point at the latest snapshot for fresh-install DDL.
- `_migrate_to_v5`, `_v10`, `_v15`, `_v16` reference their version-locked constant. CASE WHEN translations dropped from v5 and v10 (they were anachronistic compensation for the brittle constant reuse); v16 keeps its CASE WHEN.
- `await db.commit()` before `PRAGMA foreign_keys=OFF` in v5, v10, v15, v16 so the PRAGMA actually takes effect.
- `DROP TABLE IF EXISTS cooldowns_new` at the start of v15 for partial-failure recovery.
- New parametrized historical-migration test covering every shipped schema version (4, 5, 7, 8, 9, 10, 11, 12) with realistic Whisparr v2 cooldown and search_log seed data; v17 self-heal idempotency; v15 partial-crash recovery; v4 -> v17 cooldown preservation through v10's rebuild.
- AGENTS.md note documenting the version-locked constants pattern for future migrations.

## Test plan

- [x] `just test tests/test_database.py` passes (32 cases, including 8 new historical-migration parametrize cases plus partial-crash and idempotency tests).
- [x] `just check` passes (lint, fmt-check, mypy, bandit, full pytest: 2595 passed).
- [x] End-to-end smoke: every shipped schema version (`{4, 5, 7, 8, 9, 10, 11, 12, 17}`) -> v17 with diverse seeded data + triple `init_db` preserves every cooldown row, renames every `whisparr_episode` to `whisparr_v2_episode`, and leaves no `*_new` tables behind.
- [x] Negative test: post-migration cooldowns CHECK still rejects `'whisparr_episode'` and arbitrary invalid item_types (no silent loosening).