### PR TITLE
docs(changelog): backfill Security entry for urllib3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Transient library-fetch failures on any *arr no longer produce a recurring `upgrade pool fetch failed` log row each upgrade cycle. (#620)
 
+### Security
+
+- `urllib3` bumped to 2.7.0; closes two upstream advisories on decompression-bomb safeguards and sensitive-header forwarding through proxied redirects. Houndarr does not exercise either code path today, but the bump removes the alerts from `pip-audit` and Trivy. (#623)
+
 ---
 
 ## [1.11.0] - 2026-04-29


### PR DESCRIPTION
## Summary

Adds the `### Security` entry to the `## [Unreleased]` block that #623 didn't include. Documents which release cleared the two upstream urllib3 advisories (GHSA-mf9v-mfxr-j63j decompression-bomb, GHSA-qccp-gfcp-xxvc proxied-redirect headers) for self-hosters who audit their pulled releases via pip-audit or trivy.

Closes #626

## Changes

- `CHANGELOG.md`: one bullet under `## [Unreleased] > ### Security` naming the urllib3 bump in #623, the two closed advisories, and the operator-visible signal (alerts no longer flagged by `pip-audit` / Trivy).

## Testing

CHANGELOG-only change; the six main workflows ignore `**/*.md`, and `ci-skip.yml` will satisfy the required check names for branch protection. The `version-check.yml` validator runs on CHANGELOG changes and pins the `## [Unreleased]` shape (`### Security` is one of the allowed Keep-a-Changelog headers).

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way