### PR TITLE
chore: adopt Keep a Changelog 1.1.0 flow

### DIFF
--- a/.claude/commands/bump.md
+++ b/.claude/commands/bump.md
@@ -8,6 +8,12 @@ allowed-tools: Read, Write, Edit, Bash(git *), Bash(gh *), Bash(date *), Bash(.v
 
 Prepare a release PR following the Houndarr versioning workflow.
 
+Houndarr follows Keep a Changelog 1.1.0: every shipped PR adds a
+bullet under `## [Unreleased]` as part of its own commit, so by the
+time `/bump` runs, the upcoming release's bullets are already in the
+file.  This command's job is to **promote** the Unreleased block to a
+versioned block, not to draft one from PR titles.
+
 ## 1. Read Current Version
 
 ```
@@ -26,15 +32,19 @@ Parse `$ARGUMENTS`:
 
 Validate the new version is greater than the current one.
 
-## 3. Draft CHANGELOG Entries
+## 3. Verify the Unreleased Block
 
-### 3a. Gather commits since the last tag
+### 3a. Refuse to bump an empty Unreleased
 
 ```
-git log $(git describe --tags --abbrev=0)..HEAD --oneline
+awk '/^## \[Unreleased\]$/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md
 ```
 
-### 3b. Verify every claim before you write the bullet
+If the extracted block contains nothing more than the trailing `---`
+separator, stop with `"## [Unreleased] is empty. Nothing to release."`
+and do not touch VERSION or CHANGELOG.
+
+### 3b. Verify every bullet's claim before promoting
 
 **This step is mandatory. Skipping it is how inaccurate release
 notes ship.** The v1.9.0 release went out with two factually wrong
@@ -45,7 +55,7 @@ picks one random page per cycle) because the draft was built from
 PR titles and memory. Fixing it required a CHANGELOG-correction PR,
 a GitHub Release delete, a tag re-cut, and a Docker image rebuild.
 
-For every PR you plan to reference in the CHANGELOG:
+For every PR referenced in the Unreleased block:
 
 ```bash
 gh pr view N --repo <owner>/<repo> --json title,body
@@ -66,30 +76,56 @@ upgraders.
 reference: a PR-body sentence, a diff fragment, or a source
 `file:line`. If you cannot cite one, rewrite the bullet or drop it.
 
-### 3c. Filter to user-facing changes
+If the Unreleased block has any bullets that no longer reflect the
+current code (e.g. a feature was reverted between merge and bump),
+edit them in place before continuing.
 
-**Include:**
+### 3c. Final filter and language pass
+
+The /ship workflow should already filter out non-user-facing changes
+and apply the project style guide when adding to Unreleased.  Double-
+check here, against the **Changelog style guide** in `AGENTS.md`
+(`## Versioning, Changelog & Releases` → `### Changelog style guide`).
+
+**Keep only user-facing entries:**
+
 - Features (Added)
 - Bug fixes (Fixed)
-- Behavioral changes, UI changes, config changes (Changed)
+- Behavioural / UI / config changes (Changed)
 - Removed functionality (Removed)
+- Deprecations (Deprecated)
+- Security fixes (Security)
 
-**Exclude:**
-- CI changes, refactors, test-only changes, docs-only changes
-- Chore/infrastructure work that does not affect the user
+**Drop:**
 
-If after filtering there are NO user-facing changes, report
-"No user-facing changes since vX.Y.Z. Nothing to release." and stop.
-Do not create a branch, do not touch VERSION or CHANGELOG.
+- CI changes, pure refactors, test-only changes, docs-only changes
+- Chore / infrastructure work that does not affect the operator
+- Dependency bumps with no security or behaviour impact
 
-**Format:**
+If after filtering the Unreleased block has no user-facing entries,
+report `"No user-facing changes in Unreleased. Nothing to release."`
+and stop.
+
+**Language pass:**
+
+Walk every remaining bullet against the AGENTS.md style guide.
+Flag and rewrite any bullet that:
+
+- References an internal Python class, private helper, or `src/...`
+  file path (rewrite to describe the user-visible behaviour).
+- Exceeds 250 characters or stretches across more than one sentence
+  without a migration / upgrade reason (split it).
+- Uses banned phrasings: "various", "improved", "enhanced", "better",
+  marketing adverbs ("seamlessly", "robustly", "significantly"),
+  empty verbs ("leverages", "utilizes"), bold lead-ins, marketing
+  trail clauses, em dashes.
+- Reads as past-tense narration ("We added...") instead of noun-led
+  present-tense state ("Logs page distinguishes...").
+
+**Format reminder:**
 
 ```markdown
 ## [X.Y.Z] - YYYY-MM-DD
-
-### Fixed
-
-- One sentence. User-facing impact first. Issue/PR ref at end (#N).
 
 ### Added
 
@@ -99,6 +135,10 @@ Do not create a branch, do not touch VERSION or CHANGELOG.
 
 - One sentence per bullet. (#N)
 
+### Fixed
+
+- One sentence. User-facing impact first. Issue/PR ref at end (#N).
+
 ### Removed
 
 - One sentence per bullet. (#N)
@@ -107,11 +147,12 @@ Do not create a branch, do not touch VERSION or CHANGELOG.
 ```
 
 **Rules:**
+
 - Every bullet must be justified by a PR-body sentence, a diff
   fragment, or a source `file:line`. Do not draft from PR titles,
   commit messages, or memory alone. See §3b.
-- Allowed `###` headers: `Added`, `Fixed`, `Changed`, `Removed` only.
-  Omit any section that has no entries.
+- Allowed `###` headers: `Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`, `Security` only. Omit any section that has no entries.
 - One sentence per bullet; no multi-line prose.
 - Lead with user-facing impact, not implementation details.
 - End with `(#N)` issue/PR reference.
@@ -123,12 +164,14 @@ Do not create a branch, do not touch VERSION or CHANGELOG.
 - Be specific: `Connection errors now log at WARNING with instance name`
   not `Improved error handling`.
 - Each version block ends with a `---` line (blank line before and after).
-- Do not use `## [Unreleased]`.
 
-## 4. Present Draft for Review
+## 4. Present the Promotion Plan for Review
 
-Show me the draft CHANGELOG block before writing it. Wait for my
-approval or edits. Do not proceed until I confirm.
+Show me a unified diff of the planned CHANGELOG.md change: the renamed
+heading (`## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD`), any bullet
+edits made in §3b, and the fresh empty `## [Unreleased]` block that
+will sit above it.  Wait for my approval or edits.  Do not proceed
+until I confirm.
 
 ## 5. Create Branch and Tracking Issue
 
@@ -150,10 +193,26 @@ gh issue create --title "chore: bump version to X.Y.Z" \
 Write the new version (single line, no `v` prefix, no trailing newline
 beyond what was already there).
 
-## 7. Write CHANGELOG.md
+## 7. Promote Unreleased in CHANGELOG.md
 
-Insert the new version block at the top of CHANGELOG.md, directly
-after any header content and before the previous version block.
+Two edits, in this order:
+
+1. Rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (today's date,
+   ISO 8601).
+2. Insert a fresh, empty Unreleased block at the top, directly after
+   the file header:
+
+   ```markdown
+   ## [Unreleased]
+
+   ---
+
+   ## [X.Y.Z] - YYYY-MM-DD
+   ```
+
+The fresh block intentionally has only the heading + `---` separator;
+the version-check workflow is fine with an empty body so long as the
+trailing `---` is present.
 
 ## 8. Run Quality Gates
 
@@ -186,7 +245,9 @@ Closes #N
 
 ## What changed
 
-Version bump to X.Y.Z. Only VERSION and CHANGELOG.md are modified.
+Version bump to X.Y.Z. Only VERSION and CHANGELOG.md are modified;
+the changelog promotes the existing `## [Unreleased]` block to a
+versioned heading and reseeds an empty Unreleased above it.
 
 ## Release notes (from CHANGELOG)
 
@@ -197,6 +258,7 @@ Version bump to X.Y.Z. Only VERSION and CHANGELOG.md are modified.
 - [x] Linked issue has `type:*` and `priority:*` labels
 - [x] Only VERSION and CHANGELOG.md changed
 - [x] CHANGELOG entry follows existing format
+- [x] Fresh `## [Unreleased]` block reseeded above the new version
 PREOF
 )"
 ```

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -32,6 +32,11 @@ jobs:
           set -euo pipefail
           errors=0
 
+          # Allowed `### Section` headers per Keep a Changelog 1.1.0.
+          # Houndarr extends the strict set with Deprecated and Security so
+          # future deprecation/security entries do not need a workflow tweak.
+          ALLOWED_HEADERS='^### (Added|Changed|Deprecated|Removed|Fixed|Security)$'
+
           # --- VERSION file format ---
           if [ ! -f VERSION ]; then
             echo "::error::VERSION file not found"
