### PR TITLE
fix(settings): copy api key on http installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Copy key` button in the API key reveal dialog now writes the plaintext key to the clipboard on HTTP installs; the textarea fallback was silently running over an empty selection while the toast claimed success. (#647)
+
 ---
 
 ## [1.12.0] - 2026-05-22

--- a/src/houndarr/static/js/settings.js
+++ b/src/houndarr/static/js/settings.js
@@ -12,24 +12,30 @@ function initSettingsPage() {
   const { signal } = controller;
 
   (() => {
-    async function writeClipboard(text) {
+    async function writeClipboard(text, host = document.body) {
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(text);
         return;
       }
+      // Non-secure-context fallback: a textarea + execCommand('copy') shim.
+      // The textarea must live inside any open modal <dialog> because
+      // content outside an open modal dialog is inert per the HTML spec:
+      // focus() and select() become no-ops, the selection stays empty,
+      // and execCommand('copy') silently runs over nothing while still
+      // returning true.
       const ta = document.createElement('textarea');
       ta.value = text;
       ta.style.position = 'fixed';
       ta.style.opacity = '0';
-      document.body.appendChild(ta);
+      host.appendChild(ta);
       ta.focus();
       ta.select();
       try {
-        if (!document.execCommand('copy')) {
+        if (!document.execCommand('copy') || ta.selectionEnd !== ta.value.length) {
           throw new Error('Copy command failed');
         }
       } finally {
-        document.body.removeChild(ta);
+        host.removeChild(ta);
       }
     }
 
@@ -49,7 +55,8 @@ function initSettingsPage() {
         showToast('Nothing to copy');
         return;
       }
-      writeClipboard(text)
+      const host = copyBtn.closest('dialog[open]') || document.body;
+      writeClipboard(text, host)
         .then(() => showToast('Houndarr API key copied'))
         .catch(() => showToast('Copy failed'));
     }, { signal });

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -814,3 +814,77 @@ def test_changelog_preferences_switch_rolls_back_on_error(
         )
     finally:
         page.unroute(pattern)
+
+
+@pytest.mark.integration
+def test_api_key_reveal_copy_fallback_targets_open_dialog(
+    logged_in_page: Page, houndarr_url: str
+) -> None:
+    """The Copy key button writes the plaintext key in non-secure contexts.
+
+    The reveal modal opens via ``<dialog>.showModal()``; content outside
+    an open modal dialog is inert per the HTML spec, so a fallback
+    textarea appended to ``document.body`` never receives focus or
+    selection and ``execCommand('copy')`` silently succeeds over nothing
+    while the toast misleadingly reports success.  The fallback host
+    must therefore be the open dialog itself.  Instrument
+    ``execCommand`` and assert the textarea sits inside the dialog and
+    the selection covers the full key at call time.
+    """
+    page = logged_in_page
+    page.goto(f"{houndarr_url}/settings")
+    _open_admin_dropdown(page)
+
+    # Open the reveal dialog. Generate from a clean state, or regenerate
+    # if a previous test in the session already configured a key.
+    submit = page.locator('form[action="/settings/api-key/generate"] button[type="submit"]')
+    if submit.inner_text().strip() == "Regenerate key":
+        submit.click()
+        page.locator("#confirm-go").click()
+    else:
+        submit.click()
+    reveal = page.locator("dialog#api-key-reveal-modal[open]")
+    expect(reveal).to_be_visible(timeout=4_000)
+
+    # Force the non-secure-context fallback path by removing the
+    # clipboard API, and instrument execCommand to capture the textarea
+    # state at the moment the copy call fires.
+    page.evaluate(
+        """() => {
+            Object.defineProperty(navigator, 'clipboard', {
+                value: undefined,
+                configurable: true,
+            });
+            window.__execCopyState = null;
+            const orig = document.execCommand.bind(document);
+            document.execCommand = function(cmd) {
+                const ta =
+                    document.querySelector('dialog[open] textarea')
+                    || document.querySelector('body > textarea');
+                window.__execCopyState = {
+                    cmd,
+                    selectionEnd: ta ? ta.selectionEnd : null,
+                    valueLength: ta ? ta.value.length : null,
+                    parentTag: ta ? ta.parentElement.tagName : null,
+                };
+                return orig(cmd);
+            };
+        }"""
+    )
+
+    page.get_by_role("button", name="Copy key").click()
+    page.wait_for_function("() => window.__execCopyState !== null")
+    state = page.evaluate("() => window.__execCopyState")
+
+    assert state["cmd"] == "copy"
+    assert state["valueLength"] is not None and state["valueLength"] > 0, (
+        f"fallback textarea never received the key text: {state!r}"
+    )
+    assert state["selectionEnd"] == state["valueLength"], (
+        f"selection covered {state['selectionEnd']} of "
+        f"{state['valueLength']} chars; the fallback textarea was likely "
+        "inert because it landed outside the open modal dialog"
+    )
+    assert state["parentTag"] == "DIALOG", (
+        f"fallback textarea parent was {state['parentTag']!r}, expected DIALOG"
+    )


### PR DESCRIPTION
## Summary

`Copy key` button in the API key reveal dialog silently fails on HTTP installs. The toast says "Houndarr API key copied" but the clipboard is empty.

Closes #647

## Changes

- `src/houndarr/static/js/settings.js`: `writeClipboard()` takes a `host` argument (default `document.body`) and the click handler passes `copyBtn.closest('dialog[open]')` so the fallback textarea lands inside the open modal. Added `ta.selectionEnd !== ta.value.length` as a sanity check so future regressions throw instead of resolving with an empty clipboard.
- `tests/e2e_browser/test_flows.py`: regression test that disables `navigator.clipboard`, instruments `execCommand`, and asserts the fallback textarea sits inside the open dialog with the full key selected.
- `CHANGELOG.md`: one `Fixed` bullet under `Unreleased`.

## Why

The reveal modal opens via `<dialog>.showModal()`. Per the HTML spec, content outside an open modal `<dialog>` is inert: `focus()` and `select()` become no-ops, the selection stays empty, and `document.execCommand('copy')` runs over nothing while still returning `true`. The promise resolves, the toast claims success, but the clipboard is untouched.

Reproduced empirically with Playwright:

| Path | execCommand | selection length | active element | Clipboard updated |
|------|-------------|------------------|----------------|-------------------|
| Secure context (localhost) | n/a | n/a | n/a | yes |
| Fallback, textarea on `document.body` (before) | `true` | 0 | BUTTON | no |
| Fallback, textarea inside open `<dialog>` (after) | `true` | full key length | TEXTAREA | yes |

The new browser test fails on the buggy code with `fallback textarea parent was 'BODY', expected DIALOG` and passes on the fix.

## Testing

Local quality gates pass: ruff lint + format, mypy strict, bandit. Targeted unit tests for the API key flows (`tests/test_routes/test_settings_api_key.py`, `tests/test_auth_houndarr_api_key.py`, `tests/test_repositories/test_widget_api_key.py`) green. The new Playwright regression test passes against a local dev server (chromium); the workflow exercises chromium + firefox + webkit.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`fix/api-key-copy-modal-inertness`)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (N/A)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way