### PR TITLE
feat(cli): friendly stderr when Python is older than 3.13

### DIFF
--- a/src/houndarr/__main__.py
+++ b/src/houndarr/__main__.py
@@ -4,13 +4,9 @@ from __future__ import annotations
 
 import sys
 
-# Minimum Python the codebase parses against.  Mirrors
-# ``pyproject.toml``'s ``requires-python``; ``_check_python_version``
-# below is the runtime backstop for the rare path where the install
-# bypasses package metadata (``pip install --ignore-requires-python``,
-# a pre-existing venv reused after a downgrade, etc.).  Keep the
-# tuple form so ``sys.version_info[:2] < _REQUIRED_PYTHON`` is a plain
-# tuple comparison.
+# Mirrors ``pyproject.toml``'s ``requires-python``.  Tuple form lets
+# ``sys.version_info[:2] < _REQUIRED_PYTHON`` stay a plain tuple
+# comparison without parse-time string surgery.
 _REQUIRED_PYTHON: tuple[int, int] = (3, 13)
 
 
@@ -29,6 +25,10 @@ def _check_python_version(version_info: tuple[int, int] | None = None) -> None:
         version_info: Optional ``(major, minor)`` tuple, used by tests
             to inject a synthetic Python version.  Defaults to
             ``sys.version_info[:2]`` for the real runtime path.
+
+    Raises:
+        SystemExit: Code 2 when the running interpreter is older than
+            :data:`_REQUIRED_PYTHON`.
     """
     actual = version_info if version_info is not None else sys.version_info[:2]
     if actual < _REQUIRED_PYTHON:

--- a/src/houndarr/__main__.py
+++ b/src/houndarr/__main__.py
@@ -2,9 +2,51 @@
 
 from __future__ import annotations
 
-import click
+import sys
 
-from houndarr import __version__
+# Minimum Python the codebase parses against.  Mirrors
+# ``pyproject.toml``'s ``requires-python``; ``_check_python_version``
+# below is the runtime backstop for the rare path where the install
+# bypasses package metadata (``pip install --ignore-requires-python``,
+# a pre-existing venv reused after a downgrade, etc.).  Keep the
+# tuple form so ``sys.version_info[:2] < _REQUIRED_PYTHON`` is a plain
+# tuple comparison.
+_REQUIRED_PYTHON: tuple[int, int] = (3, 13)
+
+
+def _check_python_version(version_info: tuple[int, int] | None = None) -> None:
+    """Refuse to start on a Python older than :data:`_REQUIRED_PYTHON`.
+
+    Writes a short stderr message naming the version requirement and a
+    handful of common installer paths, then exits with code 2.  The
+    package metadata gate in ``pyproject.toml`` handles the normal
+    install path; this function is the safety net for forced-install
+    or stale-venv scenarios where the import below would otherwise
+    crash with a bare ``SyntaxError`` from a 3.13-only feature with no
+    context for the operator.
+
+    Args:
+        version_info: Optional ``(major, minor)`` tuple, used by tests
+            to inject a synthetic Python version.  Defaults to
+            ``sys.version_info[:2]`` for the real runtime path.
+    """
+    actual = version_info if version_info is not None else sys.version_info[:2]
+    if actual < _REQUIRED_PYTHON:
+        required = ".".join(str(p) for p in _REQUIRED_PYTHON)
+        running = ".".join(str(p) for p in actual)
+        sys.stderr.write(
+            f"Houndarr requires Python {required} or newer; running Python {running}.\n"
+            f"Install a newer Python (`uv python install 3.13`, `pyenv install 3.13`, "
+            f"or your distro's `python3.13` package) and re-run.\n"
+        )
+        raise SystemExit(2)
+
+
+_check_python_version()
+
+import click  # noqa: E402
+
+from houndarr import __version__  # noqa: E402
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/tests/test_cli_version_check.py
+++ b/tests/test_cli_version_check.py
@@ -1,0 +1,51 @@
+"""Pin the runtime Python-version backstop in ``houndarr.__main__``.
+
+The package-metadata gate in ``pyproject.toml`` (``requires-python =
+">=3.13"``) handles the normal install path, but a forced install or
+a stale venv can still drop the operator into ``python -m houndarr``
+on Python 3.12 or older.  ``_check_python_version`` is the friendly
+stderr message + non-zero exit that closes that gap (issue #628).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.__main__ import _check_python_version
+
+
+def test_check_python_version_accepts_current_runtime() -> None:
+    """Real interpreter is >=3.13; the bare call must be a no-op."""
+    _check_python_version()
+
+
+def test_check_python_version_accepts_future_versions() -> None:
+    """A Python newer than the floor stays accepted (3.14, 4.0, ...)."""
+    _check_python_version((3, 14))
+    _check_python_version((3, 50))
+    _check_python_version((4, 0))
+
+
+def test_check_python_version_rejects_old(capsys: pytest.CaptureFixture[str]) -> None:
+    """A 3.12 runtime writes the install hint and exits with code 2."""
+    with pytest.raises(SystemExit) as exc:
+        _check_python_version((3, 12))
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "Houndarr requires Python 3.13" in err
+    assert "running Python 3.12" in err
+    # The hint must mention at least one concrete install path so the
+    # operator has something to copy-paste.
+    assert "uv python install 3.13" in err
+    assert "pyenv install 3.13" in err
+
+
+def test_check_python_version_rejects_pre_3_release(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A wildly old (2.x or pre-3.13) tuple still falls into the reject branch."""
+    with pytest.raises(SystemExit) as exc:
+        _check_python_version((2, 7))
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "running Python 2.7" in err


### PR DESCRIPTION
## Summary

Add a small runtime backstop in `python -m houndarr` so operators on an unsupported Python interpreter see an actionable install hint instead of a deep import-time traceback.

Closes #628

## Changes

- `src/houndarr/__main__.py`: `_check_python_version()` runs at module import (before any `from houndarr import …`) and exits with code 2 on Python <3.13 after writing a short stderr message naming the version requirement and three install paths (`uv python install 3.13`, `pyenv install 3.13`, distro `python3.13` package). The package-metadata gate in `pyproject.toml` still handles the normal install path; this is the safety net for forced installs and stale venvs.
- `tests/test_cli_version_check.py`: four unit tests pin the accept-current-runtime, accept-future-version, reject-3.12, and reject-pre-3 cases by passing synthetic `(major, minor)` tuples through the same function.

## Testing

`just check` clean: ruff lint + format, mypy strict, bandit, **2663 pytest cases** (4 new).

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way