### PR TITLE
fix(e2e): open admin dropdown before clicking the eye toggle

### DIFF
--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -368,6 +368,13 @@ def test_password_eye_toggle_works_after_422_swap(
 
     page = logged_in_page
     page.goto(f"{houndarr_url}/settings")
+    # ``#admin-security`` lives inside the collapsible ``#admin-grouped``
+    # panel that ships closed on every fresh page load.  ``fill`` /
+    # ``requestSubmit`` / text-assertions go through JS and work on a
+    # collapsed subtree, but the toggle ``click()`` below issues a real
+    # pointer event the closed panel intercepts.  Open the panel up
+    # front so the click can land on the post-swap button.
+    _open_admin_dropdown(page)
     section = page.locator("#admin-security")
     expect(section).to_be_visible()
 


### PR DESCRIPTION
Closes #567

## What changed

`tests/e2e_browser/test_flows.py::test_password_eye_toggle_works_after_422_swap` now calls the existing `_open_admin_dropdown(page)` helper after navigating to `/settings` and before locating `#admin-security`.

## Why

`#admin-security` lives inside `#admin-grouped`, the Admin collapsible section that ships closed (`data-open=\"false\"`) on every page load. Earlier steps in the test work because `fill()`, `requestSubmit()`, and text assertions all go through JS and don't need pointer events. The eye-toggle `click()` needs a real pointer event, which the closed panel intercepts. Playwright surfaces this as:

\`\`\`
<section data-open=\"false\" id=\"admin-grouped\" ...> intercepts pointer events
<main id=\"app-content\" ...> intercepts pointer events
<button id=\"admin-toggle\" ...> intercepts pointer events
\`\`\`

Sister tests on the same form avoid the issue because they only `fill`, `focus`, or read text — they never click inside the panel. This is the first one to do so, and that surfaces the long-standing precondition gap.

## Test plan

- `just check`: 2597 passed locally (e2e_browser excluded by default).
- CI re-runs the e2e suite against chromium / firefox / webkit; expecting all three green.

## Checklist

- [x] Linked issue has \`type:*\` and \`priority:*\` labels
- [x] All five quality gates pass locally (\`just check\`)
- [x] Single-file change, no behavioral product change