@@ -44,6 +49,34 @@ jobs:
             errors=$((errors + 1))
           fi
 
+          # --- ## [Unreleased] section must exist and sit above every
+          #     versioned block (Keep a Changelog 1.1.0 §"Unreleased"). ---
+          if ! grep -qE '^## \[Unreleased\]$' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md missing required '## [Unreleased]' section"
+            errors=$((errors + 1))
+          fi
+
+          FIRST_BLOCK=$(grep -m1 -E '^## \[' CHANGELOG.md || true)
+          if [ "$FIRST_BLOCK" != "## [Unreleased]" ]; then
+            echo "::error::'## [Unreleased]' must be the first '## [...]' block in CHANGELOG.md (got '$FIRST_BLOCK')"
+            errors=$((errors + 1))
+          fi
+
+          # --- Unreleased block: validate headers + trailing separator. ---
+          UNRELEASED=$(awk '/^## \[Unreleased\]$/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md)
+
+          if ! echo "$UNRELEASED" | grep -qE '^---$'; then
+            echo "::error::'## [Unreleased]' block is missing trailing '---' separator"
+            errors=$((errors + 1))
+          fi
+
+          BAD_UNRELEASED=$(echo "$UNRELEASED" | grep -E '^### ' | grep -vE "$ALLOWED_HEADERS" || true)
+          if [ -n "$BAD_UNRELEASED" ]; then
+            echo "::error::'## [Unreleased]' contains disallowed ### headers:"
+            echo "$BAD_UNRELEASED"
+            errors=$((errors + 1))
+          fi
+
           # --- CHANGELOG heading must match VERSION ---
           if ! grep -qE "^## \[${FILE_VERSION}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no '## [${FILE_VERSION}] - YYYY-MM-DD' entry"
@@ -52,8 +85,8 @@ jobs:
 
           # --- Matched block must contain at least one ### subsection ---
           BLOCK=$(awk "/^## \[${FILE_VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
-          if ! echo "$BLOCK" | grep -qE '^### (Added|Fixed|Changed|Removed)'; then
-            echo "::error::CHANGELOG block for ${FILE_VERSION} has no valid ### subsection (Added/Fixed/Changed/Removed)"
+          if ! echo "$BLOCK" | grep -qE "$ALLOWED_HEADERS"; then
+            echo "::error::CHANGELOG block for ${FILE_VERSION} has no valid ### subsection"
             errors=$((errors + 1))
           fi
 
@@ -64,7 +97,7 @@ jobs:
           fi
 
           # --- ### headers must be from the allowed set ---
-          BAD_HEADERS=$(echo "$BLOCK" | grep -E '^### ' | grep -vE '^### (Added|Fixed|Changed|Removed)$' || true)
+          BAD_HEADERS=$(echo "$BLOCK" | grep -E '^### ' | grep -vE "$ALLOWED_HEADERS" || true)
           if [ -n "$BAD_HEADERS" ]; then
             echo "::error::CHANGELOG block for ${FILE_VERSION} contains disallowed ### headers:"
             echo "$BAD_HEADERS"
@@ -76,4 +109,4 @@ jobs:
             exit 1
           fi
 
-          echo "Version check passed: VERSION=${FILE_VERSION}, CHANGELOG entry valid"
+          echo "Version check passed: VERSION=${FILE_VERSION}, Unreleased section present, ${FILE_VERSION} block valid"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -685,38 +685,168 @@ Subject line max 50 characters (including the `type(scope): ` prefix); body line
 (GitHub Releases, Docker tags, GHCR `latest`) is derived automatically.
 
 - `VERSION`: one line, plain `X.Y.Z` (no `v` prefix)
-- `CHANGELOG.md`: Keep a Changelog format
+- `CHANGELOG.md`: [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)
+  with a `## [Unreleased]` section at the top and one versioned block per
+  release below it
 
 ### Release workflow
 
 ```
-1. Fix/feature PR merged to main
-2. Open a separate "chore: bump version to X.Y.Z" PR
-   - Change only VERSION and CHANGELOG.md
-   - No other files
-3. Merge the version bump PR
+1. Each fix/feature PR adds a bullet under `## [Unreleased]` in
+   CHANGELOG.md as part of its own commit (the /ship workflow
+   handles this for user-facing changes; non-user-facing PRs skip
+   the bullet).
+2. When ready to release, open a separate "chore: bump version to
+   X.Y.Z" PR via /bump:
+   - Promote `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`
+   - Reseed an empty `## [Unreleased]` block above the new
+     versioned block
+   - Change only VERSION and CHANGELOG.md (no other files)
+3. Merge the version bump PR.
 4. Tag and push:  git tag vX.Y.Z && git push origin vX.Y.Z
    → docker.yml  builds + pushes to GHCR as vX.Y.Z + latest
-   → release.yml extracts CHANGELOG block, creates GitHub Release
+   → release.yml extracts the X.Y.Z CHANGELOG block, creates GitHub Release
    → chart.yml   packages + pushes Helm chart to oci://ghcr.io/av1155/charts
 ```
 
-Never push a `v*` tag without a matching `## [X.Y.Z]` block in `CHANGELOG.md`.
+Never push a `v*` tag without a matching `## [X.Y.Z] - YYYY-MM-DD` block
+in `CHANGELOG.md`.
+
+### Changelog style guide
+
+The audience is self-hosters and homelab operators running Houndarr
+in Docker or Kubernetes alongside the *arr stack.  They read config
+files, env vars, log lines, and SQLite schemas; they do not read the
+Python source.  Tune every bullet for that reader.
+
+**Voice (noun-led, present tense):**
+
+The category heading carries the verb (`### Added`, `### Fixed`,
+`### Changed`).  Bullets describe the post-change state from the
+reader's vantage point, not the maintainer's action:
+
+- Good: `Logs page distinguishes a fresh install (No log entries yet)
+  from a filter that matches nothing (No entries match those filters.). (#566)`
+- Avoid: `We added a fresh-install vs filter-empty distinction to the
+  logs page.` (narrator voice)
+- Avoid: `Distinguish fresh-install from filter-empty on the logs
+  page.` (imperative; reserved for SDK changelogs)
+
+This matches the convention used by Authelia, AdGuard Home, Plausible,
+Caddy, and other self-hosted tools targeting the same audience.
+
+**Length:**
+
+- Target: 80 to 160 characters per bullet.
+- Hard ceiling: 250 characters.  A bullet longer than that must split
+  into two unrelated bullets, or the second clause moves to the PR body.
+- One sentence per bullet.  A second sentence is permitted only when
+  a migration or upgrade-affecting consequence must ride with the
+  change (rare).
+
+**Vocabulary the operator can act on, only:**
+
+- Use: env var names (`HOUNDARR_COOKIE_SAMESITE`), config keys, schema
+  version numbers (`Schema v16`), database column names that survive
+  in the SQLite file (`monitored_total`, `whisparr_episode`), HTTP
+  routes (`/api/status`), log strings the operator can grep
+  (`hourly limit reached (N/hr)`), CVE IDs, dependency versions when
+  a security or behaviour change ties to the bump.
+- Avoid: internal Python class names (`InstanceValidationError`,
+  `AuthMiddleware._dispatch_proxy`), private helpers
+  (`_redirect_guard`, `_run_search_pass`), file paths under `src/`,
+  module attribute names that have no user surface.  Describe the
+  user-visible behaviour instead.
+- Borderline: public library types that surface in tracebacks
+  (`httpx.TransportError`).  Allowed when the user actually sees the
+  type name in their logs, otherwise paraphrase to "transport-level
+  error".
+
+**Banned phrasings (drift signals; rewrite or drop):**
+
+- Vague: "Various bug fixes", "Minor improvements", "Misc updates",
+  "Bug fixes and stability improvements".
+- Marketing: "We are thrilled to...", "delightful new experience",
+  "groundbreaking", "exciting".
+- Magic adverbs without measurement: "seamlessly", "robustly",
+  "significantly", "dramatically".  Either quantify ("reduces idle
+  CPU by 60%") or omit.
+- Empty verbs: "leverages", "utilizes", "harnesses", "facilitates".
+  Pick the concrete verb.
+- Vague comparatives: "Improved error handling", "Enhanced UX",
+  "Better performance".  Name the change: "Connection errors now
+  log at WARNING with the instance name."
+- Bold lead-ins: `**Performance:** faster X`.  Plain bullet.
+- Marketing trail clauses: "for a smoother experience".  Stop at the
+  technical fact.
+- Past-tense narration: "We added...", "We fixed...".  Drop the
+  pronoun.
+- Em dashes anywhere (project-wide rule; use a colon, semicolon,
+  comma, period, or parentheses).
+
+**What does NOT belong in the changelog:**
+
+- Pure refactors with no user-visible behaviour change (Common
+  Changelog explicitly excludes these; they live in PR bodies).
+- Test-only changes.
+- Docs-only changes (the docs site has its own deploy log).
+- CI / workflow changes that do not affect deployers.
+- Dependency bumps with no security or behaviour impact.
+
+**Schema version bumps:**
+
+When a release ships a SQLite schema migration, name the schema
+number, what the migration touches, and any rollback constraint.  An
+AdGuard-Home-style "to roll back, downgrade to <previous tag>" line
+helps operators who restore from a backup.
+
+**Examples (verbatim from the repo, judged):**
+
+- Exemplary: ``Helm chart `appVersion` is now prefixed with `v` so it
+  matches the published Docker image tags. (#364)`` (102 chars; named
+  user-visible attribute; one causal clause).
+- Exemplary: ``Hourly rate-limit skip rows now read `hourly limit
+  reached (N/hr)` across missing, cutoff, and upgrade passes. (#491)``
+  (names the exact log string the operator greps for).
+- Over-technical (rewrite before merging): ``Curated
+  `InstanceValidationError.public_message` text replaces the raw
+  exception in instance validation banners`` should read ``Instance
+  validation banner shows a curated message instead of the raw Python
+  exception``.
+- Over-technical (rewrite): ``Random search order now uses a
+  stratified-shuffle page deck plus partial-page sentinel padding``
+  should read ``Random search order spreads dispatch probability
+  uniformly across the backlog so no page is over- or under-selected``.
 
 ### CHANGELOG entry rules
 
+CHANGELOG.md always carries a `## [Unreleased]` section above every
+versioned block:
+
 ```markdown
-## [X.Y.Z] - YYYY-MM-DD
+## [Unreleased]
+
+### Added
+
+- One sentence per bullet. (#N)
 
 ### Fixed
 
 - One sentence. User-facing impact first. Issue/PR ref at end (#N).
+
+---
+
+## [X.Y.Z] - YYYY-MM-DD
 
 ### Added
 
 - One sentence per bullet. (#N)
 
 ### Changed
+
+- One sentence per bullet. (#N)
+
+### Fixed
 
 - One sentence per bullet. (#N)
 
@@ -727,11 +857,15 @@ Never push a `v*` tag without a matching `## [X.Y.Z]` block in `CHANGELOG.md`.
 ---
 ```
 
-**Allowed `###` headers:** `Added`, `Fixed`, `Changed`, `Removed` only.
-Level-4 `####` subheadings may group items within `###` sections for major
-releases.
+**Allowed `###` headers (Keep a Changelog 1.1.0):** `Added`, `Changed`,
+`Deprecated`, `Removed`, `Fixed`, `Security`. Level-4 `####` subheadings
+may group items within `###` sections for major releases. Omit any
+section that has no entries.
 
 **Bullet rules:**
+- Add the bullet to `## [Unreleased]` as part of the same PR that
+  ships the change. /bump promotes the accumulated Unreleased block
+  to a versioned heading at release time.
 - Every bullet must be justified by a PR-body sentence, a diff fragment,
   or a source `file:line`. Do not draft from PR titles, commit messages,
   or memory alone. The verification protocol lives in
@@ -741,28 +875,40 @@ releases.
   "new default for fresh installs; existing instances keep their prior
   behaviour," the bullet says "new default for newly added instances,"
   not "new default."
-- One sentence per bullet; no multi-line prose
-- Lead with user-facing impact, not implementation details
-- End with `(#N)` issue/PR reference
-- Use backticks for identifiers, file names, env vars, UI elements
+- One sentence per bullet; no multi-line prose.
+- Lead with user-facing impact, not implementation details.
+- End with `(#N)` issue/PR reference.
+- Use backticks for identifiers, file names, env vars, UI elements.
 - Use markdown `[text](url)` syntax for links; bare URLs do not auto-link
   in the in-app `What's New` modal (GitHub's CHANGELOG view autolinks both,
   but the modal's `_render_changelog_bullet` filter only accepts the
-  `[text](url)` form)
+  `[text](url)` form).
 - Be specific: `Connection errors now log at WARNING with instance name`
-  not `Improved error handling`
+  not `Improved error handling`.
 
-**Separators:** Each version block ends with a `---` line (blank line before
-and after). Do not use `## [Unreleased]`.
+**Separators:** Both `## [Unreleased]` and every versioned block end with
+a `---` line (blank line before and after). The fresh Unreleased block
+reseeded by /bump carries only the heading and the trailing `---`.
+
+**Non-user-facing PRs:** CI-only, refactor-only, test-only, docs-only,
+and chore/infrastructure changes do not get a Changelog bullet. The
+/ship workflow filters these out automatically.
 
 ### CI-enforced validation
 
 1. **PR-time** (`version-check.yml`): Runs on PRs touching `VERSION` or
-   `CHANGELOG.md`. Validates format, heading match, valid `###` headers,
-   `---` separator.
-2. **Tag-time** (`release.yml`): Validates VERSION == tag, extracts release
-   notes via `awk`, creates GitHub Release using `--notes-file` (avoids
-   backtick shell substitution).
+   `CHANGELOG.md`. Validates VERSION format, requires `## [Unreleased]`
+   as the topmost `## [...]` block, validates the Unreleased block's
+   `###` headers + trailing `---` separator, and validates the `## [VERSION] - YYYY-MM-DD`
+   block matches VERSION with valid `###` headers + trailing `---`.
+2. **Tag-time** (`release.yml`): Validates VERSION == tag, extracts the
+   `## [X.Y.Z]` block via `awk`, creates GitHub Release using
+   `--notes-file` (avoids backtick shell substitution).
+
+The in-app `What's New` modal parser (`src/houndarr/services/changelog.py`)
+silently skips `## [Unreleased]` because the heading lacks the `X.Y.Z`
+plus ISO-date suffix that `_VERSION_HEADING` requires; users only see
+versioned blocks until /bump promotes Unreleased.
 
 ---
 
@@ -817,8 +963,9 @@ someone comments, so reporters get immediate feedback.
 
 - Do not modify the 11 required check job names; branch protection depends
   on exact name matches
-- Do not add `## [Unreleased]` to CHANGELOG.md; the release workflow
-  extracts content between `## [X.Y.Z]` headings
+- Do not delete the `## [Unreleased]` block at the top of CHANGELOG.md;
+  `version-check.yml` requires it as the topmost `## [...]` block on every
+  PR, and `/bump` reseeds an empty one after each promotion
 - Do not change `ci-skip.yml` job names without updating branch protection
 - If mypy CI fails with "merge ref not found": push an empty commit to retrigger
 - Keep `paths-ignore` patterns in sync across the six main workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Changelog modal and add-instance settings modal cap to a sensible desktop width again, restoring the limit lost from the production CSS bundle by the `1.10.0` macro refactor. (#574)
+
+---
 
 ## [1.10.0] - 2026-04-28
 

--- a/src/houndarr/services/changelog.py
+++ b/src/houndarr/services/changelog.py
@@ -1,13 +1,19 @@
 """Parse CHANGELOG.md and decide when the "What's new" modal should render.
 
-The parser expects the strict subset of Keep a Changelog that
+The parser expects the strict subset of Keep a Changelog 1.1.0 that
 ``.github/workflows/version-check.yml`` enforces on every release PR:
 
-- ``## [X.Y.Z] - YYYY-MM-DD`` opens a block.
-- ``### Added|Changed|Fixed|Removed`` (or any other ``###`` header, rendered
-  permissively) opens a section within a block.
+- ``## [X.Y.Z] - YYYY-MM-DD`` opens a versioned block.
+- ``### Added|Changed|Deprecated|Removed|Fixed|Security`` (or any other
+  ``###`` header, rendered permissively) opens a section within a block.
 - ``- `` starts a bullet (may continue onto wrapped lines).
 - ``---`` closes the block.
+
+The ``## [Unreleased]`` block at the top of CHANGELOG.md is intentionally
+skipped: ``_VERSION_HEADING`` requires a strict ``X.Y.Z`` plus an ISO date,
+so the heading does not match and bullets accumulated for the next release
+stay invisible to the in-app modal until ``/bump`` promotes them to a
+versioned block.
 
 Unexpected content is skipped rather than raising; a malformed file
 degrades to an empty changelog so the modal short-circuits instead of


### PR DESCRIPTION
## Summary

Adopt the Keep a Changelog 1.1.0 `## [Unreleased]` convention so every shipped PR accumulates its own bullet at the top of `CHANGELOG.md` rather than relying on `/bump` to draft the entire release block from PR titles.  v1.9.0 had to be re-cut after exactly that failure mode (#420), and the modal-cap regression in #574 was the kind of small fix that previously had no good place to land between bumps.

This PR:

- Adds a `## [Unreleased]` block at the top of `CHANGELOG.md` with the modal-cap fix from #574 logged under `### Fixed`.
- Updates `version-check.yml` to require the Unreleased section as the topmost `## [...]` block on every PR, broadens the allowed `### Section` headers to the full Keep a Changelog 1.1.0 set (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`), and validates the trailing `---` separator.
- Rewrites `.claude/commands/bump.md` so `/bump` promotes Unreleased to a versioned heading and reseeds an empty Unreleased above it.
- Adds a `### Changelog style guide` section to `AGENTS.md` with audience definition, voice (noun-led present tense), length cap (target 80-160 chars, hard ceiling 250), banned phrasings, vocabulary scope, and worked examples judged against peer self-hosted projects (Authelia, AdGuard Home, Plausible, Caddy, Linkwarden, Sonarr, Radarr).
- Updates `src/houndarr/services/changelog.py` docstring to make explicit that the in-app `What's New` modal parser silently skips `## [Unreleased]` (the heading lacks the strict `X.Y.Z` plus ISO-date suffix that `_VERSION_HEADING` requires).

The companion update to `~/.claude/skills/ship/SKILL.md` (global skill, not part of this repo) lands separately so `/ship` detects Keep a Changelog format, decides user-facing vs not from the branch type plus changed paths, finds the project's style guide, and drafts a bullet that respects the local rules.

Closes #575

## Changes

- `CHANGELOG.md`: bumps the format-reference link from 1.0.0 to 1.1.0; adds `## [Unreleased]` with one bullet for #574.
- `.github/workflows/version-check.yml`: adds Unreleased-block validation and the `Deprecated` / `Security` headers; the existing per-version validation is preserved.
- `.claude/commands/bump.md`: rewrites the flow around promoting Unreleased; preserves the verify-every-claim discipline (now applied to bullets contributors wrote at ship time rather than to `/bump`-time drafts).
- `AGENTS.md`: adds the Changelog style guide; updates Release workflow, CHANGELOG entry rules, and CI-enforced validation; removes the prior "Do not use `## [Unreleased]`" guidance.
- `src/houndarr/services/changelog.py`: docstring-only update.

## Testing

`just quick` passes (2590 unit tests).  Locally validated:

- The new `version-check.yml` logic accepts the updated `CHANGELOG.md` (current Unreleased + 1.10.0 block).
- The same logic accepts a synthesised post-bump shape (empty Unreleased + new versioned block).
- `release.yml`'s `awk` extraction still produces the correct release notes for `v1.10.0`, and would correctly extract a hypothetical `v1.11.0` block sitting between the Unreleased section and `## [1.10.0]`.
- The 96 changelog parser tests in `tests/test_services/test_changelog.py`, `tests/test_routes/test_changelog.py`, and `tests/test_routes/test_changelog_pinning.py` pass against the new `CHANGELOG.md`.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way