### PR TITLE
chore: ground /api/v1/widget design (CONTEXT, ADR-0001)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,14 @@
             "Bash(which *)",
             "Bash(curl *)",
             "Bash(grep *)",
-            "Bash(date *)"
+            "Bash(date *)",
+            "Bash(ruff check *)",
+            "Bash(awk *)",
+            "Bash(uvx pyright *)",
+            "Bash(pnpm typecheck)",
+            "Bash(pnpm lint)",
+            "mcp__plugin_context7_context7__query-docs",
+            "mcp__plugin_context7_context7__resolve-library-id"
         ],
         "deny": [
             "Read(./.env)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,10 @@ Tailwind CSS CDN. Published to GHCR at `ghcr.io/av1155/houndarr`.
 search for missing, cutoff-unmet, or upgrade-eligible media in a controlled,
 polite way.
 Do not add download-client integration, indexer management, request workflows,
-multi-user support, or media file manipulation.
+multi-user support, or media file manipulation. External API endpoints expose
+curated read-only views of Houndarr's existing data; write actions and broad
+data access via external API are out of scope and require dedicated scope
+review before being added.
 
 ---
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,88 @@
+# Houndarr
+
+Houndarr is a self-hosted polite search scheduler for missing,
+cutoff-unmet, and upgrade-eligible media across Sonarr, Radarr,
+Lidarr, Readarr, and Whisparr instances. It triggers search commands
+in small, rate-limited batches without managing downloads, parsing
+releases, or evaluating quality.
+
+## Language
+
+### Credentials
+
+**Instance API key** (also: *arr API key when contrasting):
+The credential a *arr instance issues, used by Houndarr to
+authenticate outbound calls to that *arr's REST API. Stored
+Fernet-encrypted in `instances.encrypted_api_key`.
+_Avoid_: "the API key" without qualifier when both inbound and
+outbound credentials are in scope.
+
+**Houndarr API key**:
+The credential Houndarr issues so external tools (Homepage widgets,
+custom integrations, CLI scrapers) can authenticate inbound calls to
+Houndarr's external-stable API. Stored SHA-256-hashed in
+`widget_api_key`; verified against the `X-Api-Key` header on
+`/api/v1/widget`.
+_Avoid_: "public API key" (the endpoint isn't unauthenticated),
+"widget API key" (consumers aren't only widgets).
+
+### Library state
+
+**Tracked**:
+Total items Houndarr's enabled, healthy instances are responsible
+for. Equals **Eligible** + **Gated** + **Unreleased** + items in
+upgrade cooldown.
+
+**Eligible**:
+Monitored items Houndarr can dispatch a search for right now (no
+active cooldown, post-release grace expired).
+_Avoid_: "wanted" (overloaded by *arr's `/wanted/*` API namespace),
+"ready" (vague).
+
+**Gated**:
+Items in per-item cooldown after a recent missing or cutoff search.
+Returns to **Eligible** once the cooldown elapses.
+_Avoid_: "queued" (overloaded by *arr download-queue terminology).
+
+**Unreleased**:
+Monitored items still awaiting their release date. Becomes
+**Eligible** automatically once released.
+
+## Relationships
+
+- An **Instance** owns one **Instance API key** (encrypted) and
+  contributes per-instance counts to **Tracked**, **Eligible**,
+  **Gated**, and **Unreleased** while enabled and healthy.
+- A Houndarr installation owns at most one **Houndarr API key**
+  (hashed) authorizing access to the external-stable API.
+- The header `X-Api-Key` is used in both credential directions
+  (Houndarr -> *arr outbound, external tool -> Houndarr inbound);
+  the route disambiguates which key is expected.
+
+## Example dialogue
+
+> **Dev:** "Where do we store the API key?"
+>
+> **Maintainer:** "Which one? The **Instance API key** (the *arr's
+> key Houndarr uses outbound) is Fernet-encrypted in
+> `instances.encrypted_api_key`. The **Houndarr API key** (the key
+> external tools use to call us inbound) is SHA-256-hashed in
+> `widget_api_key`."
+
+> **Dev:** "The library-health bar shows Eligible 1234, Gated 89,
+> Unreleased 12. What's Tracked?"
+>
+> **Maintainer:** "Tracked is the rollup that includes those three
+> plus upgrade cooldowns, which sit outside the *arr's `/wanted/*`
+> namespace but are still items Houndarr is responsible for."
+
+## Flagged ambiguities
+
+- "API key" was used to mean both **Instance API key** (outbound,
+  Fernet-encrypted) and **Houndarr API key** (inbound,
+  SHA-256-hashed). Resolved: distinct concepts with distinct storage
+  models. Use the qualified term whenever the contrast matters.
+- "wanted" overlapped with *arr's `/wanted/*` API namespace and a
+  vague user concept. Resolved: avoid "wanted" as a Houndarr-domain
+  term; use **Eligible** / **Gated** / **Unreleased** for the
+  precise states.

--- a/docs/adr/0001-auth-mode-agnostic-api-key-lane.md
+++ b/docs/adr/0001-auth-mode-agnostic-api-key-lane.md
@@ -1,0 +1,44 @@
+# 0001 Auth-mode-agnostic Houndarr API key lane
+
+The Houndarr API key is the sole credential authorizing requests to
+`/api/v1/widget`, regardless of whether `HOUNDARR_AUTH_MODE` is
+`builtin` or `proxy`. This creates a disjoint trust path: session
+cookies and proxy auth headers alone do not grant access; a Houndarr
+API key alone does. We chose this over a hybrid `session OR key`
+fallback so external integrations work consistently across both auth
+modes without operators threading their reverse-proxy authentication
+through every consumer tool, and so the key's portability cannot
+accidentally narrow when the auth mode is switched.
+
+## Considered options
+
+- **Hybrid (`session OR key`)**: any of session, proxy header, or
+  Houndarr API key would have authorized `/api/v1/widget`. Rejected:
+  three auth paths multiply test surface and create scenarios where
+  switching modes silently changes the key's effective scope.
+- **Builtin-only key lane**: the key would only work when
+  `HOUNDARR_AUTH_MODE=builtin`. Rejected: forces proxy-mode operators
+  to either route Homepage through their auth proxy (which not all
+  proxies cleanly support per-tool) or abandon proxy mode entirely.
+- **Public endpoint (no key)**: `/api/v1/widget` would have been
+  added to `_PUBLIC_PATHS`. Rejected: introduces a second
+  unauthenticated surface beyond `/api/health` and discloses
+  aggregate library metrics to anyone with network reach to port
+  8877.
+
+## Consequences
+
+- **Disjoint mental model for proxy-mode operators.** Documentation
+  must explicitly call out that the key lane is independent of the
+  proxy gate, since the existing threat model frames the proxy as
+  the gate. Captured in `website/docs/security/threat-model.md`
+  under "Credential classes."
+- **Stolen key impact is bounded by the endpoint's narrow contract.**
+  A leaked Houndarr API key exposes only the `/api/v1/widget`
+  summary fields, not session-scoped routes or per-instance secrets.
+  Limits blast radius compared with a hybrid model where a stolen
+  key would fall through to broader access.
+- **Revocation is immediate.** Deleting the row in `widget_api_key`
+  invalidates the key on the next request; no propagation delay
+  because the validator hashes the incoming header against the
+  stored hash without caching plaintext.


### PR DESCRIPTION
## Summary

Foundational design artefacts for the upcoming `/api/v1/widget` feature, ahead of the implementation slices. Reference and doctrine only; no runtime code, no schema changes, no new behaviour.

Closes #613
Refs #603 (parent PRD)

## Changes

- `CONTEXT.md` (new): project glossary disambiguating Instance API key (outbound, Fernet-encrypted) from Houndarr API key (inbound, SHA-256-hashed); library-state vocabulary (Tracked / Eligible / Gated / Unreleased); relationships and flagged ambiguities.
- `docs/adr/0001-auth-mode-agnostic-api-key-lane.md` (new): captures the disjoint trust path decision (key-only on `/api/v1/widget`, regardless of `HOUNDARR_AUTH_MODE`), with considered alternatives (hybrid `session OR key`, builtin-only, public endpoint) and consequences.
- `AGENTS.md`: scope guard tightened with one sentence committing external API endpoints to read-only summary surfaces; broader access requires dedicated scope review.
- `.claude/settings.json`: read-only allowlist additions observed across recent sessions (`ruff check *`, `awk *`, `uvx pyright *`, `pnpm typecheck`, `pnpm lint`, plus two Context7 MCP tools used by `/review`).

## Testing

Markdown-and-JSON-only diff. The six main workflows have `paths-ignore: ["docs/**", "**/*.md", "website/**", ".claude/**"]`, which matches every file in this PR; `ci-skip.yml` provides the required no-op jobs so branch protection is satisfied without invoking the heavyweight workflows.

Verified locally:

- `CONTEXT.md` and `docs/adr/0001-...md` are well-formed Markdown.
- `python3 -c 'import json; json.load(open(".claude/settings.json"))'` passes; allowlist contains 41 entries (was 32 + 9 added).
- AGENTS.md scope-guard sentence is the only change to that file.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #613`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/houndarr-api-key-design`; predates the issue but covers the same scope)
- [ ] Tests added/updated for all changes (N/A: docs + tooling only)
- [ ] Type check passes (`mypy src/`) (N/A: no Python changes)
- [ ] Lint passes (`ruff check .`) (N/A: no Python changes)
- [ ] Format passes (`ruff format --check .`) (N/A: no Python changes)
- [x] Documentation updated (this PR is the documentation change)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: Grounds the upcoming widget feature, which surfaces existing search-engine state for self-hoster dashboards in a controlled, read-only way.