### PR TITLE
fix(ui): restore changelog/add-instance modal cap

### DIFF
--- a/src/houndarr/static/css/input.css
+++ b/src/houndarr/static/css/input.css
@@ -37,6 +37,17 @@
    explicit source so the build never misses Jinja partials. */
 @source "../../templates";
 
+/* Force-generate utility classes whose final form is composed at
+   render time from a Jinja variable (e.g. `w-[min(94vw,{{ width }})]`
+   in _macros/modals.html). Tailwind's static scanner sees the literal
+   `{{ width }}` and cannot derive `w-[min(94vw,42rem)]`, so the rule
+   would be missing from the production Docker build (templates-only
+   scan) even though it survives locally because tests reference the
+   literal. Keep this list aligned with the dialog_shell call sites:
+   42rem = changelog modal, 52rem = add-instance modal. */
+@source inline("w-[min(94vw,42rem)]");
+@source inline("w-[min(94vw,52rem)]");
+
 /* daisyUI v5 component plugin. Runs at Tailwind build time; nothing
    ships to the browser except compiled CSS. themes: false disables
    the built-in theme set because we define our own "station" theme

--- a/src/houndarr/templates/_macros/modals.html
+++ b/src/houndarr/templates/_macros/modals.html
@@ -41,9 +41,15 @@
       id:       required dialog id.  Used by the per-modal
                 <style> block and by the JS controller that
                 opens / closes the modal.
-      width:    the upper bound passed to `w-[min(94vw,WIDTH)]`.
-                Two values used in production: "38rem" (changelog)
-                and "52rem" (add-instance).
+      width:    the upper bound passed to the dialog's
+                `w-[min(94vw,WIDTH)]` arbitrary-value class.  Tailwind
+                v4 cannot derive the resolved class through the Jinja
+                interpolation, so every value used here MUST also be
+                listed in `@source inline(...)` directives in
+                `static/css/input.css` or the rule disappears from
+                the production CSS bundle.  Two values are used in
+                production: "42rem" (changelog) and "52rem"
+                (add-instance).
       aria_labelledby: optional id of the heading the dialog
                 names.  The changelog modal sets this to its
                 title id; the add-instance modal leaves it None

--- a/src/houndarr/templates/partials/changelog_modal.html
+++ b/src/houndarr/templates/partials/changelog_modal.html
@@ -1,7 +1,7 @@
 {%- import "_macros/modals.html" as modals -%}
 {% call modals.dialog_shell(
     id="changelog-modal",
-    width="38rem",
+    width="42rem",
     aria_labelledby="changelog-modal-title",
     aria_describedby="changelog-modal-subtitle" if range_label else none,
 ) %}

--- a/tests/test_templates/test_macros_modals.py
+++ b/tests/test_templates/test_macros_modals.py
@@ -140,14 +140,14 @@ class TestDialogShellConsumerCallSites:
         self, render_macro: Callable[[str], str]
     ) -> None:
         src = (
-            _IMPORT + '{% call modals.dialog_shell(id="changelog-modal", width="38rem", '
+            _IMPORT + '{% call modals.dialog_shell(id="changelog-modal", width="42rem", '
             'aria_labelledby="changelog-modal-title", '
             'aria_describedby="changelog-modal-subtitle") %}BODY{% endcall %}'
         )
         expected = (
             "<dialog\n"
             '  id="changelog-modal"\n'
-            '  class="m-auto p-0 w-[min(94vw,38rem)] rounded-container border '
+            '  class="m-auto p-0 w-[min(94vw,42rem)] rounded-container border '
             'border-border-subtle bg-surface-1 text-slate-100 shadow-modal"\n'
             '  aria-labelledby="changelog-modal-title"\n'
             '  aria-describedby="changelog-modal-subtitle"\n'
@@ -161,13 +161,13 @@ class TestDialogShellConsumerCallSites:
         self, render_macro: Callable[[str], str]
     ) -> None:
         src = (
-            _IMPORT + '{% call modals.dialog_shell(id="changelog-modal", width="38rem", '
+            _IMPORT + '{% call modals.dialog_shell(id="changelog-modal", width="42rem", '
             'aria_labelledby="changelog-modal-title") %}BODY{% endcall %}'
         )
         expected = (
             "<dialog\n"
             '  id="changelog-modal"\n'
-            '  class="m-auto p-0 w-[min(94vw,38rem)] rounded-container border '
+            '  class="m-auto p-0 w-[min(94vw,42rem)] rounded-container border '
             'border-border-subtle bg-surface-1 text-slate-100 shadow-modal"\n'
             '  aria-labelledby="changelog-modal-title"\n'
             ">\n"


### PR DESCRIPTION
## Summary

Restore the desktop width cap on the `What's new` changelog modal and the add-instance settings modal.  PR #485 refactored both into the shared `dialog_shell` macro and parameterised the width as `w-[min(94vw,{{ width }})]`, which Tailwind v4's static scanner cannot resolve through the Jinja interpolation.  The rules are missing from the production CSS bundle, so both modals render at full UA-default width on desktop.

The bug is invisible locally because Tailwind v4 also auto-discovers `tests/test_templates/test_macros_modals.py`, which pins the literal class strings; the Dockerfile `css-build` stage scopes scanning to `src/houndarr/static/css/` and `src/houndarr/templates/`, so the test pin is out of scope in production.

Closes #573

## Changes

- Add `@source inline("w-[min(94vw,42rem)]")` and `@source inline("w-[min(94vw,52rem)]")` to `src/houndarr/static/css/input.css` so Tailwind force-generates both rules regardless of where the literal appears.
- Set the changelog modal width to `42rem` (matches `max-w-2xl`).  The previous `38rem` was right for short changelogs; the dense `1.10.0` entry has long technical bullets where `42rem` cuts wrap noise without making the modal feel wide on desktop.
- Update the `dialog_shell` macro docstring to flag that any new width value must also be added to the `@source inline(...)` list, otherwise the rule disappears in production.
- Update the two byte-equal pinned tests in `tests/test_templates/test_macros_modals.py` to track the new `42rem` value.

## Testing

A clean templates-only Tailwind build (mirroring the Dockerfile `css-build` stage) now emits `width: min(94vw, 42rem)` and `width: min(94vw, 52rem)`.  All checks pass.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way