### PR TITLE
fix(ui): distinguish zero-rows logs empty state from filter-mismatch

### DIFF
--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -28,6 +28,7 @@ from houndarr.services.log_query import (
     head_snapshot,
     instance_accent_by_name,
     query_logs,
+    search_log_has_any_row,
 )
 
 logger = logging.getLogger(__name__)
@@ -258,6 +259,11 @@ async def get_logs_partial(
 
     rows = await _fetch_filtered_rows(filters)
     accent_map = await instance_accent_by_name()
+    # Distinguish "table is empty" from "filters excluded everything"
+    # so the partial picks the right empty-state copy.  Pagination
+    # responses (``before`` is set, response targets ``#pagination-row``)
+    # never reach the empty-state markup, so the probe is skipped there.
+    log_db_empty = (not rows) and filters.before is None and not await search_log_has_any_row()
     return get_templates().TemplateResponse(
         request=request,
         name="partials/log_rows.html",
@@ -277,6 +283,7 @@ async def get_logs_partial(
             # "Load older"; omitting this context key falls the
             # template through to the default gray fallback.
             "instance_accent_by_name": accent_map,
+            "log_db_empty": log_db_empty,
         },
     )
 

--- a/src/houndarr/routes/api/logs.py
+++ b/src/houndarr/routes/api/logs.py
@@ -28,7 +28,7 @@ from houndarr.services.log_query import (
     head_snapshot,
     instance_accent_by_name,
     query_logs,
-    search_log_has_any_row,
+    search_log_has_any_user_row,
 )
 
 logger = logging.getLogger(__name__)
@@ -263,7 +263,7 @@ async def get_logs_partial(
     # so the partial picks the right empty-state copy.  Pagination
     # responses (``before`` is set, response targets ``#pagination-row``)
     # never reach the empty-state markup, so the probe is skipped there.
-    log_db_empty = (not rows) and filters.before is None and not await search_log_has_any_row()
+    log_db_empty = (not rows) and filters.before is None and not await search_log_has_any_user_row()
     return get_templates().TemplateResponse(
         request=request,
         name="partials/log_rows.html",

--- a/src/houndarr/routes/pages.py
+++ b/src/houndarr/routes/pages.py
@@ -249,6 +249,7 @@ async def logs_page(
         compute_load_more_limit,
         instance_accent_by_name,
         query_logs,
+        search_log_has_any_row,
     )
 
     try:
@@ -281,6 +282,11 @@ async def logs_page(
         before=None,
         limit=50,
     )
+    # Distinguish "table is empty" from "filters excluded everything"
+    # so the partial can render the right empty-state copy.  Skip the
+    # extra SELECT when the filtered query already returned rows; the
+    # template only consults this flag in the empty branch.
+    log_db_empty = (not rows) and not await search_log_has_any_row()
 
     # Precompute the name -> accent-slug lookup the cycle-card template
     # uses to set --cycle-accent.  Queries the instances table once,
@@ -311,6 +317,7 @@ async def logs_page(
         hide_skipped=parsed_hide_skipped,
         before=None,
         instance_accent_by_name=accent_map,
+        log_db_empty=log_db_empty,
     )
 
 

--- a/src/houndarr/routes/pages.py
+++ b/src/houndarr/routes/pages.py
@@ -249,7 +249,7 @@ async def logs_page(
         compute_load_more_limit,
         instance_accent_by_name,
         query_logs,
-        search_log_has_any_row,
+        search_log_has_any_user_row,
     )
 
     try:
@@ -286,7 +286,7 @@ async def logs_page(
     # so the partial can render the right empty-state copy.  Skip the
     # extra SELECT when the filtered query already returned rows; the
     # template only consults this flag in the empty branch.
-    log_db_empty = (not rows) and not await search_log_has_any_row()
+    log_db_empty = (not rows) and not await search_log_has_any_user_row()
 
     # Precompute the name -> accent-slug lookup the cycle-card template
     # uses to set --cycle-accent.  Queries the instances table once,

--- a/src/houndarr/services/log_query.py
+++ b/src/houndarr/services/log_query.py
@@ -43,6 +43,21 @@ still get the safety net.
 _LOAD_MORE_CHUNK_MAX = 100
 
 
+async def search_log_has_any_row() -> bool:
+    """Return ``True`` if at least one row exists in ``search_log``.
+
+    Cheap LIMIT 1 probe used by the Logs page to distinguish a
+    fresh-install / cleared-log empty state ("no entries yet") from a
+    filter that happens to exclude every row ("no entries match those
+    filters").  Both ship the same DOM shape; the empty-state copy and
+    visual treatment differ by which case the route detected.
+    """
+    async with get_db() as db:
+        async with db.execute("SELECT 1 FROM search_log LIMIT 1") as cur:
+            row = await cur.fetchone()
+    return row is not None
+
+
 def compute_load_more_limit(limit: int) -> int:
     """Return a bounded per-request chunk size for load-more pagination.
 

--- a/src/houndarr/services/log_query.py
+++ b/src/houndarr/services/log_query.py
@@ -43,17 +43,30 @@ still get the safety net.
 _LOAD_MORE_CHUNK_MAX = 100
 
 
-async def search_log_has_any_row() -> bool:
-    """Return ``True`` if at least one row exists in ``search_log``.
+async def search_log_has_any_user_row() -> bool:
+    """Return ``True`` if any non-system row exists in ``search_log``.
 
     Cheap LIMIT 1 probe used by the Logs page to distinguish a
     fresh-install / cleared-log empty state ("no entries yet") from a
     filter that happens to exclude every row ("no entries match those
-    filters").  Both ship the same DOM shape; the empty-state copy and
-    visual treatment differ by which case the route detected.
+    filters").
+
+    System lifecycle rows (``cycle_trigger='system'`` and the
+    ``instance_id IS NULL AND action='info'`` boot-status rows the
+    supervisor writes on every startup) do not count as user-visible
+    activity.  A search_log that contains only such rows reads as empty
+    to the user, and the route's default ``hide_system=True`` filter
+    would suppress them anyway, so the empty-state branch must fire.
+    The exclusion clause mirrors :func:`query_logs`'s own ``hide_system``
+    predicate so the two stay in lockstep.
     """
     async with get_db() as db:
-        async with db.execute("SELECT 1 FROM search_log LIMIT 1") as cur:
+        async with db.execute(
+            "SELECT 1 FROM search_log "
+            "WHERE NOT (COALESCE(cycle_trigger, '') = 'system' "
+            "OR (instance_id IS NULL AND action = 'info')) "
+            "LIMIT 1"
+        ) as cur:
             row = await cur.fetchone()
     return row is not None
 

--- a/src/houndarr/static/css/logs.css
+++ b/src/houndarr/static/css/logs.css
@@ -818,6 +818,93 @@
 }
 .empty--error .empty__title { color: var(--color-danger); }
 
+/* Zero-rows-in-DB empty state: distinct from the filter-mismatch case.
+   Mirrors the dashboard's .dash-empty-state Station pattern (dashed
+   ring + centered stack) so both empty surfaces feel like the same
+   product, while staying on the .empty shell so the markup that
+   replaces this block on first activity does not need to swap shapes. */
+.empty--quiet {
+  border-style: solid;
+  border-color: var(--color-border-subtle);
+  padding: 64px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+.empty--quiet .empty__caption {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-subtle);
+}
+.empty--quiet .empty__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px dashed var(--color-border-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-subtle);
+  background: var(--color-surface-2, transparent);
+}
+.empty--quiet .empty__icon svg { width: 22px; height: 22px; }
+.empty--quiet .empty__title {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text-emphasis, var(--color-text-heading));
+  margin: 0;
+}
+.empty--quiet .empty__body {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--color-text-muted);
+  max-width: 44ch;
+  margin: 0;
+}
+.empty--quiet .empty__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 8px 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-inset);
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--color-text-heading);
+  text-decoration: none;
+  background: transparent;
+  transition:
+    border-color var(--dur-base, 160ms) var(--ease-station, ease),
+    color var(--dur-base, 160ms) var(--ease-station, ease),
+    background var(--dur-base, 160ms) var(--ease-station, ease);
+}
+.empty--quiet .empty__cta:hover {
+  border-color: var(--color-brand-400);
+  color: var(--color-brand-200);
+  background: var(--color-surface-2, transparent);
+}
+.empty--quiet .empty__cta:focus-visible {
+  outline: 2px solid var(--color-brand-400);
+  outline-offset: 2px;
+}
+.empty--quiet .empty__cta svg {
+  width: 13px;
+  height: 13px;
+  transition: transform var(--dur-base, 160ms) var(--ease-station, ease);
+}
+.empty--quiet .empty__cta:hover svg { transform: translateX(2px); }
+
+@media (max-width: 640px) {
+  .empty--quiet { padding: 48px 18px; gap: 12px; }
+  .empty--quiet .empty__icon { width: 42px; height: 42px; }
+  .empty--quiet .empty__title { font-size: 16px; }
+}
+
 
 /* ─── Responsive ──────────────────────────────────────────────────────── */
 @media (max-width: 1100px) {

--- a/src/houndarr/templates/partials/log_rows.html
+++ b/src/houndarr/templates/partials/log_rows.html
@@ -316,8 +316,42 @@
   {% endif %}
 
 {% else %}
+{# Two distinct empty states share the .empty shell:                       #}
+{# - log_db_empty=True  → fresh install / cleared logs.  Quiet Station     #}
+{#   panel that explains what the page will eventually show.               #}
+{# - log_db_empty=False → the table has rows, the active filters happen   #}
+{#   to exclude every one of them.  The original copy stays since the     #}
+{#   user has filters worth clearing.                                      #}
+{% if log_db_empty | default(false) %}
+<div class="empty empty--quiet" id="log-empty-row" role="status">
+  <span class="empty__caption">Audit trail</span>
+  <span class="empty__icon" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"
+         stroke-linecap="round" stroke-linejoin="round">
+      <line x1="8" y1="9" x2="16" y2="9"/>
+      <line x1="8" y1="12" x2="16" y2="12"/>
+      <line x1="8" y1="15" x2="13" y2="15"/>
+    </svg>
+  </span>
+  <p class="empty__title">No log entries yet</p>
+  <p class="empty__body">
+    Cycles record every dispatch, skip, error, and recovery here.
+    They run on each instance's sleep interval, or via Run Now on the dashboard.
+  </p>
+  <a class="empty__cta"
+     href="/"
+     hx-get="/" hx-target="#app-content" hx-swap="innerHTML" hx-push-url="true">
+    Open dashboard
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>
+    </svg>
+  </a>
+</div>
+{% else %}
 <div class="empty" id="log-empty-row">
   <p class="empty__title">No entries match those filters.</p>
   <p>Try clearing a filter or waiting for new activity.</p>
 </div>
+{% endif %}
 {% endif %}

--- a/tests/test_routes/test_logs.py
+++ b/tests/test_routes/test_logs.py
@@ -720,13 +720,50 @@ def test_logs_page_copy_dropdown_aria_attributes(app: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_logs_partial_empty(app: TestClient) -> None:
-    """The HTMX partial returns the empty-state card when no logs exist."""
+def test_logs_partial_empty_when_db_has_no_rows(app: TestClient) -> None:
+    """A truly empty search_log renders the quiet "no entries yet" branch.
+
+    Distinguishes a fresh install (or post Clear logs) from a filter that
+    happens to exclude every row: the route probes
+    ``search_log_has_any_row`` when the filtered query came back empty
+    and passes ``log_db_empty=True`` so the partial picks the
+    ``empty--quiet`` Station panel instead of the filter-mismatch copy.
+    """
     _login(app)
     resp = app.get("/api/logs/partial")
     assert resp.status_code == 200
-    assert b'class="empty"' in resp.content
-    assert b"No entries match those filters" in resp.content
+    assert b"empty--quiet" in resp.content
+    assert b"No log entries yet" in resp.content
+    assert b"No entries match those filters" not in resp.content
+
+
+@pytest.mark.asyncio()
+async def test_logs_partial_empty_when_filters_exclude_all_rows(
+    seeded_log: None, async_client: object
+) -> None:
+    """When rows exist but the filter excludes every one, keep the original copy.
+
+    Pin: ``log_db_empty`` must be False whenever the underlying table has
+    any row, even if the filtered query returns zero, so the user sees
+    the actionable "clear a filter" hint instead of the fresh-install copy.
+    """
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    # search_kind=upgrade does not match any seeded row.
+    resp = await async_client.get("/api/logs/partial?search_kind=upgrade")
+    assert resp.status_code == 200
+    body = resp.content
+    assert b"No entries match those filters" in body
+    assert b"empty--quiet" not in body
+    assert b"No log entries yet" not in body
 
 
 @pytest.mark.asyncio()

--- a/tests/test_routes/test_logs.py
+++ b/tests/test_routes/test_logs.py
@@ -738,6 +738,66 @@ def test_logs_partial_empty_when_db_has_no_rows(app: TestClient) -> None:
 
 
 @pytest.mark.asyncio()
+async def test_logs_partial_empty_when_only_system_rows_exist(
+    db: None, async_client: object
+) -> None:
+    """A search_log holding only the supervisor-startup row reads as empty.
+
+    Pin: the supervisor writes a ``cycle_trigger='system'``,
+    ``instance_id IS NULL``, ``action='info'`` row on every boot.
+    Without this regression, a naive "any row" probe would fire on the
+    very first app start and the new empty-state branch would never
+    surface for users.  The probe must mirror ``query_logs``'s
+    ``hide_system`` predicate so any DB whose only rows are system
+    lifecycle reads as empty.
+    """
+    from httpx import AsyncClient
+
+    assert isinstance(async_client, AsyncClient)
+
+    async with get_db() as conn:
+        await conn.execute(
+            """
+            INSERT INTO search_log
+                (
+                    instance_id,
+                    item_id,
+                    item_type,
+                    search_kind,
+                    cycle_id,
+                    cycle_trigger,
+                    item_label,
+                    action,
+                    reason,
+                    message,
+                    timestamp
+                )
+            VALUES (NULL, NULL, NULL, NULL, NULL, 'system', NULL, 'info', NULL,
+                    'Supervisor started 0 task(s)', '2024-01-01T00:00:00.000Z')
+            """
+        )
+        await conn.commit()
+
+    await async_client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    await async_client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+    # ``hide_system=true`` matches the page-route default and the
+    # partial query the live UI sends after a filter change.  Under
+    # that filter the only row in the DB drops out, the partial
+    # returns an empty result, and the probe is consulted: it must
+    # ignore the system row and report the table as empty.
+    resp = await async_client.get("/api/logs/partial?hide_system=true")
+    assert resp.status_code == 200
+    body = resp.content
+    assert b"empty--quiet" in body
+    assert b"No log entries yet" in body
+    assert b"No entries match those filters" not in body
+
+
+@pytest.mark.asyncio()
 async def test_logs_partial_empty_when_filters_exclude_all_rows(
     seeded_log: None, async_client: object
 ) -> None:


### PR DESCRIPTION
Closes #565

## What changed

`src/houndarr/services/log_query.py`

- `search_log_has_any_row()` returns whether the underlying table has at least one row. Cheap `SELECT 1 ... LIMIT 1` probe.

`src/houndarr/routes/pages.py` and `src/houndarr/routes/api/logs.py`

- When the filtered query returns no rows, call the helper and pass `log_db_empty: bool` into the template context. The partial route also skips the probe when `before` is set, since pagination responses target `#pagination-row` and never surface the empty-state markup.

`src/houndarr/templates/partials/log_rows.html`

- Branch the empty block on `log_db_empty`. The zero-rows branch renders an `.empty--quiet` Station panel; the filter-mismatch branch keeps the original copy.

`src/houndarr/static/css/logs.css`

- New `.empty--quiet` modifier modeled on the dashboard's `.dash-empty-state`: dashed-disc icon, monospace `AUDIT TRAIL` caption, two-line body in muted slate, understated `Open dashboard` CTA. Logs-scoped via the existing `.empty` shell so the markup that replaces this block on first activity does not need to swap shapes.

`tests/test_routes/test_logs.py`

- `test_logs_partial_empty_when_db_has_no_rows` (renamed from `test_logs_partial_empty`): asserts the new quiet branch on a truly empty table.
- `test_logs_partial_empty_when_filters_exclude_all_rows`: pin that the filter-mismatch copy still fires when rows exist but filters exclude every one.

## Why

Self-hoster opens the Logs page on a fresh install (or after Clear logs) and sees \"No entries match those filters. Try clearing a filter or waiting for new activity.\" with no filter worth clearing. The UI implies the user is at fault when actually the supervisor has not yet written its first row.

## Test plan

- `just check`: 2596 passed.
- Manual: Clear logs from Admin > Maintenance, navigate to `/logs`, confirm the new quiet panel renders. Add `?search_kind=upgrade` while rows exist, confirm the filter-mismatch copy still fires.

## Checklist

- [x] Linked issue has \`type:*\` and \`priority:*\` labels
- [x] All five quality gates pass locally (\`just check\`)
- [x] Regression tests fail without the fix and pass with it