### PR TITLE
docs: fix README star links and chart embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Automated missing-media search for your \*arr stack.**<br>
 Small batches. Polite intervals. Zero indexer abuse.
 
-[![GitHub stars](https://img.shields.io/github/stars/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr)
 [![License: AGPL-3.0](https://img.shields.io/github/license/av1155/houndarr?style=flat)](LICENSE)
 [![Last commit](https://img.shields.io/github/last-commit/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/commits/main)
 [![GitHub release](https://img.shields.io/github/v/release/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/releases/latest)
@@ -172,8 +172,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, coding standard
 
 <div align="center">
 
-<a href="https://star-history.com/#av1155/houndarr&Date">
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=av1155/houndarr&type=Date&theme=dark" width="600" />
+<a href="https://www.star-history.com/?repos=av1155%2Fhoundarr&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=av1155/houndarr&type=date&theme=dark&legend=top-left&sealed_token=K3eOjhjW2u-nB5sBsV3NFXcQiLyWa7ZjxAJ1Z3hteRW0T_sZugG2mrcvaflvj4IpWzWb6MSe-AZq8W9Icbvrp8EdhlTwosEbMLf9kyQ8SDELsOyH_A3q7EhwYgv6uRTUpBCs_SEIN_7GmGkE5LJhxCJ-6Xh-8DPUMUItk6iOn3VEyG0QCaTZo7GdTZXd" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=av1155/houndarr&type=date&legend=top-left&sealed_token=K3eOjhjW2u-nB5sBsV3NFXcQiLyWa7ZjxAJ1Z3hteRW0T_sZugG2mrcvaflvj4IpWzWb6MSe-AZq8W9Icbvrp8EdhlTwosEbMLf9kyQ8SDELsOyH_A3q7EhwYgv6uRTUpBCs_SEIN_7GmGkE5LJhxCJ-6Xh-8DPUMUItk6iOn3VEyG0QCaTZo7GdTZXd" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=av1155/houndarr&type=date&legend=top-left&sealed_token=K3eOjhjW2u-nB5sBsV3NFXcQiLyWa7ZjxAJ1Z3hteRW0T_sZugG2mrcvaflvj4IpWzWb6MSe-AZq8W9Icbvrp8EdhlTwosEbMLf9kyQ8SDELsOyH_A3q7EhwYgv6uRTUpBCs_SEIN_7GmGkE5LJhxCJ-6Xh-8DPUMUItk6iOn3VEyG0QCaTZo7GdTZXd" width="600" />
+  </picture>
 </a>
 
 <br><br>
@@ -184,7 +188,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, coding standard
 
 <br><br>
 
-If Houndarr is useful to you, consider giving it a <a href="https://github.com/av1155/houndarr/stargazers">star on GitHub</a>.
+If Houndarr is useful to you, consider giving it a <a href="https://github.com/av1155/houndarr">star on GitHub</a>.
 
 </div>
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -36,4 +36,8 @@ exclude = [
   "^https?://authentik-proxy([:./]|$)",
   "^https?://[^/]*\\.example\\.com",
   "^https?://your-host",
+  # Chart-rendering service used by the README star-history embed.
+  # Intermittently returns 5xx under load (star-history/star-history#546),
+  # so its availability is not a signal about our docs.
+  "^https?://api\\.star-history\\.com/",
 ]


### PR DESCRIPTION
## Summary

Repairs the README links and star history chart broken by GitHub's July 2026 stargazers restriction, and unbreaks the weekly Link Check.

Closes #674

## Changes

- Stars badge and footer star link now point at the repo root; the stargazers page is 404 for everyone but maintainers since GitHub's [access restriction](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/).
- Star history chart uses star-history's sealed-token embed (theme-aware light/dark variants); the old public SVG endpoint is dead.
- lychee no longer checks `api.star-history.com`: the chart endpoint intermittently returns 5xx under load, so it only adds noise to the weekly sweep.

## Testing

`lychee --config lychee.toml './**/*.md'` passes locally with 0 errors (was 3), and the sealed embed URL returns the chart SVG for anonymous clients.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes (N/A: README and link-checker config only)
- [ ] Type check passes (`mypy src/`) (N/A: no Python changes)
- [ ] Lint passes (`ruff check .`) (N/A: no Python changes)
- [ ] Format passes (`ruff format --check .`) (N/A: no Python changes)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way