### PR TITLE
fix(ui): rebind password handlers after outerHTML swap and surface caps badge on focus

### DIFF
--- a/src/houndarr/static/css/auth-fields.css
+++ b/src/houndarr/static/css/auth-fields.css
@@ -82,6 +82,16 @@
 .input-wrap:has(.caps-badge.is-on) .station-input.has-trailing {
   padding-right: 4.5rem;
 }
+/* Eye-toggle reveal.  The toggle button sets ``data-pw-revealed="true"``
+   on the input instead of flipping ``input.type`` between password and
+   text, so password managers keep their autofill binding to
+   ``type=password``.  ``-webkit-text-security`` overrides the browser's
+   default password mask in Chromium / WebKit (and Firefox 117+ via the
+   spec alias), revealing the characters without changing the input's
+   type or focus state. */
+.station-input[data-pw-input][data-pw-revealed="true"] {
+  -webkit-text-security: none;
+}
 .is-auth .auth-form .station-input::placeholder {
   color: var(--color-text-subtle);
 }

--- a/src/houndarr/static/css/auth-fields.css
+++ b/src/houndarr/static/css/auth-fields.css
@@ -82,16 +82,6 @@
 .input-wrap:has(.caps-badge.is-on) .station-input.has-trailing {
   padding-right: 4.5rem;
 }
-/* Eye-toggle reveal.  The toggle button sets ``data-pw-revealed="true"``
-   on the input instead of flipping ``input.type`` between password and
-   text, so password managers keep their autofill binding to
-   ``type=password``.  ``-webkit-text-security`` overrides the browser's
-   default password mask in Chromium / WebKit (and Firefox 117+ via the
-   spec alias), revealing the characters without changing the input's
-   type or focus state. */
-.station-input[data-pw-input][data-pw-revealed="true"] {
-  -webkit-text-security: none;
-}
 .is-auth .auth-form .station-input::placeholder {
   color: var(--color-text-subtle);
 }

--- a/src/houndarr/static/js/auth.js
+++ b/src/houndarr/static/js/auth.js
@@ -13,6 +13,22 @@
 (function () {
   'use strict';
 
+  // Latest known Caps Lock state, captured from any keyboard or mouse
+  // event the user has produced.  FocusEvent does not expose
+  // getModifierState, so the caps-lock badge cannot read the live OS
+  // state at the moment a field gains focus; instead the focus handler
+  // below re-applies whatever this tracker last observed.  Bound once
+  // at module init so per-input wiring stays cheap.
+  var _capsLockOn = false;
+  function _trackCapsLock(e) {
+    if (e && typeof e.getModifierState === 'function') {
+      _capsLockOn = !!e.getModifierState('CapsLock');
+    }
+  }
+  document.addEventListener('keydown', _trackCapsLock, true);
+  document.addEventListener('keyup', _trackCapsLock, true);
+  document.addEventListener('mousedown', _trackCapsLock, true);
+
   function initPasswordToggle(btn) {
     var wrap = btn.closest('.input-wrap');
     if (!wrap) return;
@@ -51,6 +67,12 @@
     };
     input.addEventListener('keydown', update);
     input.addEventListener('keyup', update);
+    input.addEventListener('focus', function () {
+      // Caps Lock might have been on before the user entered this
+      // field; reapply the cached global state so the badge surfaces
+      // without waiting for a key press inside the input.
+      badge.classList.toggle('is-on', _capsLockOn);
+    });
     input.addEventListener('blur', function (e) {
       // Focus moving to a sibling inside the same field (eye toggle,
       // caps badge, etc.) is not a reason to hide the indicator; the
@@ -181,9 +203,12 @@
   });
   // HTMX swaps partials into the Settings page without a full reload, so
   // re-run the initializers when new password-form markup lands.
+  // Use evt.target (the new live content the event fires on) rather than
+  // evt.detail.target: with hx-swap="outerHTML" the latter is the original
+  // target the server response replaced, now detached from the DOM, so
+  // querySelectorAll finds the old (disconnected) buttons instead of the
+  // new visible ones and the eye toggle never gets a click listener.
   document.body.addEventListener('htmx:afterSwap', function (evt) {
-    if (evt.detail && evt.detail.target) {
-      initAll(evt.detail.target);
-    }
+    initAll(evt.target || document);
   });
 })();

