### PR TITLE
fix(docker): skip pnpm supply-chain pass on arm64

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,15 @@
-# pnpm 11 only reads build-script allow-lists from this file. The
-# legacy `pnpm.onlyBuiltDependencies` block in package.json is
-# silently ignored after pnpm v11. This project compiles the
-# Tailwind + daisyUI CSS bundle at Docker build time; @parcel/watcher
-# runs an install-time native build for the optional watch path.
+# pnpm 11 reads these workspace settings during the Docker css-build.
+#
+# trustLockfile: pnpm 11.9.0 added a supply-chain verification pass
+# ("Verifying lockfile against supply-chain policies") that re-checks
+# minimumReleaseAge / trustPolicy against the registry on every
+# install. Under the emulated linux/arm64 image build that pass crawls
+# to a near-hang and blew past the 45-minute Docker job. The committed
+# lockfile is our own trusted base, so skip the re-verification here.
+trustLockfile: true
+
+# allowBuilds: this project compiles the Tailwind + daisyUI CSS bundle
+# at Docker build time; @parcel/watcher runs an install-time native
+# build for the optional watch path.
 allowBuilds:
   "@parcel/watcher": true


### PR DESCRIPTION
## Summary

The `v1.12.1` image build hung on the emulated `linux/arm64` `css-build` stage at `pnpm install --frozen-lockfile`. pnpm 11.9.0's supply-chain verification pass re-checks the registry on every install and crawls to a near-hang under QEMU. `trustLockfile: true` skips that pass, treating the committed lockfile as trusted.

Closes #665

## Changes

- `pnpm-workspace.yaml` (root): add `trustLockfile: true`.

## Testing

Locally, root `pnpm install --frozen-lockfile` now runs in ~180ms with no "Verifying lockfile against supply-chain policies" pass (that pass is what hung under arm64 emulation). Note the PR-time image build is amd64-only, so the arm64 path is validated by the v1.12.1 re-tag build after merge.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way