### PR TITLE
[#669] chore: bump pnpm to 11.14.0

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.9.0
+          version: 11.14.0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.9.0
+          version: 11.14.0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "houndarr-css-build",
   "private": true,
   "description": "Build-time CSS toolchain for Houndarr. Not shipped in the runtime Docker image.",
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.14.0",
   "scripts": {
     "build-css": "tailwindcss -i src/houndarr/static/css/input.css -o src/houndarr/static/css/app.built.css --minify",
     "watch-css": "tailwindcss -i src/houndarr/static/css/input.css -o src/houndarr/static/css/app.built.css --watch"

--- a/website/package.json
+++ b/website/package.json
@@ -53,5 +53,5 @@
   "engines": {
     "node": ">=22.12"
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.14.0"
 }


### PR DESCRIPTION
## Summary

Moves all four pnpm pins from 11.9.0 to 11.14.0. They have to change together: a mismatch between `packageManager` and `pnpm/action-setup` aborts with `ERR_PNPM_BAD_PM_VERSION`.

Closes #669

## Changes

- `packageManager` in `package.json` and `website/package.json`
- `pnpm/action-setup` version input in `pages.yml` and `test-deploy.yml`

## Testing

Both lockfiles are byte-unchanged and stay on `lockfileVersion 9.0`, so nothing re-resolves.

Verified the same set of checks before and after the bump:

| Check | 11.9.0 | 11.14.0 |
| --- | --- | --- |
| root `install --frozen-lockfile` | pass | pass |
| root `build-css` | pass | pass |
| website `install --frozen-lockfile` | pass | pass |
| website `build` | pass | pass |

The Docker `css-build` stage is the one that matters most, since it pulls pnpm through corepack from `packageManager` and runs `--frozen-lockfile` against the root lockfile. A real build of that stage reports `Done in 1.1s using pnpm v11.14.0` inside the container.

No job or step names changed, so the required status checks are unaffected.

Visual evidence: N/A, no user-facing surface.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way