### PR TITLE
[#604] feat: schema, auth lane, and /api/v1/widget backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- External `/api/v1/widget` endpoint returns API-key-protected dashboard totals, backed by schema v19 `widget_api_key` storage. (#604)
 - Instance settings gain an `Enable missing search` toggle that pauses the missing-search pass per instance; existing instances stay enabled after the v18 migration. (#619)
 
 ### Changed
@@ -17,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Transient library-fetch failures on any *arr no longer produce a recurring `upgrade pool fetch failed` log row each upgrade cycle. (#620)
+- Transient library-fetch failures on any \*arr no longer produce a recurring `upgrade pool fetch failed` log row each upgrade cycle. (#620)
 
 ### Security
 
@@ -62,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Per-instance `upgrade_series_window_size` setting (default `5`, range `1-100`) for Sonarr and Whisparr v2 tunes the upgrade pool series window; existing instances pick up the default at migration time. (#495)
-- Dashboard counters auto-refresh every 10 minutes via a supervisor snapshot loop, displaying per-instance monitored and unreleased totals without polling each *arr on every status request. (#461)
+- Dashboard counters auto-refresh every 10 minutes via a supervisor snapshot loop, displaying per-instance monitored and unreleased totals without polling each \*arr on every status request. (#461)
 - Per-instance hourly budget meter, search-kind icons on `Recent hunts` and `Cooldown schedule` rows, live next-patrol countdown anchored on supervisor cycle-end signals, stale-snapshot pill when monitor data exceeds 15 minutes, multi-instance error banner, and tooltips on the headline stats. (#503)
 - Settings page `Admin` dropdown adds Maintenance (`clear logs`) and Danger (`factory reset`) controls, and reorganises password and changelog preferences into the same collapsible surface. (#475)
 - Caps Lock badge on password fields appears when Caps Lock is active or when the field receives focus while Caps Lock is already on. (#499)
@@ -75,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Login and setup pages redesigned with a Station auth card (logo topbar, eyebrow, accented headings, single-column form, version footer). (#499)
 - Random search order now uses a stratified-shuffle page deck plus partial-page sentinel padding, so per-page and per-item dispatch probability stays uniform across the backlog without wrap-once or last-page over-selection. (#491)
 - Hourly rate-limit skip rows now read `hourly limit reached (N/hr)` across missing, cutoff, and upgrade passes. (#491)
-- Cooldown rows stamp their `search_kind` (missing, cutoff, upgrade) at insert time and a supervisor reconcile step prunes cooldowns whose items are no longer wanted on the *arr side, restoring accurate dashboard breakdown counts. (#463)
+- Cooldown rows stamp their `search_kind` (missing, cutoff, upgrade) at insert time and a supervisor reconcile step prunes cooldowns whose items are no longer wanted on the \*arr side, restoring accurate dashboard breakdown counts. (#463)
 - Build pipeline compiles Tailwind v4 and daisyUI v5 locally at Docker build time, eliminating the Tailwind play CDN and the `unpkg` htmx script. (#481)
 - Unified `status-dot`, `status-pill`, and `station-tooltip` components with a cyan accent band and accessible focus states across dashboard, settings, and instance forms. (#487)
 - Schema v16 disambiguates Whisparr v2 from the product family: an idempotent migration renames `whisparr_search_mode` and `upgrade_whisparr_search_mode` columns and rewrites stored `whisparr_episode` item-type values to their `whisparr_v2_*` counterparts; existing instances retain settings and id. (#493)
@@ -149,7 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Connection testing now verifies the remote application type matches the selected instance type, preventing misconfiguration (e.g. a Sonarr URL saved as Radarr). (#333)
-- Compatibility table in the installation docs listing tested *arr versions and Readarr fork support. (#333)
+- Compatibility table in the installation docs listing tested \*arr versions and Readarr fork support. (#333)
 
 ### Fixed
 
@@ -241,7 +242,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `HOUNDARR_TRUSTED_PROXIES` now accepts CIDR subnets (e.g. `172.18.0.0/16`) in addition to individual IP addresses (#245, #248)
 - Kubernetes deployment guide with StatefulSet, headless Service, and Ingress examples (#255)
-- FAQ entry explaining why Houndarr exists alongside built-in *arr search (#253)
+- FAQ entry explaining why Houndarr exists alongside built-in \*arr search (#253)
 
 ---
 
@@ -324,7 +325,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Settings help panel now describes search modes for all four apps that support them (Sonarr, Lidarr, Readarr, Whisparr) instead of Sonarr only (#210)
-- All *arr app listings across code, UI, docs, and website now use the canonical order: Radarr, Sonarr, Lidarr, Readarr, Whisparr (#210)
+- All \*arr app listings across code, UI, docs, and website now use the canonical order: Radarr, Sonarr, Lidarr, Readarr, Whisparr (#210)
 - Bug report template version field expanded from "Sonarr / Radarr" to include all five apps (#210)
 
 ---
@@ -369,9 +370,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Connection errors now write exactly one `action="error"` log row per outage instead of one per retry, preventing the dashboard *24h errors* counter from inflating during startup races or service restarts (#140)
+- Connection errors now write exactly one `action="error"` log row per outage instead of one per retry, preventing the dashboard _24h errors_ counter from inflating during startup races or service restarts (#140)
 - A recovery `action="info"` row is now written to `search_log` when an unreachable instance becomes reachable again, making the recovery event visible on the Logs page (#140)
-- A 10-second startup grace delay before the first search cycle gives co-located *arr services time to become ready (#140)
+- A 10-second startup grace delay before the first search cycle gives co-located \*arr services time to become ready (#140)
 
 ---
 
@@ -402,7 +403,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   waiting the full search interval, and logs an `INFO` recovery message once
   the instance is reachable again (#119)
 - UI Logs page message for connection errors now reads `"Could not reach
-  <url>"` instead of the raw internal error string (#119)
+<url>"` instead of the raw internal error string (#119)
 
 ---
 
@@ -441,6 +442,7 @@ First stable public release.
 ### Added
 
 #### Core
+
 - Automated missing-media search engine for Radarr and Sonarr instances
 - Episode-level search for Sonarr (`EpisodeSearch` + `episodeIds`) with optional
   season-context mode (`SeasonSearch`)
@@ -454,6 +456,7 @@ First stable public release.
   10-second shutdown
 
 #### Web UI
+
 - Dark-themed responsive web interface (FastAPI + Jinja2 + HTMX + Tailwind CSS CDN)
 - Live dashboard with instance status cards, stats grid, and run-now buttons
 - HTMX-driven partial updates (no full-page reloads after initial load)
@@ -464,6 +467,7 @@ First stable public release.
 - Cycle-grouped log display with summary statistics
 
 #### Authentication and Security
+
 - Single-admin username + bcrypt password authentication (cost 12)
 - Signed session tokens via itsdangerous
 - CSRF double-submit cookie protection on all mutating endpoints
@@ -476,6 +480,7 @@ First stable public release.
 - API key masking in UI (sentinel `__UNCHANGED__` pattern)
 
 #### Infrastructure
+
 - Single-container Docker deployment (`python:3.12-slim`, `gosu` for PUID/PGID)
 - Multi-arch container builds (amd64/arm64) via GitHub Actions
 - Automated GHCR publishing on version tags
@@ -485,6 +490,7 @@ First stable public release.
 - Click CLI with environment variable support for all configuration options
 
 #### CI/CD
+
 - Ruff linting and formatting checks
 - mypy strict type checking
 - Bandit SAST scanning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- External `/api/v1/widget` endpoint returns API-key-protected dashboard totals, backed by schema v19 `widget_api_key` storage. (#604)
 - Instance settings gain an `Enable missing search` toggle that pauses the missing-search pass per instance; existing instances stay enabled after the v18 migration. (#619)
 
 ### Changed
@@ -17,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Transient library-fetch failures on any *arr no longer produce a recurring `upgrade pool fetch failed` log row each upgrade cycle. (#620)
+- Transient library-fetch failures on any \*arr no longer produce a recurring `upgrade pool fetch failed` log row each upgrade cycle. (#620)
 
 ### Security
 
@@ -63,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Per-instance `upgrade_series_window_size` setting (default `5`, range `1-100`) for Sonarr and Whisparr v2 tunes the upgrade pool series window; existing instances pick up the default at migration time. (#495)
-- Dashboard counters auto-refresh every 10 minutes via a supervisor snapshot loop, displaying per-instance monitored and unreleased totals without polling each *arr on every status request. (#461)
+- Dashboard counters auto-refresh every 10 minutes via a supervisor snapshot loop, displaying per-instance monitored and unreleased totals without polling each \*arr on every status request. (#461)
 - Per-instance hourly budget meter, search-kind icons on `Recent hunts` and `Cooldown schedule` rows, live next-patrol countdown anchored on supervisor cycle-end signals, stale-snapshot pill when monitor data exceeds 15 minutes, multi-instance error banner, and tooltips on the headline stats. (#503)
 - Settings page `Admin` dropdown adds Maintenance (`clear logs`) and Danger (`factory reset`) controls, and reorganises password and changelog preferences into the same collapsible surface. (#475)
 - Caps Lock badge on password fields appears when Caps Lock is active or when the field receives focus while Caps Lock is already on. (#499)
@@ -76,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Login and setup pages redesigned with a Station auth card (logo topbar, eyebrow, accented headings, single-column form, version footer). (#499)
 - Random search order now uses a stratified-shuffle page deck plus partial-page sentinel padding, so per-page and per-item dispatch probability stays uniform across the backlog without wrap-once or last-page over-selection. (#491)
 - Hourly rate-limit skip rows now read `hourly limit reached (N/hr)` across missing, cutoff, and upgrade passes. (#491)
-- Cooldown rows stamp their `search_kind` (missing, cutoff, upgrade) at insert time and a supervisor reconcile step prunes cooldowns whose items are no longer wanted on the *arr side, restoring accurate dashboard breakdown counts. (#463)
+- Cooldown rows stamp their `search_kind` (missing, cutoff, upgrade) at insert time and a supervisor reconcile step prunes cooldowns whose items are no longer wanted on the \*arr side, restoring accurate dashboard breakdown counts. (#463)
 - Build pipeline compiles Tailwind v4 and daisyUI v5 locally at Docker build time, eliminating the Tailwind play CDN and the `unpkg` htmx script. (#481)
 - Unified `status-dot`, `status-pill`, and `station-tooltip` components with a cyan accent band and accessible focus states across dashboard, settings, and instance forms. (#487)
 - Schema v16 disambiguates Whisparr v2 from the product family: an idempotent migration renames `whisparr_search_mode` and `upgrade_whisparr_search_mode` columns and rewrites stored `whisparr_episode` item-type values to their `whisparr_v2_*` counterparts; existing instances retain settings and id. (#493)
@@ -150,7 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Connection testing now verifies the remote application type matches the selected instance type, preventing misconfiguration (e.g. a Sonarr URL saved as Radarr). (#333)
-- Compatibility table in the installation docs listing tested *arr versions and Readarr fork support. (#333)
+- Compatibility table in the installation docs listing tested \*arr versions and Readarr fork support. (#333)
 
 ### Fixed
 
@@ -242,7 +243,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `HOUNDARR_TRUSTED_PROXIES` now accepts CIDR subnets (e.g. `172.18.0.0/16`) in addition to individual IP addresses (#245, #248)
 - Kubernetes deployment guide with StatefulSet, headless Service, and Ingress examples (#255)
-- FAQ entry explaining why Houndarr exists alongside built-in *arr search (#253)
+- FAQ entry explaining why Houndarr exists alongside built-in \*arr search (#253)
 
 ---
 
@@ -325,7 +326,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Settings help panel now describes search modes for all four apps that support them (Sonarr, Lidarr, Readarr, Whisparr) instead of Sonarr only (#210)
-- All *arr app listings across code, UI, docs, and website now use the canonical order: Radarr, Sonarr, Lidarr, Readarr, Whisparr (#210)
+- All \*arr app listings across code, UI, docs, and website now use the canonical order: Radarr, Sonarr, Lidarr, Readarr, Whisparr (#210)
 - Bug report template version field expanded from "Sonarr / Radarr" to include all five apps (#210)
 
 ---
@@ -370,9 +371,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Connection errors now write exactly one `action="error"` log row per outage instead of one per retry, preventing the dashboard *24h errors* counter from inflating during startup races or service restarts (#140)
+- Connection errors now write exactly one `action="error"` log row per outage instead of one per retry, preventing the dashboard _24h errors_ counter from inflating during startup races or service restarts (#140)
 - A recovery `action="info"` row is now written to `search_log` when an unreachable instance becomes reachable again, making the recovery event visible on the Logs page (#140)
-- A 10-second startup grace delay before the first search cycle gives co-located *arr services time to become ready (#140)
+- A 10-second startup grace delay before the first search cycle gives co-located \*arr services time to become ready (#140)
 
 ---
 
@@ -403,7 +404,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   waiting the full search interval, and logs an `INFO` recovery message once
   the instance is reachable again (#119)
 - UI Logs page message for connection errors now reads `"Could not reach
-  <url>"` instead of the raw internal error string (#119)
+<url>"` instead of the raw internal error string (#119)
 
 ---
 
@@ -442,6 +443,7 @@ First stable public release.
 ### Added
 
 #### Core
+
 - Automated missing-media search engine for Radarr and Sonarr instances
 - Episode-level search for Sonarr (`EpisodeSearch` + `episodeIds`) with optional
   season-context mode (`SeasonSearch`)
@@ -455,6 +457,7 @@ First stable public release.
   10-second shutdown
 
 #### Web UI
+
 - Dark-themed responsive web interface (FastAPI + Jinja2 + HTMX + Tailwind CSS CDN)
 - Live dashboard with instance status cards, stats grid, and run-now buttons
 - HTMX-driven partial updates (no full-page reloads after initial load)
@@ -465,6 +468,7 @@ First stable public release.
 - Cycle-grouped log display with summary statistics
 
 #### Authentication and Security
+
 - Single-admin username + bcrypt password authentication (cost 12)
 - Signed session tokens via itsdangerous
 - CSRF double-submit cookie protection on all mutating endpoints
@@ -477,6 +481,7 @@ First stable public release.
 - API key masking in UI (sentinel `__UNCHANGED__` pattern)
 
 #### Infrastructure
+
 - Single-container Docker deployment (`python:3.12-slim`, `gosu` for PUID/PGID)
 - Multi-arch container builds (amd64/arm64) via GitHub Actions
 - Automated GHCR publishing on version tags
@@ -486,6 +491,7 @@ First stable public release.
 - Click CLI with environment variable support for all configuration options
 
 #### CI/CD
+
 - Ruff linting and formatting checks
 - mypy strict type checking
 - Bandit SAST scanning

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -235,6 +235,7 @@ def create_app() -> FastAPI:
     from houndarr.routes.admin import router as admin_router
     from houndarr.routes.api.logs import router as logs_router
     from houndarr.routes.api.status import router as status_router
+    from houndarr.routes.api.widget import router as widget_router
     from houndarr.routes.changelog import router as changelog_router
     from houndarr.routes.health import router as health_router
     from houndarr.routes.pages import router as pages_router
@@ -244,6 +245,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router)
     app.include_router(status_router)
     app.include_router(logs_router)
+    app.include_router(widget_router)
     app.include_router(pages_router)
     app.include_router(settings_router)
     app.include_router(changelog_router)

--- a/src/houndarr/auth/__init__.py
+++ b/src/houndarr/auth/__init__.py
@@ -35,8 +35,9 @@ if TYPE_CHECKING:
     _setup_complete: bool | None
     _USERNAME_PATTERN: re.Pattern[str]
 from houndarr.auth.csrf import _CSRF_PROTECTED_METHODS, validate_csrf
+from houndarr.auth.houndarr_api_key import generate_api_key, hash_api_key, verify_api_key
 from houndarr.auth.identity import resolve_signed_in_as
-from houndarr.auth.middleware import _LOGOUT_PATH, _PUBLIC_PATHS, AuthMiddleware
+from houndarr.auth.middleware import _API_KEY_PATHS, _LOGOUT_PATH, _PUBLIC_PATHS, AuthMiddleware
 from houndarr.auth.password import BCRYPT_COST, hash_password, verify_password
 from houndarr.auth.proxy_auth import (
     _PROXY_DEAD_PATHS,
@@ -52,10 +53,15 @@ from houndarr.auth.rate_limit import (
     _LOGIN_WINDOW_SECONDS,
     _client_ip,
     _login_attempts,
+    _widget_key_attempts,
     check_login_rate_limit,
+    check_widget_key_rate_limit,
     clear_login_attempts,
+    clear_widget_key_attempts,
     record_failed_login,
+    record_failed_widget_key_attempt,
     reset_login_attempts,
+    reset_widget_key_attempts,
 )
 from houndarr.auth.session import (
     CSRF_COOKIE_NAME,
@@ -90,6 +96,7 @@ __all__ = [
     "USERNAME_MAX_LENGTH",
     "USERNAME_MIN_LENGTH",
     "AuthMiddleware",
+    "_API_KEY_PATHS",
     "_CSRF_PROTECTED_METHODS",
     "_LOGIN_MAX_ATTEMPTS",
     "_LOGIN_WINDOW_SECONDS",
@@ -105,20 +112,27 @@ __all__ = [
     "_login_attempts",
     "_validate_proxy_auth",
     "_validate_proxy_csrf",
+    "_widget_key_attempts",
     "check_credentials",
     "check_login_rate_limit",
     "check_password",
+    "check_widget_key_rate_limit",
     "clear_login_attempts",
     "clear_session",
+    "clear_widget_key_attempts",
     "create_session",
+    "generate_api_key",
     "get_session_csrf_token",
     "get_username",
+    "hash_api_key",
     "hash_password",
     "is_setup_complete",
     "normalize_username",
     "record_failed_login",
+    "record_failed_widget_key_attempt",
     "reset_auth_caches",
     "reset_login_attempts",
+    "reset_widget_key_attempts",
     "resolve_signed_in_as",
     "rotate_session_secret",
     "set_password",
@@ -126,6 +140,7 @@ __all__ = [
     "validate_csrf",
     "validate_session",
     "validate_username",
+    "verify_api_key",
     "verify_password",
 ]
 

--- a/src/houndarr/auth/houndarr_api_key.py
+++ b/src/houndarr/auth/houndarr_api_key.py
@@ -1,0 +1,25 @@
+"""Houndarr API key token generation and verification helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from hmac import compare_digest
+
+_TOKEN_PREFIX = "hndarr_"  # noqa: S105  # nosec B105 -- Public prefix, not a credential.
+_TOKEN_BYTES = 32
+
+
+def generate_api_key() -> str:
+    """Generate a new plaintext Houndarr API key token."""
+    return f"{_TOKEN_PREFIX}{secrets.token_urlsafe(_TOKEN_BYTES)}"
+
+
+def hash_api_key(token: str) -> str:
+    """Return the SHA-256 hex digest for *token*."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def verify_api_key(token: str, stored_hash: str) -> bool:
+    """Return whether *token* matches *stored_hash* using constant-time comparison."""
+    return compare_digest(hash_api_key(token), stored_hash)

--- a/src/houndarr/auth/houndarr_api_key.py
+++ b/src/houndarr/auth/houndarr_api_key.py
@@ -17,6 +17,8 @@ def generate_api_key() -> str:
 
 def hash_api_key(token: str) -> str:
     """Return the SHA-256 hex digest for *token*."""
+    # API keys are 256-bit random bearer tokens; SHA-256 stores a deterministic lookup digest.
+    # codeql[py/weak-sensitive-data-hashing]
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 

--- a/src/houndarr/auth/middleware.py
+++ b/src/houndarr/auth/middleware.py
@@ -1,10 +1,9 @@
 """ASGI middleware that composes every auth seam.
 
-Two dispatch branches share the same middleware: ``_dispatch_builtin``
-for session-cookie mode (the default) and ``_dispatch_proxy`` for
-reverse-proxy / SSO mode.  Each branch reads its public-path list and
-then delegates trust, identity, and CSRF decisions to the appropriate
-seam submodule.
+Three dispatch buckets share the same middleware: API-key-only routes,
+``_dispatch_builtin`` for session-cookie mode (the default), and
+``_dispatch_proxy`` for reverse-proxy / SSO mode.  Each bucket delegates
+trust, identity, and CSRF decisions to the appropriate seam submodule.
 
 Helpers are called through their owning modules (for example
 ``proxy_auth._is_trusted_proxy(request)`` instead of a direct
@@ -18,16 +17,18 @@ from __future__ import annotations
 import logging
 
 from fastapi import Request, Response
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.types import ASGIApp
 
+from houndarr.auth import houndarr_api_key as _houndarr_api_key
 from houndarr.auth import proxy_auth as _proxy_auth
 from houndarr.auth import rate_limit as _rate_limit
 from houndarr.auth.csrf import _CSRF_PROTECTED_METHODS, validate_csrf
 from houndarr.auth.session import CSRF_COOKIE_NAME, validate_session
 from houndarr.auth.setup import is_setup_complete
 from houndarr.config import get_settings
+from houndarr.repositories import widget_api_key as _widget_api_key_repo
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,8 @@ _PUBLIC_PATHS = frozenset(
         "/static",
     ]
 )
+
+_API_KEY_PATHS = frozenset(["/api/v1/widget"])
 
 # Logout is a safe, destructive-free action (session invalidation only).
 # We allow it without CSRF/session validation so stale legacy sessions
@@ -82,9 +85,49 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         path = request.url.path
 
+        if path in _API_KEY_PATHS:
+            return await self._dispatch_api_key(request, call_next)
         if _proxy_auth._is_proxy_auth_mode():
             return await self._dispatch_proxy(request, call_next, path)
         return await self._dispatch_builtin(request, call_next, path)
+
+    # ------------------------------------------------------------------
+    # API key auth path
+    # ------------------------------------------------------------------
+
+    async def _dispatch_api_key(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        """Require a valid Houndarr API key for external widget routes."""
+        submitted = request.headers.get("X-Api-Key")
+        stored = await _widget_api_key_repo.get()
+        if (
+            submitted is not None
+            and stored is not None
+            and _houndarr_api_key.verify_api_key(
+                submitted,
+                stored.hash,
+            )
+        ):
+            _rate_limit.clear_widget_key_attempts(request)
+            await _widget_api_key_repo.touch_last_used()
+            return await call_next(request)
+
+        if not _rate_limit.check_widget_key_rate_limit(request):
+            return JSONResponse(
+                {"detail": "Too many API key attempts."},
+                status_code=429,
+                headers={"Retry-After": "60"},
+            )
+
+        _rate_limit.record_failed_widget_key_attempt(request)
+        return JSONResponse(
+            {"detail": "Invalid API key."},
+            status_code=401,
+            headers={"WWW-Authenticate": "ApiKey"},
+        )
 
     # ------------------------------------------------------------------
     # Builtin auth path (existing behaviour, unchanged)

--- a/src/houndarr/auth/rate_limit.py
+++ b/src/houndarr/auth/rate_limit.py
@@ -21,6 +21,7 @@ from fastapi import Request
 from houndarr.config import get_settings
 
 _login_attempts: dict[str, list[float]] = {}
+_widget_key_attempts: dict[str, list[float]] = {}
 _LOGIN_MAX_ATTEMPTS = 5
 _LOGIN_WINDOW_SECONDS = 60
 
@@ -53,30 +54,55 @@ def _client_ip(request: Request) -> str:
     return direct_ip
 
 
-def check_login_rate_limit(request: Request) -> bool:
-    """Return True if the client is allowed to attempt login."""
+def _check_rate_limit(bucket: dict[str, list[float]], request: Request) -> bool:
+    """Return whether *request* may try another authentication attempt."""
     ip = _client_ip(request)
     now = time.time()
-    attempts = _login_attempts.get(ip, [])
-    # Remove attempts outside the window
+    attempts = bucket.get(ip, [])
     attempts = [t for t in attempts if now - t < _LOGIN_WINDOW_SECONDS]
-    _login_attempts[ip] = attempts
+    bucket[ip] = attempts
     return len(attempts) < _LOGIN_MAX_ATTEMPTS
+
+
+def _record_failed_attempt(bucket: dict[str, list[float]], request: Request) -> None:
+    """Record one failed authentication attempt in *bucket*."""
+    ip = _client_ip(request)
+    now = time.time()
+    attempts = bucket.get(ip, [])
+    attempts.append(now)
+    bucket[ip] = attempts
+
+
+def check_login_rate_limit(request: Request) -> bool:
+    """Return True if the client is allowed to attempt login."""
+    return _check_rate_limit(_login_attempts, request)
 
 
 def record_failed_login(request: Request) -> None:
     """Record a failed login attempt for rate limiting."""
-    ip = _client_ip(request)
-    now = time.time()
-    attempts = _login_attempts.get(ip, [])
-    attempts.append(now)
-    _login_attempts[ip] = attempts
+    _record_failed_attempt(_login_attempts, request)
+
+
+def check_widget_key_rate_limit(request: Request) -> bool:
+    """Return True if the client is allowed to try a widget API key."""
+    return _check_rate_limit(_widget_key_attempts, request)
+
+
+def record_failed_widget_key_attempt(request: Request) -> None:
+    """Record a failed widget API key attempt for rate limiting."""
+    _record_failed_attempt(_widget_key_attempts, request)
 
 
 def clear_login_attempts(request: Request) -> None:
     """Clear login attempts on successful login."""
     ip = _client_ip(request)
     _login_attempts.pop(ip, None)
+
+
+def clear_widget_key_attempts(request: Request) -> None:
+    """Clear widget key attempts on successful API key verification."""
+    ip = _client_ip(request)
+    _widget_key_attempts.pop(ip, None)
 
 
 def reset_login_attempts() -> None:
@@ -88,3 +114,8 @@ def reset_login_attempts() -> None:
     seam's module-private dict.
     """
     _login_attempts.clear()
+
+
+def reset_widget_key_attempts() -> None:
+    """Drop every tracked widget API key failure bucket."""
+    _widget_key_attempts.clear()

--- a/src/houndarr/auth/setup.py
+++ b/src/houndarr/auth/setup.py
@@ -144,3 +144,4 @@ def reset_auth_caches() -> None:
     _session.reset_serializer()
     _setup_complete = None
     _rate_limit.reset_login_attempts()
+    _rate_limit.reset_widget_key_attempts()

--- a/src/houndarr/database.py
+++ b/src/houndarr/database.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Schema version: bump when adding new migrations
 # ---------------------------------------------------------------------------
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -48,6 +48,13 @@ _SCHEMA_SQL = f"""
 CREATE TABLE IF NOT EXISTS settings (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS widget_api_key (
+    id           INTEGER PRIMARY KEY CHECK(id = 1),
+    hash         TEXT    NOT NULL CHECK(length(hash) = 64 AND hash NOT GLOB '*[^0-9a-f]*'),
+    created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_used_at TEXT
 );
 
 CREATE TABLE IF NOT EXISTS instances (
@@ -337,6 +344,7 @@ async def init_db_migrations() -> None:
         await _migrate_to_v16(db)
         await _migrate_to_v17(db)
         await _migrate_to_v18(db)
+        await _migrate_to_v19(db)
         await _ensure_v3_indexes(db)
         # PRAGMA optimize keeps the planner's sqlite_stat1 entries fresh as
         # search_log grows.  Cheap on healthy DBs, prevents silent index
@@ -394,6 +402,8 @@ async def _run_migrations(db: aiosqlite.Connection, from_version: int) -> None:
         await _migrate_to_v17(db)
     if from_version < 18:
         await _migrate_to_v18(db)
+    if from_version < 19:
+        await _migrate_to_v19(db)
 
     logger.info("Migrated database from schema version %d to %d", from_version, SCHEMA_VERSION)
     await db.execute(
@@ -1409,6 +1419,20 @@ async def _migrate_to_v18(db: aiosqlite.Connection) -> None:
         await db.execute(
             "ALTER TABLE instances ADD COLUMN missing_enabled INTEGER NOT NULL DEFAULT 1"
         )
+
+
+async def _migrate_to_v19(db: aiosqlite.Connection) -> None:
+    """Add the single-row Houndarr API key table for widget access."""
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS widget_api_key (
+            id           INTEGER PRIMARY KEY CHECK(id = 1),
+            hash         TEXT    NOT NULL CHECK(length(hash) = 64 AND hash NOT GLOB '*[^0-9a-f]*'),
+            created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            last_used_at TEXT
+        )
+        """
+    )
 
 
 async def _column_exists(db: aiosqlite.Connection, table_name: str, column_name: str) -> bool:

--- a/src/houndarr/protocols.py
+++ b/src/houndarr/protocols.py
@@ -18,7 +18,7 @@ from typing import Any, Literal, Protocol, runtime_checkable
 
 from houndarr.clients.base import ArrClient
 from houndarr.services.instances import Instance
-from houndarr.value_objects import ItemRef
+from houndarr.value_objects import ItemRef, WidgetApiKey
 
 # ``RunNowStatus`` is duplicated here (rather than imported from
 # ``houndarr.engine.supervisor``) so this Protocol module stays
@@ -45,6 +45,27 @@ class SettingsRepository(Protocol):
 
     def delete_setting(self, key: str) -> Awaitable[None]:
         """Remove *key* if it exists (no error if already absent)."""
+        ...
+
+
+@runtime_checkable
+class WidgetApiKeyRepository(Protocol):
+    """Storage boundary for the single widget API key row."""
+
+    def get(self) -> Awaitable[WidgetApiKey | None]:
+        """Return the active widget API key metadata, if configured."""
+        ...
+
+    def set(self, key_hash: str) -> Awaitable[WidgetApiKey]:
+        """Store *key_hash* as the active widget API key."""
+        ...
+
+    def touch_last_used(self) -> Awaitable[None]:
+        """Mark the active widget API key as successfully used."""
+        ...
+
+    def revoke(self) -> Awaitable[None]:
+        """Remove the active widget API key if one exists."""
         ...
 
 
@@ -252,4 +273,5 @@ __all__ = [
     "SearchLogRepository",
     "SettingsRepository",
     "SupervisorProto",
+    "WidgetApiKeyRepository",
 ]

--- a/src/houndarr/repositories/__init__.py
+++ b/src/houndarr/repositories/__init__.py
@@ -5,6 +5,8 @@ Every module here implements one of the Protocols declared in
 
 - ``settings.py``: key-value reads and writes for the ``settings``
   table.
+- ``widget_api_key.py``: single-row Houndarr API key storage for the
+  external widget endpoint.
 - ``instances.py``: ``instances`` table CRUD with
   :class:`InstanceInsert` and :class:`InstanceUpdate` payload
   dataclasses.
@@ -22,8 +24,8 @@ aggregate.  Callers depend on the structural Protocol shape, not on
 the concrete repository import, which keeps the boundary
 test-swappable without subclass gymnastics.
 
-Schema migrations (``_migrate_to_v2`` through ``_migrate_to_v13``)
-stay in :mod:`houndarr.database` and are off-limits here; repository
+Schema migrations stay in :mod:`houndarr.database` and are off-limits
+here; repository
 functions only wrap ``get_db()`` queries and never alter schema,
 PRAGMAs, or the WAL lifecycle.
 """

--- a/src/houndarr/repositories/widget_api_key.py
+++ b/src/houndarr/repositories/widget_api_key.py
@@ -1,0 +1,70 @@
+"""Repository functions for the single Houndarr widget API key."""
+
+from __future__ import annotations
+
+import re
+
+from houndarr.database import get_db
+from houndarr.value_objects import WidgetApiKey
+
+_HASH_RE = re.compile(r"[0-9a-f]{64}")
+
+
+async def get() -> WidgetApiKey | None:
+    """Return the stored widget API key metadata, if one exists."""
+    async with get_db() as db:
+        async with db.execute(
+            "SELECT hash, created_at, last_used_at FROM widget_api_key WHERE id = 1"
+        ) as cur:
+            row = await cur.fetchone()
+    if row is None:
+        return None
+    return WidgetApiKey(
+        hash=row["hash"],
+        created_at=row["created_at"],
+        last_used_at=row["last_used_at"],
+    )
+
+
+async def set(key_hash: str) -> WidgetApiKey:
+    """Store *key_hash* as the active widget API key and return its metadata."""
+    if _HASH_RE.fullmatch(key_hash) is None:
+        raise ValueError("widget API key hash must be a SHA-256 hex digest")
+
+    async with get_db() as db:
+        await db.execute(
+            """
+            INSERT INTO widget_api_key (id, hash, created_at, last_used_at)
+            VALUES (1, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), NULL)
+            ON CONFLICT(id) DO UPDATE SET
+                hash = excluded.hash,
+                created_at = excluded.created_at,
+                last_used_at = NULL
+            """,
+            (key_hash,),
+        )
+        await db.commit()
+    stored = await get()
+    if stored is None:
+        raise RuntimeError("widget API key write did not persist")
+    return stored
+
+
+async def touch_last_used() -> None:
+    """Mark the active widget API key as used at the current UTC time."""
+    async with get_db() as db:
+        await db.execute(
+            """
+            UPDATE widget_api_key
+            SET last_used_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            WHERE id = 1
+            """
+        )
+        await db.commit()
+
+
+async def revoke() -> None:
+    """Delete the active widget API key if one exists."""
+    async with get_db() as db:
+        await db.execute("DELETE FROM widget_api_key WHERE id = 1")
+        await db.commit()

--- a/src/houndarr/routes/api/__init__.py
+++ b/src/houndarr/routes/api/__init__.py
@@ -1,6 +1,8 @@
-"""JSON API routes consumed by the dashboard poll loop.
+"""JSON API routes consumed by the dashboard and external widget.
 
 :mod:`~houndarr.routes.api.status` returns the per-instance aggregate
 bundle the dashboard polls; :mod:`~houndarr.routes.api.logs` returns
-cursor-paginated ``search_log`` rows for the Logs page feed.
+cursor-paginated ``search_log`` rows for the Logs page feed;
+:mod:`~houndarr.routes.api.widget` returns the stable read-only widget
+summary for external dashboards.
 """

--- a/src/houndarr/routes/api/widget.py
+++ b/src/houndarr/routes/api/widget.py
@@ -1,0 +1,51 @@
+"""External widget API route."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from houndarr.database import get_db
+from houndarr.engine.supervisor import Supervisor
+from houndarr.services.metrics import gather_cached_searches_7d, gather_dashboard_status
+from houndarr.services.widget_metrics import compute_widget_summary
+
+router = APIRouter()
+
+
+def _generated_at() -> str:
+    """Return the current UTC timestamp for the widget envelope."""
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+@router.get("/api/v1/widget")
+async def get_widget(request: Request) -> JSONResponse:
+    """Return the stable read-only widget summary envelope."""
+    supervisor = getattr(request.app.state, "supervisor", None)
+    cycle_ends: dict[int, str] = (
+        supervisor.cycle_end_timestamps() if isinstance(supervisor, Supervisor) else {}
+    )
+    aggregate_cache = getattr(request.app.state, "aggregate_cache", None)
+    async with get_db() as db:
+        envelope = await gather_dashboard_status(
+            db,
+            cycle_ends=cycle_ends,
+            aggregate_cache=aggregate_cache,
+        )
+        instances = envelope.get("instances", [])
+        instance_ids = [int(row["id"]) for row in instances if "id" in row]
+        searches_7d = await gather_cached_searches_7d(
+            db,
+            instance_ids=instance_ids,
+            aggregate_cache=aggregate_cache,
+        )
+
+    widget_envelope: dict[str, Any] = {
+        "schema": 1,
+        "generated_at": _generated_at(),
+        "totals": compute_widget_summary(envelope, searches_7d),
+    }
+    return JSONResponse(widget_envelope)

--- a/src/houndarr/services/metrics.py
+++ b/src/houndarr/services/metrics.py
@@ -20,8 +20,8 @@ rows the SQL produces, and pulling it apart would force the caller
 to re-derive the same per-row context.
 
 Single-process cache (issue #586):  :func:`build_aggregate_cache`
-returns an ``alru_cache``-wrapped coroutine that batches the four
-slow DB-aggregation gathers into a single :class:`DashboardAggregates`
+returns an ``alru_cache``-wrapped coroutine that batches the slow
+DB-aggregation gathers into a single :class:`DashboardAggregates`
 result and caches it for ~20 s.  The cache lives on ``app.state``
 because ``async-lru`` is event-loop-bound (a module-level decorator
 binds to the first test's loop and raises on every subsequent test);
@@ -69,6 +69,13 @@ SELECT
 FROM search_log
 WHERE instance_id IN ({placeholders})
 GROUP BY instance_id
+"""
+
+_SEARCHES_7D_SQL = """
+SELECT COUNT(*) AS searches_7d
+FROM search_log
+WHERE action = 'searched'
+  AND timestamp > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-7 days')
 """
 
 _LAST_ACTIVITY_SQL = """
@@ -299,6 +306,7 @@ class DashboardAggregates:
     lifetime_map: dict[int, dict[str, Any]] = field(default_factory=dict)
     error_map: dict[int, dict[str, Any]] = field(default_factory=dict)
     recent: list[dict[str, Any]] = field(default_factory=list)
+    searches_7d: int = 0
 
 
 # Narrow surface: the route awaits the call; invalidation calls cache_clear.
@@ -327,11 +335,11 @@ async def _gather_dashboard_aggregates(
     request.  Returns an empty bundle for the no-instances case so the
     cache key is stable (an empty tuple maps to the same bundle).
     """
-    if not instance_ids_tuple:
-        return DashboardAggregates()
-
     instance_ids = list(instance_ids_tuple)
     async with get_db() as db:
+        searches_7d = await gather_searches_7d(db)
+        if not instance_ids:
+            return DashboardAggregates(searches_7d=searches_7d)
         metrics_map, activity_map = await gather_window_metrics(db, instance_ids)
         lifetime_map = await gather_lifetime_metrics(db, instance_ids)
         error_map = await gather_active_errors(db, instance_ids)
@@ -343,6 +351,7 @@ async def _gather_dashboard_aggregates(
         lifetime_map=lifetime_map,
         error_map=error_map,
         recent=recent,
+        searches_7d=searches_7d,
     )
 
 
@@ -473,6 +482,26 @@ async def gather_dashboard_status(
             )
         )
     return {"instances": rows, "recent_searches": recent}
+
+
+async def gather_searches_7d(db: aiosqlite.Connection) -> int:
+    """Return the rolling 7-day successful search count."""
+    async with db.execute(_SEARCHES_7D_SQL) as cur:  # nosem
+        row = await cur.fetchone()
+    return int(row["searches_7d"] if row is not None else 0)
+
+
+async def gather_cached_searches_7d(
+    db: aiosqlite.Connection,
+    *,
+    instance_ids: list[int],
+    aggregate_cache: DashboardAggregateCache | None = None,
+) -> int:
+    """Return the rolling 7-day searched count using the dashboard cache when available."""
+    if aggregate_cache is None:
+        return await gather_searches_7d(db)
+    aggregates = await aggregate_cache(tuple(sorted(instance_ids)))
+    return aggregates.searches_7d
 
 
 async def gather_window_metrics(

--- a/src/houndarr/services/widget_metrics.py
+++ b/src/houndarr/services/widget_metrics.py
@@ -1,0 +1,69 @@
+"""Pure aggregation helpers for the external widget API."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import isfinite
+from typing import Any
+
+
+def _to_int(value: Any) -> int:
+    """Coerce dashboard JSON scalar values with the same tolerance as JavaScript Number."""
+    if value is None:
+        return 0
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0
+    if not isfinite(number):
+        return 0
+    return int(number)
+
+
+def compute_widget_summary(envelope: Mapping[str, Any], searches_7d: int) -> dict[str, int]:
+    """Return the stable widget totals from a dashboard status envelope.
+
+    Eligible mirrors the dashboard card invariant: clamp each instance before
+    summing so one stale cooldown overshoot cannot drain another instance's
+    positive eligible count.
+    """
+    totals = {
+        "eligible": 0,
+        "gated": 0,
+        "unreleased": 0,
+        "upgrade": 0,
+    }
+    instances = envelope.get("instances", [])
+    if not isinstance(instances, list):
+        instances = []
+
+    for instance in instances:
+        if not isinstance(instance, Mapping):
+            continue
+        if not instance.get("enabled") or instance.get("active_error"):
+            continue
+
+        breakdown = instance.get("cooldown_breakdown", {})
+        if not isinstance(breakdown, Mapping):
+            breakdown = {}
+
+        monitored = _to_int(instance.get("monitored_total"))
+        missing = _to_int(breakdown.get("missing"))
+        cutoff = _to_int(breakdown.get("cutoff"))
+        upgrade = _to_int(breakdown.get("upgrade"))
+        unreleased = _to_int(instance.get("unreleased_count"))
+        gated = missing + cutoff
+
+        totals["eligible"] += max(0, monitored - gated - unreleased)
+        totals["gated"] += gated
+        totals["unreleased"] += unreleased
+        totals["upgrade"] += upgrade
+
+    tracked = totals["eligible"] + totals["gated"] + totals["upgrade"] + totals["unreleased"]
+    return {
+        "tracked": tracked,
+        "eligible": totals["eligible"],
+        "gated": totals["gated"],
+        "unreleased": totals["unreleased"],
+        "searches_7d": max(0, _to_int(searches_7d)),
+    }

--- a/src/houndarr/value_objects.py
+++ b/src/houndarr/value_objects.py
@@ -14,6 +14,21 @@ from houndarr.enums import ItemType
 
 
 @dataclass(frozen=True, slots=True)
+class WidgetApiKey:
+    """Stored Houndarr API key metadata for widget access.
+
+    Attributes:
+        hash: SHA-256 hex digest of the plaintext token.
+        created_at: UTC timestamp when the active key was generated.
+        last_used_at: UTC timestamp of the most recent successful use, if any.
+    """
+
+    hash: str
+    created_at: str
+    last_used_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class ItemRef:
     """A reference to an *arr library item that the search engine tracks.
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from houndarr.auth import (
+    _API_KEY_PATHS,
     _CSRF_PROTECTED_METHODS,
     _LOGOUT_PATH,
     _PUBLIC_PATHS,
@@ -785,6 +786,37 @@ def test_clear_login_attempts_drops_bucket(test_settings: object) -> None:
 
 
 @pytest.mark.pinning()
+def test_check_widget_key_rate_limit_prunes_stale_entries(
+    test_settings: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Widget API key attempts use the same sliding-window threshold as login."""
+    from unittest.mock import MagicMock
+
+    import houndarr.auth as _auth
+    from houndarr.auth import (
+        _LOGIN_WINDOW_SECONDS,
+        _widget_key_attempts,
+        check_widget_key_rate_limit,
+        record_failed_widget_key_attempt,
+    )
+
+    now = {"t": 1_700_000_000.0}
+    monkeypatch.setattr(_auth.time, "time", lambda: now["t"])
+
+    request = MagicMock()
+    request.client.host = "198.51.100.10"
+    request.headers.get.return_value = None
+    for _ in range(5):
+        record_failed_widget_key_attempt(request)
+    assert check_widget_key_rate_limit(request) is False
+
+    now["t"] += _LOGIN_WINDOW_SECONDS + 1
+    assert check_widget_key_rate_limit(request) is True
+    assert _widget_key_attempts["198.51.100.10"] == []
+
+
+@pytest.mark.pinning()
 def test_check_login_rate_limit_prunes_stale_entries(
     test_settings: object,
     monkeypatch: pytest.MonkeyPatch,
@@ -828,7 +860,7 @@ def test_check_login_rate_limit_prunes_stale_entries(
 @pytest.mark.asyncio()
 @pytest.mark.pinning()
 async def test_reset_auth_caches_clears_every_module_global(db: None) -> None:
-    """reset_auth_caches must clear _serializer, _setup_complete, _login_attempts.
+    """reset_auth_caches must clear session, setup, and rate-limit state.
 
     Called on factory reset (services/admin.py:263).  A stale
     ``_setup_complete=True`` after the database is wiped would short-
@@ -841,6 +873,7 @@ async def test_reset_auth_caches_clears_every_module_global(db: None) -> None:
     from houndarr.auth import (
         _get_serializer,
         record_failed_login,
+        record_failed_widget_key_attempt,
         reset_auth_caches,
         set_password,
     )
@@ -852,16 +885,19 @@ async def test_reset_auth_caches_clears_every_module_global(db: None) -> None:
     req.client.host = "198.51.100.11"
     req.headers.get.return_value = None
     record_failed_login(req)
+    record_failed_widget_key_attempt(req)
 
     assert _auth._setup_complete is True
     assert _auth._serializer is not None
     assert _auth._login_attempts
+    assert _auth._widget_key_attempts
 
     reset_auth_caches()
 
     assert _auth._setup_complete is None
     assert _auth._serializer is None
     assert _auth._login_attempts == {}
+    assert _auth._widget_key_attempts == {}
 
 
 # Session seam
@@ -1005,6 +1041,12 @@ def test_logout_path_constant_is_slash_logout() -> None:
 def test_csrf_protected_methods_constant() -> None:
     """The set of CSRF-protected methods must stay exactly {POST, PUT, PATCH, DELETE}."""
     assert frozenset(["POST", "PUT", "PATCH", "DELETE"]) == _CSRF_PROTECTED_METHODS
+
+
+@pytest.mark.pinning()
+def test_api_key_paths_constant_has_exact_contents() -> None:
+    """_API_KEY_PATHS must stay disjoint from public and mode-dependent routes."""
+    assert frozenset(["/api/v1/widget"]) == _API_KEY_PATHS
 
 
 @pytest.mark.pinning()

--- a/tests/test_auth_houndarr_api_key.py
+++ b/tests/test_auth_houndarr_api_key.py
@@ -1,0 +1,47 @@
+"""Tests for Houndarr API key token primitives."""
+
+from __future__ import annotations
+
+import base64
+import re
+
+import pytest
+
+from houndarr.auth import houndarr_api_key
+
+
+def test_generate_api_key_returns_prefixed_urlsafe_32_byte_token() -> None:
+    """Generated tokens should carry the public prefix and 32 random bytes."""
+    token = houndarr_api_key.generate_api_key()
+    assert token.startswith("hndarr_")
+    suffix = token.removeprefix("hndarr_")
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", suffix)
+    padding = "=" * (-len(suffix) % 4)
+    assert len(base64.urlsafe_b64decode(suffix + padding)) == 32
+
+
+def test_hash_api_key_is_sha256_hex_digest() -> None:
+    digest = houndarr_api_key.hash_api_key("sample-token")
+    assert len(digest) == 64
+    assert re.fullmatch(r"[0-9a-f]{64}", digest)
+    assert digest == houndarr_api_key.hash_api_key("sample-token")
+
+
+def test_verify_api_key_uses_constant_time_compare(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_compare(left: str, right: str) -> bool:
+        calls.append((left, right))
+        return left == right
+
+    monkeypatch.setattr(houndarr_api_key, "compare_digest", fake_compare)
+    token = "hndarr_example"
+    stored_hash = houndarr_api_key.hash_api_key(token)
+
+    assert houndarr_api_key.verify_api_key(token, stored_hash) is True
+    assert calls == [(stored_hash, stored_hash)]
+
+
+def test_verify_api_key_rejects_non_matching_token() -> None:
+    stored_hash = houndarr_api_key.hash_api_key("hndarr_right")
+    assert houndarr_api_key.verify_api_key("hndarr_wrong", stored_hash) is False

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,13 +25,41 @@ async def test_schema_created(db: None) -> None:
     assert "instances" in tables
     assert "cooldowns" in tables
     assert "search_log" in tables
+    assert "widget_api_key" in tables
 
 
 @pytest.mark.asyncio()
 async def test_schema_version_set(db: None) -> None:
     """Schema version should be set after init."""
     version = await get_setting("schema_version")
-    assert version == "18"
+    assert version == "19"
+
+
+@pytest.mark.asyncio()
+async def test_widget_api_key_schema_has_single_row_invariant(db: None) -> None:
+    """Widget API key storage should allow only the fixed singleton row."""
+    async with get_db() as conn:
+        async with conn.execute("PRAGMA table_info(widget_api_key)") as cur:
+            columns = {row[1]: row async for row in cur}
+        async with conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='widget_api_key'"
+        ) as cur:
+            ddl_row = await cur.fetchone()
+        assert ddl_row is not None
+        ddl = str(ddl_row[0])
+
+        assert set(columns) == {"id", "hash", "created_at", "last_used_at"}
+        assert columns["hash"][3] == 1
+        assert columns["created_at"][3] == 1
+        compact_ddl = "".join(ddl.split())
+        assert "CHECK(id=1)" in compact_ddl
+        assert "length(hash)=64" in compact_ddl
+
+        with pytest.raises(aiosqlite.IntegrityError):
+            await conn.execute(
+                "INSERT INTO widget_api_key (id, hash, created_at) VALUES (2, ?, 'now')",
+                ("a" * 64,),
+            )
 
 
 @pytest.mark.asyncio()
@@ -108,11 +136,14 @@ async def test_init_db_migrates_v1_schema_to_v3(tmp_path: Path) -> None:
         get_db() as conn,
         conn.execute("PRAGMA table_info(search_log)") as search_log_cur,
         conn.execute("PRAGMA table_info(instances)") as instances_cur,
+        conn.execute("SELECT name FROM sqlite_master WHERE name = 'widget_api_key'") as widget_cur,
     ):
         search_log_columns = {row[1] async for row in search_log_cur}
         instance_columns = {row[1] async for row in instances_cur}
+        widget_table = await widget_cur.fetchone()
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
+    assert widget_table is not None
     assert "item_label" in search_log_columns
     assert "search_kind" in search_log_columns
     assert "cycle_id" in search_log_columns
@@ -181,7 +212,7 @@ async def test_init_db_migrates_v2_schema_to_v4(tmp_path: Path) -> None:
         async with conn.execute("PRAGMA table_info(search_log)") as cur:
             search_log_columns = {row[1] async for row in cur}
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
     assert "cycle_id" in search_log_columns
     assert "cycle_trigger" in search_log_columns
 
@@ -248,7 +279,7 @@ async def test_init_db_migrates_v3_schema_to_v4(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
             instance_columns = {row[1] async for row in cur}
@@ -331,7 +362,7 @@ async def test_init_db_migrates_v4_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
 
     async with get_db() as conn:
         # Verify new columns exist
@@ -465,7 +496,7 @@ async def test_init_db_migrates_v5_schema_to_v6(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -562,7 +593,7 @@ async def test_init_db_migrates_v6_schema_to_v7(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -675,7 +706,7 @@ async def test_init_db_self_heals_v9_and_v10_when_version_already_current(
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -818,7 +849,7 @@ async def test_init_db_is_idempotent_on_healthy_v12(tmp_path: Path) -> None:
 
     # Second call: should be a no-op through the self-heal branch.
     await init_db()
-    assert await get_setting("schema_version") == first_version == "18"
+    assert await get_setting("schema_version") == first_version == "19"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -913,7 +944,7 @@ async def test_migrate_to_v12_adds_search_order_column(tmp_path: Path) -> None:
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
 
     async with get_db() as conn:
         async with conn.execute("PRAGMA table_info(instances)") as cur:
@@ -1056,7 +1087,7 @@ async def test_migrate_to_v15_coerces_invalid_search_kind(tmp_path: Path) -> Non
     set_db_path(str(db_path))
     await init_db()
 
-    assert await get_setting("schema_version") == "18"
+    assert await get_setting("schema_version") == "19"
 
     async with get_db() as conn:
         await conn.execute("PRAGMA foreign_keys=ON")
@@ -1560,7 +1591,7 @@ async def test_init_db_migrates_whisparr_episode_rows_through_to_current(
         async with conn.execute("SELECT value FROM settings WHERE key = 'schema_version'") as cur:
             row = await cur.fetchone()
         assert row is not None
-        assert row[0] == "18"
+        assert row[0] == "19"
 
         # 2. The Whisparr v2 cooldown rows survived and were renamed.
         async with conn.execute(
@@ -1678,7 +1709,7 @@ async def test_init_db_migrates_v4_preserves_cooldowns_through_v10_rebuild(
         async with conn.execute("SELECT value FROM settings WHERE key = 'schema_version'") as cur:
             row = await cur.fetchone()
         assert row is not None
-        assert row[0] == "18"
+        assert row[0] == "19"
 
         # All four cooldown rows must survive the v10 instances rebuild.
         async with conn.execute(

--- a/tests/test_huntarr_vulns.py
+++ b/tests/test_huntarr_vulns.py
@@ -22,6 +22,7 @@ from fastapi.testclient import TestClient
 
 import houndarr.auth as _auth_module
 from houndarr.auth import (
+    _API_KEY_PATHS,
     _PUBLIC_PATHS,
     CSRF_COOKIE_NAME,
     SESSION_COOKIE_NAME,
@@ -118,6 +119,12 @@ class TestUnauthenticatedAccessSweep:
         assert resp.headers.get("location") in _AUTH_LOCATIONS, (
             f"{method} {path} redirected to unexpected location: {resp.headers.get('location')!r}"
         )
+
+    def test_widget_route_uses_api_key_challenge_without_session(self, app: TestClient) -> None:
+        """The external widget route is protected by API key auth, not session redirects."""
+        resp = app.get("/api/v1/widget", follow_redirects=False)
+        assert resp.status_code == 401
+        assert resp.headers["WWW-Authenticate"] == "ApiKey"
 
 
 # ---------------------------------------------------------------------------
@@ -533,6 +540,13 @@ class TestCSRFImplementation:
         expected = frozenset(["/setup", "/login", "/api/health", "/static"])
         assert expected == _PUBLIC_PATHS, (
             f"_PUBLIC_PATHS changed: got {_PUBLIC_PATHS!r}, expected {expected!r}"
+        )
+
+    def test_api_key_paths_is_exact_expected_set(self) -> None:
+        """_API_KEY_PATHS must contain only the widget endpoint."""
+        expected = frozenset(["/api/v1/widget"])
+        assert expected == _API_KEY_PATHS, (
+            f"_API_KEY_PATHS changed: got {_API_KEY_PATHS!r}, expected {expected!r}"
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_protocols_repositories.py
+++ b/tests/test_protocols_repositories.py
@@ -7,7 +7,7 @@ invariants for the rest of the codebase to rely on them:
   ``isinstance(obj, Proto)`` as a conformance check.
 * Every Protocol can be imported from ``houndarr.protocols``
   without pulling in any runtime-heavy modules (e.g. FastAPI).
-* The module's ``__all__`` re-exports the five Protocol names.
+* The module's ``__all__`` re-exports the repository and factory Protocol names.
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from houndarr.protocols import (
     InstanceRepository,
     SearchLogRepository,
     SettingsRepository,
+    WidgetApiKeyRepository,
 )
 
 pytestmark = pytest.mark.pinning
@@ -36,6 +37,7 @@ class TestRepositoryProtocolsDeclared:
             InstanceRepository,
             SearchLogRepository,
             SettingsRepository,
+            WidgetApiKeyRepository,
         ],
     )
     def test_each_protocol_is_runtime_checkable(self, proto: type) -> None:
@@ -43,7 +45,7 @@ class TestRepositoryProtocolsDeclared:
 
         ``@runtime_checkable`` Protocols raise ``TypeError`` from
         ``isinstance`` only when the Protocol carries non-method
-        members; all five declarations here use method-only syntax, so
+        members; all declarations here use method-only syntax, so
         a no-op ``isinstance(object(), proto)`` should return ``False``
         cleanly without raising.
         """
@@ -52,7 +54,7 @@ class TestRepositoryProtocolsDeclared:
     def test_module_all_exports_every_protocol(self) -> None:
         """``houndarr.protocols.__all__`` must list every declared symbol.
 
-        Covers the five repository + factory Protocols plus
+        Covers the repository + factory Protocols plus
         the :class:`SupervisorProto` and the :data:`RunNowStatus`
         Literal declared in :mod:`houndarr.protocols`.
         """
@@ -66,6 +68,7 @@ class TestRepositoryProtocolsDeclared:
             "SearchLogRepository",
             "SettingsRepository",
             "SupervisorProto",
+            "WidgetApiKeyRepository",
         }
 
     def test_empty_stub_is_not_accepted_as_instance_repository(self) -> None:

--- a/tests/test_repositories/test_widget_api_key.py
+++ b/tests/test_repositories/test_widget_api_key.py
@@ -1,0 +1,52 @@
+"""Tests for the widget API key repository."""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.auth.houndarr_api_key import hash_api_key
+from houndarr.repositories import widget_api_key
+
+
+@pytest.mark.asyncio()
+async def test_get_returns_none_when_no_widget_key_exists(db: None) -> None:
+    assert await widget_api_key.get() is None
+
+
+@pytest.mark.asyncio()
+async def test_set_inserts_and_replaces_single_widget_key(db: None) -> None:
+    first_hash = hash_api_key("hndarr_first")
+    second_hash = hash_api_key("hndarr_second")
+
+    first = await widget_api_key.set(first_hash)
+    assert first.hash == first_hash
+    assert first.created_at
+    assert first.last_used_at is None
+
+    await widget_api_key.touch_last_used()
+    touched = await widget_api_key.get()
+    assert touched is not None
+    assert touched.last_used_at is not None
+
+    second = await widget_api_key.set(second_hash)
+    assert second.hash == second_hash
+    assert second.last_used_at is None
+
+
+@pytest.mark.asyncio()
+async def test_touch_last_used_noops_without_key(db: None) -> None:
+    await widget_api_key.touch_last_used()
+    assert await widget_api_key.get() is None
+
+
+@pytest.mark.asyncio()
+async def test_set_rejects_non_sha256_digest(db: None) -> None:
+    with pytest.raises(ValueError):
+        await widget_api_key.set("not-a-digest")
+
+
+@pytest.mark.asyncio()
+async def test_revoke_deletes_widget_key(db: None) -> None:
+    await widget_api_key.set(hash_api_key("hndarr_revoke"))
+    await widget_api_key.revoke()
+    assert await widget_api_key.get() is None

--- a/tests/test_routes/test_handler_loc.py
+++ b/tests/test_routes/test_handler_loc.py
@@ -88,13 +88,13 @@ def _walk_handlers() -> list[tuple[str, str, int]]:
 
 
 def test_handler_count_matches_audit_snapshot() -> None:
-    """The handler inventory count matches the current snapshot (33 handlers).
+    """The handler inventory count matches the current snapshot (34 handlers).
 
     A regression here means a handler was added or removed without
     an accompanying update to this count.  Update this count
     together with the route change so the audit stays honest.
     """
-    assert len(_walk_handlers()) == 33
+    assert len(_walk_handlers()) == 34
 
 
 def test_every_handler_under_soft_cap() -> None:

--- a/tests/test_routes/test_widget.py
+++ b/tests/test_routes/test_widget.py
@@ -1,0 +1,162 @@
+"""Tests for GET /api/v1/widget."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from houndarr.auth import _widget_key_attempts
+from houndarr.auth.houndarr_api_key import generate_api_key, hash_api_key
+from houndarr.config import AppSettings
+from houndarr.database import get_db
+from houndarr.repositories import widget_api_key
+
+
+async def _store_widget_token() -> str:
+    token = generate_api_key()
+    await widget_api_key.set(hash_api_key(token))
+    return token
+
+
+async def _seed_widget_status_rows() -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            """
+            INSERT INTO instances (
+                id, name, type, url, encrypted_api_key, enabled,
+                monitored_total, unreleased_count
+            )
+            VALUES (1, 'Widget Sonarr', 'sonarr', 'http://sonarr:8989', '', 1, 10, 1)
+            """
+        )
+        await conn.executemany(
+            """
+            INSERT INTO cooldowns (instance_id, item_id, item_type, search_kind, searched_at)
+            VALUES (1, ?, 'episode', ?, datetime('now', '-1 day'))
+            """,
+            [(101, "missing"), (102, "cutoff"), (103, "upgrade")],
+        )
+        await conn.executemany(
+            "INSERT INTO search_log (instance_id, action, timestamp) "
+            "VALUES (1, ?, datetime('now', ?))",
+            [("searched", "-1 day"), ("searched", "-8 days"), ("skipped", "-1 day")],
+        )
+        await conn.commit()
+
+
+@pytest.fixture()
+def proxy_widget_app(db: None, test_settings: AppSettings) -> Generator[TestClient]:
+    test_settings.auth_mode = "proxy"
+    test_settings.auth_proxy_header = "Remote-User"
+    test_settings.trusted_proxies = "127.0.0.1"
+    test_settings._trusted_proxy_cache = None
+
+    from houndarr.app import create_app
+
+    application = create_app()
+    with TestClient(application, raise_server_exceptions=True) as client:
+        yield client
+
+
+def test_widget_returns_locked_envelope_for_valid_key(db: None, app: TestClient) -> None:
+    asyncio.run(_seed_widget_status_rows())
+    token = asyncio.run(_store_widget_token())
+
+    resp = app.get("/api/v1/widget", headers={"X-Api-Key": token})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema"] == 1
+    assert isinstance(body["generated_at"], str)
+    assert body["totals"] == {
+        "tracked": 11,
+        "eligible": 7,
+        "gated": 2,
+        "unreleased": 1,
+        "searches_7d": 1,
+    }
+    stored = asyncio.run(widget_api_key.get())
+    assert stored is not None
+    assert stored.last_used_at is not None
+
+
+def test_widget_without_configured_key_returns_401(db: None, app: TestClient) -> None:
+    resp = app.get("/api/v1/widget", headers={"X-Api-Key": "not-the-token"})
+
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"] == "ApiKey"
+
+
+def test_widget_missing_key_returns_401(db: None, app: TestClient) -> None:
+    asyncio.run(_store_widget_token())
+
+    resp = app.get("/api/v1/widget")
+
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"] == "ApiKey"
+
+
+def test_widget_invalid_key_returns_401(db: None, app: TestClient) -> None:
+    asyncio.run(_store_widget_token())
+
+    resp = app.get("/api/v1/widget", headers={"X-Api-Key": "not-the-token"})
+
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"] == "ApiKey"
+
+
+def test_widget_valid_key_clears_prior_failed_attempts(db: None, app: TestClient) -> None:
+    token = asyncio.run(_store_widget_token())
+
+    for _ in range(5):
+        resp = app.get("/api/v1/widget", headers={"X-Api-Key": "not-the-token"})
+        assert resp.status_code == 401
+
+    resp = app.get("/api/v1/widget", headers={"X-Api-Key": token})
+    assert resp.status_code == 200
+    assert _widget_key_attempts == {}
+
+
+def test_widget_rate_limits_failed_key_attempts(db: None, app: TestClient) -> None:
+    asyncio.run(_store_widget_token())
+
+    for _ in range(5):
+        resp = app.get("/api/v1/widget", headers={"X-Api-Key": "not-the-token"})
+        assert resp.status_code == 401
+
+    resp = app.get("/api/v1/widget", headers={"X-Api-Key": "not-the-token"})
+    assert resp.status_code == 429
+    assert resp.headers["Retry-After"] == "60"
+
+
+def test_widget_valid_key_works_in_proxy_auth_mode(proxy_widget_app: TestClient) -> None:
+    token = asyncio.run(_store_widget_token())
+
+    resp = proxy_widget_app.get("/api/v1/widget", headers={"X-Api-Key": token})
+
+    assert resp.status_code == 200
+    assert resp.json()["totals"] == {
+        "tracked": 0,
+        "eligible": 0,
+        "gated": 0,
+        "unreleased": 0,
+        "searches_7d": 0,
+    }
+
+
+def test_widget_ignores_proxy_header_without_api_key(proxy_widget_app: TestClient) -> None:
+    asyncio.run(_store_widget_token())
+
+    resp = proxy_widget_app.get("/api/v1/widget", headers={"Remote-User": "alice"})
+
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"] == "ApiKey"
+
+
+def test_existing_route_auth_buckets_are_unchanged(db: None, app: TestClient) -> None:
+    assert app.get("/api/health").status_code == 200
+    assert app.get("/api/status", follow_redirects=False).status_code == 302
+    assert app.get("/settings", follow_redirects=False).status_code == 302

--- a/tests/test_services/test_metrics_cache.py
+++ b/tests/test_services/test_metrics_cache.py
@@ -1,8 +1,8 @@
 """Tests for the dashboard aggregate cache (issue #586).
 
-The cache wraps the four slow ``search_log`` aggregations
+The cache wraps the slow ``search_log`` aggregations
 (``gather_window_metrics``, ``gather_lifetime_metrics``,
-``gather_active_errors``, ``gather_recent_searches``) with a 20-second
+``gather_active_errors``, ``gather_recent_searches``, 7-day search count) with a 20-second
 TTL and single-flight semantics so tens of dashboard tabs polling the
 same envelope land on a single DB scan.  The tests below pin the
 contract: a hit avoids the DB entirely; ``cache_clear`` forces a fresh
@@ -12,12 +12,17 @@ rows) bypass the cache so the next-patrol countdown stays accurate.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
+from houndarr.database import get_db
 from houndarr.services.metrics import (
     DASHBOARD_CACHE_TTL_SECONDS,
     DashboardAggregates,
     build_aggregate_cache,
+    gather_cached_searches_7d,
+    gather_searches_7d,
     invalidate_dashboard_cache,
 )
 
@@ -109,6 +114,65 @@ async def test_cache_clear_forces_fresh_scan(monkeypatch: pytest.MonkeyPatch) ->
     await cache((1, 2))
 
     assert call_count["n"] == 2
+
+
+@pytest.mark.asyncio()
+async def test_gather_searches_7d_counts_recent_searched_rows(db: None) -> None:
+    """The widget count excludes old rows and non-search actions."""
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO search_log (action, timestamp) VALUES (?, datetime('now', ?))",
+            [
+                ("searched", "-1 day"),
+                ("searched", "-8 days"),
+                ("skipped", "-1 day"),
+            ],
+        )
+        await conn.commit()
+        assert await gather_searches_7d(conn) == 1
+
+
+@pytest.mark.asyncio()
+async def test_gather_searches_7d_uses_production_timestamp_format(db: None) -> None:
+    """The 7-day cutoff should compare against ISO timestamps written by Houndarr."""
+    cutoff = datetime.now(UTC) - timedelta(days=7)
+    before_cutoff = (cutoff - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    after_cutoff = (cutoff + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    async with get_db() as conn:
+        await conn.executemany(
+            "INSERT INTO search_log (action, timestamp) VALUES ('searched', ?)",
+            [(before_cutoff,), (after_cutoff,)],
+        )
+        await conn.commit()
+        assert await gather_searches_7d(conn) == 1
+
+
+@pytest.mark.asyncio()
+async def test_gather_cached_searches_7d_reuses_aggregate_cache(db: None) -> None:
+    """Widget polling should read the cached 7-day count when the cache is active."""
+
+    class _FakeCache:
+        def __init__(self) -> None:
+            self.ids: tuple[int, ...] | None = None
+
+        async def __call__(self, instance_ids_tuple: tuple[int, ...]) -> DashboardAggregates:
+            self.ids = instance_ids_tuple
+            return DashboardAggregates(searches_7d=44)
+
+        def cache_clear(self) -> None:
+            pass
+
+    cache = _FakeCache()
+    async with get_db() as conn:
+        count = await gather_cached_searches_7d(
+            conn,
+            instance_ids=[2, 1],
+            aggregate_cache=cache,
+        )
+
+    assert count == 44
+    assert cache.ids == (1, 2)
 
 
 def test_invalidate_dashboard_cache_no_op_when_attribute_missing() -> None:

--- a/tests/test_services/test_widget_metrics.py
+++ b/tests/test_services/test_widget_metrics.py
@@ -1,0 +1,85 @@
+"""Tests for widget summary aggregation."""
+
+from __future__ import annotations
+
+import pytest
+
+from houndarr.services.widget_metrics import compute_widget_summary
+
+
+@pytest.mark.pinning
+@pytest.mark.parametrize(
+    ("envelope", "searches_7d", "expected"),
+    [
+        (
+            {
+                "instances": [
+                    {
+                        "enabled": True,
+                        "active_error": None,
+                        "monitored_total": 10,
+                        "unreleased_count": 1,
+                        "cooldown_breakdown": {"missing": 3, "cutoff": 2, "upgrade": 4},
+                    }
+                ]
+            },
+            7,
+            {"tracked": 14, "eligible": 4, "gated": 5, "unreleased": 1, "searches_7d": 7},
+        ),
+        (
+            {
+                "instances": [
+                    {
+                        "enabled": True,
+                        "active_error": None,
+                        "monitored_total": 5,
+                        "unreleased_count": 0,
+                        "cooldown_breakdown": {"missing": 10, "cutoff": 0, "upgrade": 0},
+                    },
+                    {
+                        "enabled": True,
+                        "active_error": None,
+                        "monitored_total": 8,
+                        "unreleased_count": 1,
+                        "cooldown_breakdown": {"missing": 1, "cutoff": 1, "upgrade": 0},
+                    },
+                ]
+            },
+            3,
+            {"tracked": 18, "eligible": 5, "gated": 12, "unreleased": 1, "searches_7d": 3},
+        ),
+        (
+            {
+                "instances": [
+                    {
+                        "enabled": False,
+                        "active_error": None,
+                        "monitored_total": 99,
+                        "unreleased_count": 0,
+                        "cooldown_breakdown": {"missing": 99, "cutoff": 0, "upgrade": 0},
+                    },
+                    {
+                        "enabled": True,
+                        "active_error": "offline",
+                        "monitored_total": 99,
+                        "unreleased_count": 0,
+                        "cooldown_breakdown": {"missing": 99, "cutoff": 0, "upgrade": 0},
+                    },
+                ]
+            },
+            2,
+            {"tracked": 0, "eligible": 0, "gated": 0, "unreleased": 0, "searches_7d": 2},
+        ),
+    ],
+)
+def test_compute_widget_summary_matches_dashboard_contract(
+    envelope: dict[str, object],
+    searches_7d: int,
+    expected: dict[str, int],
+) -> None:
+    assert compute_widget_summary(envelope, searches_7d) == expected
+
+
+def test_compute_widget_summary_tolerates_missing_fields() -> None:
+    summary = compute_widget_summary({"instances": [{"enabled": True, "active_error": None}]}, -1)
+    assert summary == {"tracked": 0, "eligible": 0, "gated": 0, "unreleased": 0, "searches_7d": 0}

--- a/tests/test_value_objects.py
+++ b/tests/test_value_objects.py
@@ -5,7 +5,19 @@ from __future__ import annotations
 import pytest
 
 from houndarr.enums import ItemType
-from houndarr.value_objects import ItemRef
+from houndarr.value_objects import ItemRef, WidgetApiKey
+
+
+class TestWidgetApiKey:
+    def test_frozen_and_slotted(self) -> None:
+        key = WidgetApiKey(
+            hash="digest",
+            created_at="2026-05-15T00:00:00.000Z",
+            last_used_at=None,
+        )
+        assert set(WidgetApiKey.__slots__) == {"hash", "created_at", "last_used_at"}
+        with pytest.raises(AttributeError):
+            key.hash = "other"  # type: ignore[misc]
 
 
 class TestItemRef:


### PR DESCRIPTION
Closes #604

## Summary

- Adds schema v19 `widget_api_key` storage and repository methods.
- Adds the auth-mode-agnostic widget API-key lane with token helpers and rate limiting.
- Adds cached widget totals and `GET /api/v1/widget` with the locked response envelope.

## Validation

All local checks pass. Container build, filesystem/image scans, and the security smoke test pass locally. Workflow lint has a pre-existing warning in `browser-e2e.yml` outside this diff.

## Review

Review pass 1 completed with no findings.

## Visual evidence

N/A: backend JSON endpoint with no browser UI surface.
