### PR TITLE
chore: clean up static-analysis surface and editor LSP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ No alternative logging libraries (structlog, loguru) are used.
 | `SIM117` | Nested `async with` required by aiosqlite pattern |
 | `S104` | Intentional bind to `0.0.0.0` for self-hosted server |
 | `B008` | FastAPI `Depends()` in function defaults |
-| `S608` + `nosec B608` | Dynamic SQL with explicit column allowlist (4 files) |
+| `S608` + `nosec` | Dynamic SQL with explicit column allowlist (4 files). Use bare `# nosec` (no test ID) per [bandit#1204](https://github.com/PyCQA/bandit/issues/1204): the test-ID form emits a spurious `WARNING nosec encountered (B608), but no failed test` per f-string interpolation on bandit 1.7.3+ |
 | `BLE001` | Broad exception in background loops (always with logging) |
 | `A002` | Parameter names `type`/`id` shadowing builtins (FastAPI form/function signature convention) |
 | `SLF001` | Test fixtures and `__main__.py` accessing private module state |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,16 @@ dev = [
     "respx>=0.23.1",
     "anyio>=4.13.0",
 ]
+# Optional browser-e2e group: playwright is heavy (~80 MB of browser
+# binaries) and only the dedicated CI job and the marketing screenshot
+# script need it.  Editor users can opt in with ``uv sync --group e2e``
+# to silence the three ``reportMissingImports`` findings on
+# ``scripts/marketing/capture_screenshots.py`` and ``tests/e2e_browser/``;
+# default ``uv sync`` keeps the dev install lean.
+e2e = [
+    "playwright>=1.55.0",
+    "pytest-playwright>=0.7.1",
+]
 
 [project.scripts]
 houndarr = "houndarr.__main__:cli"
@@ -145,17 +155,16 @@ ignore_missing_imports = true
 # ---------------------------------------------------------------------------
 # Pyright (editor LSP only; mypy --strict remains the CI gate)
 # ---------------------------------------------------------------------------
-# Pins the Python version, points at the project venv so third-party imports
-# resolve, and adds the repo root to extraPaths so test files importing
-# ``tests.conftest`` and similar resolve in editors. Default ``standard`` mode
-# is intentionally kept; basedpyright also reads this section for forward
-# compatibility.
+# typeCheckingMode is pinned to "standard" so basedpyright matches upstream
+# pyright; basedpyright defaults to "all", which surfaces diagnostics that
+# mypy strict (the binding gate) does not enforce.
 [tool.pyright]
 include = ["src", "tests", "scripts"]
 extraPaths = ["."]
 pythonVersion = "3.13"
 venvPath = "."
 venv = ".venv"
+typeCheckingMode = "standard"
 
 # ---------------------------------------------------------------------------
 # Bandit (SAST)

--- a/scripts/bench_586_end_to_end.py
+++ b/scripts/bench_586_end_to_end.py
@@ -154,7 +154,10 @@ async def _login(client: httpx.AsyncClient) -> None:
 def _csrf(client: httpx.AsyncClient) -> dict[str, str]:
     from houndarr.auth import CSRF_COOKIE_NAME
 
-    token = client.cookies.get(CSRF_COOKIE_NAME, "")
+    # ``Cookies.get(name, default)`` is overloaded: pyright in standard mode
+    # collapses both arms to ``str | None``.  A redundant ``or ""`` makes
+    # the absent / empty cases collapse to a ``str`` defensively.
+    token = client.cookies.get(CSRF_COOKIE_NAME) or ""
     return {"X-CSRF-Token": token}
 
 
@@ -327,7 +330,7 @@ async def _run_variant(variant: str, rows: int) -> None:
         master_key = ensure_master_key(data_dir)
         set_db_path(os.path.join(data_dir, "houndarr.db"))
 
-        mock_server, mock_thread, mock_url = _start_mock(items=200, seed=42)
+        mock_server, mock_thread, _ = _start_mock(items=200, seed=42)
         try:
             async with _houndarr_app(data_dir, cache_ttl=cache_ttl) as client:
                 rss_before_seed = _peak_rss_mb()

--- a/scripts/marketing/capture_screenshots.py
+++ b/scripts/marketing/capture_screenshots.py
@@ -215,7 +215,7 @@ def _select_views(names: list[str] | None, seed_mode: str) -> list[View]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument(
         "--base-url",
         default="http://127.0.0.1:8902",

--- a/scripts/marketing/demo_cycles.py
+++ b/scripts/marketing/demo_cycles.py
@@ -24,9 +24,23 @@ from typing import Any
 # (instance_id, pool_key, pool_index, item_type, search_kind, action,
 #  reason or None, message or None).  ``item_label`` resolves from the
 #  pool at build time so the fixture stays in step with the title JSONs.
-_CYCLE_SPECS: list[
-    tuple[int, str, list[tuple[int | None, str, str, str, str, str | None, str | None]]]
-] = [
+#
+# ``pool_key`` / ``item_type`` / ``search_kind`` are ``None`` only on the
+# whole-cycle ``info`` and ``error`` rows where the row stands in for the
+# cycle as a unit (no per-item dispatch); the leading ``instance_id`` is
+# always known.
+RowSpec = tuple[
+    int,  # instance_id
+    str | None,  # pool_key
+    int,  # pool_idx
+    str | None,  # item_type
+    str | None,  # search_kind
+    str,  # action
+    str | None,  # reason
+    str | None,  # message
+]
+
+_CYCLE_SPECS: list[tuple[int, str, list[RowSpec]]] = [
     # minutes_ago, trigger, rows
     (
         12,

--- a/scripts/marketing/seed_demo_data.py
+++ b/scripts/marketing/seed_demo_data.py
@@ -36,6 +36,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+# E402 is acknowledged: the path adjustments above must precede these imports
+# so the script runs both as `python -m scripts.marketing.seed_demo_data`
+# (no editable install needed) and from the repo root.
 import aiosqlite  # noqa: E402
 import bcrypt  # noqa: E402
 from cryptography.fernet import Fernet  # noqa: E402
@@ -384,7 +387,7 @@ async def _run(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument(
         "--mode",
         choices=["populated", "empty"],

--- a/scripts/marketing/serve_demo.py
+++ b/scripts/marketing/serve_demo.py
@@ -28,6 +28,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
+# E402 is acknowledged: the sys.path adjustment above must precede this import.
 from houndarr.bootstrap import bootstrap_non_web  # noqa: E402
 
 
@@ -44,7 +45,7 @@ async def _noop(*_args: object, **_kwargs: object) -> int:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument(
         "--data-dir",
         type=Path,
@@ -78,7 +79,7 @@ def main() -> None:
     # background-task harness from flagging every teardown as a failure.
     import signal
 
-    def _handle_signal(signum: int, frame: object | None) -> None:  # noqa: ARG001
+    def _handle_signal(signum: int, frame: object | None) -> None:
         raise SystemExit(0)
 
     signal.signal(signal.SIGTERM, _handle_signal)

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -60,7 +60,7 @@ async def _periodic_log_retention(retention_days: int) -> None:
                 await conn.execute("PRAGMA optimize")
         except asyncio.CancelledError:
             raise
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception("Periodic log retention task failed")
 
 

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -16,16 +16,24 @@ the authoritative value the submodule owns.
 
 from __future__ import annotations
 
-# time is re-exported so tests that monkeypatch
-# ``houndarr.auth.time.time`` continue to propagate the patch through
-# to ``houndarr.auth.rate_limit``'s usage (the ``time`` module is a
-# singleton, so patching via the auth namespace affects every
-# importer).
-import time  # noqa: F401
-from typing import Any
+# Re-export ``time`` (PEP 484 explicit-export form) so tests that monkeypatch
+# ``houndarr.auth.time.time`` propagate the patch into rate_limit's calls.
+import time as time
+from typing import TYPE_CHECKING, Any
 
 from houndarr.auth import session as _session
 from houndarr.auth import setup as _setup
+
+if TYPE_CHECKING:
+    import re
+
+    from itsdangerous import URLSafeTimedSerializer
+
+    # Static declarations of names resolved live by ``__getattr__`` below;
+    # under TYPE_CHECKING so runtime stays untouched.
+    _serializer: URLSafeTimedSerializer | None
+    _setup_complete: bool | None
+    _USERNAME_PATTERN: re.Pattern[str]
 from houndarr.auth.csrf import _CSRF_PROTECTED_METHODS, validate_csrf
 from houndarr.auth.identity import resolve_signed_in_as
 from houndarr.auth.middleware import _LOGOUT_PATH, _PUBLIC_PATHS, AuthMiddleware

--- a/src/houndarr/auth/csrf.py
+++ b/src/houndarr/auth/csrf.py
@@ -17,6 +17,8 @@ from fastapi import Request
 
 from houndarr.auth.session import get_session_csrf_token
 
+__all__ = ["_CSRF_PROTECTED_METHODS", "validate_csrf"]
+
 # HTTP methods that mutate state and require CSRF protection.
 _CSRF_PROTECTED_METHODS = frozenset(["POST", "PUT", "PATCH", "DELETE"])
 

--- a/src/houndarr/auth/password.py
+++ b/src/houndarr/auth/password.py
@@ -33,5 +33,5 @@ def verify_password(password: str, hashed: str) -> bool:
     """
     try:
         return bool(bcrypt.checkpw(password.encode(), hashed.encode()))
-    except Exception:  # noqa: BLE001
+    except Exception:
         return False

--- a/src/houndarr/auth/proxy_auth.py
+++ b/src/houndarr/auth/proxy_auth.py
@@ -29,6 +29,16 @@ from fastapi import Request, Response
 from houndarr.auth.session import CSRF_COOKIE_NAME, SESSION_MAX_AGE_SECONDS
 from houndarr.config import get_settings
 
+__all__ = [
+    "_PROXY_DEAD_PATHS",
+    "_ensure_proxy_csrf_cookie",
+    "_extract_proxy_username",
+    "_is_proxy_auth_mode",
+    "_is_trusted_proxy",
+    "_validate_proxy_auth",
+    "_validate_proxy_csrf",
+]
+
 # Paths that serve no purpose in proxy mode and redirect to the dashboard.
 _PROXY_DEAD_PATHS = frozenset(["/setup", "/login"])
 
@@ -110,11 +120,13 @@ def _ensure_proxy_csrf_cookie(request: Request, response: Response) -> None:
     if request.cookies.get(CSRF_COOKIE_NAME):
         return
     settings = get_settings()
+    # HttpOnly stays off: HTMX reads the cookie via JS to echo it back as
+    # the X-CSRF-Token header for the double-submit comparison.
     response.set_cookie(
         key=CSRF_COOKIE_NAME,
         value=secrets.token_hex(32),
         max_age=SESSION_MAX_AGE_SECONDS,
-        httponly=False,
+        httponly=False,  # nosem
         samesite=settings.cookie_samesite,
         secure=settings.secure_cookies,
     )

--- a/src/houndarr/auth/session.py
+++ b/src/houndarr/auth/session.py
@@ -41,7 +41,7 @@ async def _get_serializer() -> URLSafeTimedSerializer:
     every subsequent call reuses the cached serializer until
     :func:`reset_serializer` clears it.
     """
-    global _serializer  # noqa: PLW0603
+    global _serializer
     if _serializer is None:
         secret = await get_setting("session_secret")
         if not secret:
@@ -58,7 +58,7 @@ def reset_serializer() -> None:
     and ``reset_auth_caches`` (factory reset) so cross-seam callers
     never touch this module's global directly.
     """
-    global _serializer  # noqa: PLW0603
+    global _serializer
     _serializer = None
 
 

--- a/src/houndarr/auth/setup.py
+++ b/src/houndarr/auth/setup.py
@@ -42,7 +42,7 @@ async def is_setup_complete() -> bool:
     The result is cached once True because the password_hash setting is
     monotonic: it transitions from absent to present and is never deleted.
     """
-    global _setup_complete  # noqa: PLW0603
+    global _setup_complete
     if _setup_complete is True:
         return True
     result = (await get_setting("password_hash")) is not None
@@ -53,7 +53,7 @@ async def is_setup_complete() -> bool:
 
 async def set_password(password: str) -> None:
     """Hash and persist the application password."""
-    global _setup_complete  # noqa: PLW0603
+    global _setup_complete
     await set_setting("password_hash", hash_password(password))
     _setup_complete = True
 
@@ -140,7 +140,7 @@ def reset_auth_caches() -> None:
     decisions, but resetting them keeps the module honest if the operator
     later switches modes.
     """
-    global _setup_complete  # noqa: PLW0603
+    global _setup_complete
     _session.reset_serializer()
     _setup_complete = None
     _rate_limit.reset_login_attempts()

--- a/src/houndarr/clients/__init__.py
+++ b/src/houndarr/clients/__init__.py
@@ -1,0 +1,8 @@
+"""Async HTTP clients for the *arr APIs.
+
+Each module subclasses :class:`~houndarr.clients.base.ArrClient` and owns
+its app's endpoints, sort keys, and per-app domain dataclasses.  Wire
+payloads are validated through :mod:`houndarr.clients._wire_models`
+first, so a field rename upstream surfaces as a typed validation error
+rather than a ``KeyError`` deep inside an adapter.
+"""

--- a/src/houndarr/clients/_wire_models/common.py
+++ b/src/houndarr/clients/_wire_models/common.py
@@ -14,7 +14,21 @@ Every model extends :class:`_ArrModel` which sets
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+
+__all__ = [
+    "ArrArtist",
+    "ArrAuthor",
+    "ArrSeries",
+    "PaginatedResponse",
+    "QueueStatus",
+    "SystemStatus",
+    "_ArrModel",
+    "_WireAlbumStatistics",
+    "_WireBookStatistics",
+    "_WireEpisodeFile",
+    "_WireMovieFile",
+]
 
 
 class _ArrModel(BaseModel):
@@ -49,9 +63,23 @@ class SystemStatus(_ArrModel):
     Both fields are optional because *arr forks (Bookshelf, Reading Glasses)
     sometimes omit ``appName`` or ``version`` from their status payload and
     Houndarr must still report the instance as reachable.
+
+    The ``app_name`` field uses ``validation_alias=AliasChoices(...)``
+    rather than ``alias=`` so the constructor parameter exposed to static
+    analysers stays the snake_case Python name.  Pyright's Pydantic
+    plugin reflects ``alias=`` directly into ``__init__`` and ignores
+    ``populate_by_name=True``, which would force every test caller to
+    write ``SystemStatus(appName=...)``; using ``validation_alias`` gives
+    us snake_case in code while still parsing the upstream camelCase
+    payload.  ``serialization_alias`` preserves the camelCase output for
+    the rare case anyone serialises this model back to wire form.
     """
 
-    app_name: str | None = Field(default=None, alias="appName")
+    app_name: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("appName", "app_name"),
+        serialization_alias="appName",
+    )
     version: str | None = None
 
 

--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -6,7 +6,7 @@ import ipaddress
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, Self
 from urllib.parse import urlparse
 
 import httpx
@@ -224,7 +224,7 @@ class ArrClient(ABC):
 
     # Context-manager support
 
-    async def __aenter__(self) -> ArrClient:
+    async def __aenter__(self) -> Self:
         await self._client.__aenter__()
         return self
 

--- a/src/houndarr/clients/lidarr.py
+++ b/src/houndarr/clients/lidarr.py
@@ -49,9 +49,9 @@ class LidarrClient(ArrClient):
     _WANTED_BASE_PATH: ClassVar[str] = "/api/v1/wanted"
     _WANTED_SORT_KEY: ClassVar[str] = "releaseDate"
     _WANTED_INCLUDE_PARAM: ClassVar[str | None] = "includeArtist"
-    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[LidarrWantedAlbum]]] = PaginatedResponse[
-        LidarrWantedAlbum
-    ]
+    # See SonarrClient for the rationale on dropping the per-subclass
+    # ``ClassVar`` re-annotation.
+    _WANTED_ENVELOPE = PaginatedResponse[LidarrWantedAlbum]
 
     async def get_missing(
         self,

--- a/src/houndarr/clients/radarr.py
+++ b/src/houndarr/clients/radarr.py
@@ -54,9 +54,9 @@ class RadarrClient(ArrClient):
     # for cutoff); the template's ``include_sort=True`` default captures
     # both passes here.
     _WANTED_SORT_KEY: ClassVar[str] = "inCinemas"
-    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[RadarrWantedMovie]]] = PaginatedResponse[
-        RadarrWantedMovie
-    ]
+    # See SonarrClient for the rationale on dropping the per-subclass
+    # ``ClassVar`` re-annotation.
+    _WANTED_ENVELOPE = PaginatedResponse[RadarrWantedMovie]
 
     async def get_missing(
         self,

--- a/src/houndarr/clients/readarr.py
+++ b/src/houndarr/clients/readarr.py
@@ -52,9 +52,9 @@ class ReadarrClient(ArrClient):
     _WANTED_BASE_PATH: ClassVar[str] = "/api/v1/wanted"
     _WANTED_SORT_KEY: ClassVar[str] = "releaseDate"
     _WANTED_INCLUDE_PARAM: ClassVar[str | None] = "includeAuthor"
-    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[ReadarrWantedBook]]] = PaginatedResponse[
-        ReadarrWantedBook
-    ]
+    # See SonarrClient for the rationale on dropping the per-subclass
+    # ``ClassVar`` re-annotation.
+    _WANTED_ENVELOPE = PaginatedResponse[ReadarrWantedBook]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -74,7 +74,7 @@ class ReadarrClient(ArrClient):
             return self._author_name_cache
         try:
             records = await self._get("/api/v1/author")
-        except Exception:  # noqa: BLE001
+        except Exception:
             # Transport failure fall-through: leave books with empty
             # author_name rather than bubbling a secondary failure that
             # would mask the primary wanted-page success.

--- a/src/houndarr/clients/sonarr.py
+++ b/src/houndarr/clients/sonarr.py
@@ -49,9 +49,13 @@ class SonarrClient(ArrClient):
 
     _WANTED_SORT_KEY: ClassVar[str] = "airDateUtc"
     _WANTED_INCLUDE_PARAM: ClassVar[str | None] = "includeSeries"
-    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[SonarrWantedEpisode]]] = PaginatedResponse[
-        SonarrWantedEpisode
-    ]
+    # Annotation is inherited from ``ArrClient._WANTED_ENVELOPE``
+    # (``ClassVar[type[PaginatedResponse[Any]] | None]``).  Redeclaring with
+    # ``ClassVar[type[PaginatedResponse[SonarrWantedEpisode]]]`` is invariant
+    # against the parent in pyright's variable-override check; assigning the
+    # concrete envelope under the parent's annotation lets covariance through
+    # ``type[]`` carry the narrower runtime type without re-annotation.
+    _WANTED_ENVELOPE = PaginatedResponse[SonarrWantedEpisode]
 
     async def get_missing(
         self,

--- a/src/houndarr/clients/whisparr_v2.py
+++ b/src/houndarr/clients/whisparr_v2.py
@@ -58,9 +58,9 @@ class WhisparrV2Client(ArrClient):
     # ``series`` parent like Sonarr does.
     _WANTED_SORT_KEY: ClassVar[str] = "releaseDate"
     _WANTED_INCLUDE_PARAM: ClassVar[str | None] = "includeSeries"
-    _WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[WhisparrV2WantedEpisode]]] = (
-        PaginatedResponse[WhisparrV2WantedEpisode]
-    )
+    # See SonarrClient for the rationale on dropping the per-subclass
+    # ``ClassVar`` re-annotation.
+    _WANTED_ENVELOPE = PaginatedResponse[WhisparrV2WantedEpisode]
 
     async def get_missing(
         self,

--- a/src/houndarr/config.py
+++ b/src/houndarr/config.py
@@ -306,7 +306,7 @@ def bootstrap_settings(**overrides: Unpack[BootstrapOverrides]) -> AppSettings:
         pinned instance; without overrides this is an unpinned
         env-resolved instance.
     """
-    global _runtime_settings  # noqa: PLW0603
+    global _runtime_settings
 
     if not overrides:
         _runtime_settings = None

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
+from typing import cast
 
 import aiosqlite
 from aiosqlitepool import SQLiteConnectionPool
+from aiosqlitepool.protocols import Connection as PoolConnection
 
 logger = logging.getLogger(__name__)
 
@@ -168,7 +170,7 @@ _pools: dict[str, SQLiteConnectionPool] = {}
 
 def set_db_path(path: str) -> None:
     """Set the database path before the app starts."""
-    global _db_path  # noqa: PLW0603
+    global _db_path
     _db_path = path
 
 
@@ -235,7 +237,11 @@ def _get_or_create_pool() -> SQLiteConnectionPool:
         # instance loops without materially increasing memory cost (each
         # SQLite connection holds ~20 MB of page cache via the configured
         # cache_size pragma).
-        pool = SQLiteConnectionPool(_connection_factory, pool_size=10)
+        # Cast scopes the Coroutine-vs-Awaitable variance flex to one line
+        # at the library boundary; aiosqlite.Connection structurally
+        # satisfies aiosqlitepool's Connection Protocol.
+        factory = cast("Callable[[], Awaitable[PoolConnection]]", _connection_factory)
+        pool = SQLiteConnectionPool(factory, pool_size=10)
         _pools[_db_path] = pool
     return pool
 
@@ -252,12 +258,12 @@ async def close_all_pools() -> None:
     for pool in pools:
         try:
             await pool.close()
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.exception("Error closing SQLite connection pool")
 
 
 @asynccontextmanager
-async def get_db() -> AsyncGenerator[aiosqlite.Connection]:
+async def get_db() -> AsyncIterator[aiosqlite.Connection]:
     """Borrow a pooled connection with the configured PRAGMAs applied.
 
     The pool is keyed on the active ``_db_path``, so production reuses
@@ -268,7 +274,9 @@ async def get_db() -> AsyncGenerator[aiosqlite.Connection]:
     """
     pool = _get_or_create_pool()
     async with pool.connection() as db:
-        yield db
+        # The pool re-types the connection as its structural Protocol; the
+        # underlying object is the aiosqlite.Connection from the factory.
+        yield cast("aiosqlite.Connection", db)
 
 
 # ---------------------------------------------------------------------------
@@ -448,7 +456,7 @@ async def _migrate_to_v5(db: aiosqlite.Connection) -> None:
     # -- 1) Recreate instances with expanded type CHECK ----------------------
     # Use the v5 snapshot of _INSTANCE_TYPES so this rebuild stays correct even
     # when the current alias rotates in a later migration.
-    await db.execute(
+    await db.execute(  # nosem
         f"""
         CREATE TABLE instances_new (
             id                   INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -497,7 +505,7 @@ async def _migrate_to_v5(db: aiosqlite.Connection) -> None:
     # -- 2) Recreate cooldowns with expanded item_type CHECK -----------------
     # v5 snapshot still allows 'whisparr_episode'; the rename to
     # 'whisparr_v2_episode' belongs to v16, not here.
-    await db.execute(
+    await db.execute(  # nosem
         f"""
         CREATE TABLE cooldowns_new (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -524,7 +532,7 @@ async def _migrate_to_v5(db: aiosqlite.Connection) -> None:
     )
 
     # -- 3) Recreate search_log with expanded item_type CHECK ----------------
-    await db.execute(
+    await db.execute(  # nosem
         f"""
         CREATE TABLE search_log_new (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -755,7 +763,7 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
     # -- 1) Recreate instances with expanded type CHECK + rename whisparr ------
     # v10 snapshot of _INSTANCE_TYPES locks the CHECK clause to what this
     # migration introduced; later renames live in their own migrations.
-    await db.execute(
+    await db.execute(  # nosem
         f"""
         CREATE TABLE instances_new (
             id                   INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -806,9 +814,9 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
             created_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             updated_at           TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
         )
-        """  # noqa: S608  # nosec B608
+        """  # nosec
     )
-    await db.execute(
+    await db.execute(  # nosem
         f"""
         INSERT INTO instances_new
         SELECT id, name,
@@ -827,7 +835,7 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
                missing_page_offset, cutoff_page_offset,
                enabled, created_at, updated_at
         FROM instances
-        """  # noqa: S608  # nosec B608
+        """,  # noqa: S608  # nosec
     )
     await db.execute("DROP TABLE instances")
     await db.execute("ALTER TABLE instances_new RENAME TO instances")
@@ -836,7 +844,7 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
     # v10 snapshot still allows 'whisparr_episode'; v16 is the migration that
     # renames it.  Keeping that responsibility in one place keeps each
     # migration's intent clear.
-    await db.execute(
+    await db.execute(  # nosem
         f"""
         CREATE TABLE cooldowns_new (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -863,7 +871,7 @@ async def _migrate_to_v10(db: aiosqlite.Connection) -> None:
     )
 
     # -- 3) Recreate search_log with expanded item_type CHECK ------------------
-    await db.execute(
+    await db.execute(  # nosem
         f"""
         CREATE TABLE search_log_new (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1104,7 +1112,7 @@ async def _migrate_to_v15(db: aiosqlite.Connection) -> None:
         # below would otherwise leave cooldowns_new behind and break retry.
         await db.execute("DROP TABLE IF EXISTS cooldowns_new")
 
-        await db.execute(
+        await db.execute(  # nosem
             f"""
             CREATE TABLE cooldowns_new (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1204,7 +1212,7 @@ async def _migrate_to_v16(db: aiosqlite.Connection) -> None:
         # Use the v16 snapshot — this migration is the rename, so it pins
         # the post-rename list and is unaffected by future changes to the
         # current _ITEM_TYPES alias.
-        await db.execute(
+        await db.execute(  # nosem
             f"""
             CREATE TABLE cooldowns_new (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1243,7 +1251,7 @@ async def _migrate_to_v16(db: aiosqlite.Connection) -> None:
         )
 
         # search_log rebuild with the v16 item_type CHECK + UPDATE rows.
-        await db.execute(
+        await db.execute(  # nosem
             f"""
             CREATE TABLE search_log_new (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1385,6 +1393,8 @@ async def _migrate_to_v17(db: aiosqlite.Connection) -> None:
 
 async def _column_exists(db: aiosqlite.Connection, table_name: str, column_name: str) -> bool:
     """Return whether *column_name* exists on *table_name*."""
-    async with db.execute(f"PRAGMA table_info({table_name})") as cur:  # noqa: S608  # nosec B608
+    async with db.execute(  # nosec  # nosem
+        f"PRAGMA table_info({table_name})"
+    ) as cur:
         rows = await cur.fetchall()
     return any(row[1] == column_name for row in rows)

--- a/src/houndarr/engine/__init__.py
+++ b/src/houndarr/engine/__init__.py
@@ -1,0 +1,8 @@
+"""Search engine: per-instance asyncio cycle that drives the *arr APIs.
+
+:mod:`~houndarr.engine.supervisor` runs one task per enabled instance;
+:mod:`~houndarr.engine.search_loop` runs one cycle of missing / cutoff /
+upgrade passes for one instance; :mod:`~houndarr.engine.adapters`
+registers each *arr's :class:`AppAdapterProto` so the loop stays
+per-app agnostic.
+"""

--- a/src/houndarr/engine/adapters/lidarr.py
+++ b/src/houndarr/engine/adapters/lidarr.py
@@ -330,7 +330,7 @@ async def fetch_reconcile_sets(client: LidarrClient, instance: Instance) -> Reco
 
 async def fetch_instance_snapshot(
     client: LidarrClient,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> InstanceSnapshot:
     """Compose the dashboard snapshot for a Lidarr instance.
 
@@ -338,10 +338,11 @@ async def fetch_instance_snapshot(
     (single ISO string).  Albums with no release date fall through to
     "already released", consistent with :func:`_lidarr_unreleased_reason`.
     """
-    return await compute_default_snapshot(
-        client,
-        anchor_fn=lambda al: al.release_date,
-    )
+
+    def _anchor(album: MissingAlbum) -> str | None:
+        return album.release_date
+
+    return await compute_default_snapshot(client, anchor_fn=_anchor)
 
 
 class LidarrAdapter:

--- a/src/houndarr/engine/adapters/protocols.py
+++ b/src/houndarr/engine/adapters/protocols.py
@@ -29,26 +29,32 @@ class AppAdapterProto(Protocol):
     @property
     def adapt_missing(self) -> Callable[..., SearchCandidate]:
         """Build a :class:`SearchCandidate` from a raw missing-pass item."""
+        ...
 
     @property
     def adapt_cutoff(self) -> Callable[..., SearchCandidate]:
         """Build a :class:`SearchCandidate` from a raw cutoff-unmet item."""
+        ...
 
     @property
     def adapt_upgrade(self) -> Callable[..., SearchCandidate]:
         """Build a :class:`SearchCandidate` from a raw upgrade-pool item."""
+        ...
 
     @property
     def fetch_upgrade_pool(self) -> Callable[..., Awaitable[list[Any]]]:
         """Fetch the per-cycle upgrade candidate list from the *arr app."""
+        ...
 
     @property
     def dispatch_search(self) -> Callable[..., Awaitable[None]]:
         """Send the *arr search command for one candidate."""
+        ...
 
     @property
     def make_client(self) -> Callable[[Instance], ArrClient]:
         """Return a fresh (unopened) :class:`ArrClient` for *instance*."""
+        ...
 
     @property
     def fetch_reconcile_sets(self) -> Callable[..., Awaitable[ReconcileSets]]:
@@ -63,6 +69,7 @@ class AppAdapterProto(Protocol):
         the synthetic parent ids derived from leaf parent metadata so
         the DB match stays pure set membership.
         """
+        ...
 
     @property
     def fetch_instance_snapshot(self) -> Callable[..., Awaitable[InstanceSnapshot]]:
@@ -79,3 +86,4 @@ class AppAdapterProto(Protocol):
         :func:`compute_default_snapshot` while Whisparr v3 walks its
         cached ``/api/v3/movie`` response inline.
         """
+        ...

--- a/src/houndarr/engine/adapters/radarr.py
+++ b/src/houndarr/engine/adapters/radarr.py
@@ -148,7 +148,7 @@ def adapt_upgrade(item: LibraryMovie, instance: Instance) -> SearchCandidate:
 
 async def fetch_upgrade_pool(
     client: RadarrClient,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> list[LibraryMovie]:
     """Fetch and filter Radarr library for upgrade-eligible movies.
 
@@ -218,7 +218,7 @@ def make_client(instance: Instance) -> RadarrClient:
 
 async def fetch_instance_snapshot(
     client: RadarrClient,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> InstanceSnapshot:
     """Compose the dashboard snapshot for a Radarr instance.
 

--- a/src/houndarr/engine/adapters/readarr.py
+++ b/src/houndarr/engine/adapters/readarr.py
@@ -320,7 +320,7 @@ async def fetch_reconcile_sets(client: ReadarrClient, instance: Instance) -> Rec
 
 async def fetch_instance_snapshot(
     client: ReadarrClient,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> InstanceSnapshot:
     """Compose the dashboard snapshot for a Readarr instance.
 
@@ -328,10 +328,11 @@ async def fetch_instance_snapshot(
     (single ISO string).  Books with no release date fall through to
     "already released", consistent with :func:`_readarr_unreleased_reason`.
     """
-    return await compute_default_snapshot(
-        client,
-        anchor_fn=lambda bk: bk.release_date,
-    )
+
+    def _anchor(book: MissingBook) -> str | None:
+        return book.release_date
+
+    return await compute_default_snapshot(client, anchor_fn=_anchor)
 
 
 class ReadarrAdapter:

--- a/src/houndarr/engine/adapters/sonarr.py
+++ b/src/houndarr/engine/adapters/sonarr.py
@@ -31,6 +31,19 @@ from houndarr.engine.candidates import (
 )
 from houndarr.services.instances import Instance, SonarrSearchMode
 
+__all__ = [
+    "SonarrAdapter",
+    "_UPGRADE_MAX_SERIES_PER_CYCLE",
+    "adapt_cutoff",
+    "adapt_missing",
+    "adapt_upgrade",
+    "dispatch_search",
+    "fetch_instance_snapshot",
+    "fetch_reconcile_sets",
+    "fetch_upgrade_pool",
+    "make_client",
+]
+
 logger = logging.getLogger(__name__)
 
 _UPGRADE_MAX_SERIES_PER_CYCLE = 5
@@ -426,7 +439,7 @@ async def fetch_reconcile_sets(client: SonarrClient, instance: Instance) -> Reco
 
 async def fetch_instance_snapshot(
     client: SonarrClient,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> InstanceSnapshot:
     """Compose the dashboard snapshot for a Sonarr instance.
 
@@ -436,10 +449,11 @@ async def fetch_instance_snapshot(
     the search-loop's classification — Sonarr-without-air-date is not
     something Houndarr should flag as pre-release on the dashboard.
     """
-    return await compute_default_snapshot(
-        client,
-        anchor_fn=lambda ep: ep.air_date_utc,
-    )
+
+    def _anchor(ep: MissingEpisode) -> str | None:
+        return ep.air_date_utc
+
+    return await compute_default_snapshot(client, anchor_fn=_anchor)
 
 
 class SonarrAdapter:

--- a/src/houndarr/engine/adapters/whisparr_v2.py
+++ b/src/houndarr/engine/adapters/whisparr_v2.py
@@ -419,7 +419,7 @@ async def fetch_reconcile_sets(client: WhisparrV2Client, instance: Instance) -> 
 
 async def fetch_instance_snapshot(
     client: WhisparrV2Client,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> InstanceSnapshot:
     """Compose the dashboard snapshot for a Whisparr v2 instance.
 
@@ -430,9 +430,13 @@ async def fetch_instance_snapshot(
     helper takes the dt-typed branch via ``anchor_is_dt=True`` so the
     re-parse step is skipped.
     """
+
+    def _anchor(ep: MissingWhisparrV2Episode) -> datetime | None:
+        return ep.release_date
+
     return await compute_default_snapshot(
         client,
-        anchor_fn=lambda ep: ep.release_date,
+        anchor_fn=_anchor,
         anchor_is_dt=True,
     )
 

--- a/src/houndarr/engine/adapters/whisparr_v3.py
+++ b/src/houndarr/engine/adapters/whisparr_v3.py
@@ -154,7 +154,7 @@ def adapt_upgrade(item: LibraryWhisparrV3Movie, instance: Instance) -> SearchCan
 
 async def fetch_upgrade_pool(
     client: WhisparrV3Client,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> list[LibraryWhisparrV3Movie]:
     """Fetch and filter the Whisparr v3 library for upgrade-eligible movies/scenes.
 
@@ -197,7 +197,7 @@ def make_client(instance: Instance) -> WhisparrV3Client:
 
 async def fetch_reconcile_sets(
     client: WhisparrV3Client,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> ReconcileSets:
     """Return the authoritative wanted / upgrade-pool sets for Whisparr v3.
 
@@ -231,7 +231,7 @@ async def fetch_reconcile_sets(
 
 async def fetch_instance_snapshot(
     client: WhisparrV3Client,
-    instance: Instance,  # noqa: ARG001
+    instance: Instance,
 ) -> InstanceSnapshot:
     """Compose the dashboard snapshot for a Whisparr v3 instance.
 

--- a/src/houndarr/engine/candidates.py
+++ b/src/houndarr/engine/candidates.py
@@ -15,7 +15,13 @@ from typing import Any
 
 from houndarr.enums import ItemType
 
-__all__ = ["ItemType", "SearchCandidate"]
+__all__ = [
+    "ItemType",
+    "SearchCandidate",
+    "_is_unreleased",
+    "_is_unreleased_dt",
+    "_is_within_post_release_grace",
+]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -45,6 +45,8 @@ from houndarr.services.time_window import (
 )
 from houndarr.value_objects import ItemRef
 
+__all__ = ["_reset_random_deck", "run_instance_search"]
+
 logger = logging.getLogger(__name__)
 
 _MAX_LIST_PAGES_PER_PASS = 5
@@ -127,7 +129,7 @@ def _draw_next_random_page(instance_id: int, search_kind: SearchKind | str, max_
     state = _random_decks.get(key)
     if state is None or state.max_page != max_page or not state.remaining:
         deck = list(range(1, max_page + 1))
-        random.shuffle(deck)  # noqa: S311  # nosec B311
+        random.shuffle(deck)  # nosec B311
         state = _RandomDeckState(max_page=max_page, remaining=deck)
         _random_decks[key] = state
     return state.remaining.pop()
@@ -367,7 +369,7 @@ async def _dispatch_with_typed_wrap(
             await dispatch_fn(client, candidate)
     except (EngineError, ClientError):
         raise
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise EngineDispatchError(str(exc)) from exc
 
 
@@ -407,7 +409,7 @@ async def _persist_offset_with_typed_wrap(
         await update_instance(instance_id, master_key=master_key, **offsets)
     except (EngineError, ClientError):
         raise
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise EngineOffsetPersistError(str(exc)) from exc
 
 
@@ -438,14 +440,14 @@ async def _fetch_pool_with_typed_wrap(
             return await adapter.fetch_upgrade_pool(client, instance)
     except (EngineError, ClientError):
         raise
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise EnginePoolFetchError(str(exc)) from exc
 
 
 # Unified search pass
 
 
-async def _run_search_pass(  # noqa: C901
+async def _run_search_pass(
     instance: Instance,
     adapter: AppAdapterProto,
     config: SearchPassConfig,
@@ -507,7 +509,7 @@ async def _run_search_pass(  # noqa: C901
     if instance.schedule.search_order == SearchOrder.random and total_fn is not None:
         try:
             total = await total_fn()
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning(
                 "[%s] %stotal probe failed (%s); falling back to page %d",
                 instance.core.name,
@@ -541,7 +543,7 @@ async def _run_search_pass(  # noqa: C901
             while len(items) < page_size:
                 items.append(_SHUFFLE_PAD)
         if instance.schedule.search_order == SearchOrder.random and items:
-            random.shuffle(items)  # noqa: S311  # nosec B311
+            random.shuffle(items)  # nosec B311
         logger.debug(
             "[%s] fetched %d %sitem(s) from page %d",
             instance.core.name,
@@ -900,7 +902,7 @@ async def _run_upgrade_pass(
     # Chronological mode keeps the deterministic rotation so coverage is
     # guaranteed over time.
     if instance.schedule.search_order == SearchOrder.random:
-        random.shuffle(pool)  # noqa: S311  # nosec B311
+        random.shuffle(pool)  # nosec B311
         offset = 0
         rotated = pool
     else:
@@ -1091,7 +1093,7 @@ async def run_instance_search(
         raise
     except (EngineError, ClientError):
         raise
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         raise EngineError(
             f"unhandled error in search cycle for {instance.core.name!r}: {exc}"
         ) from exc

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -441,7 +441,7 @@ class Supervisor:
                 await self._refresh_all_snapshots_once()
             except asyncio.CancelledError:
                 raise
-            except Exception:  # noqa: BLE001
+            except Exception:
                 logger.exception("Supervisor: snapshot refresh iteration failed")
 
             try:
@@ -487,7 +487,7 @@ class Supervisor:
                             "keeping existing cooldowns.",
                             instance.core.name,
                         )
-                    except Exception:  # noqa: BLE001
+                    except Exception:
                         reconcile_sets = ReconcileSets.empty()
                         logger.exception(
                             "Supervisor: reconcile fetch failed for %r; "
@@ -524,7 +524,7 @@ class Supervisor:
                     "Supervisor: snapshot refresh skipped for %r; instance unreachable",
                     instance.core.name,
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:
                 logger.exception("Supervisor: snapshot refresh failed for %r", instance.core.name)
 
     async def _refresh_all_snapshots_once(self) -> None:

--- a/src/houndarr/protocols.py
+++ b/src/houndarr/protocols.py
@@ -37,12 +37,15 @@ class SettingsRepository(Protocol):
 
     def get_setting(self, key: str) -> Awaitable[str | None]:
         """Return the stored value for *key*, or ``None`` if absent."""
+        ...
 
     def set_setting(self, key: str, value: str) -> Awaitable[None]:
         """Insert or update *key* with *value*."""
+        ...
 
     def delete_setting(self, key: str) -> Awaitable[None]:
         """Remove *key* if it exists (no error if already absent)."""
+        ...
 
 
 @runtime_checkable
@@ -61,9 +64,11 @@ class InstanceRepository(Protocol):
 
     def list_instances(self, *, master_key: bytes) -> Awaitable[list[Instance]]:
         """Return every instance ordered by id ascending."""
+        ...
 
     def get_instance(self, instance_id: int, *, master_key: bytes) -> Awaitable[Instance | None]:
         """Return the instance identified by *instance_id*, or ``None``."""
+        ...
 
     def insert_instance(
         self,
@@ -78,6 +83,7 @@ class InstanceRepository(Protocol):
         the Protocol; the concrete implementation takes an
         :class:`~houndarr.repositories.instances.InstanceInsert`.
         """
+        ...
 
     def update_instance(
         self,
@@ -93,9 +99,11 @@ class InstanceRepository(Protocol):
         takes an :class:`~houndarr.repositories.instances.InstanceUpdate`
         and no-ops when every field is ``None``.
         """
+        ...
 
     def delete_instance(self, instance_id: int) -> Awaitable[bool]:
         """Delete the instance row; return ``True`` iff a row was removed."""
+        ...
 
     def update_instance_snapshot(
         self,
@@ -105,6 +113,7 @@ class InstanceRepository(Protocol):
         unreleased_count: int,
     ) -> Awaitable[None]:
         """Refresh the three v13 snapshot columns for *instance_id*."""
+        ...
 
 
 @runtime_checkable
@@ -118,12 +127,15 @@ class CooldownRepository(Protocol):
 
     def exists_active_cooldown(self, ref: ItemRef, cooldown_days: int) -> Awaitable[bool]:
         """Return ``True`` when *ref* is within its cooldown window."""
+        ...
 
     def upsert_cooldown(self, ref: ItemRef) -> Awaitable[None]:
         """Record *ref* as just-searched, upserting the existing row."""
+        ...
 
     def delete_cooldowns_for_instance(self, instance_id: int) -> Awaitable[int]:
         """Delete every cooldown row for *instance_id* and return the count."""
+        ...
 
 
 @runtime_checkable
@@ -150,6 +162,7 @@ class SearchLogRepository(Protocol):
         message: str | None = None,
     ) -> Awaitable[None]:
         """Insert a single row into ``search_log``."""
+        ...
 
     def fetch_log_rows(
         self,
@@ -162,6 +175,7 @@ class SearchLogRepository(Protocol):
         after_id: int | None = None,
     ) -> Awaitable[list[dict[str, Any]]]:
         """Return a filtered page of log rows."""
+        ...
 
     def fetch_recent_searches(
         self,
@@ -171,9 +185,11 @@ class SearchLogRepository(Protocol):
         within_seconds: int,
     ) -> Awaitable[int]:
         """Count ``action='searched'`` rows in the trailing window."""
+        ...
 
     def delete_logs_for_instance(self, instance_id: int) -> Awaitable[int]:
         """Delete every ``search_log`` row for *instance_id*."""
+        ...
 
 
 # Supervisor
@@ -193,12 +209,15 @@ class SupervisorProto(Protocol):
 
     async def trigger_run_now(self, instance_id: int) -> RunNowStatus:
         """Kick off one manual cycle for the instance identified by id."""
+        ...
 
     async def reconcile_instance(self, instance_id: int) -> None:
         """Re-evaluate whether the instance should have a running task."""
+        ...
 
     async def stop_instance_task(self, instance_id: int) -> bool:
         """Stop the instance's running task; return ``True`` if one was cancelled."""
+        ...
 
 
 # Client construction
@@ -219,6 +238,7 @@ class ClientFactory(Protocol):
 
     def __call__(self, instance: Instance) -> ArrClient:
         """Build a fresh (unopened) :class:`ArrClient` for *instance*."""
+        ...
 
 
 # Re-exports for downstream imports

--- a/src/houndarr/repositories/instances.py
+++ b/src/houndarr/repositories/instances.py
@@ -468,7 +468,7 @@ async def insert_instance(payload: InstanceInsert, *, master_key: bytes) -> int:
         )
         await db.commit()
         row_id = cur.lastrowid
-        assert row_id is not None  # noqa: S101
+        assert row_id is not None
         return row_id
 
 
@@ -509,9 +509,9 @@ async def update_instance(
 
     assignments.append("updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')")
     values.append(instance_id)
-    sql = f"UPDATE instances SET {', '.join(assignments)} WHERE id = ?"  # noqa: S608  # nosec B608
+    sql = f"UPDATE instances SET {', '.join(assignments)} WHERE id = ?"  # noqa: S608  # nosec
     async with get_db() as db:
-        await db.execute(sql, values)
+        await db.execute(sql, values)  # nosem
         await db.commit()
 
 

--- a/src/houndarr/repositories/search_log.py
+++ b/src/houndarr/repositories/search_log.py
@@ -172,9 +172,9 @@ async def fetch_log_rows(
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
     values.append(int(limit))
 
-    sql = f"SELECT * FROM search_log {where_clause} ORDER BY timestamp DESC, id DESC LIMIT ?"  # noqa: S608  # nosec B608
+    sql = f"SELECT * FROM search_log {where_clause} ORDER BY timestamp DESC, id DESC LIMIT ?"  # noqa: S608  # nosec
     async with get_db() as db:
-        async with db.execute(sql, values) as cur:
+        async with db.execute(sql, values) as cur:  # nosem
             rows = await cur.fetchall()
     return [dict(row) for row in rows]
 

--- a/src/houndarr/routes/__init__.py
+++ b/src/houndarr/routes/__init__.py
@@ -1,0 +1,7 @@
+"""FastAPI route handlers: HTMX page surface and JSON API.
+
+Page modules render Jinja2 partials for the HTMX shell;
+:mod:`~houndarr.routes.api` exposes JSON polling endpoints plus the
+Docker ``/api/health`` probe.  Authentication is global via
+:class:`~houndarr.auth.AuthMiddleware`; no per-route auth decorators.
+"""

--- a/src/houndarr/routes/_templates.py
+++ b/src/houndarr/routes/_templates.py
@@ -39,7 +39,7 @@ def get_templates() -> Jinja2Templates:
     ``module._templates = None`` before calling :func:`get_templates`
     again.
     """
-    global _templates  # noqa: PLW0603
+    global _templates
     if _templates is None:
         templates_dir = Path(__file__).resolve().parent.parent / "templates"
         _templates = Jinja2Templates(directory=str(templates_dir))

--- a/src/houndarr/routes/admin.py
+++ b/src/houndarr/routes/admin.py
@@ -231,6 +231,6 @@ async def admin_factory_reset(
         # to the hybrid fallback because the entire event loop dies inside
         # request_process_exit(). There is nothing to keep alive past the
         # os._exit() call.
-        asyncio.create_task(_delayed_exit())  # noqa: RUF006
+        asyncio.create_task(_delayed_exit())
 
     return response

--- a/src/houndarr/routes/api/__init__.py
+++ b/src/houndarr/routes/api/__init__.py
@@ -1,0 +1,6 @@
+"""JSON API routes consumed by the dashboard poll loop.
+
+:mod:`~houndarr.routes.api.status` returns the per-instance aggregate
+bundle the dashboard polls; :mod:`~houndarr.routes.api.logs` returns
+cursor-paginated ``search_log`` rows for the Logs page feed.
+"""

--- a/src/houndarr/routes/changelog.py
+++ b/src/houndarr/routes/changelog.py
@@ -36,6 +36,8 @@ from houndarr.services.changelog import (
     should_show,
 )
 
+__all__ = ["_render_changelog_bullet", "router"]
+
 router = APIRouter(prefix="/settings/changelog", tags=["changelog"])
 
 _GITHUB_ISSUES_URL = "https://github.com/av1155/houndarr/issues"
@@ -112,7 +114,7 @@ def _render_changelog_bullet(raw: str) -> Markup:
     # Input was escape()d first, then a closed vocabulary of markdown patterns
     # (code, bold, links, issue refs) was re-applied with escaped capture groups.
     # No user-authored raw HTML reaches the template context.
-    return Markup(safe)  # noqa: S704  # nosec B704
+    return Markup(safe)  # noqa: S704  # nosec  # nosem
 
 
 def _empty_slot_response() -> HTMLResponse:

--- a/src/houndarr/routes/settings/instances.py
+++ b/src/houndarr/routes/settings/instances.py
@@ -84,7 +84,7 @@ async def instance_add_form(request: Request) -> HTMLResponse:
 @router.post("/settings/instances/test-connection", response_class=HTMLResponse)
 async def instance_test_connection(
     master_key: Annotated[bytes, Depends(get_master_key)],
-    type: Annotated[str, Form()],  # noqa: A002
+    type: Annotated[str, Form()],
     url: Annotated[str, Form()],
     api_key: Annotated[str, Form()],
     instance_id: Annotated[str, Form()] = "",
@@ -115,7 +115,7 @@ async def instance_create(
     request: Request,
     master_key: Annotated[bytes, Depends(get_master_key)],
     name: Annotated[str, Form()],
-    type: Annotated[str, Form()],  # noqa: A002
+    type: Annotated[str, Form()],
     url: Annotated[str, Form()],
     api_key: Annotated[str, Form()],
     batch_size: Annotated[int, Form()] = DEFAULT_BATCH_SIZE,
@@ -227,7 +227,7 @@ async def instance_update(
     master_key: Annotated[bytes, Depends(get_master_key)],
     instance_id: int,
     name: Annotated[str, Form()],
-    type: Annotated[str, Form()],  # noqa: A002
+    type: Annotated[str, Form()],
     url: Annotated[str, Form()],
     api_key: Annotated[str, Form()],
     batch_size: Annotated[int, Form()] = DEFAULT_BATCH_SIZE,

--- a/src/houndarr/routes/update_check.py
+++ b/src/houndarr/routes/update_check.py
@@ -31,6 +31,8 @@ from houndarr.services.update_check import (
     set_enabled,
 )
 
+__all__ = ["_timeago", "router"]
+
 router = APIRouter(prefix="/settings/admin/update-check", tags=["update-check"])
 
 

--- a/src/houndarr/services/__init__.py
+++ b/src/houndarr/services/__init__.py
@@ -1,0 +1,8 @@
+"""Service layer: business logic between routes and repositories.
+
+Routes call into services; services call into
+:mod:`houndarr.repositories` for SQL.  No service opens a database
+connection directly, exposes a Pydantic wire model, or imports a route
+module: those boundaries keep the layer testable without a running
+FastAPI app.
+"""

--- a/src/houndarr/services/admin.py
+++ b/src/houndarr/services/admin.py
@@ -202,7 +202,7 @@ async def factory_reset(*, app: FastAPI, data_dir: str) -> None:
         # Already typed by an inner boundary (e.g. file deletion); keep
         # the richer message.
         raise
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.exception("Factory reset: unhandled error in re-init")
         raise ServiceError(f"factory reset re-init failed: {exc}") from exc
 
@@ -261,7 +261,7 @@ async def _factory_reset_impl(*, app: FastAPI, data_dir: str) -> None:
                 path.unlink()
             except FileNotFoundError:
                 continue
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.exception("Factory reset: file deletion failed")
         raise ServiceError(f"factory reset file deletion failed: {exc}") from exc
 

--- a/src/houndarr/services/changelog.py
+++ b/src/houndarr/services/changelog.py
@@ -57,6 +57,17 @@ class ReleaseEntry:
     sections: list[ReleaseSection]
 
 
+__all__ = [
+    "CHANGELOG_PATH",
+    "ReleaseEntry",
+    "ReleaseSection",
+    "_reset_changelog_cache",
+    "get_changelog",
+    "releases_between",
+    "should_show",
+]
+
+
 # ---------------------------------------------------------------------------
 # Regexes (module-level so the compile cost is paid once)
 # ---------------------------------------------------------------------------
@@ -198,7 +209,7 @@ def get_changelog() -> list[ReleaseEntry]:
     ``routes/pages.py`` so parse failures surface on the route that needs
     them, not during app startup.
     """
-    global _cache  # noqa: PLW0603
+    global _cache
     if _cache is None:
         _cache = _parse_changelog(CHANGELOG_PATH)
     return _cache
@@ -206,7 +217,7 @@ def get_changelog() -> list[ReleaseEntry]:
 
 def _reset_changelog_cache() -> None:
     """Clear the cache. Test-only hook."""
-    global _cache  # noqa: PLW0603
+    global _cache
     _cache = None
 
 

--- a/src/houndarr/services/cooldown.py
+++ b/src/houndarr/services/cooldown.py
@@ -30,6 +30,20 @@ from datetime import UTC, datetime, timedelta
 from houndarr.engine.candidates import ItemType
 from houndarr.value_objects import ItemRef
 
+__all__ = [
+    "InfoLogKey",
+    "SkipLogKey",
+    "_reset_info_log_cache",
+    "_reset_skip_log_cache",
+    "clear_cooldowns",
+    "is_on_cooldown",
+    "is_on_cooldown_ref",
+    "record_search",
+    "record_search_ref",
+    "should_log_info",
+    "should_log_skip",
+]
+
 # Skip-log throttle sentinel (single-process LRU with TTL)
 
 SkipLogKey = tuple[int, int, str, str]

--- a/src/houndarr/services/cooldown_reconcile.py
+++ b/src/houndarr/services/cooldown_reconcile.py
@@ -101,8 +101,8 @@ async def reconcile_cooldowns(instance_id: int, sets: ReconcileSets) -> int:
         for chunk_start in range(0, len(stale), batch_size):
             chunk = stale[chunk_start : chunk_start + batch_size]
             placeholders = ",".join("?" for _ in chunk)
-            await db.execute(
-                f"DELETE FROM cooldowns WHERE id IN ({placeholders})",  # noqa: S608  # nosec B608
+            await db.execute(  # nosem
+                f"DELETE FROM cooldowns WHERE id IN ({placeholders})",  # noqa: S608  # nosec
                 chunk,
             )
         await db.commit()

--- a/src/houndarr/services/instance_submit.py
+++ b/src/houndarr/services/instance_submit.py
@@ -170,7 +170,7 @@ async def submit_create(
     *,
     master_key: bytes,
     name: str,
-    type: str,  # noqa: A002
+    type: str,
     url: str,
     api_key: str,
     batch_size: int,
@@ -305,7 +305,7 @@ async def submit_update(
     *,
     master_key: bytes,
     name: str,
-    type: str,  # noqa: A002
+    type: str,
     url: str,
     api_key: str,
     batch_size: int,

--- a/src/houndarr/services/instances.py
+++ b/src/houndarr/services/instances.py
@@ -300,7 +300,7 @@ async def create_instance(
     *,
     master_key: bytes,
     name: str,
-    type: InstanceType,  # noqa: A002
+    type: InstanceType,
     url: str,
     api_key: str,
     enabled: bool = True,
@@ -422,11 +422,11 @@ async def create_instance(
     row_id = await _repo_insert_instance(payload, master_key=master_key)
 
     instance = await get_instance(row_id, master_key=master_key)
-    assert instance is not None  # just inserted, cannot be None  # noqa: S101
+    assert instance is not None  # just inserted, cannot be None
     return instance
 
 
-async def get_instance(id: int, *, master_key: bytes) -> Instance | None:  # noqa: A002
+async def get_instance(id: int, *, master_key: bytes) -> Instance | None:
     """Fetch a single instance by *id*, or ``None`` if not found.
 
     Thin delegator over
@@ -482,7 +482,7 @@ async def active_error_instance_ids() -> set[int]:
 
 
 async def update_instance(
-    id: int,  # noqa: A002
+    id: int,
     *,
     master_key: bytes,
     **fields: Any,
@@ -538,7 +538,7 @@ async def update_instance(
     return await get_instance(id, master_key=master_key)
 
 
-async def delete_instance(id: int) -> bool:  # noqa: A002
+async def delete_instance(id: int) -> bool:
     """Delete an instance row (cascade removes cooldowns).
 
     Thin delegator over
@@ -556,7 +556,7 @@ async def delete_instance(id: int) -> bool:  # noqa: A002
 
 
 async def update_instance_snapshot(
-    id: int,  # noqa: A002
+    id: int,
     *,
     monitored_total: int,
     unreleased_count: int,

--- a/src/houndarr/services/log_query.py
+++ b/src/houndarr/services/log_query.py
@@ -210,7 +210,7 @@ async def query_logs(
         # query parameterised (placeholders only, never user values)
         # and leaves the bandit suppression below honest.
         placeholders = ",".join("?" * len(instance_ids))
-        conditions.append(f"sl.instance_id IN ({placeholders})")  # noqa: S608  # nosec B608
+        conditions.append(f"sl.instance_id IN ({placeholders})")
         params.extend(instance_ids)
 
     if action is not None:
@@ -301,10 +301,10 @@ async def query_logs(
         {where_clause}
         ORDER BY sl.timestamp DESC, sl.id DESC
         LIMIT ?
-    """  # noqa: S608  # nosec B608
+    """  # noqa: S608  # nosec
     params.append(limit)
 
-    async with get_db() as db, db.execute(sql, params) as cur:
+    async with get_db() as db, db.execute(sql, params) as cur:  # nosem
         rows = await cur.fetchall()
 
     raw = [dict(row) for row in rows]

--- a/src/houndarr/services/metrics.py
+++ b/src/houndarr/services/metrics.py
@@ -35,10 +35,10 @@ so the single-process assumption holds in practice.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import aiosqlite
 from async_lru import alru_cache
@@ -299,13 +299,20 @@ class DashboardAggregates:
     recent: list[dict[str, Any]] = field(default_factory=list)
 
 
-# A function with ``cache_clear`` plus the alru_cache extras.  We keep
-# the surface narrow on purpose: the route only ever awaits the call,
-# and invalidation only ever calls cache_clear; the rest of alru_cache's
-# API (cache_info, cache_invalidate, jitter, etc.) is intentionally not
-# exposed because the centralised invalidation path is the supported
-# contract.
-DashboardAggregateCache = Callable[[tuple[int, ...]], Awaitable[DashboardAggregates]]
+# Narrow surface: the route awaits the call; invalidation calls cache_clear.
+# The rest of alru_cache's API (cache_info, cache_invalidate, jitter) stays
+# off the contract so the centralised invalidation path is the only seam.
+@runtime_checkable
+class DashboardAggregateCache(Protocol):
+    """Callable cache exposing ``cache_clear`` for the invalidation path."""
+
+    def __call__(self, instance_ids_tuple: tuple[int, ...]) -> Awaitable[DashboardAggregates]:
+        """Return the cached aggregate bundle for *instance_ids_tuple*."""
+        ...
+
+    def cache_clear(self) -> None:
+        """Drop every cached entry; the next call repopulates from source."""
+        ...
 
 
 async def _gather_dashboard_aggregates(
@@ -417,9 +424,8 @@ async def gather_dashboard_status(
         ``JSONResponse``.  Empty installs short-circuit with both
         lists empty.
     """
-    async with db.execute(
-        f"SELECT {_STATUS_INSTANCE_COLS} FROM instances ORDER BY id ASC"  # noqa: S608  # nosec B608
-    ) as cur:
+    sql = f"SELECT {_STATUS_INSTANCE_COLS} FROM instances ORDER BY id ASC"  # noqa: S608  # nosec
+    async with db.execute(sql) as cur:  # nosem
         instances = await cur.fetchall()
 
     if not instances:
@@ -494,7 +500,9 @@ async def gather_window_metrics(
     placeholders = ",".join("?" * len(instance_ids))
 
     metrics: dict[int, dict[str, Any]] = {}
-    async with db.execute(_METRICS_SQL.format(placeholders=placeholders), instance_ids) as cur:
+    async with db.execute(  # nosem
+        _METRICS_SQL.format(placeholders=placeholders), instance_ids
+    ) as cur:
         async for row in cur:
             iid = row["instance_id"]
             metrics[iid] = {
@@ -506,7 +514,7 @@ async def gather_window_metrics(
             }
 
     activity: dict[int, tuple[str | None, str | None]] = {}
-    async with db.execute(
+    async with db.execute(  # nosem
         _LAST_ACTIVITY_SQL.format(placeholders=placeholders), instance_ids
     ) as cur:
         async for row in cur:
@@ -534,7 +542,9 @@ async def gather_lifetime_metrics(
         return {}
     placeholders = ",".join("?" * len(instance_ids))
     out: dict[int, dict[str, Any]] = {}
-    async with db.execute(_LIFETIME_SQL.format(placeholders=placeholders), instance_ids) as cur:
+    async with db.execute(  # nosem
+        _LIFETIME_SQL.format(placeholders=placeholders), instance_ids
+    ) as cur:
         async for row in cur:
             out[row["instance_id"]] = {
                 "lifetime_searched": int(row["lifetime_searched"] or 0),
@@ -570,7 +580,9 @@ async def gather_active_errors(
         return {}
     placeholders = ",".join("?" * len(instance_ids))
     out: dict[int, dict[str, Any]] = {}
-    async with db.execute(_LATEST_ROW_SQL.format(placeholders=placeholders), instance_ids) as cur:
+    async with db.execute(  # nosem
+        _LATEST_ROW_SQL.format(placeholders=placeholders), instance_ids
+    ) as cur:
         async for row in cur:
             if row["action"] != "error":
                 continue
@@ -680,7 +692,9 @@ async def gather_cooldown_data(
     }
 
     per_instance_rows: dict[int, list[dict[str, Any]]] = {iid: [] for iid in instance_ids}
-    async with db.execute(_COOLDOWNS_SQL.format(placeholders=placeholders), instance_ids) as cur:
+    async with db.execute(  # nosem
+        _COOLDOWNS_SQL.format(placeholders=placeholders), instance_ids
+    ) as cur:
         async for row in cur:
             iid = int(row["instance_id"])
             # search_kind is a stamped column constrained to the three

--- a/tests/e2e_browser/mock_arr.py
+++ b/tests/e2e_browser/mock_arr.py
@@ -119,7 +119,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Mock *arr service for Houndarr e2e")
     parser.add_argument("--app", required=True, choices=["Sonarr", "Radarr"])
     parser.add_argument("--port", type=int, required=True)
-    parser.add_argument("--host", default="0.0.0.0")  # noqa: S104
+    parser.add_argument("--host", default="0.0.0.0")
     args = parser.parse_args()
 
     app = make_app(args.app)

--- a/tests/test_app_lifespan_pinning.py
+++ b/tests/test_app_lifespan_pinning.py
@@ -15,7 +15,10 @@ production over it.
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from houndarr import app as app_module
@@ -108,7 +111,7 @@ class TestLifespanStartup:
         app: TestClient,
     ) -> None:
         """After the TestClient exits the lifespan, retention_task is cancelled."""
-        retention = getattr(app.app.state, "retention_task", None)
+        retention = getattr(cast("FastAPI", app.app).state, "retention_task", None)
         assert retention is not None
         # TestClient has yielded (we are still inside the with-block via fixture).
         # Sanity: task was created and is alive.
@@ -136,7 +139,7 @@ class TestLifespanStartup:
 
         fastapi_app = app_module.create_app()
         with TestClient(fastapi_app) as client:
-            assert getattr(client.app.state, "retention_task", "missing") is None
+            assert getattr(cast("FastAPI", client.app).state, "retention_task", "missing") is None
 
 
 # RequestValidationError split

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,9 +9,9 @@ import pytest
 from fastapi.testclient import TestClient
 
 from houndarr.auth import (
-    _CSRF_PROTECTED_METHODS,  # noqa: SLF001
-    _LOGOUT_PATH,  # noqa: SLF001
-    _PUBLIC_PATHS,  # noqa: SLF001
+    _CSRF_PROTECTED_METHODS,
+    _LOGOUT_PATH,
+    _PUBLIC_PATHS,
     BCRYPT_COST,
     CSRF_COOKIE_NAME,
     SESSION_COOKIE_NAME,
@@ -155,7 +155,7 @@ def test_client_ip_honours_xff_for_cidr_trusted_proxy(
     """_client_ip honours X-Forwarded-For when direct IP is in a trusted subnet."""
     from unittest.mock import MagicMock
 
-    from houndarr.auth import _client_ip  # noqa: SLF001
+    from houndarr.auth import _client_ip
     from houndarr.config import bootstrap_settings
 
     try:
@@ -174,7 +174,7 @@ def test_client_ip_ignores_xff_when_not_in_trusted_subnet(
     """_client_ip ignores X-Forwarded-For when direct IP is NOT in trusted subnet."""
     from unittest.mock import MagicMock
 
-    from houndarr.auth import _client_ip  # noqa: SLF001
+    from houndarr.auth import _client_ip
     from houndarr.config import bootstrap_settings
 
     try:
@@ -767,7 +767,7 @@ def test_clear_login_attempts_drops_bucket(test_settings: object) -> None:
     from unittest.mock import MagicMock
 
     from houndarr.auth import (
-        _login_attempts,  # noqa: SLF001
+        _login_attempts,
         check_login_rate_limit,
         clear_login_attempts,
         record_failed_login,
@@ -800,8 +800,8 @@ def test_check_login_rate_limit_prunes_stale_entries(
 
     import houndarr.auth as _auth
     from houndarr.auth import (
-        _LOGIN_WINDOW_SECONDS,  # noqa: SLF001
-        _login_attempts,  # noqa: SLF001
+        _LOGIN_WINDOW_SECONDS,
+        _login_attempts,
         check_login_rate_limit,
         record_failed_login,
     )
@@ -839,7 +839,7 @@ async def test_reset_auth_caches_clears_every_module_global(db: None) -> None:
 
     import houndarr.auth as _auth
     from houndarr.auth import (
-        _get_serializer,  # noqa: SLF001
+        _get_serializer,
         record_failed_login,
         reset_auth_caches,
         set_password,
@@ -853,15 +853,15 @@ async def test_reset_auth_caches_clears_every_module_global(db: None) -> None:
     req.headers.get.return_value = None
     record_failed_login(req)
 
-    assert _auth._setup_complete is True  # noqa: SLF001
-    assert _auth._serializer is not None  # noqa: SLF001
-    assert _auth._login_attempts  # noqa: SLF001
+    assert _auth._setup_complete is True
+    assert _auth._serializer is not None
+    assert _auth._login_attempts
 
     reset_auth_caches()
 
-    assert _auth._setup_complete is None  # noqa: SLF001
-    assert _auth._serializer is None  # noqa: SLF001
-    assert _auth._login_attempts == {}  # noqa: SLF001
+    assert _auth._setup_complete is None
+    assert _auth._serializer is None
+    assert _auth._login_attempts == {}
 
 
 # Session seam
@@ -872,13 +872,13 @@ async def test_reset_auth_caches_clears_every_module_global(db: None) -> None:
 async def test_get_serializer_lazy_init_reads_session_secret(db: None) -> None:
     """First call generates-and-persists the secret; subsequent calls reuse it."""
     import houndarr.auth as _auth
-    from houndarr.auth import _get_serializer  # noqa: SLF001
+    from houndarr.auth import _get_serializer
 
-    assert _auth._serializer is None  # noqa: SLF001
+    assert _auth._serializer is None
     assert await get_setting("session_secret") is None
 
     first = await _get_serializer()
-    assert _auth._serializer is first  # noqa: SLF001
+    assert _auth._serializer is first
     persisted = await get_setting("session_secret")
     assert persisted is not None and len(persisted) == 64  # 32 bytes hex
 
@@ -899,7 +899,7 @@ async def test_rotate_session_secret_invalidates_prior_token(db: None) -> None:
     """
     from itsdangerous import BadSignature
 
-    from houndarr.auth import _get_serializer, rotate_session_secret  # noqa: SLF001
+    from houndarr.auth import _get_serializer, rotate_session_secret
 
     serializer = await _get_serializer()
     signed = serializer.dumps({"ts": 1, "csrf": "tok"})
@@ -1034,7 +1034,7 @@ def test_extract_proxy_username_returns_none_on_missing_or_blank(
     """
     from unittest.mock import MagicMock
 
-    from houndarr.auth import _extract_proxy_username  # noqa: SLF001
+    from houndarr.auth import _extract_proxy_username
     from houndarr.config import bootstrap_settings
 
     try:
@@ -1131,7 +1131,7 @@ async def test_dispatch_proxy_calls_trust_gate_before_header_read(
         request.method = "GET"
         request.client.host = "10.0.0.1"
         call_next = AsyncMock()
-        await middleware._dispatch_proxy(request, call_next, "/settings")  # noqa: SLF001
+        await middleware._dispatch_proxy(request, call_next, "/settings")
 
         assert calls == ["trust"], (
             f"expected only trust gate to run when IP is untrusted, got {calls!r}"

--- a/tests/test_bootstrap/test_bootstrap_non_web.py
+++ b/tests/test_bootstrap/test_bootstrap_non_web.py
@@ -189,12 +189,12 @@ class TestRuntimeSettingsPinning:
         # get_settings() on every call. Pinning would trap the derived
         # object and break later env changes, so we explicitly do not.
         bootstrap_non_web(data_dir=str(tmp_path))
-        assert _cfg._runtime_settings is None  # noqa: SLF001
+        assert _cfg._runtime_settings is None
 
     def test_overrides_pin_the_singleton(self, tmp_path: Path) -> None:
         bootstrap_non_web(data_dir=str(tmp_path), port=9999)
-        assert _cfg._runtime_settings is not None  # noqa: SLF001
-        assert _cfg._runtime_settings.port == 9999  # noqa: SLF001
+        assert _cfg._runtime_settings is not None
+        assert _cfg._runtime_settings.port == 9999
 
     def test_prior_pin_is_cleared_before_resolving(self, tmp_path: Path) -> None:
         # A stale pin from a previous run must not leak into the new one.

--- a/tests/test_clients/test_client_edge_cases.py
+++ b/tests/test_clients/test_client_edge_cases.py
@@ -300,4 +300,4 @@ async def test_client_aclose_callable() -> None:
     """aclose() can be called without error, closing the underlying client."""
     client = SonarrClient(url="http://sonarr:8989", api_key="test")
     await client.aclose()
-    assert client._client.is_closed  # noqa: SLF001
+    assert client._client.is_closed

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -697,7 +697,9 @@ async def test_init_db_self_heals_v9_and_v10_when_version_already_current(
 
         # v10 self-heal: 'whisparr_v3_movie' accepted in cooldowns CHECK.
         v3_id_row = await conn.execute("SELECT id FROM instances WHERE name = 'v10 guard'")
-        v3_id = (await v3_id_row.fetchone())[0]
+        v3_row = await v3_id_row.fetchone()
+        assert v3_row is not None, "expected v10 guard row to exist"
+        v3_id = v3_row[0]
         await conn.execute(
             "INSERT INTO cooldowns (instance_id, item_id, item_type, searched_at)"
             " VALUES (?, 1, 'whisparr_v3_movie', '2024-01-01T00:00:00Z')",
@@ -927,7 +929,7 @@ async def test_migrate_to_v12_adds_search_order_column(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio()
-async def test_cooldowns_search_kind_check_enforced(db: None) -> None:  # noqa: ARG001
+async def test_cooldowns_search_kind_check_enforced(db: None) -> None:
     """Every initialised DB rejects search_kind values outside the CHECK.
 
     Fresh installs pick this up from ``_SCHEMA_SQL``; databases that

--- a/tests/test_e2e/test_search_cycle.py
+++ b/tests/test_e2e/test_search_cycle.py
@@ -262,7 +262,7 @@ async def test_second_cycle_items_skipped_on_cooldown(
 @respx.mock
 async def test_hourly_cap_enforced(
     db: None,
-    master_key: bytes,  # noqa: ARG001
+    master_key: bytes,
 ) -> None:
     """When hourly cap is already exhausted, the next item is skipped immediately."""
     # Create an instance with cap=1
@@ -316,7 +316,7 @@ async def test_hourly_cap_enforced(
 @respx.mock
 async def test_supervisor_graceful_shutdown(
     sonarr_instance: Instance,
-    master_key: bytes,  # noqa: ARG001
+    master_key: bytes,
 ) -> None:
     """Supervisor tasks are cancelled on stop() with no unhandled exceptions."""
     # The search loop will block on get_missing; we just need it to be running
@@ -325,14 +325,14 @@ async def test_supervisor_graceful_shutdown(
 
     sup = Supervisor(master_key=master_key)
     await sup.start()
-    assert len(sup._tasks) == 1  # noqa: SLF001
+    assert len(sup._tasks) == 1
 
     # Give the task a moment to spin up and hit the (failing) HTTP call
     await asyncio.sleep(0.05)
 
     # stop() must complete without raising
     await sup.stop()
-    assert sup._tasks == {}  # noqa: SLF001
+    assert sup._tasks == {}
 
 
 @pytest.mark.integration
@@ -341,7 +341,7 @@ async def test_supervisor_no_instances_starts_cleanly(db: None, master_key: byte
     """Supervisor with zero instances should start and stop without error."""
     sup = Supervisor(master_key=master_key)
     await sup.start()
-    assert sup._tasks == {}  # noqa: SLF001
+    assert sup._tasks == {}
     await sup.stop()  # must be a no-op
 
 
@@ -379,7 +379,7 @@ async def test_supervisor_runs_both_instances(
     ):
         sup = Supervisor(master_key=master_key)
         await sup.start()
-        assert len(sup._tasks) == 2  # noqa: SLF001
+        assert len(sup._tasks) == 2
 
         # Let both tasks complete their first search cycle before stopping
         await asyncio.sleep(0.2)

--- a/tests/test_engine/conftest.py
+++ b/tests/test_engine/conftest.py
@@ -310,17 +310,26 @@ async def seed_release_timing_retry(
     *,
     instance_id: int,
     item_id: int,
-    item_type: ItemType,
+    item_type: ItemType | str,
     reason: str = "not yet released",
 ) -> None:
-    """Set up an item on cooldown with a release-timing skip reason."""
+    """Set up an item on cooldown with a release-timing skip reason.
+
+    ``item_type`` accepts ``ItemType | str`` to match the production
+    helpers (:func:`houndarr.services.cooldown.record_search` and
+    :func:`insert_search_log_row` both accept the StrEnum or its raw
+    string value).  Tests typically pass the bare ``"episode"`` /
+    ``"movie"`` form because the enum compares equal to its value at
+    runtime; widening the signature lets pyright agree with that
+    intentional duck typing.
+    """
     from houndarr.services.cooldown import record_search
 
     await record_search(instance_id, item_id, item_type)
     await insert_search_log_row(
         instance_id=instance_id,
         item_id=item_id,
-        item_type=item_type,
+        item_type=str(item_type),
         search_kind="missing",
         action="skipped",
         reason=reason,

--- a/tests/test_engine/test_instance_structure_gate.py
+++ b/tests/test_engine/test_instance_structure_gate.py
@@ -26,6 +26,7 @@ Locked invariants:
 from __future__ import annotations
 
 import dataclasses
+from typing import Any
 
 import pytest
 
@@ -75,16 +76,24 @@ def test_instance_is_plain_dataclass_with_seven_sub_struct_fields() -> None:
 
 
 def test_instance_rejects_pre_refactor_flat_kwargs() -> None:
-    """The flat-kwarg __init__ surface raises ``TypeError``."""
+    """The flat-kwarg __init__ surface raises ``TypeError``.
+
+    The flat kwargs travel through ``**dict`` so pyright cannot resolve
+    them to named parameters and (correctly) flag this negative test.
+    The runtime semantics are identical: Instance's actual __init__ only
+    accepts the seven sub-struct fields, so any of these legacy names
+    raise ``TypeError``.
+    """
+    legacy_flat_kwargs: dict[str, Any] = {
+        "id": 1,
+        "name": "legacy",
+        "type": InstanceType.sonarr,
+        "url": "http://host:8989",
+        "api_key": "k",
+        "enabled": True,
+    }
     with pytest.raises(TypeError):
-        Instance(  # type: ignore[call-arg]
-            id=1,
-            name="legacy",
-            type=InstanceType.sonarr,
-            url="http://host:8989",
-            api_key="k",
-            enabled=True,
-        )
+        Instance(**legacy_flat_kwargs)
 
 
 def test_flat_attribute_access_raises_attribute_error() -> None:

--- a/tests/test_engine/test_search_loop.py
+++ b/tests/test_engine/test_search_loop.py
@@ -228,7 +228,7 @@ async def _seed_release_timing_retry(
     *,
     instance_id: int,
     item_id: int,
-    item_type: ItemType,
+    item_type: ItemType | str,
     reason: str = "not yet released",
 ) -> None:
     from houndarr.services.cooldown import record_search
@@ -237,7 +237,7 @@ async def _seed_release_timing_retry(
     await _insert_search_log_row(
         instance_id=instance_id,
         item_id=item_id,
-        item_type=item_type,
+        item_type=str(item_type),
         search_kind="missing",
         action="skipped",
         reason=reason,
@@ -1996,7 +1996,7 @@ async def test_supervisor_starts_and_stops_cleanly(db: None) -> None:
     sup = Supervisor(master_key=MASTER_KEY)
     await sup.start()
     await sup.stop()
-    assert sup._tasks == {}  # noqa: SLF001
+    assert sup._tasks == {}
 
 
 @pytest.mark.asyncio()
@@ -2043,7 +2043,7 @@ async def test_supervisor_stop_cancels_tasks(seeded_instances: None) -> None:
         await asyncio.sleep(0.05)
         await sup.stop()
 
-    assert sup._tasks == {}  # noqa: SLF001
+    assert sup._tasks == {}
 
 
 @pytest.mark.asyncio()
@@ -2072,7 +2072,7 @@ async def test_supervisor_stop_completes_within_timeout(seeded_instances: None) 
 
     # Should complete far below the 10s timeout (tasks cancel immediately)
     assert elapsed < 5.0
-    assert sup._tasks == {}  # noqa: SLF001
+    assert sup._tasks == {}
 
 
 @pytest.mark.asyncio()
@@ -2087,7 +2087,7 @@ async def test_supervisor_reconcile_starts_task_for_enabled_instance(db: None) -
     ):
         sup = Supervisor(master_key=MASTER_KEY)
         await sup.start()
-        assert sup._tasks == {}  # noqa: SLF001
+        assert sup._tasks == {}
 
         encrypted = encrypt("test-api-key", MASTER_KEY)
         async with get_db() as conn:
@@ -2101,7 +2101,7 @@ async def test_supervisor_reconcile_starts_task_for_enabled_instance(db: None) -
             await conn.commit()
 
         await sup.reconcile_instance(1)
-        assert 1 in sup._tasks  # noqa: SLF001
+        assert 1 in sup._tasks
 
         await sup.stop()
 
@@ -2125,14 +2125,14 @@ async def test_supervisor_reconcile_stops_task_when_instance_disabled(
     ):
         sup = Supervisor(master_key=MASTER_KEY)
         await sup.start()
-        assert 1 in sup._tasks  # noqa: SLF001
+        assert 1 in sup._tasks
 
         async with get_db() as conn:
             await conn.execute("UPDATE instances SET enabled = 0 WHERE id = ?", (1,))
             await conn.commit()
 
         await sup.reconcile_instance(1)
-        assert 1 not in sup._tasks  # noqa: SLF001
+        assert 1 not in sup._tasks
 
         await sup.stop()
 
@@ -2164,7 +2164,7 @@ async def test_trigger_run_now_deduplicates_pending_manual_runs(
 
         assert status_1 == "accepted"
         assert status_2 == "accepted"
-        assert len(sup._manual_runs) == 1  # noqa: SLF001
+        assert len(sup._manual_runs) == 1
 
         gate.set()
         await asyncio.sleep(0)

--- a/tests/test_engine/test_skip_throttle_concurrency.py
+++ b/tests/test_engine/test_skip_throttle_concurrency.py
@@ -113,10 +113,10 @@ async def test_concurrent_passes_produce_at_most_one_skip_row(
     # candidate.  fetch_fn returns exactly one raw item per call.
     _raw_item: dict[str, Any] = {"id": _ITEM_ID}
 
-    async def fetch_one(page: int, page_size: int) -> list[Any]:  # noqa: ARG001
+    async def fetch_one(page: int, page_size: int) -> list[Any]:
         return [_raw_item]
 
-    def adapt_passthrough(item: Any, instance: Any) -> SearchCandidate:  # noqa: ARG001
+    def adapt_passthrough(item: Any, instance: Any) -> SearchCandidate:
         return candidate
 
     # dispatch_fn must be awaitable; it should NEVER be called in this test

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -140,8 +140,8 @@ async def test_instance_loop_waits_startup_grace_before_first_cycle(
         ) as mock_search,
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
-        with pytest.raises(asyncio.CancelledError):  # noqa: PT012
-            await supervisor._instance_loop(instance.core.id)  # noqa: SLF001
+        with pytest.raises(asyncio.CancelledError):
+            await supervisor._instance_loop(instance.core.id)
 
     # The very first sleep must be the startup grace, not the inter-cycle sleep.
     assert sleep_calls, "expected at least one asyncio.sleep call"
@@ -172,8 +172,8 @@ async def test_instance_loop_applies_startup_offset(
         ) as mock_search,
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
-        with pytest.raises(asyncio.CancelledError):  # noqa: PT012
-            await supervisor._instance_loop(instance.core.id, startup_offset=60)  # noqa: SLF001
+        with pytest.raises(asyncio.CancelledError):
+            await supervisor._instance_loop(instance.core.id, startup_offset=60)
 
     assert sleep_calls, "expected at least one asyncio.sleep call"
     assert sleep_calls[0] == 70  # 10 (grace) + 60 (offset)
@@ -194,7 +194,7 @@ async def test_start_staggers_instance_tasks() -> None:
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
         mock_start = AsyncMock(return_value=True)
-        supervisor.start_instance_task = mock_start  # noqa: SLF001
+        supervisor.start_instance_task = mock_start
         await supervisor.start()
 
     assert mock_start.call_count == 2
@@ -235,7 +235,7 @@ async def test_first_connect_error_writes_exactly_one_error_row(
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
         with pytest.raises(asyncio.CancelledError):
-            await supervisor._instance_loop(instance.core.id)  # noqa: SLF001
+            await supervisor._instance_loop(instance.core.id)
 
     rows = await _get_log_rows()
     error_rows = [r for r in rows if r["action"] == "error"]
@@ -269,7 +269,7 @@ async def test_repeated_connect_errors_write_only_one_error_row(
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
         with pytest.raises(asyncio.CancelledError):
-            await supervisor._instance_loop(instance.core.id)  # noqa: SLF001
+            await supervisor._instance_loop(instance.core.id)
 
     rows = await _get_log_rows()
     error_rows = [r for r in rows if r["action"] == "error"]
@@ -306,7 +306,7 @@ async def test_recovery_after_connect_error_writes_info_row(
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
         with pytest.raises(asyncio.CancelledError):
-            await supervisor._instance_loop(instance.core.id)  # noqa: SLF001
+            await supervisor._instance_loop(instance.core.id)
 
     rows = await _get_log_rows()
     info_rows = [r for r in rows if r["action"] == "info"]
@@ -343,7 +343,7 @@ async def test_no_extra_log_rows_during_retry_sequence(
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
         with pytest.raises(asyncio.CancelledError):
-            await supervisor._instance_loop(instance.core.id)  # noqa: SLF001
+            await supervisor._instance_loop(instance.core.id)
 
     rows = await _get_log_rows()
     # Expect exactly: 1 error (first failure) + 1 info (recovery) = 2 rows total
@@ -395,7 +395,7 @@ async def test_refresh_all_snapshots_once_updates_enabled_instances(
         patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
-        await supervisor._refresh_all_snapshots_once()  # noqa: SLF001
+        await supervisor._refresh_all_snapshots_once()
 
     refreshed = await get_instance(inst.core.id, master_key=MASTER_KEY)
     assert refreshed is not None
@@ -419,7 +419,7 @@ async def test_refresh_all_snapshots_skips_disabled(
         patch("houndarr.engine.supervisor.get_adapter", side_effect=fake_client_call),
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
-        await supervisor._refresh_all_snapshots_once()  # noqa: SLF001
+        await supervisor._refresh_all_snapshots_once()
 
     assert fake_client_call.await_count == 0
     refreshed = await get_instance(inst.core.id, master_key=MASTER_KEY)
@@ -468,7 +468,7 @@ async def test_refresh_one_snapshot_logs_big_unreleased_jump(
         patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
-        await supervisor._refresh_one_snapshot(inst)  # noqa: SLF001
+        await supervisor._refresh_one_snapshot(inst)
 
     matching = [r for r in caplog.records if "unreleased jumped" in r.getMessage()]
     assert len(matching) == 1
@@ -520,7 +520,7 @@ async def test_refresh_one_snapshot_quiet_on_small_unreleased_change(
         patch("houndarr.engine.supervisor.get_adapter", return_value=fake_adapter),
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
-        await supervisor._refresh_one_snapshot(inst)  # noqa: SLF001
+        await supervisor._refresh_one_snapshot(inst)
 
     matching = [r for r in caplog.records if "unreleased jumped" in r.getMessage()]
     assert matching == []
@@ -570,7 +570,7 @@ async def test_refresh_all_snapshots_handles_transport_error(
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
         # Should not raise.
-        await supervisor._refresh_all_snapshots_once()  # noqa: SLF001
+        await supervisor._refresh_all_snapshots_once()
 
     error_records = [r for r in caplog.records if r.levelname in {"ERROR", "CRITICAL"}]
     assert error_records == [], (
@@ -633,7 +633,7 @@ async def test_refresh_one_snapshot_reconcile_transport_error_keeps_cooldowns(
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
         # Should not raise.
-        await supervisor._refresh_one_snapshot(inst)  # noqa: SLF001
+        await supervisor._refresh_one_snapshot(inst)
 
     error_records = [r for r in caplog.records if r.levelname in {"ERROR", "CRITICAL"}]
     assert error_records == [], (
@@ -673,9 +673,7 @@ async def test_run_search_cycle_returns_retry_for_transport_error(
         AsyncMock(side_effect=transport_exc),
     ):
         supervisor = Supervisor(master_key=MASTER_KEY)
-        retry = await supervisor._run_search_cycle(  # noqa: SLF001
-            instance, cycle_trigger="scheduled"
-        )
+        retry = await supervisor._run_search_cycle(instance, cycle_trigger="scheduled")
 
     assert retry is True, "transport error must signal retry, not error-path completion"
     rows = await _get_log_rows()

--- a/tests/test_engine/test_supervisor_edge_cases.py
+++ b/tests/test_engine/test_supervisor_edge_cases.py
@@ -157,11 +157,11 @@ async def test_run_now_duplicate_returns_accepted(seeded_instances: None) -> Non
     assert r1 == "accepted"
     assert r2 == "accepted"
     # Only one manual task should exist
-    assert len(supervisor._manual_runs) <= 1  # noqa: SLF001
+    assert len(supervisor._manual_runs) <= 1
 
     # Cleanup: release the event and cancel tasks
     long_running.set()
-    for task in list(supervisor._manual_runs.values()):  # noqa: SLF001
+    for task in list(supervisor._manual_runs.values()):
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
@@ -221,7 +221,7 @@ async def test_stop_instance_task_cancels_task(seeded_instances: None) -> None:
         result = await supervisor.stop_instance_task(1)
 
     assert result is True
-    assert 1 not in supervisor._tasks  # noqa: SLF001
+    assert 1 not in supervisor._tasks
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +240,7 @@ async def test_reconcile_starts_for_enabled(seeded_instances: None) -> None:
     with patch.object(Supervisor, "_instance_loop", _wait_forever):
         await supervisor.reconcile_instance(1)
 
-    assert 1 in supervisor._tasks  # noqa: SLF001
+    assert 1 in supervisor._tasks
     await supervisor.stop()
 
 
@@ -260,7 +260,7 @@ async def test_reconcile_stops_for_disabled(seeded_instances: None) -> None:
         await conn.commit()
 
     await supervisor.reconcile_instance(1)
-    assert 1 not in supervisor._tasks  # noqa: SLF001
+    assert 1 not in supervisor._tasks
 
 
 # ---------------------------------------------------------------------------
@@ -284,7 +284,7 @@ async def test_connection_error_first_failure_logs_error(seeded_instances: None)
         return 0
 
     async def _sleep_then_cancel(secs: float) -> None:
-        if secs == _supervisor_mod._CONNECT_RETRY_SECS:  # noqa: SLF001
+        if secs == _supervisor_mod._CONNECT_RETRY_SECS:
             raise asyncio.CancelledError
 
     with (
@@ -293,7 +293,7 @@ async def test_connection_error_first_failure_logs_error(seeded_instances: None)
         patch("asyncio.sleep", side_effect=_sleep_then_cancel),
     ):
         with contextlib.suppress(asyncio.CancelledError):
-            await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+            await supervisor._instance_loop(1, startup_offset=0)
 
     rows = await _get_log_rows()
     error_rows = [r for r in rows if r["action"] == "error"]
@@ -330,7 +330,7 @@ async def test_connection_recovery_logs_info(seeded_instances: None) -> None:
         patch("asyncio.sleep", side_effect=_controlled_sleep),
     ):
         with contextlib.suppress(asyncio.CancelledError):
-            await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+            await supervisor._instance_loop(1, startup_offset=0)
 
     rows = await _get_log_rows()
     info_rows = [r for r in rows if r["action"] == "info" and r.get("message")]
@@ -388,9 +388,9 @@ async def test_graceful_shutdown_cancels_tasks(seeded_instances: None) -> None:
     with patch.object(Supervisor, "_instance_loop", _wait_forever):
         await supervisor.start_instance_task(1)
 
-    assert 1 in supervisor._tasks  # noqa: SLF001
+    assert 1 in supervisor._tasks
     await supervisor.stop()
-    assert len(supervisor._tasks) == 0  # noqa: SLF001
+    assert len(supervisor._tasks) == 0
 
 
 @pytest.mark.asyncio()
@@ -405,7 +405,7 @@ async def test_instance_deleted_exits_loop(seeded_instances: None) -> None:
         patch.object(_supervisor_mod, "get_instance", return_value=None),
         patch("asyncio.sleep", side_effect=_controlled_sleep),
     ):
-        await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+        await supervisor._instance_loop(1, startup_offset=0)
 
     # Loop should have exited without error
 
@@ -423,7 +423,7 @@ async def test_instance_disabled_exits_loop(seeded_instances: None) -> None:
         patch.object(_supervisor_mod, "get_instance", return_value=instance),
         patch("asyncio.sleep", side_effect=_controlled_sleep),
     ):
-        await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+        await supervisor._instance_loop(1, startup_offset=0)
 
 
 @pytest.mark.asyncio()
@@ -453,7 +453,7 @@ async def test_normal_cycle_sleeps_instance_interval(seeded_instances: None) -> 
         patch("asyncio.sleep", side_effect=_capture_sleep),
     ):
         with contextlib.suppress(asyncio.CancelledError):
-            await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+            await supervisor._instance_loop(1, startup_offset=0)
 
     # First sleep is startup grace (10 + 0), second is interval (5 * 60 = 300)
     assert len(sleep_values) >= 2
@@ -486,7 +486,7 @@ async def test_connection_retry_sleeps_30s(seeded_instances: None) -> None:
         patch("asyncio.sleep", side_effect=_capture_sleep),
     ):
         with contextlib.suppress(asyncio.CancelledError):
-            await supervisor._instance_loop(1, startup_offset=0)  # noqa: SLF001
+            await supervisor._instance_loop(1, startup_offset=0)
 
     # First sleep is startup grace, second is retry interval
     assert len(sleep_values) >= 2

--- a/tests/test_huntarr_vulns.py
+++ b/tests/test_huntarr_vulns.py
@@ -22,7 +22,7 @@ from fastapi.testclient import TestClient
 
 import houndarr.auth as _auth_module
 from houndarr.auth import (
-    _PUBLIC_PATHS,  # noqa: SLF001
+    _PUBLIC_PATHS,
     CSRF_COOKIE_NAME,
     SESSION_COOKIE_NAME,
     SESSION_MAX_AGE_SECONDS,

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -51,8 +51,8 @@ def proxy_settings(tmp_data_dir: str) -> AppSettings:
         auth_proxy_header=_AUTH_HEADER,
         trusted_proxies=_TRUSTED_IP,
     )
-    _auth_mod._serializer = None  # noqa: SLF001
-    _auth_mod._login_attempts.clear()  # noqa: SLF001
+    _auth_mod._serializer = None
+    _auth_mod._login_attempts.clear()
     return settings
 
 
@@ -71,7 +71,7 @@ def proxy_app(proxy_settings: AppSettings) -> Generator[TestClient]:
     # Wrap the ASGI app to inject a trusted-proxy client IP
     original_app = application
 
-    async def _patched_app(scope, receive, send):  # type: ignore[no-untyped-def]  # noqa: ANN001
+    async def _patched_app(scope, receive, send):  # type: ignore[no-untyped-def]
         if scope["type"] == "http":
             scope["client"] = (_TRUSTED_IP, 0)
         await original_app(scope, receive, send)
@@ -89,7 +89,7 @@ def untrusted_proxy_app(proxy_settings: AppSettings) -> Generator[TestClient]:
 
     original_app = application
 
-    async def _patched_app(scope, receive, send):  # type: ignore[no-untyped-def]  # noqa: ANN001
+    async def _patched_app(scope, receive, send):  # type: ignore[no-untyped-def]
         if scope["type"] == "http":
             scope["client"] = (_UNTRUSTED_IP, 0)
         await original_app(scope, receive, send)

--- a/tests/test_repositories/test_instances_reads.py
+++ b/tests/test_repositories/test_instances_reads.py
@@ -140,7 +140,7 @@ async def test_get_instance_decrypts_with_correct_key(db: None, master_key: byte
         api_key="s3cret",
     )
     other_key = Fernet.generate_key()
-    with pytest.raises(Exception):  # noqa: B017, PT011
+    with pytest.raises(Exception):  # noqa: B017
         await repo.get_instance(created.core.id, master_key=other_key)
 
 

--- a/tests/test_repositories/test_instances_writes.py
+++ b/tests/test_repositories/test_instances_writes.py
@@ -401,7 +401,7 @@ async def test_service_delete_instance_delegates_to_repo(db: None, master_key: b
 @pytest.mark.pinning()
 def test_instance_insert_is_frozen_dataclass_with_slots() -> None:
     """InstanceInsert is a frozen slotted dataclass for immutability + memory."""
-    with pytest.raises(Exception):  # noqa: B017, PT011
+    with pytest.raises(Exception):  # noqa: B017
         payload = InstanceInsert(
             name="x",
             type=InstanceType.sonarr,
@@ -414,7 +414,7 @@ def test_instance_insert_is_frozen_dataclass_with_slots() -> None:
 @pytest.mark.pinning()
 def test_instance_update_is_frozen_dataclass_with_slots() -> None:
     """InstanceUpdate is a frozen slotted dataclass for immutability + memory."""
-    with pytest.raises(Exception):  # noqa: B017, PT011
+    with pytest.raises(Exception):  # noqa: B017
         payload = InstanceUpdate(name="x")
         payload.name = "mutated"  # type: ignore[misc]
 

--- a/tests/test_routes/test_admin.py
+++ b/tests/test_routes/test_admin.py
@@ -53,7 +53,7 @@ def _login(client: TestClient) -> None:
 def _proxy_csrf(client: TestClient) -> str:
     """Prime the CSRF cookie in proxy mode and return its value."""
     client.get("/", headers={_AUTH_HEADER: _AUTH_USER})
-    return client.cookies.get(CSRF_COOKIE_NAME, "")
+    return client.cookies.get(CSRF_COOKIE_NAME) or ""
 
 
 # ---------------------------------------------------------------------------
@@ -69,9 +69,9 @@ def proxy_settings(tmp_data_dir: str) -> AppSettings:
         auth_proxy_header=_AUTH_HEADER,
         trusted_proxies=_TRUSTED_IP,
     )
-    _auth_mod._serializer = None  # noqa: SLF001
-    _auth_mod._setup_complete = None  # noqa: SLF001
-    _auth_mod._login_attempts.clear()  # noqa: SLF001
+    _auth_mod._serializer = None
+    _auth_mod._setup_complete = None
+    _auth_mod._login_attempts.clear()
     return settings
 
 
@@ -82,7 +82,7 @@ def proxy_app(proxy_settings: AppSettings) -> Generator[TestClient]:
     application = create_app()
     original_app = application
 
-    async def _patched_app(scope, receive, send):  # type: ignore[no-untyped-def]  # noqa: ANN001
+    async def _patched_app(scope, receive, send):  # type: ignore[no-untyped-def]
         if scope["type"] == "http":
             scope["client"] = (_TRUSTED_IP, 0)
         await original_app(scope, receive, send)
@@ -137,7 +137,7 @@ def test_reset_instances_happy_path(app: TestClient) -> None:
     # Create an instance with a non-default batch_size so we can observe the reset.
     app.post(
         "/settings/instances",
-        data={**_VALID_INSTANCE, "batch_size": 99},
+        data={**_VALID_INSTANCE, "batch_size": "99"},
         headers=csrf_headers(app),
     )
     resp = app.post(

--- a/tests/test_routes/test_changelog_pinning.py
+++ b/tests/test_routes/test_changelog_pinning.py
@@ -180,5 +180,5 @@ class TestEmptySlotResponse:
 
     def test_body_is_single_div_with_aria_hidden(self) -> None:
         resp = _empty_slot_response()
-        body = resp.body.decode("utf-8")
+        body = bytes(resp.body).decode("utf-8")
         assert body == '<div id="changelog-slot" aria-hidden="true"></div>'

--- a/tests/test_routes/test_logs_pinning.py
+++ b/tests/test_routes/test_logs_pinning.py
@@ -235,14 +235,14 @@ class TestPartialValidationError:
 
     def test_detail_is_html_escaped(self) -> None:
         resp = _partial_validation_error("<script>alert(1)</script>")
-        body = resp.body.decode("utf-8")
+        body = bytes(resp.body).decode("utf-8")
         assert "&lt;script&gt;" in body
         assert "<script>" not in body
 
     def test_response_is_feed_shaped(self) -> None:
         """Pin the shape so HTMX swap into #log-feed keeps feed structure."""
         resp = _partial_validation_error("bad input")
-        body = resp.body.decode("utf-8")
+        body = bytes(resp.body).decode("utf-8")
         assert body.startswith('<div id="log-error-row"')
         assert 'class="empty empty--error"' in body
         assert body.endswith("</div>")

--- a/tests/test_routes/test_settings_instances_pinning.py
+++ b/tests/test_routes/test_settings_instances_pinning.py
@@ -165,7 +165,7 @@ class TestConnectionResponses:
     def test_success_status_response_shape(self) -> None:
         resp = connection_status_response("Connected", ok=True, status_code=200)
         assert resp.status_code == 200
-        body = resp.body.decode("utf-8")
+        body = bytes(resp.body).decode("utf-8")
         assert "text-green-400" in body
         assert "Connected" in body
         assert resp.headers.get("HX-Trigger") == "houndarr-connection-test-success"
@@ -173,14 +173,14 @@ class TestConnectionResponses:
     def test_failure_status_response_shape(self) -> None:
         resp = connection_status_response("Failed", ok=False, status_code=422)
         assert resp.status_code == 422
-        body = resp.body.decode("utf-8")
+        body = bytes(resp.body).decode("utf-8")
         assert "text-red-400" in body
         assert "Failed" in body
         assert resp.headers.get("HX-Trigger") == "houndarr-connection-test-failure"
 
     def test_status_response_escapes_message(self) -> None:
         resp = connection_status_response("<script>alert(1)</script>", ok=False, status_code=422)
-        body = resp.body.decode("utf-8")
+        body = bytes(resp.body).decode("utf-8")
         assert "&lt;script&gt;" in body
         assert "<script>" not in body
 
@@ -190,10 +190,10 @@ class TestConnectionResponses:
         assert resp.headers.get("HX-Retarget") == "#instance-connection-status"
         assert resp.headers.get("HX-Reswap") == "innerHTML"
         assert resp.headers.get("HX-Trigger") == "houndarr-connection-test-failure"
-        assert "Verify first" in resp.body.decode("utf-8")
+        assert "Verify first" in bytes(resp.body).decode("utf-8")
 
     def test_guard_response_escapes_message(self) -> None:
         resp = connection_guard_response("<b>bold</b>")
-        body = resp.body.decode("utf-8")
+        body = bytes(resp.body).decode("utf-8")
         assert "&lt;b&gt;bold&lt;/b&gt;" in body
         assert "<b>bold</b>" not in body

--- a/tests/test_routes/test_status.py
+++ b/tests/test_routes/test_status.py
@@ -908,7 +908,7 @@ def test_status_v2_cooldown_breakdown_splits_by_kind(app: TestClient) -> None:
     assert body["cooldown_breakdown"] == {"missing": 2, "cutoff": 1, "upgrade": 1}
 
 
-def test_status_monitored_total_reads_column(app: TestClient, async_client: object) -> None:  # noqa: ARG001
+def test_status_monitored_total_reads_column(app: TestClient, async_client: object) -> None:
     """monitored_total reflects the authoritative column written by the
     supervisor's snapshot refresh task."""
     from houndarr.services.instances import update_instance_snapshot

--- a/tests/test_routes/test_status_cache_integration.py
+++ b/tests/test_routes/test_status_cache_integration.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from typing import cast
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from houndarr.clients._wire_models import SystemStatus
@@ -191,7 +193,7 @@ async def test_run_now_schedules_deferred_reinvalidation(
 
             return DashboardAggregates()
 
-    app.app.state.aggregate_cache = _RecordingCache()
+    cast("FastAPI", app.app).state.aggregate_cache = _RecordingCache()
 
     resp = app.post("/api/instances/1/run-now", headers=csrf_headers(app))
     assert resp.status_code == 202

--- a/tests/test_routes/test_templates_singleton_pinning.py
+++ b/tests/test_routes/test_templates_singleton_pinning.py
@@ -26,7 +26,7 @@ from houndarr.routes._templates import get_templates
 @pytest.fixture(autouse=True)
 def _reset_templates() -> None:
     """Clear the cached singleton before each test."""
-    tpl._templates = None  # noqa: SLF001
+    tpl._templates = None
 
 
 @pytest.mark.pinning()
@@ -65,7 +65,7 @@ def test_timeago_filter_is_registered() -> None:
 def test_reset_hook_rebuilds_singleton() -> None:
     """Setting the module-level cache to None forces a fresh build."""
     first = get_templates()
-    tpl._templates = None  # noqa: SLF001
+    tpl._templates = None
     second = get_templates()
     assert first is not second
 

--- a/tests/test_services/test_admin.py
+++ b/tests/test_services/test_admin.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncGenerator
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 from cryptography.fernet import Fernet
+from fastapi import FastAPI
 
 from houndarr.config import (
     DEFAULT_BATCH_SIZE,
@@ -238,6 +240,18 @@ class _FakeSupervisor:
 
 
 class _FakeApp:
+    """Test double for ``FastAPI`` covering only the ``state`` surface
+    that :func:`houndarr.services.admin.factory_reset` reads / writes.
+
+    ``state`` is typed ``Any`` so the dynamic attribute assignment and
+    access used by ``factory_reset`` (``state.supervisor`` and
+    ``state.master_key``) type-check without extra annotations.  The
+    :func:`factory_reset` call sites in this module cast the test double
+    to ``FastAPI`` since the helper takes a fully-typed ``FastAPI`` arg.
+    """
+
+    state: Any
+
     def __init__(self, supervisor: object | None, master_key: bytes) -> None:
         self.state = type("State", (), {})()
         self.state.supervisor = supervisor
@@ -267,7 +281,7 @@ async def test_factory_reset_deletes_files_and_reinits(
         AsyncMock(return_value=None),
     )
 
-    await factory_reset(app=fake_app, data_dir=tmp_data_dir)
+    await factory_reset(app=cast("FastAPI", fake_app), data_dir=tmp_data_dir)
 
     # DB file recreated, master-key file rotated.
     assert Path(db_path).exists()
@@ -281,9 +295,9 @@ async def test_factory_reset_deletes_files_and_reinits(
     # Auth caches reset.
     import houndarr.auth as _auth
 
-    assert _auth._setup_complete is None  # noqa: SLF001
-    assert _auth._serializer is None  # noqa: SLF001
-    assert _auth._login_attempts == {}  # noqa: SLF001
+    assert _auth._setup_complete is None
+    assert _auth._serializer is None
+    assert _auth._login_attempts == {}
 
 
 @pytest.mark.asyncio()
@@ -315,7 +329,7 @@ async def test_factory_reset_propagates_reinit_failure(
     monkeypatch.setattr("houndarr.services.admin.init_db", _boom)
 
     with pytest.raises(ServiceError) as exc_info:
-        await factory_reset(app=fake_app, data_dir=tmp_data_dir)
+        await factory_reset(app=cast("FastAPI", fake_app), data_dir=tmp_data_dir)
 
     # Typed wrap: the original RuntimeError lives on __cause__ so the
     # observability hook still sees the underlying shape.

--- a/tests/test_services/test_cooldown_reconcile.py
+++ b/tests/test_services/test_cooldown_reconcile.py
@@ -26,7 +26,7 @@ _ENC_KEY = "gAAAAABlX_fake_fernet_value_long_enough_to_pass_validation=="
 
 
 @pytest_asyncio.fixture()
-async def seeded_instance(db: None) -> AsyncGenerator[None]:  # noqa: ARG001
+async def seeded_instance(db: None) -> AsyncGenerator[None]:
     """Seed one instance row so cooldowns FKs resolve."""
     async with get_db() as conn:
         await conn.execute(
@@ -65,7 +65,7 @@ async def _count_cooldowns(instance_id: int) -> int:
 
 
 @pytest.mark.asyncio()
-async def test_empty_sets_skip_delete(seeded_instance: None) -> None:  # noqa: ARG001
+async def test_empty_sets_skip_delete(seeded_instance: None) -> None:
     """An empty ReconcileSets is a hard skip: never wipe the table."""
     await _seed_cooldown(1, 100, "episode", "missing")
     await _seed_cooldown(1, 200, "episode", "cutoff")
@@ -75,7 +75,7 @@ async def test_empty_sets_skip_delete(seeded_instance: None) -> None:  # noqa: A
 
 
 @pytest.mark.asyncio()
-async def test_keeps_matching_rows(seeded_instance: None) -> None:  # noqa: ARG001
+async def test_keeps_matching_rows(seeded_instance: None) -> None:
     """Rows whose (item_type, item_id) is in the matching set stay."""
     await _seed_cooldown(1, 100, "episode", "missing")
     await _seed_cooldown(1, 200, "episode", "cutoff")
@@ -90,7 +90,7 @@ async def test_keeps_matching_rows(seeded_instance: None) -> None:  # noqa: ARG0
 
 
 @pytest.mark.asyncio()
-async def test_deletes_orphan_rows(seeded_instance: None) -> None:  # noqa: ARG001
+async def test_deletes_orphan_rows(seeded_instance: None) -> None:
     """Rows not in the matching set get deleted."""
     await _seed_cooldown(1, 100, "episode", "missing")  # orphan
     await _seed_cooldown(1, 101, "episode", "missing")  # keeper
@@ -106,7 +106,7 @@ async def test_deletes_orphan_rows(seeded_instance: None) -> None:  # noqa: ARG0
 
 
 @pytest.mark.asyncio()
-async def test_search_kind_scoped_to_pass(seeded_instance: None) -> None:  # noqa: ARG001
+async def test_search_kind_scoped_to_pass(seeded_instance: None) -> None:
     """A row tagged 'missing' matches the missing set even if the cutoff
     set contains the same (item_type, item_id)."""
     await _seed_cooldown(1, 100, "episode", "missing")
@@ -121,7 +121,7 @@ async def test_search_kind_scoped_to_pass(seeded_instance: None) -> None:  # noq
 
 
 @pytest.mark.asyncio()
-async def test_context_synth_id_kept(seeded_instance: None) -> None:  # noqa: ARG001
+async def test_context_synth_id_kept(seeded_instance: None) -> None:
     """Season-context synthetic negative id survives reconcile when the
     adapter unions it into the pass set."""
     synth = -1234  # -(series_id * 1000 + season_number) for (1, 234)
@@ -137,7 +137,7 @@ async def test_context_synth_id_kept(seeded_instance: None) -> None:  # noqa: AR
 
 
 @pytest.mark.asyncio()
-async def test_batched_delete_many_rows(seeded_instance: None) -> None:  # noqa: ARG001
+async def test_batched_delete_many_rows(seeded_instance: None) -> None:
     """Deleting more than the batch size (500) still succeeds."""
     # Seed 600 orphan rows.
     tasks = [_seed_cooldown(1, i, "episode", "missing") for i in range(1, 601)]

--- a/tests/test_services/test_factory_reset_pinning.py
+++ b/tests/test_services/test_factory_reset_pinning.py
@@ -23,10 +23,11 @@ service layer can raise.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from cryptography.fernet import Fernet
+from fastapi import FastAPI
 
 from houndarr.errors import ServiceError
 from houndarr.services.admin import factory_reset
@@ -78,7 +79,7 @@ class TestFactoryResetTypedSurface:
         app = _FakeApp()
 
         with pytest.raises(ServiceError) as exc_info:
-            await factory_reset(app=app, data_dir=str(tmp_data_dir_factory))
+            await factory_reset(app=cast("FastAPI", app), data_dir=str(tmp_data_dir_factory))
 
         assert exc_info.value.__cause__ is original
         assert "file deletion failed" in str(exc_info.value)
@@ -99,7 +100,7 @@ class TestFactoryResetTypedSurface:
         app = _FakeApp()
 
         with pytest.raises(ServiceError) as exc_info:
-            await factory_reset(app=app, data_dir=str(tmp_data_dir_factory))
+            await factory_reset(app=cast("FastAPI", app), data_dir=str(tmp_data_dir_factory))
 
         assert exc_info.value.__cause__ is original
         assert "re-init failed" in str(exc_info.value)
@@ -124,7 +125,7 @@ class TestFactoryResetTypedSurface:
         app = _FakeApp()
 
         with pytest.raises(ServiceError) as exc_info:
-            await factory_reset(app=app, data_dir=str(tmp_data_dir_factory))
+            await factory_reset(app=cast("FastAPI", app), data_dir=str(tmp_data_dir_factory))
 
         assert exc_info.value.__cause__ is original
 
@@ -144,7 +145,7 @@ class TestFactoryResetTypedSurface:
         app = _FakeApp()
 
         with pytest.raises(ServiceError) as exc_info:
-            await factory_reset(app=app, data_dir=str(tmp_data_dir_factory))
+            await factory_reset(app=cast("FastAPI", app), data_dir=str(tmp_data_dir_factory))
 
         assert exc_info.value is inner
 
@@ -167,6 +168,6 @@ class TestFactoryResetTypedSurface:
         monkeypatch.setattr("houndarr.services.admin._factory_reset_impl", _noop)
         app = _FakeApp()
 
-        result = await factory_reset(app=app, data_dir=str(tmp_data_dir_factory))
+        result = await factory_reset(app=cast("FastAPI", app), data_dir=str(tmp_data_dir_factory))
 
         assert result is None

--- a/tests/test_services/test_instance_immutability_pinning.py
+++ b/tests/test_services/test_instance_immutability_pinning.py
@@ -69,7 +69,13 @@ def test_instance_is_frozen_after_freeze() -> None:
     compose :func:`dataclasses.replace`.
     """
     assert dataclasses.is_dataclass(Instance)
-    assert Instance.__dataclass_params__.frozen is True
+    # ``__dataclass_params__`` is a runtime attribute the ``@dataclass``
+    # decorator stamps on every dataclass type; pyright does not model it
+    # on ``type[T]`` because the dunder is private to the dataclasses
+    # module.  Direct access reads cleanly in CPython, and the
+    # ``# pyright: ignore`` keeps the editor LSP quiet without losing
+    # the assertion.
+    assert Instance.__dataclass_params__.frozen is True  # pyright: ignore[reportAttributeAccessIssue]
     assert set(Instance.__slots__) == {
         "core",
         "missing",
@@ -129,11 +135,11 @@ class _ForbiddenWriteVisitor(ast.NodeVisitor):
             isinstance(target.value, ast.Attribute)
             and target.value.attr in _FORBIDDEN_ATTR_PREFIXES
         ):
-            self.findings.append((node.lineno, target.attr))
+            self.findings.append((getattr(node, "lineno", 0), target.attr))
             return
         # Match foo.missing_page_offset etc. (flat writes through the facade).
         if target.attr in _FORBIDDEN_ATTRS:
-            self.findings.append((node.lineno, target.attr))
+            self.findings.append((getattr(node, "lineno", 0), target.attr))
 
 
 def test_offset_advancement_persisted_via_repository_only() -> None:

--- a/tests/test_services/test_instance_substructs.py
+++ b/tests/test_services/test_instance_substructs.py
@@ -502,16 +502,21 @@ def test_instance_rejects_pre_refactor_flat_kwargs() -> None:
     A caller that still passes ``Instance(id=..., name=...)`` must
     fail loudly at the call site instead of silently ignoring the
     kwargs; sub-struct kwargs are the only accepted form.
+
+    The kwargs travel through ``**dict`` so pyright cannot resolve them
+    against Instance's seven sub-struct __init__ parameters and (rightly)
+    flag the negative case statically.  Runtime behaviour is identical.
     """
+    legacy_flat_kwargs: dict[str, Any] = {
+        "id": 1,
+        "name": "legacy",
+        "type": InstanceType.sonarr,
+        "url": "http://host:8989",
+        "api_key": "k",
+        "enabled": True,
+    }
     with pytest.raises(TypeError):
-        Instance(  # type: ignore[call-arg]
-            id=1,
-            name="legacy",
-            type=InstanceType.sonarr,
-            url="http://host:8989",
-            api_key="k",
-            enabled=True,
-        )
+        Instance(**legacy_flat_kwargs)
 
 
 @pytest.mark.parametrize("flat_name", sorted(FLAT_TO_SUB))

--- a/tests/test_services/test_time_window.py
+++ b/tests/test_services/test_time_window.py
@@ -298,7 +298,7 @@ def test_validate_rejects_zero_duration(spec: str) -> None:
 def test_validate_messages_do_not_echo_user_input() -> None:
     """Error strings must be constants, so nothing from the raw spec flows
     into HTTP responses. Regression guard for CodeQL py/stack-trace-exposure."""
-    suspicious_token = "<script>EVIL</script>"  # noqa: S105 - literal marker
+    suspicious_token = "<script>EVIL</script>"
     probe = f"09:00-12:00,{suspicious_token}"
     msg = validate_allowed_time_window(probe)
     assert msg is not None

--- a/uv.lock
+++ b/uv.lock
@@ -199,6 +199,63 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -367,6 +424,43 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +503,10 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
 ]
+e2e = [
+    { name = "playwright" },
+    { name = "pytest-playwright" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -441,6 +539,10 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.15.10" },
+]
+e2e = [
+    { name = "playwright", specifier = ">=1.55.0" },
+    { name = "pytest-playwright", specifier = ">=0.7.1" },
 ]
 
 [[package]]
@@ -716,6 +818,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -805,6 +926,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -842,6 +975,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -853,6 +999,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6b/913e36aa421b35689ec95ed953ff7e8df3f2ee1c7b8ab2a3f1fd39d95faf/pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770", size = 16928, upload-time = "2025-11-24T03:43:22.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/61/4d333d8354ea2bea2c2f01bad0a4aa3c1262de20e1241f78e73360e9b620/pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38", size = 16881, upload-time = "2025-11-24T03:43:24.423Z" },
 ]
 
 [[package]]
@@ -884,6 +1045,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -920,6 +1093,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -994,6 +1182,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1012,6 +1209,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Drops `pyright` errors 127 -> 0 (`basedpyright` 245 -> 0) and silences every `bandit` `WARNING nosec encountered` line, by fixing root causes in source instead of suppressing per-line. Also adds `__all__` to nine modules so the 15 underscore-prefixed cross-module exports stop greying out in the editor.

Closes #599

## Changes

- Terminate every `Protocol` method body with `...` (38 errors).
- Convert four adapter `anchor_fn=lambda` callsites to typed inner `def`s so PEP 695 generic inference binds correctly.
- `[tool.pyright] typeCheckingMode = "standard"` pinned in `pyproject.toml` so `basedpyright` (LazyVim's default LSP) stops applying its `all` mode.
- Switch `SystemStatus.app_name` to `validation_alias=AliasChoices(...)` + `serialization_alias=` so the constructor accepts the snake_case Python name (silences ~13 test-side `reportCallIssue`s).
- `ArrClient.__aenter__ -> Self` (PEP 673) so subclass methods are visible after `async with`.
- Stop redeclaring `_WANTED_ENVELOPE: ClassVar[type[PaginatedResponse[X]]]` in subclasses; the parent's annotation governs.
- `auth/__init__.py`: explicit `import time as time` re-export + `if TYPE_CHECKING:` declarations for `_serializer` / `_setup_complete` / `_USERNAME_PATTERN`.
- `[dependency-groups] e2e = ["playwright>=1.55.0", "pytest-playwright>=0.7.1"]` so editor users opt in via `uv sync --group e2e`; resolves the three `reportMissingImports`.
- Refactor `Instance(...)` negative tests to `**dict` indirection (preserves `TypeError` runtime contract).
- Widen `seed_release_timing_retry` helpers to `ItemType | str` to match `record_search`.
- Tighten misc test surface: `bytes(memoryview).decode()`, `cast("FastAPI", client.app)` for ASGI-wrapper state, `DashboardAggregateCache` upgraded to a `Protocol` exposing `cache_clear`.
- Replace every `# nosec B608` and `# nosec B704` with bare `# nosec` per [PyCQA/bandit#1204](https://github.com/PyCQA/bandit/issues/1204): bandit 1.7.3+ emits a spurious `WARNING nosec encountered (B608), but no failed test` per f-string interpolation under the test-ID form. Verified empirically on the pinned 1.9.4. AGENTS.md updated.
- Purge 172 stale `# noqa` via `ruff --select RUF100 --fix`; precisely restore the active `S608` / `S704` / `N803` / `E402` / `B017` / `F401` / `F811` markers at the lines each rule reports.
- Add `__all__` to `auth/csrf.py`, `auth/proxy_auth.py`, `clients/_wire_models/common.py`, `engine/adapters/sonarr.py`, `engine/candidates.py`, `engine/search_loop.py`, `routes/changelog.py`, `routes/update_check.py`, `services/changelog.py`, `services/cooldown.py` to silence pyright's hint-level "is not accessed" diagnostic on 15 cross-module exports.
- Add module docstrings to five public-package `__init__.py` files (`clients/`, `engine/`, `routes/`, `routes/api/`, `services/`).
- Trim verbose comments to match `docs/commenting-standard.md` (explain why, not what).

## Testing

- `just check` clean.
- `pyright` 0/0/0 (errors / warnings / info).
- `basedpyright` 0/0/0.
- `bandit -r src/ -c pyproject.toml`: "No issues identified", **zero WARNINGs** (was 14 on `main`).
- `pytest -m "not integration" -n auto`: 2638 passed.
- OSV-Scanner: 0 dependency vulnerabilities.
- Opengrep curated security ruleset: every finding triaged + suppressed at the precise sink.
- Programmatic orphan detector: 0 underscore-prefixed cross-module exports without `__all__`.
- `nvim src/houndarr/<any>.py`: zero buffer diagnostics.

## Type of Change

- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #599`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`chore/static-analysis-and-editor-cleanup`)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable) — N/A; AGENTS.md `# nosec` table updated, no user-facing docs touched
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way — N/A; pure tooling cleanup with no user-visible behaviour change