### PR TITLE
chore(agents): port slash commands to .agents/skills for cross-tool use

### DIFF
--- a/.agents/skills/bump/SKILL.md
+++ b/.agents/skills/bump/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: bump
+description: Bump Houndarr version and prepare a release PR. Promotes the Unreleased CHANGELOG block to a versioned block, runs quality gates, opens the PR. Use when the user asks to bump the version, prepare a release, or run /bump. Trigger phrases include bump, release, version bump, prepare release.
+---
+
+# Bump Version and Release
+
+Prepare a release PR following the Houndarr versioning workflow.
+
+Houndarr follows Keep a Changelog 1.1.0: every shipped PR adds a bullet under `## [Unreleased]` as part of its own commit, so by the time bump runs, the upcoming release's bullets are already in the file. This skill's job is to **promote** the Unreleased block to a versioned block, not to draft one from PR titles.
+
+The user's argument is the version bump kind: `patch`, `minor`, or an explicit `X.Y.Z`.
+
+## 1. Read Current Version
+
+```
+cat VERSION
+```
+
+Note the current version (plain X.Y.Z, no `v` prefix).
+
+## 2. Calculate New Version
+
+- `patch`: increment patch (e.g. 1.6.5 → 1.6.6)
+- `minor`: increment minor, reset patch
+- Explicit `X.Y.Z`: use as-is
+
+Validate the new version is greater than the current one.
+
+## 3. Verify the Unreleased Block
+
+### 3a. Refuse to bump an empty Unreleased
+
+```
+awk '/^## \[Unreleased\]$/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md
+```
+
+If the extracted block contains nothing more than the trailing `---`, stop with `"## [Unreleased] is empty. Nothing to release."` and do not touch VERSION or CHANGELOG.
+
+### 3b. Verify every bullet's claim before promoting
+
+**Mandatory.** For every PR referenced in the Unreleased block:
+
+```bash
+gh pr view N --repo <owner>/<repo> --json title,body
+gh pr diff N --repo <owner>/<repo> | head -400
+```
+
+For any bullet that claims behavior (a default, a UI element, an error string, an API response shape), read the relevant source file and pin the claim to a specific `file:line`. Adopt the PR author's vocabulary for nuance. Every bullet must be defensible with a concrete reference; if you cannot cite one, rewrite or drop the bullet.
+
+### 3c. Final filter and language pass
+
+Keep only user-facing entries (Added, Changed, Fixed, Removed, Deprecated, Security). Drop CI/refactor/test-only/docs-only/chore/dep-bump-without-impact entries.
+
+If no user-facing entries remain, report `"No user-facing changes in Unreleased. Nothing to release."` and stop.
+
+Language pass: rewrite bullets that reference internal Python classes / private helpers / `src/...` paths, exceed 250 chars without a migration reason, use banned phrasings (various / improved / enhanced / better / seamlessly / robustly / significantly / leverages / utilizes / em dashes), or read as past-tense narration. Use markdown `[text](url)` for links.
+
+## 4. Present the Promotion Plan for Review
+
+Show the planned CHANGELOG.md unified diff. Wait for approval. Do not proceed without confirmation.
+
+## 5. Create Branch and Tracking Issue
+
+```
+git fetch origin
+git checkout -b chore/bump-X.Y.Z origin/main
+gh issue create --title "chore: bump version to X.Y.Z" \
+  --label "type: chore" --label "priority: medium" \
+  --body "Release X.Y.Z with <brief summary of user-facing changes>."
+```
+
+## 6. Update VERSION File
+
+Write the new version (single line, no `v` prefix).
+
+## 7. Promote Unreleased in CHANGELOG.md
+
+Rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` and insert a fresh empty Unreleased block at the top.
+
+## 8. Run Quality Gates
+
+```
+.venv/bin/python -m ruff check src/ tests/
+.venv/bin/python -m ruff format --check src/ tests/
+.venv/bin/python -m mypy src/
+.venv/bin/python -m bandit -r src/ -c pyproject.toml
+```
+
+## 9. Commit and Push
+
+```
+git add VERSION CHANGELOG.md
+git commit -m "chore: bump version to X.Y.Z"
+git push -u origin HEAD
+```
+
+## 10. Create PR
+
+```
+gh pr create --title "chore: bump version to X.Y.Z" --body "..."
+```
+
+After merge, remind the user to run `git tag vX.Y.Z && git push origin vX.Y.Z` to trigger docker.yml, release.yml, and chart.yml.

--- a/.agents/skills/check/SKILL.md
+++ b/.agents/skills/check/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: check
+description: Run Houndarr's full quality gate (ruff lint, ruff format check, mypy, bandit, pytest) and report results in a single table. Use when the user asks to run quality gates, check the code, run all checks, or invokes /check. Trigger phrases include quality gate, check, lint, run all checks.
+---
+
+# Full Quality Gate Review
+
+Run every quality check in sequence. Report results clearly. Stop and fix if any check fails.
+
+## 1. Lint
+
+```
+.venv/bin/python -m ruff check src/ tests/
+```
+
+Report: pass or fail with error count.
+
+## 2. Format Check
+
+```
+.venv/bin/python -m ruff format --check src/ tests/
+```
+
+If files are unformatted, run `.venv/bin/python -m ruff format src/ tests/` to fix, then re-check.
+
+## 3. Type Check
+
+```
+.venv/bin/python -m mypy src/
+```
+
+Report: pass or fail with error count and locations.
+
+## 4. SAST
+
+```
+.venv/bin/python -m bandit -r src/ -c pyproject.toml
+```
+
+Report: pass or fail with any findings.
+
+## 5. Tests
+
+```
+.venv/bin/pytest
+```
+
+Report: total tests, passed, failed, skipped.
+
+## Summary
+
+Present a single table:
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Lint (ruff) | ... | ... |
+| Format (ruff) | ... | ... |
+| Type check (mypy) | ... | ... |
+| SAST (bandit) | ... | ... |
+| Tests (pytest) | ... | ... |
+
+If all pass, say "All quality gates pass." and nothing else. If any fail, list the specific failures and suggest fixes. Do NOT recite exact test counts in a reporting style.

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: test
+description: Run Houndarr tests with various options (full suite, single file, keyword filter, coverage). Use when the user asks to run tests, run pytest, check test status, or invokes /test. Trigger phrases include run tests, test, pytest, coverage.
+---
+
+# Run Tests
+
+Parse the user's argument and run the appropriate test command. Argument forms: `[full|file:<path>|keyword:<expr>|coverage]` or a bare path.
+
+## Dispatch
+
+- **No argument or `full`**: run the full test suite.
+
+```
+.venv/bin/pytest
+```
+
+- **`file:<path>`**: run a single test file with verbose output.
+
+```
+.venv/bin/pytest <path> -v
+```
+
+- **`keyword:<expr>`**: run tests matching a keyword expression.
+
+```
+.venv/bin/pytest -k "<expr>" -v
+```
+
+- **`coverage`**: run with coverage reporting.
+
+```
+.venv/bin/pytest --cov=houndarr --cov-report=term-missing
+```
+
+- **Bare path** (no prefix): treat as a direct pytest path argument.
+
+```
+.venv/bin/pytest <path> -v
+```
+
+## Reporting
+
+Report pass/fail clearly. If there are failures, show the failing test names and short tracebacks. Do not recite pass counts unless there are failures to contextualize.


### PR DESCRIPTION
## Summary

Port the three project slash commands at `.claude/commands/{bump,check,test}.md` into SKILL.md files under `.agents/skills/`. This is the cross-tool discovery path for Codex CLI (`\$REPO_ROOT/.agents/skills`, per [Codex skills docs](https://developers.openai.com/codex/skills)) and OpenCode (`.agents/skills`, per [OpenCode skills docs](https://opencode.ai/docs/skills/)).

Body content is preserved verbatim. CC-specific frontmatter (`allowed-tools`, `argument-hint`) is omitted because Codex skill frontmatter only honors `name` + `description`. CC keeps reading the originals at `.claude/commands/` unchanged; this PR only adds, never modifies.

OpenCode-native slash commands at `.opencode/commands/{bump,check,test}.md` also exist locally as proper `/<name>` slash commands, but the repo gitignores `.opencode/` so they stay developer-local.

## Test plan

- [ ] Codex `\$bump` (or implicit description match) loads the bump skill in any directory under this repo
- [ ] Codex `\$check` runs the quality-gate sequence
- [ ] Codex `\$test` accepts and dispatches the [full|file:|keyword:|coverage] argument forms
- [ ] CC `/bump`, `/check`, `/test` continue to work via the original `.claude/commands/` files