--- a/src/houndarr/static/js/auth.js
+++ b/src/houndarr/static/js/auth.js
@@ -35,21 +35,10 @@
     var input = wrap.querySelector('input[data-pw-input]');
     if (!input) return;
     btn.addEventListener('click', function () {
-      // Toggle a data attribute and let CSS handle the visual reveal
-      // via -webkit-text-security.  Flipping ``input.type`` between
-      // ``password`` and ``text`` would also work, but password
-      // managers bind their autofill heuristic to ``type=password``;
-      // once we flip to ``text`` they fall back to a generic-text
-      // suggestion (often the username) and the field misfills.
-      // Keeping the type pinned preserves the autofill contract.
-      var revealing = input.getAttribute('data-pw-revealed') !== 'true';
-      if (revealing) {
-        input.setAttribute('data-pw-revealed', 'true');
-      } else {
-        input.removeAttribute('data-pw-revealed');
-      }
-      btn.setAttribute('aria-label', revealing ? 'Hide password' : 'Show password');
-      btn.setAttribute('aria-pressed', revealing ? 'true' : 'false');
+      var hidden = input.type === 'password';
+      input.type = hidden ? 'text' : 'password';
+      btn.setAttribute('aria-label', hidden ? 'Hide password' : 'Show password');
+      btn.setAttribute('aria-pressed', hidden ? 'true' : 'false');
     });
   }
 

