### PR TITLE
[#671] test: replace fixed wait in changelog switch rollback test

### DIFF
--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -806,12 +806,11 @@ def test_changelog_preferences_switch_rolls_back_on_error(
             toggle_label.click()
         assert resp_info.value.status == 500
 
-        # The htmx:responseError handler flips the checkbox back; give it a
-        # moment to run and then assert the state matches the initial value.
-        page.wait_for_timeout(200)
-        assert checkbox.is_checked() == initial_checked, (
-            "switch should roll back to its persisted state when the server rejects /preferences"
-        )
+        # The click flips the switch optimistically and the
+        # htmx:responseError handler flips it back.  expect() retries the
+        # read until the handler lands, so the rollback does not have to
+        # finish inside a fixed wait.
+        expect(checkbox).to_be_checked(checked=initial_checked)
     finally:
         page.unroute(pattern)
 


### PR DESCRIPTION
## Summary

`test_changelog_preferences_switch_rolls_back_on_error` waited a fixed 200ms for the `htmx:responseError` handler, then read the checkbox once with `is_checked()`. Nothing gated that read: `page.expect_response` returns when the 500 reaches the browser, not when htmx has finished handling it, and the click flips the switch optimistically. Swapping in an auto-retrying `expect()` removes the ungated read and the fixed wait.

Closes #671

## Changes

- Replace `page.wait_for_timeout(200)` plus `assert checkbox.is_checked() == initial_checked` with `expect(checkbox).to_be_checked(checked=initial_checked)`.

## Testing

Ran against the local e2e stack on chromium.

| Configuration | Result |
| --- | --- |
| Before, 200ms wait | 5/5 pass |
| Before, wait dropped to 0ms | 5/5 pass |
| Before, 0ms under heavy CPU load | 6/6 pass |
| After | 8/8 pass |
| After, full browser suite | 18/18 pass |

Worth being precise about what this does and does not fix. The ungated read is real, but it has never been observed failing, and it did not reproduce even with the wait at 0ms under load: the in-browser handler finishes before the Playwright driver round-trip returns, and starving the CPU slows both sides equally. This is a latent correctness issue rather than an active flake.

The change stands on its own terms: it removes a one-shot read of asynchronously-updated state, drops 200ms of dead time from every browser run across three matrix jobs, and matches the retrying-assertion pattern the rest of this file already uses.

Visual evidence: N/A, test-only change.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way