### PR TITLE
test(e2e): allow webkit changelog-popup pageerror on HX-Refresh abort

### DIFF
--- a/tests/e2e_browser/conftest.py
+++ b/tests/e2e_browser/conftest.py
@@ -39,6 +39,20 @@ _ALLOWED_ERROR_PATTERNS = [
     # mid-flight; allow the bare event-name console errors so the
     # autouse console_guard does not flag the teardown on webkit.
     re.compile(r"^htmx:[A-Za-z]+(?:Error|Request|Swap|Send|Response)?$"),
+    # Sibling of the bare-event-name pattern above, but at the
+    # ``pageerror`` (window-level) layer instead of console.error.
+    # Webkit reports any in-flight fetch canceled by a pending
+    # navigation as ``<URL> due to access control checks.`` even on
+    # same-origin requests.  The recurring trigger for this suite is
+    # the changelog popup's ``hx-trigger="load"`` GET still being in
+    # flight when ``HX-Refresh`` after a password change calls
+    # ``location.reload()``.  No client-side mitigation exists (the
+    # browser fires the error on its own abort path), and chromium /
+    # firefox swallow the same abort silently.  Documented upstream
+    # in TanStack/router#719 and supabase/supabase#20982.  Scope the
+    # match to the changelog popup path so a real auth failure on
+    # any other endpoint still fails the teardown.
+    re.compile(r"^pageerror:\s.*/settings/changelog/popup\b[^\n]*access control checks\.?$"),
 ]
 
 


### PR DESCRIPTION
Closes #569

## What changed

`tests/e2e_browser/conftest.py` gains one entry in `_ALLOWED_ERROR_PATTERNS` matching the WebKit-only \`<URL> due to access control checks.\` pageerror, scoped to the changelog popup path.

## Why

Researched before patching ([TanStack/router#719](https://github.com/TanStack/router/issues/719), [supabase/supabase#20982](https://github.com/supabase/supabase/issues/20982), Playwright pageerror docs via Context7): the wording is WebKit's generic abort report for any in-flight fetch canceled by pending navigation, including same-origin requests. Not actually a CORS / access control evaluation. Chromium and Firefox swallow the same abort silently. No client-side mitigation exists because the error fires from the browser's own abort path; the standard Playwright pattern is the regex allowlist this conftest already implements for sibling \`htmx:*\` console errors.

The recurring trigger is the changelog popup's \`hx-trigger=\"load\"\` GET still being in flight when \`HX-Refresh\` after a successful password change calls \`location.reload()\`. \`test_password_change_hx_refresh_recovers_csrf[webkit]\` flakes on this in teardown.

## Scoping

The regex is intentionally narrow:

- Only matches the \`pageerror:\` prefix the autouse fixture stamps.
- Requires the \`/settings/changelog/popup\` path so a real auth failure on any other endpoint still fails the teardown.
- Requires the \`access control checks\` wording at the tail so unrelated pageerrors on the same endpoint (CSP violation, JS exception) still surface.

Sanity-checked against six representative messages locally; matches the real failure exactly and rejects the four negative cases.

## Test plan

- \`just check\` locally: 2602 passed.
- CI re-runs the e2e suite against chromium / firefox / webkit; expecting all three green.

## Checklist

- [x] Linked issue has \`type:*\` and \`priority:*\` labels
- [x] All five quality gates pass locally (\`just check\`)
- [x] No product code changed; test infrastructure only