### PR TITLE
chore: migrate dev deps to PEP 735 [dependency-groups]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,11 @@ dependencies = [
     "pydantic>=2.10.0",
 ]
 
-[project.optional-dependencies]
+# PEP 735 dependency groups: developer-only deps that are not part of the
+# published package metadata. uv auto-installs the `dev` group on `uv sync`,
+# so collaborators get the full dev toolchain with a single command.
+# See: https://peps.python.org/pep-0735/ and uv docs (sync ──no-default-groups).
+[dependency-groups]
 dev = [
     "ruff>=0.15.10",
     "mypy>=1.20.1",


### PR DESCRIPTION
## Summary

Moves the dev dependency list to PEP 735 `[dependency-groups]` so `uv sync` installs the full dev toolchain by default.

Closes #593

## Changes

- `pyproject.toml`: rename `[project.optional-dependencies]` → `[dependency-groups]`. Adds a comment with the PEP 735 reference.
- Dependency list itself unchanged. `requirements-dev.txt` left untouched (still the source for `pip-audit` CI).

## Testing

Local checks against the migrated branch:

- `rm -rf .venv && uv sync` → installs all 56 packages including dev (no `--extra` needed)
- `ruff check .` clean
- `ruff format --check .` clean (256 files)
- `mypy src/` clean (88 source files)
- `pytest --collect-only` collects cleanly

## Type of Change

- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`chore/pep735-dependency-groups`)
- [ ] Tests added/updated for all changes (N/A — pyproject metadata only)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable) (N/A)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: Developer-ergonomics chore; no behavioural change to the search engine