### PR TITLE
chore: tame pyright defaults for editor LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Python floor raised from 3.12 to 3.13. From-source installs and the Docker image now require a 3.13 interpreter; Python 3.13 has upstream support through October 2029. (#596)
+- Tracked `uv.lock` and removed checked-in `requirements.txt` / `requirements-dev.txt`; CI regenerates them on the fly via `uv export` for `pip-audit`. (#596)
+- `starlette` 0.52 to 1.0, `pydantic` 2.12 to 2.13, plus refreshed transitive pins. (#596)
+
 ---
 
 ## [1.11.0] - 2026-04-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Python floor raised from 3.12 to 3.13. From-source installs and the Docker image now require a 3.13 interpreter; Python 3.13 has upstream support through October 2029. (#596)
-- Tracked `uv.lock` and removed checked-in `requirements.txt` / `requirements-dev.txt`; CI regenerates them on the fly via `uv export` for `pip-audit`. (#596)
-- `starlette` 0.52 to 1.0, `pydantic` 2.12 to 2.13, plus refreshed transitive pins. (#596)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,20 @@ module = ["aiosqlite.*", "aiosqlitepool.*", "bcrypt.*"]
 ignore_missing_imports = true
 
 # ---------------------------------------------------------------------------
-# Pytest
+# Pyright (editor LSP only; mypy --strict remains the CI gate)
 # ---------------------------------------------------------------------------
+# Pins the Python version, points at the project venv so third-party imports
+# resolve, and adds the repo root to extraPaths so test files importing
+# ``tests.conftest`` and similar resolve in editors. Default ``standard`` mode
+# is intentionally kept; basedpyright also reads this section for forward
+# compatibility.
+[tool.pyright]
+include = ["src", "tests", "scripts"]
+extraPaths = ["."]
+pythonVersion = "3.13"
+venvPath = "."
+venv = ".venv"
+
 # ---------------------------------------------------------------------------
 # Bandit (SAST)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a minimal `[tool.pyright]` block to `pyproject.toml` so pyright (run by editor LSPs in nvim, VS Code, Helix, Zed) no longer flags `hatch_build.py`'s build-time hatchling import or ~36 `tests.conftest` imports as unresolved.

Also backfills one `## [Unreleased]` Changelog bullet that was missed when #596 (Python toolchain modernization) merged: the Python 3.13 floor bump. Other changes from #596 (uv.lock tracking, dependency version refresh) are contributor-facing or have no called-out behaviour impact, so they are not added.

Closes #597

## Changes

- `pyproject.toml`: new `[tool.pyright]` block. Pins `pythonVersion = "3.13"`, points `venvPath` / `venv` at the project `.venv`, scopes `include` to `src` / `tests` / `scripts`, and adds the repo root to `extraPaths`. Default `typeCheckingMode = "standard"` is intentionally kept; mypy strict remains the CI gate.
- `CHANGELOG.md`: one bullet under `## [Unreleased]` for #596's Python 3.13 floor change.

## Testing

- `uvx --from pyright pyright --outputjson` from the repo root: down from 128 to 127 errors; the only `reportMissingImports` left are the 3 expected `playwright` ones (optional dev dep installed only for the browser e2e CI job).
- `just lint` clean.
- `just fmt-check` clean.
- `mypy src/` clean (no source touched).
- TOML parse clean.

## Type of Change

- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`chore/pyright-editor-config`)
- [ ] Tests added/updated for all changes (N/A: pyproject config + Changelog only)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable) (N/A)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: editor-tooling chore; no behavioural change to the search engine