### PR TITLE
fix(perf): cure dashboard hang on large search_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `HOUNDARR_LOG_RETENTION_DAYS` env var configures the search log retention threshold (default `30`; `0` disables automatic purges, `7` to `365` overrides the default). (#586)
+- Helm chart ships a `startupProbe` with a 10-minute default budget so first-boot migrations on Kubernetes finish before the liveness probe kicks in; `failureThreshold` and `periodSeconds` are exposed in `values.yaml`. (#586)
+
+### Changed
+
+- Dashboard aggregations cache for 20 seconds in-process so polling tabs share one DB scan; mutation routes invalidate immediately, and the HTMX poll drops new triggers while a previous response is still in flight. (#586)
+- SQLite connections are reused through a connection pool with the modern operational PRAGMA stack (`synchronous=NORMAL`, `temp_store=MEMORY`, larger per-connection cache, memory-mapped reads, capped WAL growth); `PRAGMA optimize` runs after migrations and after each daily retention pass. (#586)
+
 ### Fixed
 
 - From-source installs now refuse to start with a clear error message when the compiled `app.built.css` is missing instead of silently 404-ing every stylesheet request, and the from-source install guide documents the `pnpm install` and `pnpm run build-css` step required since `1.10.0`.
+- Dashboard no longer hangs on databases with large `search_log` tables: two new composite indexes serve the v14 cooldown back-fill and the dashboard aggregation queries instead of full-table scans, and the back-fill itself only touches cooldown rows still at the default `'missing'` stamp. (#586)
 
 ---
 

--- a/charts/houndarr/templates/statefulset.yaml
+++ b/charts/houndarr/templates/statefulset.yaml
@@ -75,12 +75,30 @@ spec:
             - name: HOUNDARR_LOG_LEVEL
               value: {{ .Values.env.logLevel | quote }}
             {{- end }}
+            {{- if ne (toString .Values.env.logRetentionDays) "30" }}
+            - name: HOUNDARR_LOG_RETENTION_DAYS
+              value: {{ .Values.env.logRetentionDays | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data
+          # startupProbe gates the liveness and readiness checks until
+          # the lifespan finishes initialising the database.  On clean
+          # boots the schema/migrations/index sweep finishes in seconds,
+          # but a v1.9.0->v1.10.x upgrade against a 280k-row search_log
+          # used to spend several minutes back-filling cooldowns and
+          # building indexes (issue #586).  60 attempts at 10 s each
+          # gives up to 10 minutes; raise ``failureThreshold`` for very
+          # large histories where the first-boot index build is slower.
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
           livenessProbe:
             httpGet:
               path: /api/health

--- a/charts/houndarr/values.yaml
+++ b/charts/houndarr/values.yaml
@@ -40,6 +40,19 @@ env:
   authProxyHeader: ""
   # -- Log verbosity. One of: debug, info, warning, error.
   logLevel: info
+  # -- Number of days of search_log rows to retain.
+  # 0 disables automatic purges; 7 to 365 overrides the default of 30.
+  # Sets HOUNDARR_LOG_RETENTION_DAYS.  Lower this on small storage to
+  # keep the dashboard responsive; large libraries can extend it.
+  logRetentionDays: 30
+
+# -- Startup probe budget for first-boot migrations on large databases.
+# Defaults give 10 minutes (60 attempts * 10 s).  Raise failureThreshold
+# for v1.9.0 to v1.10.x upgrades against very large search_log tables
+# where the cooldown back-fill and index build take longer.
+startupProbe:
+  failureThreshold: 60
+  periodSeconds: 10
 
 # -- Persistent volume for /data (SQLite database and encryption master key).
 persistence:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "jinja2>=3.1.6",
     "markupsafe>=3.0.3",
     "aiosqlite>=0.22.1",
+    "aiosqlitepool==1.0.0",
+    "async-lru==2.3.0",
     "httpx>=0.28.1",
     "bcrypt>=5.0.0",
     "cryptography>=46.0.7",
@@ -115,7 +117,7 @@ warn_unused_ignores = true
 show_error_codes = true
 
 [[tool.mypy.overrides]]
-module = ["aiosqlite.*", "bcrypt.*"]
+module = ["aiosqlite.*", "aiosqlitepool.*", "bcrypt.*"]
 ignore_missing_imports = true
 
 # ---------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ uvicorn[standard]>=0.44.0
 jinja2>=3.1.6
 markupsafe>=3.0.3
 aiosqlite>=0.22.1
+aiosqlitepool==1.0.0
+async-lru==2.3.0
 httpx>=0.28.1
 bcrypt>=5.0.0
 cryptography>=46.0.7

--- a/scripts/bench_586_end_to_end.py
+++ b/scripts/bench_586_end_to_end.py
@@ -1,0 +1,434 @@
+"""End-to-end benchmark replicating issue #586 with the full Houndarr stack.
+
+Boots a Houndarr FastAPI app inside this process against a temporary data
+directory, points it at the seeded mock_arr stack on a free port, and
+exercises the production code path under the reporter's exact profile
+(280 k search_log rows, 6 000 cooldowns, 3 active *arr instances).
+Every measurement uses the real route handlers, the real connection
+pool, and the real cache.
+
+Three modes are exercised:
+
+* ``--variant post-fix``: the current branch as-is.
+* ``--variant pre-fix``: drops the two new indexes after seeding, so the
+  v14 self-heal and dashboard queries fall back to the v1.10.0 plan.
+* ``--variant cache-disabled``: keeps indexes but forces ttl_seconds=0.
+
+Per variant, the script measures:
+
+1. Wall-clock for ``init_db_schema -> purge -> init_db_migrations``.
+2. ``/api/status`` cold-cache latency over N samples.
+3. ``/api/status`` warm-cache latency.
+4. ``/api/status`` under M concurrent clients (single-flight test).
+5. Run-now invalidation and the deferred re-clear.
+6. Settings-page invalidation hooks.
+7. Retention purge wall clock.
+8. Memory before vs after seed.
+
+The output is printed as a Markdown-friendly report so it can be pasted
+into a PR description as proof.
+
+Run:
+
+    .venv/bin/python -m scripts.bench_586_end_to_end --variant post-fix
+    .venv/bin/python -m scripts.bench_586_end_to_end --variant pre-fix
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import resource
+import socket
+import statistics
+import sys
+import tempfile
+import threading
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import uvicorn
+
+import houndarr.engine.search_loop as _search_loop
+from houndarr.config import bootstrap_settings
+from houndarr.crypto import encrypt, ensure_master_key
+from houndarr.database import close_all_pools, get_db, set_db_path
+from tests.mock_arr.server import SeedConfig, create_app as create_mock_app
+
+
+_search_loop._INTER_SEARCH_DELAY_SECONDS = 0.0
+
+
+# --------------------------------------------------------------------------
+# Mock *arr lifecycle
+# --------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _start_mock(items: int, seed: int = 42) -> tuple[uvicorn.Server, threading.Thread, str]:
+    port = _free_port()
+    config = SeedConfig(
+        seed=seed,
+        sonarr_series=max(1, items // 10),
+        sonarr_episodes_per_series=max(1, items // max(1, items // 10)),
+        radarr_movies=items,
+        lidarr_artists=max(1, items // 10),
+        lidarr_albums_per_artist=max(1, items // max(1, items // 10)),
+        readarr_authors=max(1, items // 10),
+        readarr_books_per_author=max(1, items // max(1, items // 10)),
+        whisparr_v2_series=max(1, items // 10),
+        whisparr_v2_episodes_per_series=max(1, items // max(1, items // 10)),
+        whisparr_v3_movies=items,
+    )
+    app = create_mock_app(config)
+    uv_config = uvicorn.Config(app=app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(uv_config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and not server.started:
+        time.sleep(0.05)
+    if not server.started:
+        raise RuntimeError("mock failed to start")
+    return server, thread, f"http://127.0.0.1:{port}"
+
+
+def _stop_mock(server: uvicorn.Server, thread: threading.Thread) -> None:
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+# --------------------------------------------------------------------------
+# Houndarr app lifecycle (in-process, via httpx ASGITransport)
+# --------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _houndarr_app(
+    data_dir: str, *, cache_ttl: int = 20
+) -> AsyncIterator[httpx.AsyncClient]:
+    """Yield an httpx client wired to a fully-booted Houndarr ASGI app."""
+    from houndarr import app as app_module
+    from houndarr.auth import reset_auth_caches
+    import houndarr.services.metrics as metrics_module
+
+    # Re-pin settings to point at the temp dir; this also resets the
+    # runtime singleton.
+    bootstrap_settings(data_dir=data_dir, log_retention_days=30)
+    reset_auth_caches()
+
+    # Override cache TTL via attribute mutation; build_aggregate_cache
+    # reads it at call time.
+    metrics_module.DASHBOARD_CACHE_TTL_SECONDS = cache_ttl
+
+    fastapi_app = app_module.create_app()
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        # The lifespan runs lazily on the first request; trigger it.
+        async with fastapi_app.router.lifespan_context(fastapi_app):
+            yield client
+
+
+async def _login(client: httpx.AsyncClient) -> None:
+    await client.post(
+        "/setup",
+        data={
+            "username": "admin",
+            "password": "ValidPass1!",
+            "password_confirm": "ValidPass1!",
+        },
+    )
+    resp = await client.post(
+        "/login", data={"username": "admin", "password": "ValidPass1!"}, follow_redirects=False
+    )
+    assert resp.status_code in (200, 302, 303), f"login failed: {resp.status_code}"
+
+
+def _csrf(client: httpx.AsyncClient) -> dict[str, str]:
+    from houndarr.auth import CSRF_COOKIE_NAME
+
+    token = client.cookies.get(CSRF_COOKIE_NAME, "")
+    return {"X-CSRF-Token": token}
+
+
+# --------------------------------------------------------------------------
+# Seeding
+# --------------------------------------------------------------------------
+
+
+async def _seed_instances_directly(master_key: bytes, count: int = 3) -> list[int]:
+    """Seed instances via SQL with valid Fernet-encrypted api keys.
+
+    The production ``POST /settings/instances`` route runs the SSRF guard
+    that rejects ``127.0.0.1``, which makes a route-based seed
+    incompatible with the in-process mock server.  Bypassing the route
+    is acceptable for performance measurement: the bench's goal is to
+    time the lifespan + dashboard hot path against a realistic database
+    shape, not to exercise the route's input validation.
+    """
+    enc = encrypt("bench-key", master_key)
+    async with get_db() as conn:
+        for i in range(count):
+            kind = ("sonarr", "radarr", "lidarr")[i % 3]
+            await conn.execute(
+                "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (i + 1, f"Bench{kind.capitalize()}", kind, f"http://x/{i}", enc),
+            )
+        await conn.commit()
+        cur = await conn.execute("SELECT id FROM instances ORDER BY id")
+        rows = await cur.fetchall()
+    return [r["id"] for r in rows]
+
+
+async def _bulk_seed_search_log(rows: int, instance_ids: list[int]) -> None:
+    print(f"  seeding {rows:,} search_log rows + {len(instance_ids) * 2000:,} cooldowns...")
+    now = datetime.now(UTC)
+    chunk = 20_000
+
+    for offset in range(0, rows, chunk):
+        batch = []
+        for i in range(min(chunk, rows - offset)):
+            row_idx = offset + i
+            instance_id = instance_ids[row_idx % len(instance_ids)]
+            kind = ("missing", "cutoff", "upgrade")[row_idx % 3]
+            ts = (now - timedelta(minutes=row_idx % (30 * 24 * 60))).strftime(
+                "%Y-%m-%dT%H:%M:%S.000Z"
+            )
+            batch.append((instance_id, 100 + (row_idx % 5000), "episode", kind, "searched",
+                          f"Item {row_idx}", ts))
+        async with get_db() as conn:
+            await conn.executemany(
+                "INSERT INTO search_log (instance_id, item_id, item_type, search_kind,"
+                " action, item_label, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                batch,
+            )
+            await conn.commit()
+
+    cool_now = now.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    cool_rows = []
+    for instance_id in instance_ids:
+        for i in range(2000):
+            cool_rows.append((instance_id, 100 + i, "episode", "missing", cool_now))
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT OR IGNORE INTO cooldowns (instance_id, item_id, item_type,"
+            " search_kind, searched_at) VALUES (?, ?, ?, ?, ?)",
+            cool_rows,
+        )
+        await conn.commit()
+
+
+async def _drop_indexes_for_pre_fix_mode() -> None:
+    async with get_db() as conn:
+        await conn.execute("DROP INDEX IF EXISTS idx_search_log_lookup")
+        await conn.execute("DROP INDEX IF EXISTS idx_search_log_action_time")
+        await conn.commit()
+
+
+# --------------------------------------------------------------------------
+# Measurements
+# --------------------------------------------------------------------------
+
+
+def _stats(samples: list[float]) -> dict[str, float]:
+    if not samples:
+        return {"min": 0, "p50": 0, "p95": 0, "p99": 0, "max": 0, "mean": 0}
+    sorted_samples = sorted(samples)
+    n = len(sorted_samples)
+    return {
+        "min": min(sorted_samples) * 1000,
+        "p50": sorted_samples[n // 2] * 1000,
+        "p95": sorted_samples[max(0, int(n * 0.95) - 1)] * 1000,
+        "p99": sorted_samples[max(0, int(n * 0.99) - 1)] * 1000,
+        "max": max(sorted_samples) * 1000,
+        "mean": statistics.mean(sorted_samples) * 1000,
+    }
+
+
+def _human_stats(label: str, samples: list[float]) -> str:
+    s = _stats(samples)
+    return (f"  {label:30s} n={len(samples):>4d}  "
+            f"min={s['min']:>6.1f}ms  p50={s['p50']:>6.1f}ms  "
+            f"p95={s['p95']:>6.1f}ms  p99={s['p99']:>6.1f}ms  max={s['max']:>6.1f}ms")
+
+
+async def _measure_status_polls(client: httpx.AsyncClient, samples: int) -> list[float]:
+    timings = []
+    for _ in range(samples):
+        start = time.monotonic()
+        resp = await client.get("/api/status")
+        elapsed = time.monotonic() - start
+        assert resp.status_code == 200
+        timings.append(elapsed)
+    return timings
+
+
+async def _measure_concurrent_polls(
+    client: httpx.AsyncClient, concurrent: int, rounds: int
+) -> list[float]:
+    """Fire ``concurrent`` simultaneous polls per round, capture each latency.
+
+    Tests the connection pool + single-flight cache under realistic
+    multi-tab dashboard load.
+    """
+    timings = []
+    for _ in range(rounds):
+        async def _one() -> float:
+            start = time.monotonic()
+            resp = await client.get("/api/status")
+            elapsed = time.monotonic() - start
+            assert resp.status_code == 200
+            return elapsed
+        results = await asyncio.gather(*[_one() for _ in range(concurrent)])
+        timings.extend(results)
+    return timings
+
+
+def _peak_rss_mb() -> float:
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (
+        1024 * 1024 if sys.platform == "darwin" else 1024
+    )
+
+
+# --------------------------------------------------------------------------
+# Variant runner
+# --------------------------------------------------------------------------
+
+
+async def _run_variant(variant: str, rows: int) -> None:
+    print(f"\n{'=' * 70}")
+    print(f"VARIANT: {variant}  (rows={rows:,})")
+    print(f"{'=' * 70}")
+
+    cache_ttl = 0 if variant == "cache-disabled" else 20
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        master_key = ensure_master_key(data_dir)
+        set_db_path(os.path.join(data_dir, "houndarr.db"))
+
+        mock_server, mock_thread, mock_url = _start_mock(items=200, seed=42)
+        try:
+            async with _houndarr_app(data_dir, cache_ttl=cache_ttl) as client:
+                rss_before_seed = _peak_rss_mb()
+                print(f"  RSS at lifespan ready: {rss_before_seed:.1f} MB")
+
+                await _login(client)
+                instance_ids = await _seed_instances_directly(master_key, count=3)
+                instance_id = instance_ids[0]
+                print(f"  seeded {len(instance_ids)} instances directly (ids={instance_ids})")
+
+                seed_start = time.monotonic()
+                await _bulk_seed_search_log(rows, instance_ids)
+                print(f"  seed wall: {time.monotonic() - seed_start:.1f} s")
+
+                if variant == "pre-fix":
+                    await _drop_indexes_for_pre_fix_mode()
+                    print("  DROPPED idx_search_log_lookup + idx_search_log_action_time")
+
+                from houndarr.repositories.search_log import purge_old_logs
+                from houndarr.database import init_db_migrations
+
+                # Simulate a process restart: re-run the migration sweep so
+                # any v14 self-heal hits the chosen index plan.
+                t = time.monotonic()
+                await init_db_migrations()
+                init_elapsed = time.monotonic() - t
+                print(f"  init_db_migrations: {init_elapsed * 1000:.1f} ms")
+
+                t = time.monotonic()
+                purged = await purge_old_logs(30)
+                purge_elapsed = time.monotonic() - t
+                print(f"  purge_old_logs: {purge_elapsed * 1000:.1f} ms (deleted {purged})")
+
+                # Cold cache: the lifespan didn't pre-warm the cache, and
+                # variant=cache-disabled has no cache to warm.
+                cold = await _measure_status_polls(client, samples=10)
+                print(_human_stats("/api/status (cold/uncached)", cold))
+
+                # Warm cache: subsequent polls within TTL.
+                warm = await _measure_status_polls(client, samples=10)
+                print(_human_stats("/api/status (warm)", warm))
+
+                # Concurrent: 5 simultaneous polls (realistic max-tabs case).
+                # Higher concurrency exists in the test but is not modeled
+                # by the reporter's scenario (single dashboard tab).
+                concurrent = await _measure_concurrent_polls(
+                    client, concurrent=5, rounds=2
+                )
+                print(_human_stats("/api/status (5 concurrent x2)", concurrent))
+
+                # Mutation invalidation: a settings toggle should clear the
+                # cache so the next poll repopulates.  We measure both the
+                # toggle latency and the next poll latency.
+                t = time.monotonic()
+                resp = await client.post(
+                    f"/settings/instances/{instance_id}/toggle-enabled",
+                    headers=_csrf(client),
+                )
+                toggle_elapsed = time.monotonic() - t
+                assert resp.status_code == 200
+                # Toggle once more to put it back enabled; we test the
+                # invalidation effect on the next status call.
+                await client.post(
+                    f"/settings/instances/{instance_id}/toggle-enabled",
+                    headers=_csrf(client),
+                )
+                t = time.monotonic()
+                await client.get("/api/status")
+                post_invalidate = time.monotonic() - t
+                print(f"  toggle: {toggle_elapsed * 1000:.1f} ms;"
+                      f" first poll after invalidate: {post_invalidate * 1000:.1f} ms")
+
+                # Run-now: schedules a deferred re-clear after 3 s.
+                t = time.monotonic()
+                resp = await client.post(
+                    f"/api/instances/{instance_id}/run-now", headers=_csrf(client)
+                )
+                run_now_elapsed = time.monotonic() - t
+                print(f"  run-now POST: {run_now_elapsed * 1000:.1f} ms"
+                      f" (status={resp.status_code})")
+
+                # Factory-reset path is heavy; we skip it here (covered by
+                # the dedicated tests in test_services/test_admin.py).
+
+                rss_after = _peak_rss_mb()
+                print(f"  RSS at variant end:    {rss_after:.1f} MB"
+                      f" (delta={rss_after - rss_before_seed:+.1f} MB)")
+        finally:
+            await close_all_pools()
+            _stop_mock(mock_server, mock_thread)
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--variant",
+        choices=("post-fix", "pre-fix", "cache-disabled", "all"),
+        default="all",
+    )
+    parser.add_argument("--rows", type=int, default=280_000)
+    args = parser.parse_args()
+
+    variants = ("post-fix", "pre-fix", "cache-disabled") if args.variant == "all" else (
+        args.variant,
+    )
+    for variant in variants:
+        await _run_variant(variant, rows=args.rows)
+    print(f"\n{'=' * 70}")
+    print("DONE")
+    print(f"{'=' * 70}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/bench_586_end_to_end.py
+++ b/scripts/bench_586_end_to_end.py
@@ -52,13 +52,13 @@ from datetime import UTC, datetime, timedelta
 
 import httpx
 import uvicorn
+from tests.mock_arr.server import SeedConfig
+from tests.mock_arr.server import create_app as create_mock_app
 
 import houndarr.engine.search_loop as _search_loop
 from houndarr.config import bootstrap_settings
 from houndarr.crypto import encrypt, ensure_master_key
 from houndarr.database import close_all_pools, get_db, set_db_path
-from tests.mock_arr.server import SeedConfig, create_app as create_mock_app
-
 
 _search_loop._INTER_SEARCH_DELAY_SECONDS = 0.0
 
@@ -113,13 +113,11 @@ def _stop_mock(server: uvicorn.Server, thread: threading.Thread) -> None:
 
 
 @asynccontextmanager
-async def _houndarr_app(
-    data_dir: str, *, cache_ttl: int = 20
-) -> AsyncIterator[httpx.AsyncClient]:
+async def _houndarr_app(data_dir: str, *, cache_ttl: int = 20) -> AsyncIterator[httpx.AsyncClient]:
     """Yield an httpx client wired to a fully-booted Houndarr ASGI app."""
+    import houndarr.services.metrics as metrics_module
     from houndarr import app as app_module
     from houndarr.auth import reset_auth_caches
-    import houndarr.services.metrics as metrics_module
 
     # Re-pin settings to point at the temp dir; this also resets the
     # runtime singleton.
@@ -204,8 +202,17 @@ async def _bulk_seed_search_log(rows: int, instance_ids: list[int]) -> None:
             ts = (now - timedelta(minutes=row_idx % (30 * 24 * 60))).strftime(
                 "%Y-%m-%dT%H:%M:%S.000Z"
             )
-            batch.append((instance_id, 100 + (row_idx % 5000), "episode", kind, "searched",
-                          f"Item {row_idx}", ts))
+            batch.append(
+                (
+                    instance_id,
+                    100 + (row_idx % 5000),
+                    "episode",
+                    kind,
+                    "searched",
+                    f"Item {row_idx}",
+                    ts,
+                )
+            )
         async with get_db() as conn:
             await conn.executemany(
                 "INSERT INTO search_log (instance_id, item_id, item_type, search_kind,"
@@ -257,9 +264,11 @@ def _stats(samples: list[float]) -> dict[str, float]:
 
 def _human_stats(label: str, samples: list[float]) -> str:
     s = _stats(samples)
-    return (f"  {label:30s} n={len(samples):>4d}  "
-            f"min={s['min']:>6.1f}ms  p50={s['p50']:>6.1f}ms  "
-            f"p95={s['p95']:>6.1f}ms  p99={s['p99']:>6.1f}ms  max={s['max']:>6.1f}ms")
+    return (
+        f"  {label:30s} n={len(samples):>4d}  "
+        f"min={s['min']:>6.1f}ms  p50={s['p50']:>6.1f}ms  "
+        f"p95={s['p95']:>6.1f}ms  p99={s['p99']:>6.1f}ms  max={s['max']:>6.1f}ms"
+    )
 
 
 async def _measure_status_polls(client: httpx.AsyncClient, samples: int) -> list[float]:
@@ -283,12 +292,14 @@ async def _measure_concurrent_polls(
     """
     timings = []
     for _ in range(rounds):
+
         async def _one() -> float:
             start = time.monotonic()
             resp = await client.get("/api/status")
             elapsed = time.monotonic() - start
             assert resp.status_code == 200
             return elapsed
+
         results = await asyncio.gather(*[_one() for _ in range(concurrent)])
         timings.extend(results)
     return timings
@@ -335,8 +346,8 @@ async def _run_variant(variant: str, rows: int) -> None:
                     await _drop_indexes_for_pre_fix_mode()
                     print("  DROPPED idx_search_log_lookup + idx_search_log_action_time")
 
-                from houndarr.repositories.search_log import purge_old_logs
                 from houndarr.database import init_db_migrations
+                from houndarr.repositories.search_log import purge_old_logs
 
                 # Simulate a process restart: re-run the migration sweep so
                 # any v14 self-heal hits the chosen index plan.
@@ -362,9 +373,7 @@ async def _run_variant(variant: str, rows: int) -> None:
                 # Concurrent: 5 simultaneous polls (realistic max-tabs case).
                 # Higher concurrency exists in the test but is not modeled
                 # by the reporter's scenario (single dashboard tab).
-                concurrent = await _measure_concurrent_polls(
-                    client, concurrent=5, rounds=2
-                )
+                concurrent = await _measure_concurrent_polls(client, concurrent=5, rounds=2)
                 print(_human_stats("/api/status (5 concurrent x2)", concurrent))
 
                 # Mutation invalidation: a settings toggle should clear the
@@ -386,8 +395,10 @@ async def _run_variant(variant: str, rows: int) -> None:
                 t = time.monotonic()
                 await client.get("/api/status")
                 post_invalidate = time.monotonic() - t
-                print(f"  toggle: {toggle_elapsed * 1000:.1f} ms;"
-                      f" first poll after invalidate: {post_invalidate * 1000:.1f} ms")
+                print(
+                    f"  toggle: {toggle_elapsed * 1000:.1f} ms;"
+                    f" first poll after invalidate: {post_invalidate * 1000:.1f} ms"
+                )
 
                 # Run-now: schedules a deferred re-clear after 3 s.
                 t = time.monotonic()
@@ -395,15 +406,18 @@ async def _run_variant(variant: str, rows: int) -> None:
                     f"/api/instances/{instance_id}/run-now", headers=_csrf(client)
                 )
                 run_now_elapsed = time.monotonic() - t
-                print(f"  run-now POST: {run_now_elapsed * 1000:.1f} ms"
-                      f" (status={resp.status_code})")
+                print(
+                    f"  run-now POST: {run_now_elapsed * 1000:.1f} ms (status={resp.status_code})"
+                )
 
                 # Factory-reset path is heavy; we skip it here (covered by
                 # the dedicated tests in test_services/test_admin.py).
 
                 rss_after = _peak_rss_mb()
-                print(f"  RSS at variant end:    {rss_after:.1f} MB"
-                      f" (delta={rss_after - rss_before_seed:+.1f} MB)")
+                print(
+                    f"  RSS at variant end:    {rss_after:.1f} MB"
+                    f" (delta={rss_after - rss_before_seed:+.1f} MB)"
+                )
         finally:
             await close_all_pools()
             _stop_mock(mock_server, mock_thread)
@@ -419,8 +433,8 @@ async def main() -> int:
     parser.add_argument("--rows", type=int, default=280_000)
     args = parser.parse_args()
 
-    variants = ("post-fix", "pre-fix", "cache-disabled") if args.variant == "all" else (
-        args.variant,
+    variants = (
+        ("post-fix", "pre-fix", "cache-disabled") if args.variant == "all" else (args.variant,)
     )
     for variant in variants:
         await _run_variant(variant, rows=args.rows)

--- a/scripts/bench_586_replication.py
+++ b/scripts/bench_586_replication.py
@@ -36,7 +36,6 @@ from houndarr.database import (
     _migrate_to_v14,
     close_all_pools,
     get_db,
-    init_db,
     init_db_migrations,
     init_db_schema,
     set_db_path,
@@ -66,8 +65,7 @@ async def _seed_search_log(rows: int, instance_count: int) -> None:
 
     async with get_db() as conn:
         await conn.executemany(
-            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
-            " VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
             [
                 (i + 1, f"App{i + 1}", ["sonarr", "radarr", "lidarr"][i % 3], f"http://x/{i}", "")
                 for i in range(instance_count)
@@ -87,7 +85,9 @@ async def _seed_search_log(rows: int, instance_count: int) -> None:
             action = ("searched", "skipped", "searched", "info")[action_idx]
             minutes_ago = row_idx % (30 * 24 * 60)
             ts = (now - timedelta(minutes=minutes_ago)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
-            item_type = "episode" if instance_id == 1 else ("movie" if instance_id == 2 else "album")
+            item_type = (
+                "episode" if instance_id == 1 else ("movie" if instance_id == 2 else "album")
+            )
             batch.append((instance_id, item_id, item_type, kind, action, f"Item {row_idx}", ts))
 
         async with get_db() as conn:
@@ -107,10 +107,11 @@ async def _seed_cooldowns(instance_count: int, rows_per_instance: int) -> None:
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.000Z")
     async with get_db() as conn:
         for instance_id in range(1, instance_count + 1):
-            item_type = "episode" if instance_id == 1 else ("movie" if instance_id == 2 else "album")
+            item_type = (
+                "episode" if instance_id == 1 else ("movie" if instance_id == 2 else "album")
+            )
             batch = [
-                (instance_id, 100 + i, item_type, "missing", now)
-                for i in range(rows_per_instance)
+                (instance_id, 100 + i, item_type, "missing", now) for i in range(rows_per_instance)
             ]
             await conn.executemany(
                 "INSERT OR IGNORE INTO cooldowns (instance_id, item_id, item_type,"
@@ -171,7 +172,7 @@ async def _measure_dashboard(samples: int = 5, *, with_cache: bool = False) -> l
 class _StateWith:
     """Stand-in for ``app.state`` that lets us call ``invalidate_dashboard_cache``."""
 
-    def __init__(self, cache):
+    def __init__(self, cache: object) -> None:
         self.aggregate_cache = cache
 
 

--- a/scripts/bench_586_replication.py
+++ b/scripts/bench_586_replication.py
@@ -1,0 +1,233 @@
+"""Empirical replication of issue #586 against the post-fix codebase.
+
+Seeds a temporary SQLite database with the reporter's exact shape (~280k
+``search_log`` rows from 3 active instances over 30 days) and measures:
+
+1. Lifespan ``init_db()`` wall clock
+2. ``/api/status`` aggregation latency (cached and uncached)
+3. ``_migrate_to_v14`` self-heal idempotency (proves the back-fill no
+   longer re-runs every boot once stamped)
+
+The script is deliberately self-contained so it can run against the
+current branch without standing up a real *arr stack.  A second mode
+(``--without-indexes``) drops the two new composite indexes before the
+measurement to model pre-fix behaviour for direct comparison.
+
+Run::
+
+    .venv/bin/python -m scripts.bench_586_replication
+    .venv/bin/python -m scripts.bench_586_replication --without-indexes
+    .venv/bin/python -m scripts.bench_586_replication --rows 50000
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import statistics
+import sys
+import tempfile
+import time
+from datetime import UTC, datetime, timedelta
+
+from houndarr.config import bootstrap_settings
+from houndarr.database import (
+    _migrate_to_v14,
+    close_all_pools,
+    get_db,
+    init_db,
+    init_db_migrations,
+    init_db_schema,
+    set_db_path,
+)
+from houndarr.services.metrics import (
+    build_aggregate_cache,
+    gather_dashboard_status,
+    invalidate_dashboard_cache,
+)
+
+
+def _human(seconds: float) -> str:
+    if seconds < 1:
+        return f"{seconds * 1000:.0f} ms"
+    return f"{seconds:.2f} s"
+
+
+async def _seed_search_log(rows: int, instance_count: int) -> None:
+    """Seed ``rows`` rows distributed across ``instance_count`` instances.
+
+    Spreads timestamps evenly over the last 30 days so the dashboard's
+    24-hour and 7-day time windows have realistic data to filter.
+    """
+    print(f"Seeding {rows:,} search_log rows across {instance_count} instances...")
+    now = datetime.now(UTC)
+    chunk_size = 10_000
+
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+            " VALUES (?, ?, ?, ?, ?)",
+            [
+                (i + 1, f"App{i + 1}", ["sonarr", "radarr", "lidarr"][i % 3], f"http://x/{i}", "")
+                for i in range(instance_count)
+            ],
+        )
+        await conn.commit()
+
+    for offset in range(0, rows, chunk_size):
+        batch = []
+        for i in range(min(chunk_size, rows - offset)):
+            row_idx = offset + i
+            instance_id = (row_idx % instance_count) + 1
+            item_id = 100 + (row_idx % 5_000)
+            kind_idx = row_idx % 3
+            kind = ("missing", "cutoff", "upgrade")[kind_idx]
+            action_idx = row_idx % 4
+            action = ("searched", "skipped", "searched", "info")[action_idx]
+            minutes_ago = row_idx % (30 * 24 * 60)
+            ts = (now - timedelta(minutes=minutes_ago)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            item_type = "episode" if instance_id == 1 else ("movie" if instance_id == 2 else "album")
+            batch.append((instance_id, item_id, item_type, kind, action, f"Item {row_idx}", ts))
+
+        async with get_db() as conn:
+            await conn.executemany(
+                "INSERT INTO search_log (instance_id, item_id, item_type, search_kind,"
+                " action, item_label, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                batch,
+            )
+            await conn.commit()
+        if (offset + chunk_size) % 50_000 == 0 or offset + chunk_size >= rows:
+            print(f"  inserted {min(offset + chunk_size, rows):,}/{rows:,}")
+
+
+async def _seed_cooldowns(instance_count: int, rows_per_instance: int) -> None:
+    """Seed cooldown rows that the v14 back-fill will iterate over."""
+    print(f"Seeding {instance_count * rows_per_instance:,} cooldown rows...")
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    async with get_db() as conn:
+        for instance_id in range(1, instance_count + 1):
+            item_type = "episode" if instance_id == 1 else ("movie" if instance_id == 2 else "album")
+            batch = [
+                (instance_id, 100 + i, item_type, "missing", now)
+                for i in range(rows_per_instance)
+            ]
+            await conn.executemany(
+                "INSERT OR IGNORE INTO cooldowns (instance_id, item_id, item_type,"
+                " search_kind, searched_at) VALUES (?, ?, ?, ?, ?)",
+                batch,
+            )
+        await conn.commit()
+
+
+async def _drop_new_indexes() -> None:
+    """Remove the two indexes added by issue #586 to simulate pre-fix state."""
+    async with get_db() as conn:
+        await conn.execute("DROP INDEX IF EXISTS idx_search_log_lookup")
+        await conn.execute("DROP INDEX IF EXISTS idx_search_log_action_time")
+        await conn.commit()
+
+
+async def _measure_init_db() -> float:
+    """Run ``init_db_migrations()`` end-to-end (the post-PR hot path)."""
+    start = time.monotonic()
+    await init_db_migrations()
+    return time.monotonic() - start
+
+
+async def _measure_v14_backfill() -> tuple[float, float]:
+    """Time both the first and second runs of the v14 self-heal."""
+    async with get_db() as conn:
+        first_start = time.monotonic()
+        await _migrate_to_v14(conn)
+        await conn.commit()
+        first_elapsed = time.monotonic() - first_start
+
+    async with get_db() as conn:
+        second_start = time.monotonic()
+        await _migrate_to_v14(conn)
+        await conn.commit()
+        second_elapsed = time.monotonic() - second_start
+
+    return first_elapsed, second_elapsed
+
+
+async def _measure_dashboard(samples: int = 5, *, with_cache: bool = False) -> list[float]:
+    """Run ``gather_dashboard_status`` ``samples`` times and return latencies."""
+    cache = build_aggregate_cache(ttl_seconds=20) if with_cache else None
+    timings: list[float] = []
+    for i in range(samples):
+        start = time.monotonic()
+        async with get_db() as db:
+            envelope = await gather_dashboard_status(db, aggregate_cache=cache)
+        timings.append(time.monotonic() - start)
+        if i == 0:
+            assert envelope["instances"], "expected at least one instance in envelope"
+        if cache is not None and i == samples // 2:
+            invalidate_dashboard_cache(_StateWith(cache))
+    return timings
+
+
+class _StateWith:
+    """Stand-in for ``app.state`` that lets us call ``invalidate_dashboard_cache``."""
+
+    def __init__(self, cache):
+        self.aggregate_cache = cache
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=280_000)
+    parser.add_argument("--instances", type=int, default=3)
+    parser.add_argument("--cooldowns-per-instance", type=int, default=200)
+    parser.add_argument(
+        "--without-indexes",
+        action="store_true",
+        help="Drop idx_search_log_lookup + idx_search_log_action_time after seeding",
+    )
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "houndarr.db")
+        bootstrap_settings(data_dir=tmp, log_retention_days=30)
+        set_db_path(db_path)
+
+        await init_db_schema()
+        await _seed_search_log(args.rows, args.instances)
+        await _seed_cooldowns(args.instances, args.cooldowns_per_instance)
+
+        if args.without_indexes:
+            await _drop_new_indexes()
+            print("DROPPED new indexes — simulating pre-PR codepath")
+
+        size_mb = os.path.getsize(db_path) / 1024 / 1024
+        print(f"\nDatabase size: {size_mb:.1f} MB")
+
+        print("\n=== init_db_migrations() ===")
+        elapsed_init = await _measure_init_db()
+        print(f"  wall clock: {_human(elapsed_init)}")
+
+        print("\n=== _migrate_to_v14 idempotency ===")
+        first, second = await _measure_v14_backfill()
+        print(f"  first run:  {_human(first)}")
+        print(f"  second run: {_human(second)}  (idempotency guard kicked in)")
+
+        print("\n=== /api/status latency (uncached) ===")
+        uncached = await _measure_dashboard(samples=5, with_cache=False)
+        print(f"  per call: {[_human(t) for t in uncached]}")
+        print(f"  median:   {_human(statistics.median(uncached))}")
+
+        print("\n=== /api/status latency (cached, ttl=20s) ===")
+        cached = await _measure_dashboard(samples=5, with_cache=True)
+        print(f"  per call: {[_human(t) for t in cached]}")
+        print(f"  median:   {_human(statistics.median(cached))}")
+        print("  (cache invalidated after 3rd call to prove cache_clear path)")
+
+        await close_all_pools()
+
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/bench_586_v14_update_only.py
+++ b/scripts/bench_586_v14_update_only.py
@@ -1,0 +1,200 @@
+"""Isolate the v14 cooldown back-fill UPDATE cost with and without the index.
+
+The post-fix ``_migrate_to_v14`` creates ``idx_search_log_lookup`` before
+running the correlated UPDATE.  This benchmark compares the raw UPDATE
+runtime in three scenarios at the reporter's reported scale:
+
+1. WITH ``idx_search_log_lookup`` present (post-fix path).
+2. WITHOUT the index (pre-fix path, what v1.10.0 shipped).
+3. Pre-fix UPDATE plus the index built on demand (the manual workaround
+   the reporter applied to survive startup).
+
+Run::
+
+    .venv/bin/python -m scripts.bench_586_v14_update_only --rows 280000
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import tempfile
+import time
+from datetime import UTC, datetime, timedelta
+
+from houndarr.database import (
+    close_all_pools,
+    get_db,
+    init_db_schema,
+    set_db_path,
+)
+
+
+_BACKFILL_SQL = """
+UPDATE cooldowns
+   SET search_kind = (
+         SELECT sl.search_kind
+           FROM search_log sl
+          WHERE sl.instance_id = cooldowns.instance_id
+            AND sl.item_id     = cooldowns.item_id
+            AND sl.item_type   = cooldowns.item_type
+            AND sl.action      = 'searched'
+            AND sl.search_kind IN ('missing', 'cutoff', 'upgrade')
+          ORDER BY sl.timestamp DESC
+          LIMIT 1
+       )
+ WHERE EXISTS (
+         SELECT 1 FROM search_log sl2
+          WHERE sl2.instance_id = cooldowns.instance_id
+            AND sl2.item_id     = cooldowns.item_id
+            AND sl2.item_type   = cooldowns.item_type
+            AND sl2.action      = 'searched'
+            AND sl2.search_kind IN ('missing', 'cutoff', 'upgrade')
+       )
+"""
+
+
+def _human(seconds: float) -> str:
+    if seconds < 1:
+        return f"{seconds * 1000:.0f} ms"
+    return f"{seconds:.2f} s"
+
+
+async def _seed(rows: int, instance_count: int, cooldowns_per_instance: int) -> None:
+    print(f"Seeding {rows:,} log rows + {instance_count * cooldowns_per_instance:,} cooldowns...")
+    now = datetime.now(UTC)
+    chunk = 10_000
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
+            " VALUES (?, ?, ?, ?, ?)",
+            [
+                (i + 1, f"App{i + 1}", ["sonarr", "radarr", "lidarr"][i % 3], f"http://x/{i}", "")
+                for i in range(instance_count)
+            ],
+        )
+        await conn.commit()
+    for offset in range(0, rows, chunk):
+        batch = []
+        for i in range(min(chunk, rows - offset)):
+            row_idx = offset + i
+            instance_id = (row_idx % instance_count) + 1
+            item_id = 100 + (row_idx % 5_000)
+            kind = ("missing", "cutoff", "upgrade")[row_idx % 3]
+            ts = (now - timedelta(minutes=row_idx % (30 * 24 * 60))).strftime(
+                "%Y-%m-%dT%H:%M:%S.000Z"
+            )
+            item_type = ("episode", "movie", "album")[(instance_id - 1) % 3]
+            batch.append((instance_id, item_id, item_type, kind, "searched", f"Item {row_idx}", ts))
+        async with get_db() as conn:
+            await conn.executemany(
+                "INSERT INTO search_log (instance_id, item_id, item_type, search_kind,"
+                " action, item_label, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                batch,
+            )
+            await conn.commit()
+    async with get_db() as conn:
+        for instance_id in range(1, instance_count + 1):
+            item_type = ("episode", "movie", "album")[(instance_id - 1) % 3]
+            cool_batch = [
+                (instance_id, 100 + i, item_type, "missing",
+                 now.strftime("%Y-%m-%dT%H:%M:%S.000Z"))
+                for i in range(cooldowns_per_instance)
+            ]
+            await conn.executemany(
+                "INSERT OR IGNORE INTO cooldowns (instance_id, item_id, item_type,"
+                " search_kind, searched_at) VALUES (?, ?, ?, ?, ?)",
+                cool_batch,
+            )
+        await conn.commit()
+
+
+async def _drop_lookup_index() -> None:
+    async with get_db() as conn:
+        await conn.execute("DROP INDEX IF EXISTS idx_search_log_lookup")
+        await conn.commit()
+
+
+async def _create_lookup_index() -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_search_log_lookup "
+            "ON search_log(instance_id, item_id, item_type, timestamp DESC)"
+        )
+        await conn.commit()
+
+
+async def _reset_cooldowns_to_default(instance_count: int, per_instance: int) -> None:
+    """Reset cooldowns.search_kind to 'missing' so the UPDATE has work to do."""
+    async with get_db() as conn:
+        await conn.execute("UPDATE cooldowns SET search_kind = 'missing'")
+        await conn.commit()
+
+
+async def _time_update() -> float:
+    async with get_db() as conn:
+        start = time.monotonic()
+        await conn.execute(_BACKFILL_SQL)
+        await conn.commit()
+        return time.monotonic() - start
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=280_000)
+    parser.add_argument("--instances", type=int, default=3)
+    parser.add_argument("--cooldowns-per-instance", type=int, default=200)
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = os.path.join(tmp, "houndarr.db")
+        set_db_path(db_path)
+        await init_db_schema()
+        await _seed(args.rows, args.instances, args.cooldowns_per_instance)
+
+        print("\n" + "=" * 60)
+        print("SCENARIO 1: WITH idx_search_log_lookup (post-fix)")
+        print("=" * 60)
+        await _create_lookup_index()
+        await _reset_cooldowns_to_default(args.instances, args.cooldowns_per_instance)
+        elapsed_with = await _time_update()
+        print(f"  v14 UPDATE: {_human(elapsed_with)}")
+
+        print("\n" + "=" * 60)
+        print("SCENARIO 2: WITHOUT idx_search_log_lookup (pre-fix v1.10.0)")
+        print("=" * 60)
+        await _drop_lookup_index()
+        await _reset_cooldowns_to_default(args.instances, args.cooldowns_per_instance)
+        elapsed_without = await _time_update()
+        print(f"  v14 UPDATE: {_human(elapsed_without)}")
+
+        print("\n" + "=" * 60)
+        print("SCENARIO 3: Reporter's manual workaround (build index, then UPDATE)")
+        print("=" * 60)
+        await _drop_lookup_index()
+        await _reset_cooldowns_to_default(args.instances, args.cooldowns_per_instance)
+        idx_start = time.monotonic()
+        await _create_lookup_index()
+        idx_elapsed = time.monotonic() - idx_start
+        elapsed_with_built = await _time_update()
+        total = idx_elapsed + elapsed_with_built
+        print(f"  CREATE INDEX: {_human(idx_elapsed)}")
+        print(f"  v14 UPDATE:   {_human(elapsed_with_built)}")
+        print(f"  total:        {_human(total)}")
+
+        print("\n" + "=" * 60)
+        print("SUMMARY")
+        print("=" * 60)
+        speedup = elapsed_without / elapsed_with if elapsed_with > 0 else float("inf")
+        print(f"  Pre-fix UPDATE:  {_human(elapsed_without)}")
+        print(f"  Post-fix UPDATE: {_human(elapsed_with)}")
+        print(f"  Speedup:         {speedup:.1f}x")
+
+        await close_all_pools()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/bench_586_v14_update_only.py
+++ b/scripts/bench_586_v14_update_only.py
@@ -31,7 +31,6 @@ from houndarr.database import (
     set_db_path,
 )
 
-
 _BACKFILL_SQL = """
 UPDATE cooldowns
    SET search_kind = (
@@ -68,8 +67,7 @@ async def _seed(rows: int, instance_count: int, cooldowns_per_instance: int) -> 
     chunk = 10_000
     async with get_db() as conn:
         await conn.executemany(
-            "INSERT INTO instances (id, name, type, url, encrypted_api_key)"
-            " VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
             [
                 (i + 1, f"App{i + 1}", ["sonarr", "radarr", "lidarr"][i % 3], f"http://x/{i}", "")
                 for i in range(instance_count)
@@ -99,8 +97,7 @@ async def _seed(rows: int, instance_count: int, cooldowns_per_instance: int) -> 
         for instance_id in range(1, instance_count + 1):
             item_type = ("episode", "movie", "album")[(instance_id - 1) % 3]
             cool_batch = [
-                (instance_id, 100 + i, item_type, "missing",
-                 now.strftime("%Y-%m-%dT%H:%M:%S.000Z"))
+                (instance_id, 100 + i, item_type, "missing", now.strftime("%Y-%m-%dT%H:%M:%S.000Z"))
                 for i in range(cooldowns_per_instance)
             ]
             await conn.executemany(

--- a/src/houndarr/__main__.py
+++ b/src/houndarr/__main__.py
@@ -104,6 +104,19 @@ from houndarr import __version__
         "(Authentik), 'X-Auth-Request-User' (oauth2-proxy)."
     ),
 )
+@click.option(
+    "--log-retention-days",
+    default="",
+    show_default=False,
+    envvar="HOUNDARR_LOG_RETENTION_DAYS",
+    help=(
+        "Number of days of search log rows to keep during the daily "
+        "retention sweep.  '0' disables automatic purges; '7' to '365' "
+        "overrides the default of 30 days.  Operators on small storage "
+        "lower this to keep the dashboard responsive on long-lived "
+        "instances; large libraries can extend it.  See issue #586."
+    ),
+)
 def cli(
     data_dir: str,
     host: str,
@@ -115,6 +128,7 @@ def cli(
     trusted_proxies: str,
     auth_mode: str,
     auth_proxy_header: str,
+    log_retention_days: str,
 ) -> None:
     """Houndarr: search for missing media in your *arr stack, politely.
 
@@ -128,7 +142,7 @@ def cli(
     import uvicorn
 
     from houndarr.bootstrap import bootstrap_non_web
-    from houndarr.config import _parse_samesite
+    from houndarr.config import _parse_log_retention_days, _parse_samesite
 
     # Configure the root logger so that application loggers (houndarr.*)
     # respect --log-level.  Without this, only uvicorn's own loggers are
@@ -154,6 +168,7 @@ def cli(
         trusted_proxies=trusted_proxies,
         auth_mode=auth_mode.lower(),
         auth_proxy_header=auth_proxy_header,
+        log_retention_days=_parse_log_retention_days(log_retention_days),
     )
 
     # Validate authentication configuration before starting
@@ -180,6 +195,7 @@ def cli(
     os.environ["HOUNDARR_TRUSTED_PROXIES"] = trusted_proxies
     os.environ["HOUNDARR_AUTH_MODE"] = auth_mode.lower()
     os.environ["HOUNDARR_AUTH_PROXY_HEADER"] = auth_proxy_header
+    os.environ["HOUNDARR_LOG_RETENTION_DAYS"] = log_retention_days
 
     uvicorn.run(
         "houndarr.app:create_app",

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -16,31 +16,48 @@ from fastapi.staticfiles import StaticFiles
 from houndarr import __version__
 from houndarr.auth import AuthMiddleware
 from houndarr.cache_headers import CacheControlMiddleware
-from houndarr.config import DEFAULT_LOG_RETENTION_DAYS, get_settings
+from houndarr.config import get_settings
 from houndarr.crypto import ensure_master_key
-from houndarr.database import init_db, set_db_path
+from houndarr.database import (
+    close_all_pools,
+    get_db,
+    init_db_migrations,
+    init_db_schema,
+    set_db_path,
+)
 from houndarr.engine.supervisor import Supervisor
 from houndarr.repositories.search_log import purge_old_logs
 from houndarr.routes._htmx import is_hx_request
 from houndarr.services.instances import list_instances
+from houndarr.services.metrics import build_aggregate_cache
 
 logger = logging.getLogger(__name__)
 
 _LOG_RETENTION_INTERVAL_SECONDS = 24 * 60 * 60
 
 
-async def _periodic_log_retention() -> None:
-    """Periodically purge old search_log rows during app uptime."""
+async def _periodic_log_retention(retention_days: int) -> None:
+    """Periodically purge old search_log rows during app uptime.
+
+    The supervisor task fires once every 24 hours and respects
+    ``log_retention_days`` from :class:`AppSettings`.  When the value is
+    ``0`` the lifespan never spawns this task (see :func:`_lifespan`).
+    """
     while True:
         await asyncio.sleep(_LOG_RETENTION_INTERVAL_SECONDS)
         try:
-            purged = await purge_old_logs(DEFAULT_LOG_RETENTION_DAYS)
+            purged = await purge_old_logs(retention_days)
             if purged > 0:
                 logger.info(
                     "Periodic retention purged %d search_log rows older than %d days",
                     purged,
-                    DEFAULT_LOG_RETENTION_DAYS,
+                    retention_days,
                 )
+            # Refresh sqlite_stat1 so the planner reflects the post-purge
+            # row counts; otherwise dashboard aggregations could regress
+            # to a stale plan after a large delete (issue #586).
+            async with get_db() as conn:
+                await conn.execute("PRAGMA optimize")
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001
@@ -88,38 +105,64 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.master_key = ensure_master_key(settings.data_dir)
     logger.info("Master key loaded from %s", settings.master_key_path)
 
-    # Configure and initialize the database
+    # Configure and initialize the database.  Retention runs between the
+    # schema DDL and the migration sweep so the v14 cooldown back-fill
+    # doesn't grind through 30+ days of unused rows on Kubernetes pods
+    # whose liveness probe would otherwise kill the process before any
+    # request lands (issue #586).
     set_db_path(str(settings.db_path))
-    await init_db()
-    logger.info("Database ready at %s", settings.db_path)
+    await init_db_schema()
 
-    # Purge old search log rows to prevent unbounded growth
-    purged = await purge_old_logs(DEFAULT_LOG_RETENTION_DAYS)
-    if purged > 0:
-        logger.info(
-            "Purged %d search_log rows older than %d days", purged, DEFAULT_LOG_RETENTION_DAYS
-        )
+    retention_days = settings.log_retention_days
+    if retention_days > 0:
+        purged = await purge_old_logs(retention_days)
+        if purged > 0:
+            logger.info("Purged %d search_log rows older than %d days", purged, retention_days)
+    else:
+        logger.info("Search log retention disabled (HOUNDARR_LOG_RETENTION_DAYS=0)")
+
+    await init_db_migrations()
+    logger.info("Database ready at %s", settings.db_path)
 
     # Warn if no instances are configured yet
     instances = await list_instances(master_key=app.state.master_key)
     if not instances:
         logger.warning("No instances configured. Visit the Settings page to add an instance.")
 
+    # Build the dashboard aggregate cache before the supervisor starts.
+    # Order matters: as soon as ``supervisor.start()`` returns, a
+    # background cycle can write to ``search_log`` and a request can
+    # land on ``/api/status``.  Attaching the cache first guarantees
+    # the route's ``getattr(app.state, 'aggregate_cache', None)`` lookup
+    # never sees ``None`` after lifespan completion, so the very first
+    # post-startup request still benefits from caching.  async-lru
+    # rejects cross-loop reuse with RuntimeError, so the cache lives
+    # per-app instead of as a module global; one app per event loop in
+    # production, one app per test in pytest-asyncio function scope.
+    app.state.aggregate_cache = build_aggregate_cache()
+
     # Start the background search supervisor
     supervisor = Supervisor(master_key=app.state.master_key)
     await supervisor.start()
     app.state.supervisor = supervisor
 
-    retention_task = asyncio.create_task(_periodic_log_retention(), name="log-retention-loop")
+    if retention_days > 0:
+        retention_task: asyncio.Task[None] | None = asyncio.create_task(
+            _periodic_log_retention(retention_days), name="log-retention-loop"
+        )
+    else:
+        retention_task = None
     app.state.retention_task = retention_task
 
     yield  # Application runs here
 
     logger.info("Houndarr shutting down")
-    retention_task.cancel()
-    with suppress(asyncio.CancelledError):
-        await retention_task
+    if retention_task is not None:
+        retention_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await retention_task
     await supervisor.stop()
+    await close_all_pools()
 
 
 def create_app() -> FastAPI:

--- a/src/houndarr/bootstrap.py
+++ b/src/houndarr/bootstrap.py
@@ -52,6 +52,7 @@ class AppSettingsOverrides(TypedDict, total=False):
     auth_mode: str
     auth_proxy_header: str
     update_check_repo: str
+    log_retention_days: int
 
 
 def bootstrap_non_web(
@@ -69,7 +70,8 @@ def bootstrap_non_web(
         **overrides: Additional :class:`AppSettings` field values (``host``,
             ``port``, ``dev``, ``log_level``, ``secure_cookies``,
             ``cookie_samesite``, ``trusted_proxies``, ``auth_mode``,
-            ``auth_proxy_header``, ``update_check_repo``). When any
+            ``auth_proxy_header``, ``update_check_repo``,
+            ``log_retention_days``). When any
             override is supplied, :class:`AppSettings` is constructed
             directly and pinned into the runtime singleton so the whole
             process agrees on the overridden values. When no overrides

--- a/src/houndarr/bootstrap.py
+++ b/src/houndarr/bootstrap.py
@@ -30,7 +30,8 @@ from typing import Literal, TypedDict, Unpack
 
 from houndarr.config import AppSettings, bootstrap_settings
 from houndarr.crypto import ensure_master_key
-from houndarr.database import init_db, set_db_path
+from houndarr.database import init_db_migrations, init_db_schema, set_db_path
+from houndarr.repositories.search_log import purge_old_logs
 
 
 class AppSettingsOverrides(TypedDict, total=False):
@@ -120,6 +121,21 @@ def bootstrap_non_web(
     master_key = ensure_master_key(settings.data_dir)
 
     set_db_path(str(settings.db_path))
-    asyncio.run(init_db())
+
+    async def _bootstrap_db() -> None:
+        # Mirror the lifespan order so the v14 cooldown back-fill runs
+        # against the post-retention search_log on the very first boot
+        # under ``python -m houndarr`` instead of the full unpruned
+        # table.  Without this split the lifespan's later purge sees a
+        # DB whose migrations already ran; the new index still keeps
+        # v14 fast on its own, but the symmetry with the lifespan means
+        # the docstring's "trim before migrate" guarantee actually
+        # holds for the CLI entry point too (issue #586).
+        await init_db_schema()
+        if settings.log_retention_days > 0:
+            await purge_old_logs(settings.log_retention_days)
+        await init_db_migrations()
+
+    asyncio.run(_bootstrap_db())
 
     return settings, settings.db_path, master_key

--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -157,6 +157,49 @@ _DEFAULT_UPDATE_CHECK_REPO = "av1155/houndarr"
 _UPDATE_CHECK_REPO_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 
+_LOG_RETENTION_MIN_DAYS = 7
+_LOG_RETENTION_MAX_DAYS = 365
+_LOG_RETENTION_DEFAULT_DAYS = 30
+
+
+def _parse_log_retention_days(raw: str) -> int:
+    """Validate HOUNDARR_LOG_RETENTION_DAYS, falling back to the default on junk.
+
+    Accepts ``0`` to disable automatic purges (operator opts out of
+    Houndarr's retention entirely), or a value in
+    ``[7, 365]`` days to override the default.  Anything else logs a
+    warning and falls back to :data:`_LOG_RETENTION_DEFAULT_DAYS`; the
+    bound matches what self-hosted peers expose (Pi-hole's ``maxDBdays``
+    range) and protects the dashboard polling path from a misconfigured
+    one-day window that would purge rows the metric queries still need.
+    """
+    value = raw.strip()
+    if not value:
+        return _LOG_RETENTION_DEFAULT_DAYS
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning(
+            "HOUNDARR_LOG_RETENTION_DAYS=%r is not an integer; falling back to %d days",
+            value,
+            _LOG_RETENTION_DEFAULT_DAYS,
+        )
+        return _LOG_RETENTION_DEFAULT_DAYS
+    if parsed == 0:
+        return 0
+    if parsed < _LOG_RETENTION_MIN_DAYS or parsed > _LOG_RETENTION_MAX_DAYS:
+        logger.warning(
+            "HOUNDARR_LOG_RETENTION_DAYS=%d is outside the allowed range "
+            "(0 disables, otherwise %d-%d); falling back to %d days",
+            parsed,
+            _LOG_RETENTION_MIN_DAYS,
+            _LOG_RETENTION_MAX_DAYS,
+            _LOG_RETENTION_DEFAULT_DAYS,
+        )
+        return _LOG_RETENTION_DEFAULT_DAYS
+    return parsed
+
+
 def _parse_update_check_repo(raw: str) -> str:
     """Validate HOUNDARR_UPDATE_CHECK_REPO; fall back to the default on junk.
 
@@ -203,6 +246,9 @@ def get_settings() -> AppSettings:
         update_check_repo=_parse_update_check_repo(
             os.environ.get("HOUNDARR_UPDATE_CHECK_REPO", "")
         ),
+        log_retention_days=_parse_log_retention_days(
+            os.environ.get("HOUNDARR_LOG_RETENTION_DAYS", "")
+        ),
     )
 
 
@@ -227,6 +273,7 @@ class BootstrapOverrides(TypedDict, total=False):
     auth_mode: str
     auth_proxy_header: str
     update_check_repo: str
+    log_retention_days: int
 
 
 def bootstrap_settings(**overrides: Unpack[BootstrapOverrides]) -> AppSettings:
@@ -308,6 +355,11 @@ class AppSettings:
             Houndarr repository; forks override via
             ``HOUNDARR_UPDATE_CHECK_REPO`` so no code change is needed to
             redirect the check at their own release stream.
+        log_retention_days: Number of days of ``search_log`` rows to keep
+            during the periodic retention sweep.  ``0`` disables automatic
+            purges; ``7`` to ``365`` overrides the default of ``30``
+            (which matches the value shipped through v1.10.x).
+            Corresponds to ``HOUNDARR_LOG_RETENTION_DAYS`` env var.
     """
 
     data_dir: str = "/data"
@@ -321,6 +373,7 @@ class AppSettings:
     auth_mode: str = "builtin"
     auth_proxy_header: str = ""
     update_check_repo: str = _DEFAULT_UPDATE_CHECK_REPO
+    log_retention_days: int = _LOG_RETENTION_DEFAULT_DAYS
 
     # Derived paths (computed from data_dir)
     db_path: Path = field(init=False)

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import aiosqlite
+from aiosqlitepool import SQLiteConnectionPool
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +136,17 @@ CREATE INDEX IF NOT EXISTS idx_search_log_timestamp
     ON search_log(timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_search_log_instance
     ON search_log(instance_id, timestamp DESC);
+-- Serves the v14 cooldown back-fill correlated lookup and the cooldown
+-- item_label N+1 in services/metrics._COOLDOWNS_SQL.  Without this the
+-- back-fill runs O(N*M) against an unindexed search_log and starves the
+-- Kubernetes liveness probe on large databases (issue #586).
+CREATE INDEX IF NOT EXISTS idx_search_log_lookup
+    ON search_log(instance_id, item_id, item_type, timestamp DESC);
+-- Covers action-filtered window aggregations (24h SUMs, last-activity
+-- ROW_NUMBER) on the dashboard poll path.  The leading instance_id keeps
+-- per-instance scans bounded; trailing timestamp lets ORDER BY skip a sort.
+CREATE INDEX IF NOT EXISTS idx_search_log_action_time
+    ON search_log(instance_id, action, timestamp DESC);
 """
 
 
@@ -144,6 +156,15 @@ CREATE INDEX IF NOT EXISTS idx_search_log_instance
 
 _db_path: str = ""
 
+# Per-path pool registry.  ``_db_path`` is mutated per-test by the ``db``
+# fixture in tests/conftest.py (~2580 tests rely on per-test temp files);
+# a single global pool would bind to the first path and break every
+# subsequent test.  Keying on the path lets the same module-level state
+# back both the production lifecycle (one path, one pool) and the test
+# suite (many paths, many short-lived pools, all torn down by the
+# autouse close_all_pools fixture).
+_pools: dict[str, SQLiteConnectionPool] = {}
+
 
 def set_db_path(path: str) -> None:
     """Set the database path before the app starts."""
@@ -151,12 +172,102 @@ def set_db_path(path: str) -> None:
     _db_path = path
 
 
+async def _connection_factory() -> aiosqlite.Connection:
+    """Open and configure one connection for the active pool.
+
+    Called by aiosqlitepool whenever the pool needs to grow.  The PRAGMAs
+    set here apply once per pool member instead of on every borrow, which
+    is both faster (no extra round-trips) and safer (a connection cannot
+    leave the pool without the configured row factory and FK enforcement).
+
+    Why each PRAGMA matters:
+
+    * ``synchronous=NORMAL`` is corruption-safe in WAL mode and roughly
+      2-3x faster than ``FULL``; SQLite's own docs recommend it for WAL.
+    * ``temp_store=MEMORY`` keeps temp B-trees (used by the dashboard's
+      window-function aggregations) in RAM instead of spilling to /tmp.
+    * ``cache_size=-20000`` is 20 MB per connection (negative = KB).
+      Default 2 MB starves the page cache for the 280 k-row aggregation
+      queries on the dashboard hot path.
+    * ``mmap_size=134217728`` (128 MB) maps the DB file into the process
+      address space; cold reads become memcpy instead of pread().
+    * ``journal_size_limit=67108864`` (64 MB) caps WAL growth even if a
+      reader stalls; defends against a runaway WAL on long-lived pods.
+    * ``foreign_keys=ON`` enforces the FKs declared on cooldowns and
+      search_log; SQLite defaults to OFF on every fresh connection.
+    * ``busy_timeout=5000`` waits 5 s before raising SQLITE_BUSY, so
+      transient writer contention does not produce user-visible errors.
+    """
+    conn = await aiosqlite.connect(_db_path)
+    conn.row_factory = aiosqlite.Row
+    # journal_mode=WAL must precede synchronous=NORMAL: NORMAL is only
+    # corruption-safe in WAL mode (per sqlite.org/pragma.html#pragma_synchronous).
+    # The pragma is file-level and idempotent, so it is a no-op fetch on
+    # every pool member after the first.
+    await conn.execute("PRAGMA journal_mode=WAL")
+    await conn.execute("PRAGMA synchronous=NORMAL")
+    await conn.execute("PRAGMA temp_store=MEMORY")
+    await conn.execute("PRAGMA cache_size=-20000")
+    await conn.execute("PRAGMA mmap_size=134217728")
+    await conn.execute("PRAGMA journal_size_limit=67108864")
+    await conn.execute("PRAGMA foreign_keys=ON")
+    await conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def _get_or_create_pool() -> SQLiteConnectionPool:
+    """Return the pool for the active ``_db_path``, creating it on first use.
+
+    Lazy initialisation keeps the production lifecycle simple (the first
+    ``get_db()`` call after ``set_db_path`` builds the pool) and lets test
+    fixtures swap in a new path without touching pool plumbing.
+    """
+    pool = _pools.get(_db_path)
+    if pool is None:
+        # ``pool_size=10`` budgets two connections per concurrent dashboard
+        # request: the route's outer connection holds the instance fetch +
+        # cooldown gather, and ``_gather_dashboard_aggregates`` borrows a
+        # second connection on cache miss to run the four aggregations.  At
+        # the default 5 a thundering-herd cold start with 5 simultaneous
+        # tabs could saturate the pool and queue clients on
+        # ``acquisition_timeout=30s`` (audit finding from the #586 review).
+        # 10 leaves comfortable headroom for the supervisor's parallel
+        # instance loops without materially increasing memory cost (each
+        # SQLite connection holds ~20 MB of page cache via the configured
+        # cache_size pragma).
+        pool = SQLiteConnectionPool(_connection_factory, pool_size=10)
+        _pools[_db_path] = pool
+    return pool
+
+
+async def close_all_pools() -> None:
+    """Close every per-path pool and clear the registry.
+
+    Called from the FastAPI lifespan exit and from the autouse pytest
+    teardown so per-test temp DB files are released and their dedicated
+    aiosqlite threads exit cleanly.
+    """
+    pools = list(_pools.values())
+    _pools.clear()
+    for pool in pools:
+        try:
+            await pool.close()
+        except Exception:  # noqa: BLE001
+            logger.exception("Error closing SQLite connection pool")
+
+
 @asynccontextmanager
 async def get_db() -> AsyncGenerator[aiosqlite.Connection, None]:
-    """Yield a database connection with foreign keys enabled."""
-    async with aiosqlite.connect(_db_path) as db:
-        db.row_factory = aiosqlite.Row
-        await db.execute("PRAGMA foreign_keys=ON")
+    """Borrow a pooled connection with the configured PRAGMAs applied.
+
+    The pool is keyed on the active ``_db_path``, so production reuses
+    long-lived hot-cache connections and tests get a fresh pool per
+    temporary database file.  The yielded connection is returned to the
+    pool when the context exits; callers are responsible for committing
+    or rolling back, exactly as before.
+    """
+    pool = _get_or_create_pool()
+    async with pool.connection() as db:
         yield db
 
 
@@ -165,17 +276,27 @@ async def get_db() -> AsyncGenerator[aiosqlite.Connection, None]:
 # ---------------------------------------------------------------------------
 
 
-async def init_db() -> None:
-    """Create tables and run migrations if needed."""
+async def init_db_schema() -> None:
+    """Apply the fresh-install DDL so the core tables exist.
+
+    Split out from :func:`init_db` so the lifespan can run
+    :func:`~houndarr.repositories.search_log.purge_old_logs` between the
+    schema DDL and the migration sweep on upgrade boots.  Trimming the log
+    first keeps the v14 cooldown back-fill from grinding through 30+ days
+    of unused rows on Kubernetes deployments where the liveness probe
+    would otherwise kill the pod (issue #586).
+    """
     async with get_db() as db:
-        # WAL mode is a database-level setting that persists on the file.
-        # Set it once here rather than on every connection.
-        await db.execute("PRAGMA journal_mode=WAL")
-
-        # Create all tables
+        # WAL is set in :func:`_connection_factory`, so the connection
+        # this borrows from the pool is already in WAL mode by the time
+        # the DDL writes start.
         await db.executescript(_SCHEMA_SQL)
+        await db.commit()
 
-        # Check/set schema version
+
+async def init_db_migrations() -> None:
+    """Advance the schema to the current ``SCHEMA_VERSION`` and re-heal."""
+    async with get_db() as db:
         async with db.execute("SELECT value FROM settings WHERE key = 'schema_version'") as cur:
             row = await cur.fetchone()
 
@@ -187,26 +308,44 @@ async def init_db() -> None:
             await _ensure_v3_indexes(db)
             await db.commit()
             logger.info("Database initialized at schema version %d", SCHEMA_VERSION)
-        else:
-            current = int(row["value"])
-            if current < SCHEMA_VERSION:
-                await _run_migrations(db, current)
-            # Self-heal: re-apply the latest idempotent migration so that
-            # a corrupted state (version bumped but columns missing) is
-            # repaired automatically.  Each guard inside the migration
-            # checks _column_exists first, so this is a no-op on a
-            # healthy database.
-            await _migrate_to_v9(db)
-            await _migrate_to_v10(db)
-            await _migrate_to_v11(db)
-            await _migrate_to_v12(db)
-            await _migrate_to_v13(db)
-            await _migrate_to_v14(db)
-            await _migrate_to_v15(db)
-            await _migrate_to_v16(db)
-            await _migrate_to_v17(db)
-            await _ensure_v3_indexes(db)
-            await db.commit()
+            return
+
+        current = int(row["value"])
+        if current < SCHEMA_VERSION:
+            await _run_migrations(db, current)
+        # Self-heal: re-apply the latest idempotent migration so that
+        # a corrupted state (version bumped but columns missing) is
+        # repaired automatically.  Each guard inside the migration
+        # checks _column_exists first, so this is a no-op on a
+        # healthy database.
+        await _migrate_to_v9(db)
+        await _migrate_to_v10(db)
+        await _migrate_to_v11(db)
+        await _migrate_to_v12(db)
+        await _migrate_to_v13(db)
+        await _migrate_to_v14(db)
+        await _migrate_to_v15(db)
+        await _migrate_to_v16(db)
+        await _migrate_to_v17(db)
+        await _ensure_v3_indexes(db)
+        # PRAGMA optimize keeps the planner's sqlite_stat1 entries fresh as
+        # search_log grows.  Cheap on healthy DBs, prevents silent index
+        # regressions after large back-fills (issue #586).
+        await db.execute("PRAGMA optimize")
+        await db.commit()
+
+
+async def init_db() -> None:
+    """Compatibility shim: schema DDL then migrations, in order.
+
+    Call sites that don't need to interleave a step between the two
+    (tests, scripts, marketing seeders) can keep calling :func:`init_db`
+    unchanged.  The lifespan in :mod:`houndarr.app` calls
+    :func:`init_db_schema` and :func:`init_db_migrations` separately so
+    log retention can run in between.
+    """
+    await init_db_schema()
+    await init_db_migrations()
 
 
 async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
@@ -858,11 +997,21 @@ async def _migrate_to_v14(db: aiosqlite.Connection) -> None:
         await db.execute(
             "ALTER TABLE cooldowns ADD COLUMN search_kind TEXT NOT NULL DEFAULT 'missing'"
         )
-    # Backfill any rows that still carry the literal default from the
-    # ALTER.  The SELECT mirrors the classifier that used to live in
-    # services/metrics.py's cooldown breakdown SQL; newer log rows
-    # override older ones so the stamp matches what the dashboard used
-    # to infer at read time.
+    # Materialise idx_search_log_lookup before the UPDATE so the correlated
+    # subquery hits an index instead of full-scanning search_log per cooldown
+    # row.  Without this the back-fill is O(N_cooldowns * N_search_log) and
+    # blocks the lifespan past any reasonable Kubernetes liveness budget on
+    # 30+-day databases (issue #586).
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_search_log_lookup "
+        "ON search_log(instance_id, item_id, item_type, timestamp DESC)"
+    )
+    # Back-fill rows that still carry the literal default from the ALTER.
+    # The leading ``cooldowns.search_kind = 'missing'`` filter short-circuits
+    # the correlated EXISTS on every row that has already been stamped, so
+    # the self-heal call in init_db() becomes a near-instant no-op once the
+    # initial back-fill has run; only newly-defaulted rows (none in normal
+    # operation) trigger the EXISTS scan.
     await db.execute(
         """
         UPDATE cooldowns
@@ -877,7 +1026,8 @@ async def _migrate_to_v14(db: aiosqlite.Connection) -> None:
                   ORDER BY sl.timestamp DESC
                   LIMIT 1
                )
-         WHERE EXISTS (
+         WHERE cooldowns.search_kind = 'missing'
+           AND EXISTS (
                  SELECT 1 FROM search_log sl2
                   WHERE sl2.instance_id = cooldowns.instance_id
                     AND sl2.item_id     = cooldowns.item_id
@@ -887,9 +1037,9 @@ async def _migrate_to_v14(db: aiosqlite.Connection) -> None:
                )
         """
     )
-    # Index creation lives in _ensure_v3_indexes so fresh installs
-    # (which skip migrations) still get it; the helper runs after both
-    # the fresh-install DDL and the upgrade migration path.
+    # idx_cooldowns_search_kind and idx_search_log_action_time are emitted by
+    # _ensure_v3_indexes so fresh installs (which skip migrations) still get
+    # them; the helper runs after both fresh DDL and the upgrade path.
 
 
 async def _migrate_to_v15(db: aiosqlite.Connection) -> None:
@@ -1180,6 +1330,18 @@ async def _ensure_v3_indexes(db: aiosqlite.Connection) -> None:
     await db.execute(
         "CREATE INDEX IF NOT EXISTS idx_cooldowns_search_kind "
         "ON cooldowns(instance_id, search_kind)"
+    )
+    # idx_search_log_lookup and idx_search_log_action_time are also emitted
+    # by _SCHEMA_SQL on fresh installs; re-running CREATE INDEX IF NOT EXISTS
+    # here picks up databases that migrated through earlier schema versions
+    # before these indexes existed (issue #586).
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_search_log_lookup "
+        "ON search_log(instance_id, item_id, item_type, timestamp DESC)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_search_log_action_time "
+        "ON search_log(instance_id, action, timestamp DESC)"
     )
 
 

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -1006,12 +1006,26 @@ async def _migrate_to_v14(db: aiosqlite.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_search_log_lookup "
         "ON search_log(instance_id, item_id, item_type, timestamp DESC)"
     )
+    # Skip the back-fill if a previous boot already ran it to completion.
+    # The marker lives in ``settings`` so the gate persists across upgrades
+    # without a second schema bump; the row is created below right after
+    # the UPDATE commits, so a crash mid-back-fill leaves the marker
+    # absent and the next boot retries.  Even with the
+    # ``cooldowns.search_kind = 'missing'`` WHERE filter, a row whose
+    # latest search_log entry is also of kind ``'missing'`` would still
+    # match and be rewritten to the same value on every boot, producing
+    # bounded WAL write amplification on long-lived deployments; the
+    # marker eliminates that re-write entirely.
+    async with db.execute("SELECT 1 FROM settings WHERE key = 'v14_backfill_complete'") as cur:
+        already_done = await cur.fetchone() is not None
+    if already_done:
+        return
     # Back-fill rows that still carry the literal default from the ALTER.
     # The leading ``cooldowns.search_kind = 'missing'`` filter short-circuits
-    # the correlated EXISTS on every row that has already been stamped, so
-    # the self-heal call in init_db() becomes a near-instant no-op once the
-    # initial back-fill has run; only newly-defaulted rows (none in normal
-    # operation) trigger the EXISTS scan.
+    # the correlated EXISTS on rows the app has already stamped via
+    # ``upsert_cooldown``; only the rows added before v14 (or by a
+    # newly-installed instance whose search_log is empty) trigger the
+    # EXISTS scan.
     await db.execute(
         """
         UPDATE cooldowns
@@ -1036,6 +1050,10 @@ async def _migrate_to_v14(db: aiosqlite.Connection) -> None:
                     AND sl2.search_kind IN ('missing', 'cutoff', 'upgrade')
                )
         """
+    )
+    await db.execute(
+        "INSERT INTO settings (key, value) VALUES ('v14_backfill_complete', '1')"
+        " ON CONFLICT(key) DO NOTHING"
     )
     # idx_cooldowns_search_kind and idx_search_log_action_time are emitted by
     # _ensure_v3_indexes so fresh installs (which skip migrations) still get

--- a/src/houndarr/routes/admin.py
+++ b/src/houndarr/routes/admin.py
@@ -47,6 +47,7 @@ from houndarr.services.admin import (
     request_process_exit,
     reset_all_instance_policy,
 )
+from houndarr.services.metrics import invalidate_dashboard_cache
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +96,8 @@ async def admin_reset_instances(
     supervisor = getattr(request.app.state, "supervisor", None)
     count = await reset_all_instance_policy(master_key=master_key, supervisor=supervisor)
 
+    invalidate_dashboard_cache(request.app.state)
+
     if count == 0:
         message = "No instances configured: nothing to reset."
     else:
@@ -113,6 +116,7 @@ async def admin_reset_instances(
 async def admin_clear_logs(request: Request) -> HTMLResponse:
     """Truncate ``search_log`` and leave a single audit breadcrumb."""
     removed = await clear_all_search_logs()
+    invalidate_dashboard_cache(request.app.state)
     if removed == 0:
         message = "Logs were already empty."
     else:

--- a/src/houndarr/routes/api/status.py
+++ b/src/houndarr/routes/api/status.py
@@ -15,8 +15,9 @@ maps the run-now status strings to HTTP status codes.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -25,11 +26,33 @@ from houndarr.database import get_db
 from houndarr.deps import get_supervisor
 from houndarr.engine.supervisor import Supervisor
 from houndarr.protocols import SupervisorProto
-from houndarr.services.metrics import gather_dashboard_status
+from houndarr.services.metrics import gather_dashboard_status, invalidate_dashboard_cache
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Run-now's background write lands ~1-2 s after the route returns; the
+# initial synchronous invalidate plus a re-clear after this delay covers
+# the dashboard's worst poll alignment without wedging the supervisor.
+# Tunable but unlikely to need tuning: anything beyond 5 s starts to
+# overlap the next 30 s HTMX poll and adds no value.
+_RUN_NOW_REINVALIDATE_DELAY_SECONDS = 3.0
+
+
+async def _reinvalidate_after(delay_seconds: float, app_state: Any) -> None:
+    """Sleep then drop the dashboard cache once the run-now write should have landed.
+
+    Best-effort: a process shutdown cancels the task cleanly via the
+    asyncio loop teardown.  ``invalidate_dashboard_cache`` is a no-op
+    when the cache attribute is missing, so a torn-down ``app.state``
+    cannot raise.
+    """
+    try:
+        await asyncio.sleep(delay_seconds)
+    except asyncio.CancelledError:
+        return
+    invalidate_dashboard_cache(app_state)
 
 
 @router.get("/api/status")
@@ -58,13 +81,19 @@ async def get_status(request: Request) -> JSONResponse:
     cycle_ends: dict[int, str] = (
         supervisor.cycle_end_timestamps() if isinstance(supervisor, Supervisor) else {}
     )
+    aggregate_cache = getattr(request.app.state, "aggregate_cache", None)
     async with get_db() as db:
-        envelope = await gather_dashboard_status(db, cycle_ends=cycle_ends)
+        envelope = await gather_dashboard_status(
+            db,
+            cycle_ends=cycle_ends,
+            aggregate_cache=aggregate_cache,
+        )
     return JSONResponse(envelope)
 
 
 @router.post("/api/instances/{instance_id}/run-now", status_code=202)
 async def run_now(
+    request: Request,
     instance_id: int,
     supervisor: Annotated[SupervisorProto, Depends(get_supervisor)],
 ) -> JSONResponse:
@@ -74,6 +103,19 @@ async def run_now(
         raise HTTPException(status_code=404, detail="Instance not found")
     if status == "disabled":
         raise HTTPException(status_code=409, detail="Instance is disabled")
+
+    # The supervisor's run-now path writes to ``search_log`` on a
+    # background task ~1-2 s later.  The synchronous invalidate clears
+    # any cached envelope so a poll that lands during the gap fetches
+    # fresh; the deferred re-clear (3 s) ensures the row written by the
+    # supervisor's background task does not get hidden behind a cache
+    # entry warmed in the milliseconds before it landed.  Both calls
+    # are no-ops when the cache is disabled or absent.
+    invalidate_dashboard_cache(request.app.state)
+    asyncio.create_task(
+        _reinvalidate_after(_RUN_NOW_REINVALIDATE_DELAY_SECONDS, request.app.state),
+        name=f"run-now-reinvalidate-{instance_id}",
+    )
 
     logger.info("run-now accepted for instance id=%d", instance_id)
     return JSONResponse({"status": "accepted", "instance_id": instance_id}, status_code=202)

--- a/src/houndarr/routes/settings/instances.py
+++ b/src/houndarr/routes/settings/instances.py
@@ -61,6 +61,7 @@ from houndarr.services.instances import (
     list_instances,
     update_instance,
 )
+from houndarr.services.metrics import invalidate_dashboard_cache
 
 router = APIRouter()
 
@@ -188,6 +189,8 @@ async def instance_create(
     if isinstance(supervisor, Supervisor):
         await supervisor.reconcile_instance(instance.core.id)
 
+    invalidate_dashboard_cache(request.app.state)
+
     instances = await list_instances(master_key=master_key)
     error_ids = await active_error_instance_ids()
     # HTMX: return just the refreshed table body partial
@@ -303,6 +306,8 @@ async def instance_update(
     except InstanceValidationError as exc:
         return connection_guard_response(exc.public_message)
 
+    invalidate_dashboard_cache(request.app.state)
+
     # HTMX: return just the refreshed row
     error_ids = await active_error_instance_ids()
     return render(
@@ -321,6 +326,7 @@ async def instance_delete(request: Request, instance_id: int) -> Response:
         await supervisor.stop_instance_task(instance_id)
 
     await delete_instance(instance_id)
+    invalidate_dashboard_cache(request.app.state)
     # Return an empty 200. HTMX hx-swap="outerHTML" with empty content
     # removes the row from the DOM.
     return Response(status_code=200)
@@ -355,6 +361,8 @@ async def instance_toggle_enabled(
     supervisor = getattr(request.app.state, "supervisor", None)
     if isinstance(supervisor, Supervisor):
         await supervisor.reconcile_instance(updated.core.id)
+
+    invalidate_dashboard_cache(request.app.state)
 
     error_ids = await active_error_instance_ids()
     return render(

--- a/src/houndarr/services/admin.py
+++ b/src/houndarr/services/admin.py
@@ -244,6 +244,17 @@ async def _factory_reset_impl(*, app: FastAPI, data_dir: str) -> None:
     # milliseconds the DB is being rebuilt. The key is atomically replaced
     # once the new one is ready.
 
+    # Close every pooled connection before unlinking the DB files.  On
+    # Unix, an unlinked file with an open fd survives as an orphaned
+    # inode that subsequent writes through that fd land on; if we leave
+    # the pool alive across the unlink, the recreated houndarr.db is an
+    # empty file and the running connections still write to the ghost.
+    # close_all_pools is idempotent and safe to call before the files are
+    # deleted.
+    from houndarr.database import close_all_pools
+
+    await close_all_pools()
+
     try:
         for path in paths_to_delete:
             try:
@@ -271,11 +282,24 @@ async def _factory_reset_impl(*, app: FastAPI, data_dir: str) -> None:
     # Lazy import avoids a circular dependency: houndarr.app imports
     # this module's siblings during router registration.
     from houndarr.app import _periodic_log_retention
+    from houndarr.config import get_settings
 
-    app.state.retention_task = asyncio.create_task(
-        _periodic_log_retention(),
-        name="log-retention-loop",
-    )
+    retention_days = get_settings().log_retention_days
+    if retention_days > 0:
+        app.state.retention_task = asyncio.create_task(
+            _periodic_log_retention(retention_days),
+            name="log-retention-loop",
+        )
+    else:
+        app.state.retention_task = None
+
+    # Drop every cached dashboard aggregate from the wiped DB so the
+    # next /api/status poll repopulates against the empty schema.
+    # invalidate_dashboard_cache is a no-op when no cache is attached
+    # (for tests that bypass create_app's lifespan).
+    from houndarr.services.metrics import invalidate_dashboard_cache
+
+    invalidate_dashboard_cache(app.state)
 
 
 def request_process_exit() -> None:

--- a/src/houndarr/services/metrics.py
+++ b/src/houndarr/services/metrics.py
@@ -18,14 +18,32 @@ unlock-time computation, batch-clone spread for ``unlocking_next``)
 lives next to the SQL: it has no useful lifetime apart from the
 rows the SQL produces, and pulling it apart would force the caller
 to re-derive the same per-row context.
+
+Single-process cache (issue #586):  :func:`build_aggregate_cache`
+returns an ``alru_cache``-wrapped coroutine that batches the four
+slow DB-aggregation gathers into a single :class:`DashboardAggregates`
+result and caches it for ~20 s.  The cache lives on ``app.state``
+because ``async-lru`` is event-loop-bound (a module-level decorator
+binds to the first test's loop and raises on every subsequent test);
+giving each FastAPI app its own cache makes the cross-loop case
+impossible.  Multi-replica deployments would have one cache per
+replica and rely on per-replica invalidation, so the dashboard would
+go stale (bounded to the TTL) on writes routed to a different
+replica; Houndarr's StatefulSet ships a PVC and ``replicaCount=1``
+so the single-process assumption holds in practice.
 """
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import aiosqlite
+from async_lru import alru_cache
+
+from houndarr.database import get_db
 
 _METRICS_SQL = """
 SELECT
@@ -242,10 +260,139 @@ def _build_instance_status_row(
     }
 
 
+# ---------------------------------------------------------------------------
+# Aggregate cache
+# ---------------------------------------------------------------------------
+
+# TTL is short enough that an operator action (Run Now, instance toggle)
+# always feels live within one polling cycle, but long enough that 30
+# tabs polling the same envelope land on a single DB scan.  Tuned to
+# the dashboard's 30 s HTMX trigger; keep them in lockstep.
+DASHBOARD_CACHE_TTL_SECONDS = 20
+
+
+@dataclass(slots=True, frozen=True)
+class DashboardAggregates:
+    """Frozen-shape bundle of every cached gather result.
+
+    Lives in the cache for at most :data:`DASHBOARD_CACHE_TTL_SECONDS`
+    seconds.  The route handler merges this with live-state fields
+    (cycle-end timestamps from the supervisor, cooldown rows) before
+    serialising the JSON envelope, so user actions and the
+    next-patrol countdown never wait on the cache window.
+
+    Read-only contract: ``frozen=True`` blocks field reassignment, but
+    the wrapped maps remain Python ``dict``/``list`` instances.
+    Callers must treat them as immutable.  Mutating a cached map (for
+    example, ``aggregates.metrics_map[iid]['errors_24h'] += 1``) would
+    silently poison every subsequent dashboard poll within the cache
+    TTL.  Defensive copies were considered and rejected: every call
+    site is read-only today, and copying ~5 dicts per request just
+    to defend against a hypothetical future mutator would erase the
+    point of caching.
+    """
+
+    metrics_map: dict[int, dict[str, Any]] = field(default_factory=dict)
+    activity_map: dict[int, tuple[str | None, str | None]] = field(default_factory=dict)
+    lifetime_map: dict[int, dict[str, Any]] = field(default_factory=dict)
+    error_map: dict[int, dict[str, Any]] = field(default_factory=dict)
+    recent: list[dict[str, Any]] = field(default_factory=list)
+
+
+# A function with ``cache_clear`` plus the alru_cache extras.  We keep
+# the surface narrow on purpose: the route only ever awaits the call,
+# and invalidation only ever calls cache_clear; the rest of alru_cache's
+# API (cache_info, cache_invalidate, jitter, etc.) is intentionally not
+# exposed because the centralised invalidation path is the supported
+# contract.
+DashboardAggregateCache = Callable[[tuple[int, ...]], Awaitable[DashboardAggregates]]
+
+
+async def _gather_dashboard_aggregates(
+    instance_ids_tuple: tuple[int, ...],
+) -> DashboardAggregates:
+    """Run the four slow gathers against a freshly-borrowed connection.
+
+    Opens its own pool connection because the cache wraps this function
+    once per app-lifetime and the cached result outlives the calling
+    request.  Returns an empty bundle for the no-instances case so the
+    cache key is stable (an empty tuple maps to the same bundle).
+    """
+    if not instance_ids_tuple:
+        return DashboardAggregates()
+
+    instance_ids = list(instance_ids_tuple)
+    async with get_db() as db:
+        metrics_map, activity_map = await gather_window_metrics(db, instance_ids)
+        lifetime_map = await gather_lifetime_metrics(db, instance_ids)
+        error_map = await gather_active_errors(db, instance_ids)
+        recent = await gather_recent_searches(db, limit=5)
+
+    return DashboardAggregates(
+        metrics_map=metrics_map,
+        activity_map=activity_map,
+        lifetime_map=lifetime_map,
+        error_map=error_map,
+        recent=recent,
+    )
+
+
+def build_aggregate_cache(
+    ttl_seconds: int | None = None,
+) -> DashboardAggregateCache | None:
+    """Return a fresh ``alru_cache``-wrapped aggregator, or ``None`` to disable.
+
+    Called once per FastAPI app instance from the lifespan startup so
+    each app owns its own cache and there is no cross-event-loop
+    sharing.  Tests that build many apps therefore get many caches and
+    no ``RuntimeError`` from async-lru's loop-affinity guard.
+
+    The default reads :data:`DASHBOARD_CACHE_TTL_SECONDS` at call
+    time, not at function-definition time, so the conftest fixture
+    that monkeypatches the module attribute to ``0`` opts every
+    legacy test out of caching without surgery.  Passing
+    ``ttl_seconds=0`` returns ``None``; the route handler's
+    ``aggregate_cache is None`` branch then falls through to a fresh
+    DB scan on every request.  Production sees the 20 s TTL.
+
+    The returned callable accepts a hashable ``tuple[int, ...]`` of
+    instance ids (lists are not hashable; the route converts) and
+    yields a :class:`DashboardAggregates` bundle.  ``cache_clear()``
+    on the returned callable invalidates every entry, which is the
+    only invalidation pattern Houndarr uses; per-args invalidation
+    via ``cache_invalidate`` is available but not used.
+    """
+    effective_ttl = DASHBOARD_CACHE_TTL_SECONDS if ttl_seconds is None else ttl_seconds
+    if effective_ttl <= 0:
+        return None
+    return alru_cache(maxsize=4, ttl=effective_ttl)(
+        _gather_dashboard_aggregates,
+    )
+
+
+def invalidate_dashboard_cache(app_state: Any) -> None:
+    """Drop every cached :class:`DashboardAggregates` on the active app.
+
+    Safe to call when the cache has not been built (early lifespan,
+    tests that bypass ``create_app``); the missing-attribute branch
+    short-circuits without touching the database.
+
+    Args:
+        app_state: The :class:`fastapi.FastAPI` ``app.state`` namespace
+            that owns the cache.  The route handlers pass
+            ``request.app.state`` here.
+    """
+    cache = getattr(app_state, "aggregate_cache", None)
+    if cache is None:
+        return
+    cache.cache_clear()
+
+
 async def gather_dashboard_status(
     db: aiosqlite.Connection,
     *,
     cycle_ends: dict[int, str] | None = None,
+    aggregate_cache: DashboardAggregateCache | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """Build the full ``/api/status`` JSON envelope against an open connection.
 
@@ -279,11 +426,28 @@ async def gather_dashboard_status(
         return {"instances": [], "recent_searches": []}
 
     instance_ids = [row["id"] for row in instances]
-    metrics_map, activity_map = await gather_window_metrics(db, instance_ids)
-    lifetime_map = await gather_lifetime_metrics(db, instance_ids)
-    error_map = await gather_active_errors(db, instance_ids)
+    if aggregate_cache is not None:
+        # Sort the cache key so reordering the SELECT (e.g. switching
+        # ORDER BY columns later) cannot defeat the cache.  The route's
+        # consumer reads ``metrics_map[iid]`` by id, not by position,
+        # so canonicalising the key has no observable effect.
+        aggregates = await aggregate_cache(tuple(sorted(instance_ids)))
+        metrics_map = aggregates.metrics_map
+        activity_map = aggregates.activity_map
+        lifetime_map = aggregates.lifetime_map
+        error_map = aggregates.error_map
+        recent = aggregates.recent
+    else:
+        # Tests and direct callers that pass an open connection without
+        # a cache (the legacy contract) get a fresh DB scan every time.
+        metrics_map, activity_map = await gather_window_metrics(db, instance_ids)
+        lifetime_map = await gather_lifetime_metrics(db, instance_ids)
+        error_map = await gather_active_errors(db, instance_ids)
+        recent = await gather_recent_searches(db, limit=5)
+    # Cooldown rows reflect the most recent supervisor reconcile pass and
+    # the user's manual ``Run Now`` button presses; both expect the dash
+    # to update on the next 30 s poll, so this gather always runs live.
     cooldown_map = await gather_cooldown_data(db, list(instances))
-    recent = await gather_recent_searches(db, limit=5)
     cycle_ends = cycle_ends or {}
 
     rows: list[dict[str, Any]] = []

--- a/src/houndarr/templates/partials/pages/dashboard_content.html
+++ b/src/houndarr/templates/partials/pages/dashboard_content.html
@@ -767,11 +767,20 @@
        below so the shell animation ships with content already in place
        (matching how logs and settings render).  HTMX polls every 30 s
        for subsequent updates; the beforeSwap listener parses those
-       responses and rewrites the grid + top section. -->
+       responses and rewrites the grid + top section.
+
+       ``queue:none`` drops new poll triggers while a previous response
+       is still in flight.  The default ``queue:last`` would cascade a
+       multi-second response into a backlog of pending polls (issue
+       #586): every 30 s another request entered the queue, so once
+       ``/api/status`` exceeded the interval the dashboard piled up
+       polls behind each other and the page never recovered until the
+       table was trimmed.  ``none`` lets a slow cycle skip rather than
+       stack. -->
   <div
     id="instance-grid"
     hx-get="/api/status"
-    hx-trigger="every 30s"
+    hx-trigger="every 30s queue:none"
     hx-swap="innerHTML"
     hx-target="#instance-grid"
   ></div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,8 @@ from houndarr.database import init_db, set_db_path
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _ensure_css_bundle_for_tests() -> Generator[None, None, None]:
+@pytest.fixture(autouse=True)
+def _ensure_css_bundle_for_tests() -> None:
     """Stub `app.built.css` so the lifespan preflight passes in tests.
 
     The real bundle is produced by `pnpm run build-css` (run by the
@@ -32,22 +32,18 @@ def _ensure_css_bundle_for_tests() -> Generator[None, None, None]:
     to start without it, which would otherwise fail every TestClient
     fixture in the suite.
 
-    Tests do not exercise CSS contents, only header behaviour and
-    routing, so a small stub satisfies the contract.  Local dev
-    runs that already produced the real bundle keep theirs.
+    Function-scoped on purpose: under ``pytest-xdist`` the workers each
+    own their own session, and a session-scope teardown that deleted
+    the stub raced with sibling workers still running tests, sporadically
+    breaking unrelated TestClient fixtures.  No teardown here: the file
+    is gitignored, the next CI run starts clean, and local dev runs that
+    already produced the real bundle still see theirs.
     """
     from houndarr import app as app_module
 
     css_bundle = Path(app_module.__file__).parent / "static" / "css" / "app.built.css"
-    created = False
     if not css_bundle.is_file():
         css_bundle.write_text("/* pytest stub */\n", encoding="utf-8")
-        created = True
-    try:
-        yield
-    finally:
-        if created and css_bundle.is_file():
-            css_bundle.unlink()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,29 @@ def _zero_inter_search_delay(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_sl, "_INTER_SEARCH_DELAY_SECONDS", 0.0)
 
 
+@pytest.fixture(autouse=True)
+def _disable_dashboard_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the dashboard aggregate cache off in the default fixture.
+
+    The legacy tests in ``tests/test_routes/test_status.py`` and
+    sibling files seed ``search_log`` directly via SQL between
+    ``/api/status`` calls; the production cache would serve the
+    pre-seed snapshot back to the second call and break their
+    assertions.  Setting ``ttl=0`` makes
+    :func:`build_aggregate_cache` return ``None`` so every request
+    hits the database, matching the v1.10.x behaviour the tests were
+    written against.
+
+    Cache-specific tests opt back in by re-monkeypatching
+    ``DASHBOARD_CACHE_TTL_SECONDS`` to a non-zero value before
+    constructing their own app, or by calling
+    :func:`build_aggregate_cache(ttl_seconds=20)` directly.
+    """
+    import houndarr.services.metrics as _metrics
+
+    monkeypatch.setattr(_metrics, "DASHBOARD_CACHE_TTL_SECONDS", 0)
+
+
 @pytest.fixture()
 def tmp_data_dir() -> Generator[str, None, None]:
     """Provide a temporary data directory for each test."""
@@ -82,14 +105,25 @@ async def db(tmp_data_dir: str) -> AsyncGenerator[None, None]:
     Also resets the auth-package caches so tests that request only
     ``db`` (not ``test_settings``) cannot see a ``_setup_complete`` /
     ``_serializer`` / ``_login_attempts`` state from a prior test.
+
+    Yields, then closes any aiosqlite connection pools created against
+    the temp file so the per-test ``tmp_data_dir`` cleanup can release
+    the SQLite handle.  Without the close-on-exit step the pool would
+    keep one or more aiosqlite reader threads alive until process exit
+    and the OS would refuse to delete the temp directory on Windows
+    runners.
     """
     from houndarr.auth import reset_auth_caches
+    from houndarr.database import close_all_pools
 
     db_path = os.path.join(tmp_data_dir, "test.db")
     set_db_path(db_path)
     await init_db()
     reset_auth_caches()
-    yield
+    try:
+        yield
+    finally:
+        await close_all_pools()
 
 
 @pytest.fixture()

--- a/tests/test_app_lifespan_pinning.py
+++ b/tests/test_app_lifespan_pinning.py
@@ -1,10 +1,16 @@
 """Pin app.py lifespan + RequestValidationError handler contract.
 
 Locks the startup-order sequence (validate -> master_key ->
-set_db_path -> init_db -> purge_old_logs -> Supervisor.start) and
-the HTMX-vs-JSON split on the validation-error handler so later
-changes to the lifespan wiring do not silently shift either
-contract.
+set_db_path -> init_db_schema -> purge_old_logs ->
+init_db_migrations -> Supervisor.start) and the HTMX-vs-JSON split
+on the validation-error handler so later changes to the lifespan
+wiring do not silently shift either contract.
+
+The schema/purge/migrations split lands log retention before the
+v14 cooldown back-fill (issue #586): on long-lived databases the
+back-fill grinds through 30+ days of unused rows otherwise, and
+the Kubernetes liveness probe has shipped pods to crash-loop in
+production over it.
 """
 
 from __future__ import annotations
@@ -14,7 +20,7 @@ from fastapi.testclient import TestClient
 
 from houndarr import app as app_module
 from houndarr.app import _periodic_log_retention
-from houndarr.config import DEFAULT_LOG_RETENTION_DAYS, AppSettings
+from houndarr.config import AppSettings
 
 pytestmark = pytest.mark.pinning
 
@@ -44,12 +50,19 @@ class TestLifespanStartup:
         test_settings: AppSettings,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """ensure_master_key -> set_db_path -> init_db -> purge_old_logs -> supervisor.start."""
+        """master_key -> set_db_path -> schema DDL -> purge -> migrations.
+
+        Schema DDL must precede the purge call so ``search_log`` exists
+        when ``DELETE FROM search_log`` fires on fresh installs.  The
+        purge then runs *before* migrations so the v14 cooldown back-fill
+        never sees rows that retention is about to delete.
+        """
         order: list[str] = []
 
         real_ensure = app_module.ensure_master_key
         real_set_db_path = app_module.set_db_path
-        real_init_db = app_module.init_db
+        real_init_schema = app_module.init_db_schema
+        real_init_migrations = app_module.init_db_migrations
         real_purge = app_module.purge_old_logs
 
         def spy_ensure(data_dir: str) -> bytes:
@@ -60,9 +73,13 @@ class TestLifespanStartup:
             order.append("set_db_path")
             real_set_db_path(path)
 
-        async def spy_init_db() -> None:
-            order.append("init_db")
-            await real_init_db()
+        async def spy_init_schema() -> None:
+            order.append("init_db_schema")
+            await real_init_schema()
+
+        async def spy_init_migrations() -> None:
+            order.append("init_db_migrations")
+            await real_init_migrations()
 
         async def spy_purge(days: int) -> int:
             order.append("purge_old_logs")
@@ -70,7 +87,8 @@ class TestLifespanStartup:
 
         monkeypatch.setattr(app_module, "ensure_master_key", spy_ensure)
         monkeypatch.setattr(app_module, "set_db_path", spy_set_db_path)
-        monkeypatch.setattr(app_module, "init_db", spy_init_db)
+        monkeypatch.setattr(app_module, "init_db_schema", spy_init_schema)
+        monkeypatch.setattr(app_module, "init_db_migrations", spy_init_migrations)
         monkeypatch.setattr(app_module, "purge_old_logs", spy_purge)
 
         fastapi_app = app_module.create_app()
@@ -80,8 +98,9 @@ class TestLifespanStartup:
         assert order == [
             "ensure_master_key",
             "set_db_path",
-            "init_db",
+            "init_db_schema",
             "purge_old_logs",
+            "init_db_migrations",
         ]
 
     def test_shutdown_cancels_retention_task(
@@ -94,6 +113,30 @@ class TestLifespanStartup:
         # TestClient has yielded (we are still inside the with-block via fixture).
         # Sanity: task was created and is alive.
         assert not retention.done()
+
+    def test_lifespan_skips_retention_task_when_retention_disabled(
+        self,
+        tmp_data_dir: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``log_retention_days=0`` skips the periodic loop entirely.
+
+        Operators who set the env var to ``0`` opt out of automatic
+        purges.  The lifespan should reflect that by leaving
+        ``app.state.retention_task = None`` and never spawning the
+        24-hour task; otherwise the task wakes once a day and runs a
+        no-op ``DELETE`` on a disabled threshold.
+        """
+        from houndarr.config import bootstrap_settings
+
+        bootstrap_settings(data_dir=tmp_data_dir, log_retention_days=0)
+        from houndarr.auth import reset_auth_caches
+
+        reset_auth_caches()
+
+        fastapi_app = app_module.create_app()
+        with TestClient(fastapi_app) as client:
+            assert getattr(client.app.state, "retention_task", "missing") is None
 
 
 # RequestValidationError split
@@ -122,9 +165,9 @@ class TestModuleConstants:
     def test_log_retention_interval_is_24_hours(self) -> None:
         assert app_module._LOG_RETENTION_INTERVAL_SECONDS == 24 * 60 * 60
 
-    def test_default_log_retention_days_from_config(self) -> None:
-        """The lifespan's purge call uses DEFAULT_LOG_RETENTION_DAYS."""
-        assert DEFAULT_LOG_RETENTION_DAYS >= 1
+    def test_app_settings_default_log_retention_days(self) -> None:
+        """The AppSettings default preserves the v1.10.x 30-day baseline."""
+        assert AppSettings(data_dir="/tmp").log_retention_days == 30
 
     def test_periodic_log_retention_is_async(self) -> None:
         """_periodic_log_retention is an async def (not a sync function)."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -553,7 +553,7 @@ def test_dashboard_accessible_after_login(app: TestClient) -> None:
     assert response.status_code == 200
     assert b"Dashboard" in response.content
     assert b'id="instance-grid"' in response.content
-    assert b'hx-trigger="every 30s"' in response.content
+    assert b'hx-trigger="every 30s queue:none"' in response.content
     assert b'id="dash-initial-status"' in response.content
     assert b'class="dash-main"' in response.content
     assert b'id="dash-top"' in response.content

--- a/tests/test_database_edge_cases.py
+++ b/tests/test_database_edge_cases.py
@@ -3,10 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import time
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from houndarr.database import get_db
+from houndarr.database import (
+    _connection_factory,
+    _pools,
+    close_all_pools,
+    get_db,
+    init_db,
+    set_db_path,
+)
 from houndarr.repositories.search_log import purge_old_logs
 from houndarr.repositories.settings import get_setting, set_setting
 
@@ -170,3 +179,242 @@ async def test_concurrent_get_db_calls_succeed(db: None) -> None:
     assert await get_setting("concurrent_a") == "val_a"
     assert await get_setting("concurrent_b") == "val_b"
     assert await get_setting("concurrent_c") == "val_c"
+
+
+# ---------------------------------------------------------------------------
+# Composite indexes (issue #586)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_search_log_composite_indexes_present(db: None) -> None:
+    """Both new indexes are created on a fresh schema.
+
+    ``idx_search_log_lookup`` makes the v14 cooldown back-fill fast and
+    serves the cooldown N+1 in :mod:`houndarr.services.metrics`;
+    ``idx_search_log_action_time`` covers the action-filtered window
+    aggregations on the dashboard hot path.  A regression that drops
+    either trips this test before it ships.
+    """
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='search_log'"
+        ) as cur:
+            indexes = {row["name"] async for row in cur}
+
+    assert "idx_search_log_lookup" in indexes
+    assert "idx_search_log_action_time" in indexes
+    assert "idx_search_log_timestamp" in indexes
+    assert "idx_search_log_instance" in indexes
+
+
+@pytest.mark.asyncio()
+async def test_dashboard_metric_queries_use_indexes(db: None) -> None:
+    """Every metric query the dashboard polls hits an index, not a SCAN.
+
+    Locks ``idx_search_log_lookup`` and ``idx_search_log_action_time``
+    against future planner regressions.  A query that switches to a
+    full ``SCAN search_log`` would re-introduce the dashboard hang
+    that issue #586 fixed.
+    """
+    queries = [
+        # Window aggregation filtered by instance + action.
+        (
+            "SELECT SUM(CASE WHEN action='searched' THEN 1 ELSE 0 END)"
+            " FROM search_log WHERE instance_id IN (1, 2)"
+        ),
+        # Cooldown N+1 lookup.
+        (
+            "SELECT item_label FROM search_log"
+            " WHERE instance_id=1 AND item_id=42 AND item_type='episode'"
+            " AND action='searched' ORDER BY timestamp DESC LIMIT 1"
+        ),
+        # Recent searches windowed by time.
+        (
+            "SELECT timestamp FROM search_log"
+            " WHERE action='searched' ORDER BY timestamp DESC LIMIT 5"
+        ),
+    ]
+    async with get_db() as conn:
+        for sql in queries:
+            async with conn.execute(f"EXPLAIN QUERY PLAN {sql}") as cur:
+                rows = await cur.fetchall()
+            # Inspect every step that touches search_log.  SQLite reports
+            # ``SEARCH search_log USING INDEX X`` for filtered lookups
+            # and ``SCAN search_log USING INDEX X`` for full-index walks
+            # (still optimal for ORDER BY + LIMIT on an indexed column);
+            # the pathological case is a bare ``SCAN search_log`` with
+            # no index qualifier.  We assert per-row rather than
+            # joining the plan into one string so that a hypothetical
+            # planner change that scans search_log via the rowid (no
+            # USING INDEX clause) cannot pass on the strength of an
+            # unrelated index hit elsewhere in the plan.
+            for row in rows:
+                detail = str(row["detail"])
+                if "search_log" not in detail:
+                    continue
+                assert "USING INDEX" in detail or "USING COVERING INDEX" in detail, (
+                    f"search_log step missing index for query: {sql}\n"
+                    f"Offending step: {detail}\n"
+                    f"Full plan: {[str(r['detail']) for r in rows]}"
+                )
+
+
+@pytest.mark.asyncio()
+async def test_v14_backfill_indexed_is_fast(db: None) -> None:
+    """v14 cooldown back-fill completes in seconds on a 5k-row search_log.
+
+    Without ``idx_search_log_lookup`` the same workload runs O(N*M):
+    each cooldown row triggers two full scans of ``search_log``.  This
+    test seeds 500 cooldowns and 5k log rows, runs the v14 self-heal,
+    and asserts the wall-clock budget.  A regression that drops the
+    index would push this past 5+ s on CI.
+    """
+    from houndarr.database import _migrate_to_v14
+
+    async with get_db() as conn:
+        # Seed two instances; every search_log row needs a parent FK.
+        await conn.executemany(
+            "INSERT INTO instances (id, name, type, url, encrypted_api_key) VALUES (?, ?, ?, ?, ?)",
+            [(1, "Sonarr", "sonarr", "http://x", ""), (2, "Radarr", "radarr", "http://y", "")],
+        )
+        # 5k synthetic search_log rows spread over the last 30 days.
+        now = datetime.now(UTC)
+        log_rows = [
+            (
+                (i % 2) + 1,
+                100 + (i % 250),  # 250 distinct items per instance
+                "episode" if i % 2 == 0 else "movie",
+                "missing" if i % 3 == 0 else ("cutoff" if i % 3 == 1 else "upgrade"),
+                "searched",
+                f"Item {i}",
+                (now - timedelta(minutes=i % 43200)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+            )
+            for i in range(5000)
+        ]
+        await conn.executemany(
+            "INSERT INTO search_log (instance_id, item_id, item_type, search_kind,"
+            " action, item_label, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            log_rows,
+        )
+        # 1k cooldown rows referencing items that exist in search_log.
+        cooldown_rows = [
+            (
+                (i % 2) + 1,
+                100 + (i % 250),
+                "episode" if i % 2 == 0 else "movie",
+                "missing",
+                now.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+            )
+            for i in range(500)
+        ]
+        await conn.executemany(
+            "INSERT OR IGNORE INTO cooldowns (instance_id, item_id, item_type,"
+            " search_kind, searched_at) VALUES (?, ?, ?, ?, ?)",
+            cooldown_rows,
+        )
+        await conn.commit()
+
+    # Run the v14 self-heal twice; second run should be a near-instant
+    # no-op thanks to the search_kind = 'missing' guard.
+    async with get_db() as conn:
+        first_start = time.monotonic()
+        await _migrate_to_v14(conn)
+        await conn.commit()
+        first_elapsed = time.monotonic() - first_start
+
+    async with get_db() as conn:
+        second_start = time.monotonic()
+        await _migrate_to_v14(conn)
+        await conn.commit()
+        second_elapsed = time.monotonic() - second_start
+
+    assert first_elapsed < 5.0, f"First v14 back-fill too slow: {first_elapsed:.2f}s"
+    assert second_elapsed < 0.5, f"Second v14 self-heal not idempotent-fast: {second_elapsed:.2f}s"
+
+
+# ---------------------------------------------------------------------------
+# Connection pool (issue #586)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_pool_factory_applies_full_pragma_stack(db: None) -> None:
+    """A connection borrowed from the pool carries every operational PRAGMA."""
+    async with get_db() as conn:
+        async with conn.execute("PRAGMA journal_mode") as cur:
+            row = await cur.fetchone()
+            assert row is not None
+            assert row[0] == "wal"
+
+        async with conn.execute("PRAGMA synchronous") as cur:
+            row = await cur.fetchone()
+            assert row is not None
+            assert row[0] == 1  # NORMAL
+
+        async with conn.execute("PRAGMA temp_store") as cur:
+            row = await cur.fetchone()
+            assert row is not None
+            assert row[0] == 2  # MEMORY
+
+        async with conn.execute("PRAGMA foreign_keys") as cur:
+            row = await cur.fetchone()
+            assert row is not None
+            assert row[0] == 1
+
+
+@pytest.mark.asyncio()
+async def test_pool_per_db_path_isolation(tmp_data_dir: str) -> None:
+    """Setting a new ``_db_path`` builds a fresh pool, leaving the old one closed.
+
+    The test fixture pattern relies on this: every test calls
+    ``set_db_path`` to a unique tmp file, and the autouse teardown
+    closes the previous pool.  A regression that shares one pool
+    across paths would silently route writes to the wrong DB on the
+    next test.
+    """
+    import os
+
+    path_a = os.path.join(tmp_data_dir, "pool_a.db")
+    path_b = os.path.join(tmp_data_dir, "pool_b.db")
+
+    set_db_path(path_a)
+    await init_db()
+    async with get_db() as conn:
+        await conn.execute("INSERT INTO settings (key, value) VALUES ('marker', 'A')")
+        await conn.commit()
+
+    pool_a = _pools.get(path_a)
+    assert pool_a is not None
+
+    set_db_path(path_b)
+    await init_db()
+    async with get_db() as conn:
+        async with conn.execute("SELECT value FROM settings WHERE key='marker'") as cur:
+            row = await cur.fetchone()
+            assert row is None  # path_b has its own DB
+
+    pool_b = _pools.get(path_b)
+    assert pool_b is not None
+    assert pool_a is not pool_b
+
+    await close_all_pools()
+    assert path_a not in _pools
+    assert path_b not in _pools
+
+
+@pytest.mark.asyncio()
+async def test_connection_factory_returns_row_factory_connection(tmp_data_dir: str) -> None:
+    """``_connection_factory`` builds a connection ready for dict-style row access."""
+    import os
+
+    path = os.path.join(tmp_data_dir, "factory.db")
+    set_db_path(path)
+    conn = await _connection_factory()
+    try:
+        async with conn.execute("SELECT 1 AS one") as cur:
+            row = await cur.fetchone()
+        assert row is not None
+        assert row["one"] == 1
+    finally:
+        await conn.close()

--- a/tests/test_gates/test_bootstrap_wiring_gate.py
+++ b/tests/test_gates/test_bootstrap_wiring_gate.py
@@ -111,6 +111,7 @@ class TestOverridesTypedDict:
             "auth_mode",
             "auth_proxy_header",
             "update_check_repo",
+            "log_retention_days",
         }
 
 

--- a/tests/test_routes/test_status_cache_integration.py
+++ b/tests/test_routes/test_status_cache_integration.py
@@ -1,0 +1,204 @@
+"""Integration tests for the dashboard aggregate cache through the HTTP layer.
+
+The autouse ``_disable_dashboard_cache`` fixture in ``tests/conftest.py``
+patches ``DASHBOARD_CACHE_TTL_SECONDS`` to ``0`` so legacy tests run
+against an uncached route.  This module overrides that fixture to drive
+the production cache path through ``TestClient`` end-to-end and verify
+the wiring the audit flagged as unverified at the HTTP boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from houndarr.clients._wire_models import SystemStatus
+from houndarr.clients.base import ArrClient
+from houndarr.database import get_db
+from houndarr.engine import supervisor as supervisor_module
+from tests.conftest import csrf_headers
+
+
+@pytest.fixture(autouse=True)
+def _mock_connection_ping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the *arr ``ping`` so instance creation passes the connection test."""
+
+    async def _always_ok(self: ArrClient) -> SystemStatus | None:
+        name = type(self).__name__.replace("Client", "")
+        return SystemStatus(app_name=name, version="4.0.0")
+
+    monkeypatch.setattr(ArrClient, "ping", _always_ok)
+
+
+@pytest.fixture(autouse=True)
+def _mock_supervisor_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the supervisor's per-cycle search call so the loop is a no-op."""
+
+    async def _no_op(*_args: object, **_kwargs: object) -> int:
+        return 0
+
+    monkeypatch.setattr(supervisor_module, "run_instance_search", _no_op)
+
+
+@pytest.fixture(autouse=True)
+def _enable_dashboard_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-enable the cache for this module by lifting conftest's patch.
+
+    The autouse ``_disable_dashboard_cache`` fixture in conftest patches
+    ``DASHBOARD_CACHE_TTL_SECONDS`` to ``0``; pytest-applied autouse
+    fixtures stack, and the LATER monkeypatch wins.  Setting the value
+    to a generous TTL ensures the cache survives across the
+    HTTP-level operations these tests perform.
+    """
+    import houndarr.services.metrics as _metrics
+
+    monkeypatch.setattr(_metrics, "DASHBOARD_CACHE_TTL_SECONDS", 30)
+
+
+def _login(client: TestClient) -> None:
+    """Walk the setup + login flow so authenticated routes are reachable."""
+    client.post(
+        "/setup",
+        data={"username": "admin", "password": "ValidPass1!", "password_confirm": "ValidPass1!"},
+    )
+    client.post("/login", data={"username": "admin", "password": "ValidPass1!"})
+
+
+def _create_instance(client: TestClient, name: str = "Cache Sonarr") -> int:
+    """Create one instance via the settings route and return its id."""
+    form = {
+        "name": name,
+        "type": "sonarr",
+        "url": "http://sonarr:8989",
+        "api_key": "test-api-key",
+        "connection_verified": "true",
+    }
+    client.post("/settings/instances", data=form, headers=csrf_headers(client))
+    resp = client.get("/api/status")
+    assert resp.status_code == 200
+    return int(resp.json()["instances"][0]["id"])
+
+
+async def _insert_search_log_row(instance_id: int, label: str) -> None:
+    """Insert one ``searched`` row directly via SQL, bypassing every route.
+
+    Direct DB writes do not call ``invalidate_dashboard_cache``; that is
+    the whole point of these tests.  A subsequent ``/api/status`` poll
+    should serve the *previous* cached envelope until either the TTL
+    expires or a mutation route invalidates the cache.
+    """
+    now = datetime.now(UTC)
+    async with get_db() as conn:
+        await conn.execute(
+            "INSERT INTO search_log (instance_id, item_id, item_type, search_kind,"
+            " action, item_label, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                instance_id,
+                999,
+                "episode",
+                "missing",
+                "searched",
+                label,
+                (now - timedelta(seconds=5)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+            ),
+        )
+        await conn.commit()
+
+
+@pytest.mark.asyncio()
+async def test_cache_serves_stale_data_when_db_changes_outside_routes(
+    app: TestClient,
+) -> None:
+    """A direct SQL write between two polls is hidden by the cache.
+
+    Pins the production contract: only mutation routes that fan out to
+    ``invalidate_dashboard_cache`` cause a fresh DB scan.  Background
+    cycle work (which writes to ``search_log`` on every cycle) is
+    absorbed by the TTL, not by per-write invalidation.
+    """
+    _login(app)
+    iid = _create_instance(app, "Cache Sonarr A")
+
+    # Warm the cache: this poll loads the (empty) recent_searches.
+    first = app.get("/api/status").json()
+    assert first["recent_searches"] == []
+
+    # Background-style write: bypass the route, mimicking the supervisor.
+    await _insert_search_log_row(iid, "Sneaked In")
+
+    # Cached envelope still wins; the background write is invisible
+    # until the TTL expires or a mutation route invalidates.
+    second = app.get("/api/status").json()
+    assert second["recent_searches"] == []
+
+
+@pytest.mark.asyncio()
+async def test_clear_logs_route_invalidates_cache(app: TestClient) -> None:
+    """``POST /settings/admin/clear-logs`` must drop the cache.
+
+    Pins the invalidation hook in :mod:`houndarr.routes.admin`.  Without
+    it, the dashboard's ``recent_searches`` strip would still show
+    pre-clear rows for up to the cache TTL after the operator clicked
+    the maintenance button.
+    """
+    _login(app)
+    iid = _create_instance(app, "Cache Sonarr B")
+
+    # Seed one row, warm the cache so it is reflected, then clear logs
+    # and confirm the next poll returns an empty recent_searches strip.
+    await _insert_search_log_row(iid, "Pre-clear row")
+    app.post("/settings/admin/clear-logs", headers=csrf_headers(app))
+
+    after_clear = app.get("/api/status").json()
+    # ``clear_all_search_logs`` writes a single audit breadcrumb at
+    # info level, so recent_searches (which filters on action='searched')
+    # should be empty.  If the cache had leaked the pre-clear row, the
+    # length would be 1.
+    assert after_clear["recent_searches"] == []
+
+
+@pytest.mark.asyncio()
+async def test_run_now_schedules_deferred_reinvalidation(
+    app: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``POST /api/instances/{id}/run-now`` re-invalidates after the delay.
+
+    Pins the deferred ``asyncio.create_task`` that reclears the cache
+    once the supervisor's background search-log write should have
+    landed.  Reduces the delay constant so the test does not rely on
+    real-time waits.
+    """
+    import houndarr.routes.api.status as status_module
+
+    monkeypatch.setattr(status_module, "_RUN_NOW_REINVALIDATE_DELAY_SECONDS", 0.05)
+
+    _login(app)
+    _create_instance(app, "Cache Sonarr C")
+
+    # Seed app.state with a fake cache that records cache_clear calls.
+    clear_count = {"n": 0}
+
+    class _RecordingCache:
+        def cache_clear(self) -> None:
+            clear_count["n"] += 1
+
+        async def __call__(self, _ids: tuple[int, ...]) -> object:
+            from houndarr.services.metrics import DashboardAggregates
+
+            return DashboardAggregates()
+
+    app.app.state.aggregate_cache = _RecordingCache()
+
+    resp = app.post("/api/instances/1/run-now", headers=csrf_headers(app))
+    assert resp.status_code == 202
+
+    # Synchronous invalidate: 1 clear right now.
+    assert clear_count["n"] == 1
+
+    # Wait for the deferred reinvalidation to fire.
+    await asyncio.sleep(0.2)
+    assert clear_count["n"] == 2

--- a/tests/test_routes/test_status_cache_integration.py
+++ b/tests/test_routes/test_status_cache_integration.py
@@ -44,27 +44,6 @@ def _mock_supervisor_search(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _ensure_css_bundle_present() -> None:
-    """Recreate the CSS stub if a parallel xdist worker tore it down.
-
-    The session-scope ``_ensure_css_bundle_for_tests`` fixture in
-    ``tests/conftest.py`` creates the stub once per worker and deletes
-    it in finally.  Under ``pytest-xdist`` the workers can race on the
-    session boundary so a worker finishing its session deletes the
-    file out from under another worker still running tests.  This
-    function-scope guard reinstates the stub before the lifespan
-    preflight check runs.
-    """
-    from pathlib import Path
-
-    from houndarr import app as app_module
-
-    css_bundle = Path(app_module.__file__).parent / "static" / "css" / "app.built.css"
-    if not css_bundle.is_file():
-        css_bundle.write_text("/* pytest stub */\n", encoding="utf-8")
-
-
-@pytest.fixture(autouse=True)
 def _enable_dashboard_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     """Re-enable the cache for this module by lifting conftest's patch.
 

--- a/tests/test_routes/test_status_cache_integration.py
+++ b/tests/test_routes/test_status_cache_integration.py
@@ -44,6 +44,27 @@ def _mock_supervisor_search(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _ensure_css_bundle_present() -> None:
+    """Recreate the CSS stub if a parallel xdist worker tore it down.
+
+    The session-scope ``_ensure_css_bundle_for_tests`` fixture in
+    ``tests/conftest.py`` creates the stub once per worker and deletes
+    it in finally.  Under ``pytest-xdist`` the workers can race on the
+    session boundary so a worker finishing its session deletes the
+    file out from under another worker still running tests.  This
+    function-scope guard reinstates the stub before the lifespan
+    preflight check runs.
+    """
+    from pathlib import Path
+
+    from houndarr import app as app_module
+
+    css_bundle = Path(app_module.__file__).parent / "static" / "css" / "app.built.css"
+    if not css_bundle.is_file():
+        css_bundle.write_text("/* pytest stub */\n", encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
 def _enable_dashboard_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     """Re-enable the cache for this module by lifting conftest's patch.
 

--- a/tests/test_services/test_metrics_cache.py
+++ b/tests/test_services/test_metrics_cache.py
@@ -1,0 +1,142 @@
+"""Tests for the dashboard aggregate cache (issue #586).
+
+The cache wraps the four slow ``search_log`` aggregations
+(``gather_window_metrics``, ``gather_lifetime_metrics``,
+``gather_active_errors``, ``gather_recent_searches``) with a 20-second
+TTL and single-flight semantics so tens of dashboard tabs polling the
+same envelope land on a single DB scan.  The tests below pin the
+contract: a hit avoids the DB entirely; ``cache_clear`` forces a fresh
+scan on the next call; live signals (cycle-end timestamps, cooldown
+rows) bypass the cache so the next-patrol countdown stays accurate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.services.metrics import (
+    DASHBOARD_CACHE_TTL_SECONDS,
+    DashboardAggregates,
+    build_aggregate_cache,
+    invalidate_dashboard_cache,
+)
+
+
+def test_build_aggregate_cache_returns_none_when_ttl_zero() -> None:
+    """``ttl_seconds=0`` opts the route into the uncached fallback path.
+
+    The conftest ``_disable_dashboard_cache`` fixture relies on this:
+    every legacy test runs with ``DASHBOARD_CACHE_TTL_SECONDS`` patched
+    to 0, and the route handler's ``aggregate_cache is None`` branch
+    falls through to a fresh DB scan.
+    """
+    cache = build_aggregate_cache(ttl_seconds=0)
+    assert cache is None
+
+
+def test_build_aggregate_cache_returns_callable_when_ttl_positive() -> None:
+    """A non-zero TTL produces a callable with ``cache_clear``."""
+    cache = build_aggregate_cache(ttl_seconds=5)
+    assert cache is not None
+    assert callable(cache)
+    assert hasattr(cache, "cache_clear")
+
+
+def test_default_ttl_matches_dashboard_polling_cadence() -> None:
+    """The cache TTL stays in lockstep with the 30 s HTMX poll.
+
+    Pinning the constant prevents an off-by-one tuning change from
+    making the cache TTL longer than the poll, which would let a
+    settings mutation hide behind one full poll cycle even after
+    invalidation fires.
+    """
+    assert 5 < DASHBOARD_CACHE_TTL_SECONDS < 30
+
+
+@pytest.mark.asyncio()
+async def test_cache_hit_skips_db_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A second call within the TTL reuses the result without re-running.
+
+    Asserts the alru_cache wrapper's hit path: the underlying
+    ``_gather_dashboard_aggregates`` runs exactly once across two
+    awaits with the same key.  The single-flight guarantee from
+    async-lru protects the dashboard from thundering-herd polls.
+    """
+    import houndarr.services.metrics as metrics_module
+
+    call_count = {"n": 0}
+
+    async def _stub_gather(ids: tuple[int, ...]) -> DashboardAggregates:
+        call_count["n"] += 1
+        return DashboardAggregates()
+
+    monkeypatch.setattr(metrics_module, "_gather_dashboard_aggregates", _stub_gather)
+
+    cache = build_aggregate_cache(ttl_seconds=5)
+    assert cache is not None
+
+    await cache((1, 2))
+    await cache((1, 2))
+
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio()
+async def test_cache_clear_forces_fresh_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``cache_clear`` invalidates every entry, the next call hits the DB.
+
+    Every mutation route fans out to ``invalidate_dashboard_cache``
+    which calls ``cache_clear``; this is the only invalidation path
+    the production code uses.  A regression that swaps clearing for a
+    no-op would let stale data linger on the dashboard after the
+    operator created, edited, or deleted an instance.
+    """
+    import houndarr.services.metrics as metrics_module
+
+    call_count = {"n": 0}
+
+    async def _stub_gather(ids: tuple[int, ...]) -> DashboardAggregates:
+        call_count["n"] += 1
+        return DashboardAggregates()
+
+    monkeypatch.setattr(metrics_module, "_gather_dashboard_aggregates", _stub_gather)
+
+    cache = build_aggregate_cache(ttl_seconds=5)
+    assert cache is not None
+
+    await cache((1, 2))
+    cache.cache_clear()
+    await cache((1, 2))
+
+    assert call_count["n"] == 2
+
+
+def test_invalidate_dashboard_cache_no_op_when_attribute_missing() -> None:
+    """The helper is safe to call when the cache hasn't been built.
+
+    Tests that bypass the lifespan (sync-only tests, isolated unit
+    tests) leave ``app.state.aggregate_cache`` unset; the helper
+    still has to be callable from mutation routes that could be
+    exercised without a full app boot.
+    """
+
+    class _BareState:
+        pass
+
+    invalidate_dashboard_cache(_BareState())
+
+
+def test_invalidate_dashboard_cache_calls_clear_when_present() -> None:
+    """When a cache is attached, the helper invokes ``cache_clear``."""
+
+    cleared = {"called": False}
+
+    class _FakeCache:
+        def cache_clear(self) -> None:
+            cleared["called"] = True
+
+    class _State:
+        aggregate_cache: _FakeCache = _FakeCache()
+
+    invalidate_dashboard_cache(_State())
+    assert cleared["called"] is True

--- a/website/docs/guides/installation/helm.md
+++ b/website/docs/guides/installation/helm.md
@@ -128,6 +128,9 @@ The `chartRef` field (instead of `chart.spec.sourceRef`) is what connects a `Hel
 | `env.authMode` | `builtin` | `HOUNDARR_AUTH_MODE`: `builtin` or `proxy` |
 | `env.authProxyHeader` | `""` | `HOUNDARR_AUTH_PROXY_HEADER` (e.g., `Remote-User`) |
 | `env.logLevel` | `info` | `HOUNDARR_LOG_LEVEL`: `debug`, `info`, `warning`, `error` |
+| `env.logRetentionDays` | `30` | `HOUNDARR_LOG_RETENTION_DAYS`: days of `search_log` rows to keep. `0` disables purges; `7` to `365` overrides the default |
+| `startupProbe.failureThreshold` | `60` | Probe attempts before the pod is marked unhealthy. Combined with `periodSeconds`, the default gives a 10-minute startup budget for first-boot migrations |
+| `startupProbe.periodSeconds` | `10` | Seconds between startup probe attempts |
 | `persistence.size` | `1Gi` | PVC size |
 | `persistence.storageClassName` | `""` | StorageClass. Empty uses the cluster default |
 | `persistence.accessMode` | `ReadWriteOnce` | PVC access mode |

--- a/website/docs/guides/installation/unraid.md
+++ b/website/docs/guides/installation/unraid.md
@@ -118,6 +118,15 @@ the HTTP header your SSO provider injects with the authenticated
 username (for example `Remote-User` for Authelia,
 `X-authentik-username` for Authentik).
 
+### Log Retention Days (`HOUNDARR_LOG_RETENTION_DAYS`)
+
+Default: `30`. Houndarr deletes search log entries older than this
+once a day during the periodic retention sweep. Lower it to `7` or
+`14` if your dashboard feels slow on a long-running instance with
+several active *arrs; raise it (up to `365`) if you want a longer
+audit trail. Set to `0` to disable automatic purges entirely; the
+manual `Clear logs` button under Settings > Admin still works.
+
 ## First launch
 
 Apply the template. The container pulls and starts. Then:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -19,6 +19,7 @@ manifests, or the Unraid CA template.
 | `HOUNDARR_PORT` | `8877` | Port to bind the web server to |
 | `HOUNDARR_DEV` | `false` | Enable development mode (auto-reload, API docs at `/api/docs`) |
 | `HOUNDARR_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warning`, `error` |
+| `HOUNDARR_LOG_RETENTION_DAYS` | `30` | Days of `search_log` rows to retain. `0` disables automatic purges; `7` to `365` overrides the default |
 
 ## Security settings
 


### PR DESCRIPTION
## Summary

Fixes the dashboard hang and Kubernetes startup crash loop on databases with large `search_log` tables. Reporter saw multi-minute stalls that killed the pod before any request landed; the index gap + N+1 cooldown subqueries were the cause.

Closes #586

## Changes

- Two new composite indexes on `search_log` (`idx_search_log_lookup`, `idx_search_log_action_time`) so the v14 cooldown back-fill and the dashboard aggregation queries stop scanning every row.
- v14 self-heal builds `idx_search_log_lookup` before the correlated UPDATE and gates the UPDATE on `cooldowns.search_kind = 'missing'` so subsequent boots are near-instant no-ops.
- `init_db` split into `init_db_schema` and `init_db_migrations` so log retention runs between the schema DDL and the migration sweep, trimming the back-fill workload before it starts.
- aiosqlite connections are now reused through `aiosqlitepool` with the modern operational PRAGMA stack (`synchronous=NORMAL`, `temp_store=MEMORY`, `cache_size=-20000`, `mmap_size=128MB`, `journal_size_limit=64MB`, `busy_timeout=5000`); `PRAGMA optimize` runs after migrations and after each daily retention pass.
- `/api/status` aggregations cache for 20 seconds via `async-lru` with single-flight semantics; mutation routes (instance CRUD, toggle, clear-logs, reset-instance-policy, run-now, factory-reset) invalidate the cache; HTMX poll trigger uses `queue:none` so a slow response cannot pile up.
- `HOUNDARR_LOG_RETENTION_DAYS` env var + CLI flag (default `30`, allowed `0` or `7`-`365`); plumbed through `AppSettings`, `bootstrap_non_web`, the periodic retention loop, the factory-reset re-init, the Helm values, the env-var docs, and the Unraid template.
- Helm chart ships a `startupProbe` (60 attempts × 10 s = 10 minutes) so first-boot migrations on Kubernetes have time to finish before the liveness probe kicks in.

## Testing

End-to-end against the reporter's exact profile (3 instances, 280 k `search_log` rows, 6 000 cooldowns, schema_version downgraded to v14 with the new indexes dropped):

| Test | Pre-fix | Post-fix |
|---|---|---|
| v14 cooldown back-fill | 3.69 s | 9 ms (~430× faster) |
| `/api/status` per poll | 395 ms | 17 ms cached |
| Docker container restart | hangs past liveness | healthy in 1 s |
| Kubernetes pod restart with seeded PVC | crash-loop | Ready in 12 s |
| `HOUNDARR_LOG_RETENTION_DAYS=14` purge in Docker | n/a | 280 000 → 2 142 rows in 3 s |

Source-mode bench, Docker upgrade-path test, kind-based Helm install all verified locally on Apple Silicon. `just check` passes (lint, format, mypy strict, bandit, 2650 tests). Adversarial review pass (`/review`) flagged 6 findings; all CRITICAL/HIGH/MEDIUM addressed in-branch (frozen aggregate dataclass, sorted cache key, cache built before supervisor.start, pool size raised to 10, deferred run-now re-invalidation, EXPLAIN QUERY PLAN test tightened).

Bench scripts left in-tree under `scripts/bench_586_*.py` for future regression checks.

## Type of Change

- [x] Bug fix (`fix:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Branch name matches issue scope
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (env var reference, Unraid + Helm install guides)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: improves search-log hygiene and dashboard responsiveness for the existing missing/cutoff/upgrade pipeline; no new product surface.