### PR TITLE
fix(supervisor): catch ClientTransportError on soft-fail paths

### DIFF
--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -25,7 +25,7 @@ from houndarr.engine.adapters.protocols import AppAdapterProto
 from houndarr.engine.retry import ReconnectState, run_with_reconnect
 from houndarr.engine.search_loop import _write_log, run_instance_search
 from houndarr.enums import CycleTrigger, SearchAction
-from houndarr.errors import ClientError, EngineError
+from houndarr.errors import ClientError, ClientTransportError, EngineError
 from houndarr.services.cooldown_reconcile import reconcile_cooldowns
 from houndarr.services.instances import (
     Instance,
@@ -371,7 +371,12 @@ class Supervisor:
                     cycle_trigger=cycle_trigger,
                 )
                 return False
-            except httpx.TransportError:
+            except (httpx.TransportError, ClientTransportError):
+                # ``ClientTransportError`` is the typed wrapper the *arr
+                # clients raise instead of the raw ``httpx.TransportError``
+                # since the typed-error refactor; both mean the same
+                # thing here (instance unreachable) and must take the
+                # same warning + retry path.
                 logger.warning(
                     "Supervisor: could not reach %r (%s); retrying in %d s",
                     instance.core.name,
@@ -475,7 +480,7 @@ class Supervisor:
                     snap = await adapter.fetch_instance_snapshot(client, instance)
                     try:
                         reconcile_sets = await adapter.fetch_reconcile_sets(client, instance)
-                    except httpx.TransportError:
+                    except (httpx.TransportError, ClientTransportError):
                         reconcile_sets = ReconcileSets.empty()
                         logger.debug(
                             "Supervisor: reconcile sets unreachable for %r; "
@@ -514,7 +519,7 @@ class Supervisor:
                     unreleased_count=snap.unreleased_count,
                 )
                 await reconcile_cooldowns(instance.core.id, reconcile_sets)
-            except httpx.TransportError:
+            except (httpx.TransportError, ClientTransportError):
                 logger.debug(
                     "Supervisor: snapshot refresh skipped for %r; instance unreachable",
                     instance.core.name,

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -15,6 +15,7 @@ from cryptography.fernet import Fernet
 from houndarr.database import get_db
 from houndarr.engine import supervisor as _supervisor_mod
 from houndarr.engine.supervisor import Supervisor
+from houndarr.errors import ClientTransportError
 from houndarr.services.instances import (
     CutoffPolicy,
     Instance,
@@ -525,16 +526,33 @@ async def test_refresh_one_snapshot_quiet_on_small_unreleased_change(
     assert matching == []
 
 
+@pytest.mark.parametrize(
+    "transport_exc",
+    [
+        httpx.TransportError("unreachable"),
+        ClientTransportError("wanted total: transport error reaching /api/v3/wanted/missing"),
+    ],
+    ids=["httpx_transport", "client_transport"],
+)
 @pytest.mark.asyncio()
 async def test_refresh_all_snapshots_handles_transport_error(
     seeded_instances: None,
+    caplog: pytest.LogCaptureFixture,
+    transport_exc: BaseException,
 ) -> None:
-    """Transport errors are logged and suppressed; snapshot stays as-is."""
+    """Transport errors are logged at DEBUG and suppressed; no traceback escapes.
+
+    Pinned for both ``httpx.TransportError`` (the raw transport failure) and
+    ``ClientTransportError`` (the typed wrapper *arr clients raise after the
+    typed-error refactor). Both must take the silent-skip branch; the typed
+    wrapper used to fall through to the broad ``except Exception`` and emit a
+    full traceback every refresh interval.
+    """
     inst = _make_instance(enabled=True)
 
     class _BrokenCtx:
         async def __aenter__(self) -> Any:
-            raise httpx.TransportError("unreachable")
+            raise transport_exc
 
         async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
             return None
@@ -546,9 +564,120 @@ async def test_refresh_all_snapshots_handles_transport_error(
     )()
 
     with (
+        caplog.at_level("DEBUG", logger="houndarr.engine.supervisor"),
         patch("houndarr.engine.supervisor.list_instances", AsyncMock(return_value=[inst])),
         patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
         # Should not raise.
         await supervisor._refresh_all_snapshots_once()  # noqa: SLF001
+
+    error_records = [r for r in caplog.records if r.levelname in {"ERROR", "CRITICAL"}]
+    assert error_records == [], (
+        f"transport error should not log at ERROR; got {[r.getMessage() for r in error_records]}"
+    )
+    debug_msgs = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    assert any("snapshot refresh skipped" in msg for msg in debug_msgs), (
+        f"expected DEBUG skip log, got: {debug_msgs}"
+    )
+
+
+@pytest.mark.parametrize(
+    "reconcile_exc",
+    [
+        httpx.TransportError("unreachable"),
+        ClientTransportError("reconcile fetch: transport error reaching /api/v3/series"),
+    ],
+    ids=["httpx_transport", "client_transport"],
+)
+@pytest.mark.asyncio()
+async def test_refresh_one_snapshot_reconcile_transport_error_keeps_cooldowns(
+    seeded_instances: None,
+    caplog: pytest.LogCaptureFixture,
+    reconcile_exc: BaseException,
+) -> None:
+    """A transport error inside reconcile fetch falls back to empty without ERROR.
+
+    Snapshot fetch succeeds; reconcile fetch raises. The supervisor swallows
+    both raw and typed transport errors here so a transient *arr blip cannot
+    trigger a cooldown wipe.
+    """
+    from houndarr.clients.base import InstanceSnapshot
+
+    inst = _make_instance(enabled=True)
+
+    fake_client = AsyncMock()
+
+    class _CtxClient:
+        async def __aenter__(self) -> Any:
+            return fake_client
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+    fake_adapter = type(
+        "FakeAdapter",
+        (),
+        {
+            "make_client": staticmethod(lambda _inst: _CtxClient()),
+            "fetch_instance_snapshot": staticmethod(
+                AsyncMock(return_value=InstanceSnapshot(monitored_total=10, unreleased_count=0))
+            ),
+            "fetch_reconcile_sets": staticmethod(AsyncMock(side_effect=reconcile_exc)),
+        },
+    )()
+
+    with (
+        caplog.at_level("DEBUG", logger="houndarr.engine.supervisor"),
+        patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        # Should not raise.
+        await supervisor._refresh_one_snapshot(inst)  # noqa: SLF001
+
+    error_records = [r for r in caplog.records if r.levelname in {"ERROR", "CRITICAL"}]
+    assert error_records == [], (
+        f"reconcile transport error should not log at ERROR; got "
+        f"{[r.getMessage() for r in error_records]}"
+    )
+    debug_msgs = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    assert any("reconcile sets unreachable" in msg for msg in debug_msgs), (
+        f"expected DEBUG reconcile-skip log, got: {debug_msgs}"
+    )
+
+
+@pytest.mark.parametrize(
+    "transport_exc",
+    [
+        httpx.TransportError("refused"),
+        ClientTransportError("wanted total: transport error reaching /api/v3/wanted/missing"),
+    ],
+    ids=["httpx_transport", "client_transport"],
+)
+@pytest.mark.asyncio()
+async def test_run_search_cycle_returns_retry_for_transport_error(
+    seeded_instances: None,
+    transport_exc: BaseException,
+) -> None:
+    """Both raw and typed transport errors take the warning + retry branch.
+
+    Pins the contract that ``ClientTransportError`` (the typed wrapper introduced
+    by the typed-error refactor) lands on the same retry-with-warning path as
+    ``httpx.TransportError`` instead of falling through to the
+    ``(EngineError, ClientError)`` branch that writes a search_log error row.
+    """
+    instance = _make_instance()
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        AsyncMock(side_effect=transport_exc),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        retry = await supervisor._run_search_cycle(  # noqa: SLF001
+            instance, cycle_trigger="scheduled"
+        )
+
+    assert retry is True, "transport error must signal retry, not error-path completion"
+    rows = await _get_log_rows()
+    error_rows = [r for r in rows if r["action"] == "error"]
+    assert error_rows == [], "transport-error retry branch must not write a search_log error row"

--- a/tests/test_engine/test_typed_errors_pinning.py
+++ b/tests/test_engine/test_typed_errors_pinning.py
@@ -12,8 +12,11 @@ These tests lock both ends of that contract:
   three escape types (``EngineError``, ``ClientError``,
   ``httpx.TransportError``) propagate unchanged.
 * The supervisor's ``_run_search_cycle`` writes a single error row
-  for ``EngineError`` and ``ClientError`` and still returns ``True``
-  on ``httpx.TransportError`` so the reconnect loop engages.
+  for ``EngineError`` and non-transport ``ClientError`` subclasses
+  (``ClientHTTPError``, ``ClientValidationError``), and returns
+  ``True`` for both ``httpx.TransportError`` and the typed
+  ``ClientTransportError`` wrapper so the reconnect loop engages on
+  either shape.
 """
 
 from __future__ import annotations
@@ -228,7 +231,7 @@ class TestSupervisorCycleCatchSurface:
     @pytest.mark.asyncio()
     @pytest.mark.parametrize(
         "cls",
-        [ClientHTTPError, ClientTransportError, ClientValidationError],
+        [ClientHTTPError, ClientValidationError],
     )
     async def test_client_error_writes_row_and_returns_false(
         self,
@@ -236,7 +239,13 @@ class TestSupervisorCycleCatchSurface:
         monkeypatch: pytest.MonkeyPatch,
         cls: type[ClientError],
     ) -> None:
-        """Every ClientError subclass lands on the same supervisor branch."""
+        """Non-transport ClientError subclasses land on the error-row branch.
+
+        ``ClientTransportError`` is intentionally excluded: it is a
+        transport failure dressed in the typed hierarchy, so it belongs
+        on the retry branch covered by
+        :meth:`test_transport_error_returns_true_and_writes_nothing`.
+        """
         monkeypatch.setattr(
             supervisor_module,
             "run_instance_search",
@@ -255,21 +264,34 @@ class TestSupervisorCycleCatchSurface:
         assert rows[0]["message"] == "client layer"
 
     @pytest.mark.asyncio()
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectError("refused"),
+            ClientTransportError("wanted total: transport error reaching /api/v3/wanted/missing"),
+        ],
+        ids=["httpx_transport", "client_transport"],
+    )
     async def test_transport_error_returns_true_and_writes_nothing(
         self,
         seeded_supervisor_instance: None,
         monkeypatch: pytest.MonkeyPatch,
+        exc: BaseException,
     ) -> None:
-        """httpx.TransportError triggers the reconnect branch and skips the row.
+        """Transport errors trigger the reconnect branch and skip the row.
 
         Pinning: the row write happens in the outer reconnect loop the
         FIRST time a connection error is seen, not here.  This branch
         only signals the outer loop via the ``True`` return value.
+        Both the raw ``httpx.TransportError`` and the typed
+        ``ClientTransportError`` wrapper take this branch; the typed
+        wrapper used to fall through to the error-row branch before the
+        catch list was extended.
         """
         monkeypatch.setattr(
             supervisor_module,
             "run_instance_search",
-            AsyncMock(side_effect=httpx.ConnectError("refused")),
+            AsyncMock(side_effect=exc),
         )
         sup = Supervisor(master_key=_MASTER_KEY)
         instance = make_instance(instance_id=1)


### PR DESCRIPTION
Closes #560

## What changed

- `src/houndarr/engine/supervisor.py`: extended the three `except httpx.TransportError` clauses (lines 374, 478, 517) to also catch `ClientTransportError`, restoring the documented "treat transport errors as soft failures" behavior for the snapshot refresh, reconcile fetch, and scheduled cycle paths.
- Imported `ClientTransportError` from `houndarr.errors`.
- Added a one-line comment at the cycle-retry site explaining why both shapes share the branch.

## Why

Since the typed-error refactor (#448), the *arr clients wrap `httpx.RequestError` / `httpx.InvalidURL` in `houndarr.errors.ClientTransportError` (`clients/base.py:308-310` and `clients/base.py:457-460`). `ClientTransportError` does not inherit from `httpx.TransportError`, so the supervisor's catch lists no longer matched the actual error shape. Result:

- Snapshot/reconcile fell through to the broad `except Exception` and emitted a full traceback every 10-minute refresh for any unreachable instance.
- The scheduled cycle fell through to `(EngineError, ClientError)` and wrote a `search_log` error row instead of taking the warning + retry path the docstring promises (`supervisor.py:454`).

## Tests

- Updated `tests/test_engine/test_typed_errors_pinning.py::TestSupervisorCycleCatchSurface` to reflect the corrected contract: `ClientTransportError` is no longer parametrized into the error-row branch and is now part of the transport-retry parametrization alongside `httpx.ConnectError`.
- Added parametrized regression tests in `tests/test_engine/test_supervisor.py` covering both error shapes for all three catch sites: snapshot fetch, reconcile fetch, and `_run_search_cycle` retry signal.
- Full suite: 2600 passed.

## Checklist

- [x] Linked issue has `type:*` and `priority:*` labels
- [x] All five quality gates pass locally (`just check`)
- [x] Regression tests fail without the fix and pass with it