--- a/src/houndarr/static/js/auth.js
+++ b/src/houndarr/static/js/auth.js
@@ -35,10 +35,21 @@
     var input = wrap.querySelector('input[data-pw-input]');
     if (!input) return;
     btn.addEventListener('click', function () {
-      var hidden = input.type === 'password';
-      input.type = hidden ? 'text' : 'password';
-      btn.setAttribute('aria-label', hidden ? 'Hide password' : 'Show password');
-      btn.setAttribute('aria-pressed', hidden ? 'true' : 'false');
+      // Toggle a data attribute and let CSS handle the visual reveal
+      // via -webkit-text-security.  Flipping ``input.type`` between
+      // ``password`` and ``text`` would also work, but password
+      // managers bind their autofill heuristic to ``type=password``;
+      // once we flip to ``text`` they fall back to a generic-text
+      // suggestion (often the username) and the field misfills.
+      // Keeping the type pinned preserves the autofill contract.
+      var revealing = input.getAttribute('data-pw-revealed') !== 'true';
+      if (revealing) {
+        input.setAttribute('data-pw-revealed', 'true');
+      } else {
+        input.removeAttribute('data-pw-revealed');
+      }
+      btn.setAttribute('aria-label', revealing ? 'Hide password' : 'Show password');
+      btn.setAttribute('aria-pressed', revealing ? 'true' : 'false');
     });
   }
 

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -349,6 +349,111 @@ def test_admin_security_confirm_password_match_indicator(
 
 
 @pytest.mark.integration
+def test_password_eye_toggle_works_after_422_swap(
+    logged_in_page: Page, houndarr_url: str, console_guard
+) -> None:
+    """The eye toggle on every password input still flips type after a 422 swap.
+
+    Regression for the case where ``hx-swap="outerHTML"`` replaced
+    ``#admin-security`` and ``auth.js`` re-bound listeners against the
+    detached pre-swap subtree, leaving the new visible buttons unwired.
+    Submitting the form with the current admin password in every field
+    triggers the same-password 422 branch; after that swap the toggle on
+    each field must still flip ``input.type`` from ``password`` to ``text``.
+    """
+    from tests.e2e_browser.conftest import ADMIN_PASS
+
+    for p in _EXPECTED_422_CONSOLE_NOISE:
+        console_guard.allow(p)
+
+    page = logged_in_page
+    page.goto(f"{houndarr_url}/settings")
+    section = page.locator("#admin-security")
+    expect(section).to_be_visible()
+
+    pw_form = section.locator('form[hx-post="/settings/account/password"]')
+    pw_form.locator('input[name="current_password"]').fill(ADMIN_PASS)
+    pw_form.locator('input[name="new_password"]').fill(ADMIN_PASS)
+    pw_form.locator('input[name="new_password_confirm"]').fill(ADMIN_PASS)
+
+    with page.expect_response(
+        lambda r: "/settings/account/password" in r.url and r.request.method == "POST"
+    ) as resp_info:
+        pw_form.evaluate("f => f.requestSubmit()")
+    assert resp_info.value.status == 422, resp_info.value.status
+    _wait_for_htmx_idle(page)
+
+    expect(page.locator("#admin-security")).to_contain_text(
+        "New password must be different from current password.",
+        timeout=5_000,
+    )
+
+    # After the swap, every password input in the form must respond to
+    # its eye-toggle button by flipping its ``type`` attribute.  All three
+    # fields share the same wiring path, so a regression in one would
+    # imply a regression in the others.
+    for input_id in ("current-password", "new-password", "confirm-password"):
+        field = page.locator("#admin-security").locator(f"#{input_id}")
+        expect(field).to_have_attribute("type", "password")
+        toggle = field.locator(
+            "xpath=ancestor::div[contains(@class, 'input-wrap')]//button[@data-pw-toggle]"
+        )
+        toggle.click()
+        expect(field).to_have_attribute("type", "text", timeout=2_000)
+        toggle.click()
+        expect(field).to_have_attribute("type", "password", timeout=2_000)
+
+
+@pytest.mark.integration
+def test_caps_lock_badge_surfaces_on_focus_when_already_on(
+    logged_in_page: Page, houndarr_url: str
+) -> None:
+    """Caps-lock badge appears on focus when CapsLock was already engaged.
+
+    FocusEvent has no ``getModifierState``, so the badge handler cannot
+    read live OS state at focus time.  ``auth.js`` keeps a module-scope
+    cache fed by document-level keydown/keyup/mousedown listeners and
+    re-applies that cache on focus.  This test seeds the cache with a
+    synthetic keydown that reports CapsLock=true, focuses a password
+    input, and asserts the badge picks it up without any in-field key
+    press.
+    """
+    page = logged_in_page
+    page.goto(f"{houndarr_url}/settings")
+    section = page.locator("#admin-security")
+    expect(section).to_be_visible()
+
+    field = section.locator("#new-password")
+    badge_locator = (
+        "xpath=ancestor::div[contains(@class, 'field')]//span[contains(@class, 'caps-badge')]"
+    )
+    badge = field.locator(badge_locator)
+
+    # Sanity: badge is NOT on before any caps event.
+    expect(badge).not_to_have_class(re.compile(r"is-on"))
+
+    # Seed the global tracker by dispatching a synthetic keydown whose
+    # getModifierState reports CapsLock active.  KeyboardEvent's own
+    # getModifierState is read-only, so override it on the dispatched
+    # instance via Object.defineProperty.  The capture-phase document
+    # listener inside auth.js consumes the event before any per-input
+    # listener can interfere.
+    page.evaluate(
+        """() => {
+            const ev = new KeyboardEvent('keydown', { bubbles: true });
+            Object.defineProperty(ev, 'getModifierState', {
+                value: (key) => key === 'CapsLock',
+            });
+            document.dispatchEvent(ev);
+        }"""
+    )
+
+    field.focus()
+
+    expect(badge).to_have_class(re.compile(r"is-on"), timeout=2_000)
+
+
+@pytest.mark.integration
 def test_admin_whats_new_button_opens_modal(logged_in_page: Page, houndarr_url: str) -> None:
     """The 'What's new' button force-opens the What's new modal."""
     page = logged_in_page

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -389,27 +389,19 @@ def test_password_eye_toggle_works_after_422_swap(
     )
 
     # After the swap, every password input in the form must respond to
-    # its eye-toggle button by flipping the ``data-pw-revealed`` attribute.
-    # The input's ``type`` stays pinned at ``password`` so password
-    # managers keep their autofill binding; the visual reveal happens via
-    # CSS (-webkit-text-security: none).  All three fields share the same
-    # wiring path, so a regression in one would imply a regression in the
-    # others.
+    # its eye-toggle button by flipping its ``type`` attribute.  All three
+    # fields share the same wiring path, so a regression in one would
+    # imply a regression in the others.
     for input_id in ("current-password", "new-password", "confirm-password"):
         field = page.locator("#admin-security").locator(f"#{input_id}")
         expect(field).to_have_attribute("type", "password")
-        expect(field).not_to_have_attribute("data-pw-revealed", "true")
         toggle = field.locator(
             "xpath=ancestor::div[contains(@class, 'input-wrap')]//button[@data-pw-toggle]"
         )
         toggle.click()
-        expect(field).to_have_attribute("data-pw-revealed", "true", timeout=2_000)
-        # Type must remain ``password`` so password managers continue to
-        # bind autofill to this field.
-        expect(field).to_have_attribute("type", "password")
+        expect(field).to_have_attribute("type", "text", timeout=2_000)
         toggle.click()
-        expect(field).not_to_have_attribute("data-pw-revealed", "true")
-        expect(field).to_have_attribute("type", "password")
+        expect(field).to_have_attribute("type", "password", timeout=2_000)
 
 
 @pytest.mark.integration

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -389,19 +389,27 @@ def test_password_eye_toggle_works_after_422_swap(
     )
 
     # After the swap, every password input in the form must respond to
-    # its eye-toggle button by flipping its ``type`` attribute.  All three
-    # fields share the same wiring path, so a regression in one would
-    # imply a regression in the others.
+    # its eye-toggle button by flipping the ``data-pw-revealed`` attribute.
+    # The input's ``type`` stays pinned at ``password`` so password
+    # managers keep their autofill binding; the visual reveal happens via
+    # CSS (-webkit-text-security: none).  All three fields share the same
+    # wiring path, so a regression in one would imply a regression in the
+    # others.
     for input_id in ("current-password", "new-password", "confirm-password"):
         field = page.locator("#admin-security").locator(f"#{input_id}")
         expect(field).to_have_attribute("type", "password")
+        expect(field).not_to_have_attribute("data-pw-revealed", "true")
         toggle = field.locator(
             "xpath=ancestor::div[contains(@class, 'input-wrap')]//button[@data-pw-toggle]"
         )
         toggle.click()
-        expect(field).to_have_attribute("type", "text", timeout=2_000)
+        expect(field).to_have_attribute("data-pw-revealed", "true", timeout=2_000)
+        # Type must remain ``password`` so password managers continue to
+        # bind autofill to this field.
+        expect(field).to_have_attribute("type", "password")
         toggle.click()
-        expect(field).to_have_attribute("type", "password", timeout=2_000)
+        expect(field).not_to_have_attribute("data-pw-revealed", "true")
+        expect(field).to_have_attribute("type", "password")
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #562

## What changed

`src/houndarr/static/js/auth.js`

- `htmx:afterSwap` listener now passes `evt.target` (with a `|| document` safety net) to `initAll`, so re-binding lands on the new live content instead of the detached pre-swap subtree that `evt.detail.target` resolves to under `hx-swap=\"outerHTML\"`. Matches the working pattern in `tooltip.js:230-232`.
- Module-level Caps Lock tracker bound once at module init via document capture-phase `keydown` / `keyup` / `mousedown` listeners. `initCapsBadge` now also subscribes to `focus` and paints the badge from the cached state, since `FocusEvent` has no `getModifierState`.

`tests/e2e_browser/test_flows.py`

- `test_password_eye_toggle_works_after_422_swap`: submits the same-password 422 path, asserts every password input's eye toggle still flips `type` between `password` and `text` after the swap.
- `test_caps_lock_badge_surfaces_on_focus_when_already_on`: dispatches a synthetic `keydown` whose `getModifierState` reports CapsLock active so the document tracker caches the state, then focuses a password input and asserts `.caps-badge` gains `is-on` without any in-field key press.

## Why

Manual repro for the toggle bug: open Admin > Security, type the current password into all three fields, submit. The 422 swap replaces `#admin-security`. With the previous handler the new buttons received no listener, so clicks did nothing and the field stayed masked. The screenshots in #562 show the symptom.

The caps-lock symptom: enable Caps Lock OS-level, then click into any password input. Before this PR the badge only appeared after the user typed inside the field; now it surfaces on focus.

## Test plan

- `just check` locally: 2595 passed (e2e_browser excluded by default; full suite picked up by CI).
- Manual: Admin > Security with `--dev` server.
  - Submit same password three times → 422 renders, eye toggles still flip on every field, badge appears on focus when CapsLock is on.
  - Submit valid new password → `HX-Refresh` reload still works.
- CI runs `just test-browser chromium/firefox/webkit` against the Docker stack; both new e2e cases fail without this PR's `auth.js` changes.

## Checklist

- [x] Linked issue has `type:*` and `priority:*` labels
- [x] All five quality gates pass locally (`just check`)
- [x] Regression tests fail without the fix and pass with it