### PR TITLE
docs(install): tighten from-source guide to Diataxis how-to shape

### DIFF
--- a/website/docs/guides/installation/from-source.md
+++ b/website/docs/guides/installation/from-source.md
@@ -16,42 +16,35 @@ is for development.
 
 - Python 3.12 or later
 - pip
-- Node.js 22 or later (only needed to compile the CSS bundle)
-- pnpm via `corepack enable` (Node 20+ ships corepack)
+- Node.js 22 or later
+- pnpm (via `corepack enable`)
 
 ## Setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/av1155/houndarr.git
 cd houndarr
 
-# Create a Python virtual environment
 python3 -m venv .venv
 .venv/bin/pip install --upgrade pip
 .venv/bin/pip install -r requirements-dev.txt
 .venv/bin/pip install -e .
 
-# Compile the Tailwind + daisyUI CSS bundle
 corepack enable
 pnpm install --frozen-lockfile
 pnpm run build-css
 
-# Run in development mode
 .venv/bin/python -m houndarr --data-dir ./data-dev --dev
 ```
 
 The dev server listens on `http://localhost:8877`.
 
-The compiled `src/houndarr/static/css/app.built.css` is gitignored
-because it is a build artefact. Re-run `pnpm run build-css` whenever
-you pull commits that touch `src/houndarr/static/css/` or
-`src/houndarr/templates/`. Houndarr refuses to start if the bundle is
-missing and prints the exact command in the log.
+## Rebuild the CSS bundle
 
-The Docker image runs the same `pnpm run build-css` step
-automatically as a multi-stage build, so Docker users do not need
-Node or pnpm installed.
+Re-run `pnpm run build-css` after pulling commits that change
+`src/houndarr/static/css/` or `src/houndarr/templates/`. Houndarr
+refuses to start without the compiled bundle and prints the same
+command in the log.
 
 ## Development mode
 


### PR DESCRIPTION
Closes #583

## Summary

Tighten `website/docs/guides/installation/from-source.md` so it reads as a Diataxis how-to rather than a how-to with explanation/reference asides. The CSS build step added in #582 worked but introduced three weak spots that the [Diataxis how-to guidance](https://diataxis.fr/how-to-guides/) explicitly warns against.

## Specific edits

- Drop the "(only needed to compile the CSS bundle)" parenthetical from Requirements. The reader infers purpose from the build step that uses it.
- Drop the "because it is a build artefact" explanation. The how-to says when to re-run the build, not what the file is.
- Drop the standalone Docker comparison paragraph. Cross-page comparisons belong on the install index, not inside a how-to.
- Promote the rebuild instruction to its own `## Rebuild the CSS bundle` section so the page presents three discrete tasks (Setup, Rebuild, Development mode) the reader can map against the work they're about to do.

Net result: 7 lines added, 14 lines removed, same set of facts, more pattern-matchable structure. The `tests.yml`, `quality.yml`, etc. workflows skip on `website/**` paths so this only triggers `Link Check` and `CI Skip (docs-only)`.

## Test plan

- [x] `cd website && pnpm install && pnpm run build` produces no warnings on the changed page (verified locally).
- [x] Rendered Markdown reads as a sequential how-to: clone, venv, build CSS, run; rebuild after pulling CSS/template changes; dev-mode flag info.
- [x] No internal links altered, no anchors removed.