### PR TITLE
feat: surface sync state and run-now outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Dashboard cards show a `waiting for first sync` pill with muted counts until an instance's first snapshot completes, instead of a bare `0 / 0 / 0`. (#678)
+- Dashboard cards show a `waiting for first sync` pill and muted dashes for Wanted / Eligible until an instance's first snapshot completes. (#678)
 - `Run now` on an instance with nothing to search writes a `Run now finished: no wanted items to evaluate` log row instead of finishing silently. (#678)
+- `Run now` against an unreachable instance writes a `Could not reach <url>` error row, paired with a `reachable again` info row on the next successful cycle. (#678)
 - `Test connection` reports the \*arr's custom instance name (`Connected to Radarr v5.11.0 (instance "Radarr4K")`) when it differs from the app name. (#678)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Dashboard cards show a `waiting for first sync` pill with muted counts until an instance's first snapshot completes, instead of a bare `0 / 0 / 0`. (#678)
+- `Run now` on an instance with nothing to search writes a `Run now finished: no wanted items to evaluate` log row instead of finishing silently. (#678)
+- `Test connection` reports the \*arr's custom instance name (`Connected to Radarr v5.11.0 (instance "Radarr4K")`) when it differs from the app name. (#678)
+
+### Changed
+
+- The first failed dashboard snapshot refresh in a streak logs at WARNING with the instance URL; repeat failures stay at DEBUG. (#678)
+
 ---
 
 ## [1.12.1] - 2026-07-01

--- a/src/houndarr/clients/_wire_models/common.py
+++ b/src/houndarr/clients/_wire_models/common.py
@@ -61,9 +61,12 @@ class SystemStatus(_ArrModel):
     """Result of ``/system/status``; used by :meth:`ArrClient.ping` and the
     Test Connection flow on the Settings page.
 
-    Both fields are optional because *arr forks (Bookshelf, Reading Glasses)
+    All fields are optional because *arr forks (Bookshelf, Reading Glasses)
     sometimes omit ``appName`` or ``version`` from their status payload and
     Houndarr must still report the instance as reachable.
+    ``instance_name`` is the operator-assigned display name from the *arr's
+    own settings; it defaults to the app name upstream, so a differing value
+    is the signal that identifies which of several same-app servers answered.
 
     The ``app_name`` field uses ``validation_alias=AliasChoices(...)``
     rather than ``alias=`` so the constructor parameter exposed to static
@@ -80,6 +83,11 @@ class SystemStatus(_ArrModel):
         default=None,
         validation_alias=AliasChoices("appName", "app_name"),
         serialization_alias="appName",
+    )
+    instance_name: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("instanceName", "instance_name"),
+        serialization_alias="instanceName",
     )
     version: str | None = None
 

--- a/src/houndarr/clients/base.py
+++ b/src/houndarr/clients/base.py
@@ -259,9 +259,9 @@ class ArrClient(ABC):
         Defaults to ``/api/v3/system/status`` (Radarr, Sonarr, Whisparr);
         Lidarr and Readarr override to ``/api/v1/system/status``.
 
-        The returned :class:`SystemStatus` exposes ``app_name`` and
-        ``version``; both are optional because *arr forks sometimes omit
-        them.  Network failures and malformed payloads both collapse to
+        The returned :class:`SystemStatus` exposes ``app_name``,
+        ``instance_name``, and ``version``; all are optional because *arr
+        forks sometimes omit them.  Network failures and malformed payloads both collapse to
         ``None`` so callers can treat unreachable and unparseable alike.
         Callers that need a typed escalation of the unreachable state
         (for example the supervisor's reconnect loop) wrap the ``None``

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -1654,6 +1654,11 @@ async def _run_instance_search_impl(
         from houndarr.repositories.search_log import has_rows_for_cycle
 
         if not await has_rows_for_cycle(cycle_id_value):
+            message = (
+                "Run now finished: no wanted items to evaluate"
+                if any_pass_enabled
+                else "Run now finished: every search pass is disabled for this instance"
+            )
             await _write_log(
                 instance.core.id,
                 None,
@@ -1662,7 +1667,7 @@ async def _run_instance_search_impl(
                 cycle_id=cycle_id_value,
                 cycle_trigger=cycle_trigger,
                 reason="nothing to evaluate",
-                message="Run now finished: no wanted items to evaluate",
+                message=message,
             )
 
     return searched

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -1642,4 +1642,27 @@ async def _run_instance_search_impl(
             )
             searched += upgrade_searched
 
+    # --- Run-now empty-cycle epilogue ---
+    # A manual cycle that wrote no rows at all (empty wanted list, or
+    # every pass disabled) would otherwise finish with no visible
+    # outcome anywhere: the button flashes success and the history stays
+    # empty, which reads as "Run now is broken" to the operator.  One
+    # info row keeps the explicit user action observable.  Scheduled
+    # cycles stay quiet on purpose; they repeat every interval and an
+    # info row per empty cycle would flood the feed.
+    if cycle_trigger == "run_now" and searched == 0:
+        from houndarr.repositories.search_log import has_rows_for_cycle
+
+        if not await has_rows_for_cycle(cycle_id_value):
+            await _write_log(
+                instance.core.id,
+                None,
+                None,
+                SearchAction.info.value,
+                cycle_id=cycle_id_value,
+                cycle_trigger=cycle_trigger,
+                reason="nothing to evaluate",
+                message="Run now finished: no wanted items to evaluate",
+            )
+
     return searched

--- a/src/houndarr/engine/search_loop.py
+++ b/src/houndarr/engine/search_loop.py
@@ -1659,6 +1659,9 @@ async def _run_instance_search_impl(
                 if any_pass_enabled
                 else "Run now finished: every search pass is disabled for this instance"
             )
+            # Message-only, like the reconnect rows: the logs page renders
+            # ``reason or message``, so setting a reason here would shadow
+            # the full sentence and both variants would display alike.
             await _write_log(
                 instance.core.id,
                 None,
@@ -1666,7 +1669,6 @@ async def _run_instance_search_impl(
                 SearchAction.info.value,
                 cycle_id=cycle_id_value,
                 cycle_trigger=cycle_trigger,
-                reason="nothing to evaluate",
                 message=message,
             )
 

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -101,6 +101,13 @@ class Supervisor:
         # `last_activity_at` in that case until the first post-restart cycle
         # completes.
         self._last_cycle_end: dict[int, datetime] = {}
+        # Instances whose snapshot refresh is in a transport-failure streak.
+        # A failed refresh leaves the dashboard counters at their last-known
+        # values (0 forever on a never-synced instance), so the first failure
+        # in a streak must be visible at the default log level.  Repeats stay
+        # at debug, mirroring the reconnect state machine's one-row-per-streak
+        # rule; membership clears on the next successful refresh.
+        self._snapshot_fail_warned: set[int] = set()
 
     # Lifecycle
 
@@ -519,11 +526,21 @@ class Supervisor:
                     unreleased_count=snap.unreleased_count,
                 )
                 await reconcile_cooldowns(instance.core.id, reconcile_sets)
+                self._snapshot_fail_warned.discard(instance.core.id)
             except (httpx.TransportError, ClientTransportError):
-                logger.debug(
-                    "Supervisor: snapshot refresh skipped for %r; instance unreachable",
-                    instance.core.name,
-                )
+                if instance.core.id not in self._snapshot_fail_warned:
+                    self._snapshot_fail_warned.add(instance.core.id)
+                    logger.warning(
+                        "Supervisor: snapshot refresh failed for %r (%s); dashboard "
+                        "counts keep their last-known values until a refresh succeeds",
+                        instance.core.name,
+                        instance.core.url,
+                    )
+                else:
+                    logger.debug(
+                        "Supervisor: snapshot refresh skipped for %r; instance unreachable",
+                        instance.core.name,
+                    )
             except Exception:
                 logger.exception("Supervisor: snapshot refresh failed for %r", instance.core.name)
 

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -390,6 +390,21 @@ class Supervisor:
                     instance.core.url,
                     _CONNECT_RETRY_SECS,
                 )
+                # Manual runs bypass the reconnect state machine (it lives
+                # in the scheduled loop), so without this row an unreachable
+                # instance answers Run now with a success flash and an empty
+                # history.  Scheduled cycles leave the row to the state
+                # machine's one-per-streak transition instead.
+                if cycle_trigger == "run_now":
+                    await _write_log(
+                        instance_id=instance.core.id,
+                        item_id=None,
+                        item_type=None,
+                        action=SearchAction.error.value,
+                        cycle_id=cycle_id,
+                        cycle_trigger=cycle_trigger,
+                        message=f"Could not reach {instance.core.url}",
+                    )
                 return True
             except (EngineError, ClientError) as exc:
                 # ``run_instance_search`` wraps any non-typed escape in

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -386,7 +386,10 @@ class Supervisor:
                     cycle_trigger=cycle_trigger,
                 )
                 if instance.core.id in self._manual_error_open:
-                    self._manual_error_open.discard(instance.core.id)
+                    # Write before clearing the flag (mirrors the reconnect
+                    # state machine): a failed write leaves the flag set so
+                    # the pairing row is retried on the next success instead
+                    # of silently never landing.
                     await _write_log(
                         instance_id=instance.core.id,
                         item_id=None,
@@ -398,6 +401,7 @@ class Supervisor:
                             f"{instance.core.name!r} ({instance.core.url}) is reachable again"
                         ),
                     )
+                    self._manual_error_open.discard(instance.core.id)
                 return False
             except (httpx.TransportError, ClientTransportError):
                 # ``ClientTransportError`` is the typed wrapper the *arr
@@ -417,7 +421,6 @@ class Supervisor:
                 # history.  Scheduled cycles leave the row to the state
                 # machine's one-per-streak transition instead.
                 if cycle_trigger == "run_now":
-                    self._manual_error_open.add(instance.core.id)
                     await _write_log(
                         instance_id=instance.core.id,
                         item_id=None,
@@ -427,6 +430,10 @@ class Supervisor:
                         cycle_trigger=cycle_trigger,
                         message=f"Could not reach {instance.core.url}",
                     )
+                    # Flag only after the row exists; a failed write must not
+                    # leave an orphan flag that pairs a recovery row with an
+                    # error row that never landed.
+                    self._manual_error_open.add(instance.core.id)
                 return True
             except (EngineError, ClientError) as exc:
                 # ``run_instance_search`` wraps any non-typed escape in
@@ -564,6 +571,24 @@ class Supervisor:
                 )
                 await reconcile_cooldowns(instance.core.id, reconcile_sets)
                 self._snapshot_fail_warned.discard(instance.core.id)
+                # A successful snapshot proves the *arr is reachable, so an
+                # open run-now error can be paired here too.  Without this,
+                # a transient blip caught only by a manual click would pin
+                # the card offline (Run now button disabled) until the next
+                # scheduled cycle, up to a full sleep interval away; the
+                # snapshot loop bounds that window at its 10-minute cadence.
+                if instance.core.id in self._manual_error_open:
+                    await _write_log(
+                        instance_id=instance.core.id,
+                        item_id=None,
+                        item_type=None,
+                        action=SearchAction.info.value,
+                        cycle_trigger="system",
+                        message=(
+                            f"{instance.core.name!r} ({instance.core.url}) is reachable again"
+                        ),
+                    )
+                    self._manual_error_open.discard(instance.core.id)
             except (httpx.TransportError, ClientTransportError):
                 if instance.core.id not in self._snapshot_fail_warned:
                     self._snapshot_fail_warned.add(instance.core.id)

--- a/src/houndarr/engine/supervisor.py
+++ b/src/houndarr/engine/supervisor.py
@@ -101,6 +101,14 @@ class Supervisor:
         # `last_activity_at` in that case until the first post-restart cycle
         # completes.
         self._last_cycle_end: dict[int, datetime] = {}
+        # Instances with an unresolved run-now "Could not reach" error row.
+        # The dashboard marks a card offline while its newest row is an
+        # error, and healthy cycles on an empty backlog write no rows at
+        # all, so that row would pin the card offline forever (with the
+        # Run now button disabled) unless the next successful cycle pairs
+        # it with the same recovery info row the reconnect state machine
+        # writes for scheduled streaks.
+        self._manual_error_open: set[int] = set()
         # Instances whose snapshot refresh is in a transport-failure streak.
         # A failed refresh leaves the dashboard counters at their last-known
         # values (0 forever on a never-synced instance), so the first failure
@@ -377,6 +385,19 @@ class Supervisor:
                     cycle_id=cycle_id,
                     cycle_trigger=cycle_trigger,
                 )
+                if instance.core.id in self._manual_error_open:
+                    self._manual_error_open.discard(instance.core.id)
+                    await _write_log(
+                        instance_id=instance.core.id,
+                        item_id=None,
+                        item_type=None,
+                        action=SearchAction.info.value,
+                        cycle_id=cycle_id,
+                        cycle_trigger=cycle_trigger,
+                        message=(
+                            f"{instance.core.name!r} ({instance.core.url}) is reachable again"
+                        ),
+                    )
                 return False
             except (httpx.TransportError, ClientTransportError):
                 # ``ClientTransportError`` is the typed wrapper the *arr
@@ -396,6 +417,7 @@ class Supervisor:
                 # history.  Scheduled cycles leave the row to the state
                 # machine's one-per-streak transition instead.
                 if cycle_trigger == "run_now":
+                    self._manual_error_open.add(instance.core.id)
                     await _write_log(
                         instance_id=instance.core.id,
                         item_id=None,

--- a/src/houndarr/repositories/search_log.py
+++ b/src/houndarr/repositories/search_log.py
@@ -226,45 +226,26 @@ async def fetch_recent_searches(
     return int(row[0]) if row else 0
 
 
-async def has_rows_for_cycle(cycle_id: str, *, within_seconds: int = 3600) -> bool:
+async def has_rows_for_cycle(cycle_id: str) -> bool:
     """Return whether any ``search_log`` row was written for *cycle_id*.
 
     Used by the engine's run-now epilogue: a manual cycle that wrote no
     rows at all (empty wanted list, or every pass disabled) would
     otherwise finish invisibly, so the engine probes this and writes a
-    single info row explaining there was nothing to evaluate.
-
-    The trailing-window bound keeps the probe on
-    ``idx_search_log_timestamp`` (``cycle_id`` itself is unindexed);
-    callers check a cycle that started seconds ago, so the default
-    window is generous.
+    single info row explaining there was nothing to evaluate.  The
+    equality lookup rides ``idx_search_log_cycle``.
 
     Args:
         cycle_id: Shared cycle identifier stamped on every row of one
             cycle.
-        within_seconds: Trailing window to search. Non-positive values
-            return ``False`` without touching the database.
 
     Returns:
-        ``True`` when at least one row carries *cycle_id* inside the
-        window.
+        ``True`` when at least one row carries *cycle_id*.
     """
-    if within_seconds <= 0:
-        return False
-
-    cutoff = datetime.now(UTC) - timedelta(seconds=within_seconds)
-    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
-
     async with get_db() as db:
         async with db.execute(
-            """
-            SELECT 1
-            FROM search_log
-            WHERE timestamp > ?
-              AND cycle_id = ?
-            LIMIT 1
-            """,
-            (cutoff_iso, cycle_id),
+            "SELECT 1 FROM search_log WHERE cycle_id = ? LIMIT 1",
+            (cycle_id,),
         ) as cur:
             row = await cur.fetchone()
     return row is not None

--- a/src/houndarr/repositories/search_log.py
+++ b/src/houndarr/repositories/search_log.py
@@ -226,6 +226,50 @@ async def fetch_recent_searches(
     return int(row[0]) if row else 0
 
 
+async def has_rows_for_cycle(cycle_id: str, *, within_seconds: int = 3600) -> bool:
+    """Return whether any ``search_log`` row was written for *cycle_id*.
+
+    Used by the engine's run-now epilogue: a manual cycle that wrote no
+    rows at all (empty wanted list, or every pass disabled) would
+    otherwise finish invisibly, so the engine probes this and writes a
+    single info row explaining there was nothing to evaluate.
+
+    The trailing-window bound keeps the probe on
+    ``idx_search_log_timestamp`` (``cycle_id`` itself is unindexed);
+    callers check a cycle that started seconds ago, so the default
+    window is generous.
+
+    Args:
+        cycle_id: Shared cycle identifier stamped on every row of one
+            cycle.
+        within_seconds: Trailing window to search. Non-positive values
+            return ``False`` without touching the database.
+
+    Returns:
+        ``True`` when at least one row carries *cycle_id* inside the
+        window.
+    """
+    if within_seconds <= 0:
+        return False
+
+    cutoff = datetime.now(UTC) - timedelta(seconds=within_seconds)
+    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+    async with get_db() as db:
+        async with db.execute(
+            """
+            SELECT 1
+            FROM search_log
+            WHERE timestamp > ?
+              AND cycle_id = ?
+            LIMIT 1
+            """,
+            (cutoff_iso, cycle_id),
+        ) as cur:
+            row = await cur.fetchone()
+    return row is not None
+
+
 async def fetch_latest_missing_reason(
     instance_id: int,
     item_id: int,

--- a/src/houndarr/services/instance_validation.py
+++ b/src/houndarr/services/instance_validation.py
@@ -69,13 +69,14 @@ class ConnectionCheck:
     """Result of a connection test against an *arr instance.
 
     ``reachable`` is the only field that is always populated; the
-    other two carry the remote's self-reported name + version when
-    the probe succeeded and stay ``None`` when it failed.
+    others carry the remote's self-reported identity when the probe
+    succeeded and stay ``None`` when it failed.
     """
 
     reachable: bool
     app_name: str | None = None
     version: str | None = None
+    instance_name: str | None = None
 
 
 _APP_NAME_TO_TYPE: dict[str, InstanceType] = {
@@ -512,10 +513,22 @@ async def run_connection_test(
     # (instance_id set); "add this instance" is shown when the form
     # is creating a new one.
     action = "save changes" if instance_id else "add this instance"
+    # The remote's self-reported instance name is only shown when the
+    # operator customised it: the factory default equals the app name, and
+    # echoing that back is noise.  A custom name is the one signal that
+    # tells apart same-app servers (a 4K container, an old stack) when the
+    # user is unsure which one they just probed.
+    named = ""
+    if (
+        check.instance_name
+        and check.app_name
+        and check.instance_name.strip().lower() != check.app_name.strip().lower()
+    ):
+        named = f' (instance "{check.instance_name}")'
     if check.app_name and check.version:
-        message = f"Connected to {check.app_name} v{check.version}. You can now {action}."
+        message = f"Connected to {check.app_name} v{check.version}{named}. You can now {action}."
     elif check.app_name:
-        message = f"Connected to {check.app_name}. You can now {action}."
+        message = f"Connected to {check.app_name}{named}. You can now {action}."
     else:
         message = f"Connection successful. You can now {action}."
     return ConnectionTestOutcome(ok=True, message=message, status_code=200)
@@ -557,4 +570,5 @@ async def check_connection(
         reachable=True,
         app_name=status.app_name,
         version=status.version,
+        instance_name=status.instance_name,
     )

--- a/src/houndarr/services/instance_validation.py
+++ b/src/houndarr/services/instance_validation.py
@@ -519,12 +519,13 @@ async def run_connection_test(
     # tells apart same-app servers (a 4K container, an old stack) when the
     # user is unsure which one they just probed.
     named = ""
+    display_name = (check.instance_name or "").strip()
     if (
-        check.instance_name
+        display_name
         and check.app_name
-        and check.instance_name.strip().lower() != check.app_name.strip().lower()
+        and display_name.lower() != check.app_name.strip().lower()
     ):
-        named = f' (instance "{check.instance_name}")'
+        named = f' (instance "{display_name}")'
     if check.app_name and check.version:
         message = f"Connected to {check.app_name} v{check.version}{named}. You can now {action}."
     elif check.app_name:

--- a/src/houndarr/services/instance_validation.py
+++ b/src/houndarr/services/instance_validation.py
@@ -520,11 +520,7 @@ async def run_connection_test(
     # user is unsure which one they just probed.
     named = ""
     display_name = (check.instance_name or "").strip()
-    if (
-        display_name
-        and check.app_name
-        and display_name.lower() != check.app_name.strip().lower()
-    ):
+    if display_name and check.app_name and display_name.lower() != check.app_name.strip().lower():
         named = f' (instance "{display_name}")'
     if check.app_name and check.version:
         message = f"Connected to {check.app_name} v{check.version}{named}. You can now {action}."

--- a/src/houndarr/static/js/dashboard.js
+++ b/src/houndarr/static/js/dashboard.js
@@ -684,7 +684,23 @@ function initDashboardPage() {
     function renderStaleSnapshotPill(inst) {
       if (!inst.enabled || inst.active_error) return '';
       const ts = inst.snapshot_refreshed_at;
-      if (!ts) return '';
+      if (!ts) {
+        // Never-synced: no snapshot refresh has completed since the instance
+        // was added, so monitored_total still holds its column default and
+        // the card would otherwise show a bare 0/0/0 indistinguishable from
+        // a healthy empty instance (the failure mode users read as "broken"
+        // right after setup).  Reuses the stale-pill markup so the card only
+        // ever grows one pill shape.
+        return `
+  <span class="dash-card__stale" title="No snapshot has completed for this instance yet. Counts appear after the first refresh (usually within seconds of adding an instance; retried every 10 minutes). If this persists, check that the *arr is reachable.">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/>
+      <path d="M12 9v4"/>
+      <path d="M12 17h.01"/>
+    </svg>
+    <span>waiting for first sync</span>
+  </span>`;
+      }
       const refreshed = Date.parse(ts);
       if (Number.isNaN(refreshed)) return '';
       const age = Date.now() - refreshed;
@@ -783,14 +799,22 @@ function initDashboardPage() {
         ? ` data-tip="Lifetime: ${lifetimeVal} search${lifetimeVal === 1 ? '' : 'es'}"`
         : '';
 
+      // Never-synced instances render muted dashes instead of numbers: the
+      // snapshot columns still hold their defaults, so a numeric 0 would be
+      // asserting a count that was never actually measured.
+      const neverSynced = !disabled && !offline && !inst.snapshot_refreshed_at;
       const wantedText = offline || disabled
         ? `<dd class="dash-card__stat-value dash-card__stat-value--muted">${wantedVal || '-'}</dd>`
-        : `<dd class="dash-card__stat-value">${wantedVal}</dd>`;
+        : neverSynced
+          ? `<dd class="dash-card__stat-value dash-card__stat-value--muted">-</dd>`
+          : `<dd class="dash-card__stat-value">${wantedVal}</dd>`;
       const eligibleText = offline
         ? `<dd class="dash-card__stat-value dash-card__stat-value--muted">-</dd>`
         : disabled
           ? `<dd class="dash-card__stat-value dash-card__stat-value--muted">-</dd>`
-          : `<dd class="dash-card__stat-value dash-card__stat-value--eligible">${eligibleVal}</dd>`;
+          : neverSynced
+            ? `<dd class="dash-card__stat-value dash-card__stat-value--muted">-</dd>`
+            : `<dd class="dash-card__stat-value dash-card__stat-value--eligible">${eligibleVal}</dd>`;
       const searchedText = offline || disabled
         ? `<dd class="dash-card__stat-value dash-card__stat-value--muted">${searched24hVal}</dd>`
         : `<dd class="dash-card__stat-value dash-card__stat-value--searched">${searched24hVal}</dd>`;

--- a/tests/test_clients/test_radarr.py
+++ b/tests/test_clients/test_radarr.py
@@ -39,6 +39,33 @@ async def test_ping_success(client: RadarrClient) -> None:
 
 @pytest.mark.asyncio()
 @respx.mock
+async def test_ping_parses_instance_name(client: RadarrClient) -> None:
+    """The camelCase instanceName field survives the wire-model boundary."""
+    respx.get(f"{BASE}/api/v3/system/status").mock(
+        return_value=httpx.Response(
+            200,
+            json={"appName": "Radarr", "instanceName": "Radarr4K", "version": "5.11.0"},
+        )
+    )
+    result = await client.ping()
+    assert result is not None
+    assert result.instance_name == "Radarr4K"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_ping_without_instance_name_defaults_none(client: RadarrClient) -> None:
+    """Forks that omit instanceName still parse; the field stays None."""
+    respx.get(f"{BASE}/api/v3/system/status").mock(
+        return_value=httpx.Response(200, json={"appName": "Radarr", "version": "5.0.0"})
+    )
+    result = await client.ping()
+    assert result is not None
+    assert result.instance_name is None
+
+
+@pytest.mark.asyncio()
+@respx.mock
 async def test_ping_non_2xx_returns_none(client: RadarrClient) -> None:
     respx.get(f"{BASE}/api/v3/system/status").mock(return_value=httpx.Response(401))
     assert await client.ping() is None

--- a/tests/test_engine/test_run_now_empty_cycle.py
+++ b/tests/test_engine/test_run_now_empty_cycle.py
@@ -63,7 +63,9 @@ async def test_run_now_empty_cycle_writes_info_row(seeded_instances: None) -> No
     assert rows[0]["instance_id"] == 1
     assert rows[0]["item_id"] is None
     assert rows[0]["cycle_trigger"] == "run_now"
-    assert rows[0]["reason"] == "nothing to evaluate"
+    # Message-only: a reason would shadow the message in the logs page,
+    # which renders `reason or message`.
+    assert rows[0]["reason"] is None
     assert rows[0]["message"] == "Run now finished: no wanted items to evaluate"
 
 
@@ -116,7 +118,7 @@ async def test_run_now_all_passes_disabled_names_the_cause(seeded_instances: Non
     rows = await get_log_rows()
     assert len(rows) == 1
     assert rows[0]["action"] == "info"
-    assert rows[0]["reason"] == "nothing to evaluate"
+    assert rows[0]["reason"] is None
     assert rows[0]["message"] == "Run now finished: every search pass is disabled for this instance"
 
 

--- a/tests/test_engine/test_run_now_empty_cycle.py
+++ b/tests/test_engine/test_run_now_empty_cycle.py
@@ -1,0 +1,125 @@
+"""Tests for the run-now empty-cycle info row in run_instance_search()."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from houndarr.engine.search_loop import run_instance_search
+from houndarr.services.instances import InstanceType
+
+from .conftest import (
+    _COMMAND_RESP,
+    _EPISODE_RECORD,
+    MASTER_KEY,
+    SONARR_URL,
+    get_log_rows,
+    make_instance,
+)
+
+_EMPTY_WANTED: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 0,
+    "records": [],
+}
+
+_MISSING_SONARR_ONE: dict[str, Any] = {
+    "page": 1,
+    "pageSize": 10,
+    "totalRecords": 1,
+    "records": [_EPISODE_RECORD],
+}
+
+
+def _sonarr_instance(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "instance_id": 1,
+        "itype": InstanceType.sonarr,
+        "batch_size": 10,
+        "hourly_cap": 20,
+    }
+    defaults.update(overrides)
+    return make_instance(**defaults)
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_run_now_empty_cycle_writes_info_row(seeded_instances: None) -> None:
+    """A manual cycle that produced no rows leaves one visible info row."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_WANTED)
+    )
+
+    count = await run_instance_search(_sonarr_instance(), MASTER_KEY, cycle_trigger="run_now")
+
+    assert count == 0
+    rows = await get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "info"
+    assert rows[0]["instance_id"] == 1
+    assert rows[0]["item_id"] is None
+    assert rows[0]["cycle_trigger"] == "run_now"
+    assert rows[0]["reason"] == "nothing to evaluate"
+    assert rows[0]["message"] == "Run now finished: no wanted items to evaluate"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_scheduled_empty_cycle_stays_quiet(seeded_instances: None) -> None:
+    """Scheduled cycles keep their current no-row behaviour on empty fetches."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        return_value=httpx.Response(200, json=_EMPTY_WANTED)
+    )
+
+    count = await run_instance_search(_sonarr_instance(), MASTER_KEY, cycle_trigger="scheduled")
+
+    assert count == 0
+    assert await get_log_rows() == []
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_run_now_with_skip_row_writes_no_info_row(seeded_instances: None) -> None:
+    """When the cycle already produced a row, the epilogue adds nothing."""
+    from houndarr.services.cooldown import record_search
+
+    await record_search(1, 101, "episode")
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=_MISSING_SONARR_ONE),
+            httpx.Response(200, json=_EMPTY_WANTED),
+        ]
+    )
+
+    count = await run_instance_search(_sonarr_instance(), MASTER_KEY, cycle_trigger="run_now")
+
+    assert count == 0
+    rows = await get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "skipped"
+    assert rows[0]["reason"] == "on cooldown (7d)"
+
+
+@pytest.mark.asyncio()
+@respx.mock
+async def test_run_now_with_search_writes_no_info_row(seeded_instances: None) -> None:
+    """A manual cycle that dispatched a search never appends the info row."""
+    respx.get(f"{SONARR_URL}/api/v3/wanted/missing").mock(
+        side_effect=[
+            httpx.Response(200, json=_MISSING_SONARR_ONE),
+            httpx.Response(200, json=_EMPTY_WANTED),
+        ]
+    )
+    respx.post(f"{SONARR_URL}/api/v3/command").mock(
+        return_value=httpx.Response(201, json=_COMMAND_RESP)
+    )
+
+    count = await run_instance_search(_sonarr_instance(), MASTER_KEY, cycle_trigger="run_now")
+
+    assert count == 1
+    rows = await get_log_rows()
+    assert [r["action"] for r in rows] == ["searched"]

--- a/tests/test_engine/test_run_now_empty_cycle.py
+++ b/tests/test_engine/test_run_now_empty_cycle.py
@@ -105,6 +105,22 @@ async def test_run_now_with_skip_row_writes_no_info_row(seeded_instances: None) 
 
 
 @pytest.mark.asyncio()
+async def test_run_now_all_passes_disabled_names_the_cause(seeded_instances: None) -> None:
+    """With every search pass off, the info row says so instead of claiming
+    an empty wanted list (no HTTP call is made at all in this state)."""
+    instance = _sonarr_instance(missing_enabled=False)
+
+    count = await run_instance_search(instance, MASTER_KEY, cycle_trigger="run_now")
+
+    assert count == 0
+    rows = await get_log_rows()
+    assert len(rows) == 1
+    assert rows[0]["action"] == "info"
+    assert rows[0]["reason"] == "nothing to evaluate"
+    assert rows[0]["message"] == "Run now finished: every search pass is disabled for this instance"
+
+
+@pytest.mark.asyncio()
 @respx.mock
 async def test_run_now_with_search_writes_no_info_row(seeded_instances: None) -> None:
     """A manual cycle that dispatched a search never appends the info row."""

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -542,13 +542,13 @@ async def test_refresh_all_snapshots_handles_transport_error(
     caplog: pytest.LogCaptureFixture,
     transport_exc: BaseException,
 ) -> None:
-    """Transport errors are logged at DEBUG and suppressed; no traceback escapes.
+    """The first transport failure warns once; no traceback escapes.
 
     Pinned for both ``httpx.TransportError`` (the raw transport failure) and
     ``ClientTransportError`` (the typed wrapper *arr clients raise after the
-    typed-error refactor). Both must take the silent-skip branch; the typed
-    wrapper used to fall through to the broad ``except Exception`` and emit a
-    full traceback every refresh interval.
+    typed-error refactor). Both must land in the same streak-aware branch:
+    one WARNING on the first failure (a silently-stuck dashboard counter is
+    otherwise invisible at the default log level), never ERROR.
     """
     inst = _make_instance(enabled=True)
 
@@ -578,10 +578,79 @@ async def test_refresh_all_snapshots_handles_transport_error(
     assert error_records == [], (
         f"transport error should not log at ERROR; got {[r.getMessage() for r in error_records]}"
     )
-    debug_msgs = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
-    assert any("snapshot refresh skipped" in msg for msg in debug_msgs), (
-        f"expected DEBUG skip log, got: {debug_msgs}"
+    warning_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("snapshot refresh failed" in msg for msg in warning_msgs), (
+        f"expected WARNING on first snapshot failure, got: {warning_msgs}"
     )
+
+
+@pytest.mark.asyncio()
+async def test_snapshot_transport_failure_warns_once_per_streak(
+    seeded_instances: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Repeat failures stay at DEBUG; a successful refresh re-arms the warning."""
+    from houndarr.clients.base import InstanceSnapshot, ReconcileSets
+
+    inst = _make_instance(enabled=True)
+
+    class _BrokenCtx:
+        async def __aenter__(self) -> Any:
+            raise httpx.TransportError("unreachable")
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+    broken_adapter = type(
+        "FakeAdapter",
+        (),
+        {"make_client": staticmethod(lambda _inst: _BrokenCtx())},
+    )()
+
+    fake_client = AsyncMock()
+
+    class _CtxClient:
+        async def __aenter__(self) -> Any:
+            return fake_client
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+    working_adapter = type(
+        "FakeAdapter",
+        (),
+        {
+            "make_client": staticmethod(lambda _inst: _CtxClient()),
+            "fetch_instance_snapshot": staticmethod(
+                AsyncMock(return_value=InstanceSnapshot(monitored_total=1, unreleased_count=0))
+            ),
+            "fetch_reconcile_sets": staticmethod(AsyncMock(return_value=ReconcileSets.empty())),
+        },
+    )()
+
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    with caplog.at_level("DEBUG", logger="houndarr.engine.supervisor"):
+        with patch("houndarr.engine.supervisor.get_adapter", return_value=broken_adapter):
+            await supervisor._refresh_one_snapshot(inst)
+            await supervisor._refresh_one_snapshot(inst)
+        with patch("houndarr.engine.supervisor.get_adapter", return_value=working_adapter):
+            await supervisor._refresh_one_snapshot(inst)
+        with patch("houndarr.engine.supervisor.get_adapter", return_value=broken_adapter):
+            await supervisor._refresh_one_snapshot(inst)
+
+    warnings = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelname == "WARNING" and "snapshot refresh failed" in r.getMessage()
+    ]
+    debugs = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelname == "DEBUG" and "snapshot refresh skipped" in r.getMessage()
+    ]
+    assert len(warnings) == 2, f"one warning per streak expected, got: {warnings}"
+    assert len(debugs) == 1, f"repeat failures should stay at DEBUG, got: {debugs}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -713,6 +713,90 @@ async def test_run_now_recovery_writes_reachable_again_row(seeded_instances: Non
 
 
 @pytest.mark.asyncio()
+async def test_recovery_flag_survives_failed_write(seeded_instances: None) -> None:
+    """A failed recovery write keeps the flag so the pairing row is retried."""
+    inst = _make_instance(enabled=True)
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        AsyncMock(side_effect=httpx.ConnectError("refused")),
+    ):
+        await supervisor._run_search_cycle(inst, cycle_trigger="run_now")
+
+    with (
+        patch("houndarr.engine.supervisor.run_instance_search", AsyncMock(return_value=0)),
+        patch(
+            "houndarr.engine.supervisor._write_log",
+            AsyncMock(side_effect=RuntimeError("db locked")),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await supervisor._run_search_cycle(inst, cycle_trigger="scheduled")
+
+    assert inst.core.id in supervisor._manual_error_open
+
+    with patch("houndarr.engine.supervisor.run_instance_search", AsyncMock(return_value=0)):
+        await supervisor._run_search_cycle(inst, cycle_trigger="scheduled")
+
+    rows = await _get_log_rows()
+    assert [r["action"] for r in rows] == ["error", "info"]
+    assert inst.core.id not in supervisor._manual_error_open
+
+
+@pytest.mark.asyncio()
+async def test_snapshot_success_pairs_open_manual_error(seeded_instances: None) -> None:
+    """A successful snapshot refresh pairs an open run-now error too.
+
+    Bounds the pinned-offline window (Run now button disabled) at the
+    snapshot cadence when the *arr recovers before the next search cycle.
+    """
+    from houndarr.clients.base import InstanceSnapshot, ReconcileSets
+
+    inst = _make_instance(enabled=True)
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        AsyncMock(side_effect=httpx.ConnectError("refused")),
+    ):
+        await supervisor._run_search_cycle(inst, cycle_trigger="run_now")
+
+    fake_client = AsyncMock()
+
+    class _CtxClient:
+        async def __aenter__(self) -> Any:
+            return fake_client
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+    working_adapter = type(
+        "FakeAdapter",
+        (),
+        {
+            "make_client": staticmethod(lambda _inst: _CtxClient()),
+            "fetch_instance_snapshot": staticmethod(
+                AsyncMock(return_value=InstanceSnapshot(monitored_total=1, unreleased_count=0))
+            ),
+            "fetch_reconcile_sets": staticmethod(AsyncMock(return_value=ReconcileSets.empty())),
+        },
+    )()
+
+    with patch("houndarr.engine.supervisor.get_adapter", return_value=working_adapter):
+        await supervisor._refresh_one_snapshot(inst)
+        # A second success must not repeat the recovery row.
+        await supervisor._refresh_one_snapshot(inst)
+
+    rows = await _get_log_rows()
+    infos = [r for r in rows if r["action"] == "info"]
+    assert len(infos) == 1
+    assert infos[0]["cycle_trigger"] == "system"
+    assert infos[0]["message"] == f"{inst.core.name!r} ({inst.core.url}) is reachable again"
+    assert inst.core.id not in supervisor._manual_error_open
+
+
+@pytest.mark.asyncio()
 async def test_scheduled_transport_error_leaves_row_to_state_machine(
     seeded_instances: None,
 ) -> None:

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -672,14 +672,44 @@ async def test_run_now_transport_error_writes_error_row(seeded_instances: None) 
 
     assert got_error is True
     async with get_db() as conn:
-        async with conn.execute(
-            "SELECT action, cycle_trigger, message FROM search_log"
-        ) as cur:
+        async with conn.execute("SELECT action, cycle_trigger, message FROM search_log") as cur:
             rows = [dict(r) for r in await cur.fetchall()]
     assert len(rows) == 1
     assert rows[0]["action"] == "error"
     assert rows[0]["cycle_trigger"] == "run_now"
     assert rows[0]["message"] == f"Could not reach {inst.core.url}"
+
+
+@pytest.mark.asyncio()
+async def test_run_now_recovery_writes_reachable_again_row(seeded_instances: None) -> None:
+    """The next successful cycle pairs an open run-now error with a recovery row.
+
+    Without the pairing, the error row stays the newest row forever on an
+    empty backlog (healthy cycles write nothing there) and pins the card
+    offline with the Run now button disabled.
+    """
+    inst = _make_instance(enabled=True)
+    supervisor = Supervisor(master_key=MASTER_KEY)
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        AsyncMock(side_effect=httpx.ConnectError("refused")),
+    ):
+        await supervisor._run_search_cycle(inst, cycle_trigger="run_now")
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        AsyncMock(return_value=0),
+    ):
+        await supervisor._run_search_cycle(inst, cycle_trigger="scheduled")
+        # A second success must not repeat the recovery row.
+        await supervisor._run_search_cycle(inst, cycle_trigger="scheduled")
+
+    async with get_db() as conn:
+        async with conn.execute("SELECT action, message FROM search_log ORDER BY id") as cur:
+            rows = [dict(r) for r in await cur.fetchall()]
+    assert [r["action"] for r in rows] == ["error", "info"]
+    assert rows[1]["message"] == f"{inst.core.name!r} ({inst.core.url}) is reachable again"
 
 
 @pytest.mark.asyncio()

--- a/tests/test_engine/test_supervisor.py
+++ b/tests/test_engine/test_supervisor.py
@@ -653,6 +653,57 @@ async def test_snapshot_transport_failure_warns_once_per_streak(
     assert len(debugs) == 1, f"repeat failures should stay at DEBUG, got: {debugs}"
 
 
+@pytest.mark.asyncio()
+async def test_run_now_transport_error_writes_error_row(seeded_instances: None) -> None:
+    """A manual cycle against an unreachable instance leaves a visible error row.
+
+    Manual runs bypass the scheduled loop's reconnect state machine, so the
+    cycle itself must write the row; without it, Run now answers with a
+    success flash and an empty history (issue #678).
+    """
+    inst = _make_instance(enabled=True)
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        AsyncMock(side_effect=httpx.ConnectError("refused")),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        got_error = await supervisor._run_search_cycle(inst, cycle_trigger="run_now")
+
+    assert got_error is True
+    async with get_db() as conn:
+        async with conn.execute(
+            "SELECT action, cycle_trigger, message FROM search_log"
+        ) as cur:
+            rows = [dict(r) for r in await cur.fetchall()]
+    assert len(rows) == 1
+    assert rows[0]["action"] == "error"
+    assert rows[0]["cycle_trigger"] == "run_now"
+    assert rows[0]["message"] == f"Could not reach {inst.core.url}"
+
+
+@pytest.mark.asyncio()
+async def test_scheduled_transport_error_leaves_row_to_state_machine(
+    seeded_instances: None,
+) -> None:
+    """Scheduled cycles do not write the transport row themselves; the
+    reconnect state machine owns the one-per-streak transition rows."""
+    inst = _make_instance(enabled=True)
+
+    with patch(
+        "houndarr.engine.supervisor.run_instance_search",
+        AsyncMock(side_effect=httpx.ConnectError("refused")),
+    ):
+        supervisor = Supervisor(master_key=MASTER_KEY)
+        got_error = await supervisor._run_search_cycle(inst, cycle_trigger="scheduled")
+
+    assert got_error is True
+    async with get_db() as conn:
+        async with conn.execute("SELECT COUNT(*) AS n FROM search_log") as cur:
+            row = await cur.fetchone()
+    assert row is not None and row["n"] == 0
+
+
 @pytest.mark.parametrize(
     "reconcile_exc",
     [

--- a/tests/test_repositories/test_search_log.py
+++ b/tests/test_repositories/test_search_log.py
@@ -276,6 +276,37 @@ async def test_fetch_recent_searches_scopes_to_instance_and_kind(
     assert await repo.fetch_recent_searches(2, search_kind="missing", within_seconds=3600) == 1
 
 
+@pytest.mark.asyncio()
+async def test_has_rows_for_cycle_true_when_row_exists(seeded_instances: None) -> None:
+    """A row stamped with the cycle_id makes the probe return True."""
+    await repo.insert_log_row(
+        instance_id=1,
+        item_id=1,
+        item_type="episode",
+        action="skipped",
+        search_kind="missing",
+        cycle_id="cycle-abc",
+    )
+    assert await repo.has_rows_for_cycle("cycle-abc") is True
+
+
+@pytest.mark.asyncio()
+async def test_has_rows_for_cycle_false_for_other_cycles(seeded_instances: None) -> None:
+    """Rows from other cycles (or NULL cycle_id) do not match."""
+    await repo.insert_log_row(
+        instance_id=1,
+        item_id=1,
+        item_type="episode",
+        action="searched",
+        search_kind="missing",
+        cycle_id="cycle-abc",
+    )
+    await repo.insert_log_row(
+        instance_id=1, item_id=2, item_type="episode", action="searched", search_kind="missing"
+    )
+    assert await repo.has_rows_for_cycle("cycle-other") is False
+
+
 @pytest.mark.pinning()
 @pytest.mark.asyncio()
 async def test_delete_logs_for_instance_returns_row_count(seeded_instances: None) -> None:

--- a/tests/test_services/test_run_connection_test.py
+++ b/tests/test_services/test_run_connection_test.py
@@ -308,6 +308,89 @@ async def test_success_with_app_name_no_version(monkeypatch: pytest.MonkeyPatch)
     assert outcome.message == "Connected to Sonarr. You can now add this instance."
 
 
+@pytest.mark.asyncio()
+async def test_success_with_custom_instance_name_shows_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A customised instanceName is echoed so multi-instance mixups are visible."""
+
+    async def fake_check_connection(instance_type: Any, url: str, api_key: str) -> ConnectionCheck:
+        return ConnectionCheck(
+            reachable=True, app_name="Radarr", version="5.11.0", instance_name="Radarr4K"
+        )
+
+    monkeypatch.setattr(
+        "houndarr.services.instance_validation.check_connection", fake_check_connection
+    )
+
+    outcome = await run_connection_test(
+        master_key=b"",
+        type_value="radarr",
+        url="http://radarr:7878",
+        api_key="key",
+    )
+    assert outcome.ok is True
+    assert outcome.message == (
+        'Connected to Radarr v5.11.0 (instance "Radarr4K"). You can now add this instance.'
+    )
+
+
+@pytest.mark.asyncio()
+async def test_success_with_default_instance_name_suppresses_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The factory-default instanceName (equal to the app name) stays hidden.
+
+    Case differences do not count as customisation; upstream forks have
+    shipped both casings of the default.
+    """
+
+    async def fake_check_connection(instance_type: Any, url: str, api_key: str) -> ConnectionCheck:
+        return ConnectionCheck(
+            reachable=True, app_name="Radarr", version="5.11.0", instance_name="radarr"
+        )
+
+    monkeypatch.setattr(
+        "houndarr.services.instance_validation.check_connection", fake_check_connection
+    )
+
+    outcome = await run_connection_test(
+        master_key=b"",
+        type_value="radarr",
+        url="http://radarr:7878",
+        api_key="key",
+    )
+    assert outcome.ok is True
+    assert outcome.message == "Connected to Radarr v5.11.0. You can now add this instance."
+
+
+@pytest.mark.asyncio()
+async def test_success_with_instance_name_but_no_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The instance-name suffix also rides the no-version message shape."""
+
+    async def fake_check_connection(instance_type: Any, url: str, api_key: str) -> ConnectionCheck:
+        return ConnectionCheck(
+            reachable=True, app_name="Sonarr", version=None, instance_name="Sonarr Anime"
+        )
+
+    monkeypatch.setattr(
+        "houndarr.services.instance_validation.check_connection", fake_check_connection
+    )
+
+    outcome = await run_connection_test(
+        master_key=b"",
+        type_value="sonarr",
+        url="http://sonarr:8989",
+        api_key="key",
+    )
+    assert outcome.ok is True
+    assert outcome.message == (
+        'Connected to Sonarr (instance "Sonarr Anime"). You can now add this instance.'
+    )
+
+
 def test_connection_test_outcome_is_frozen_slotted() -> None:
     """ConnectionTestOutcome stays frozen + slotted for the slots audit."""
     import dataclasses

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -116,13 +116,14 @@ or Jellyseerr alongside your *arr stack.
 
 ## Houndarr's history shows titles that aren't in my \*arr library. Where do they come from?
 
-Every history row is copied from a live wanted list response of the
-URL configured on that instance, and a `searched` row only appears
-after that same server accepts the search command. Compare the
-instance URL in Houndarr's settings against the \*arr you are
-viewing, then look for one of the titles under that server's
-`Wanted > Missing` page. A second container (a 4K instance, an old
-stack) or an import list quietly adding items is the usual cause.
+Every title in the history was reported by the \*arr at the URL
+configured on that instance moments before the row was written, and
+a `searched` row only appears after that same server accepts the
+search command. Compare the instance URL in Houndarr's settings
+against the \*arr you are viewing; for missing items, the title
+will be under that server's `Wanted > Missing` page. A second
+container (a 4K instance, an old stack) or an import list quietly
+adding items is the usual cause.
 `Test connection` shows the server's custom instance name when it
 has one, which helps tell same-app servers apart.
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -41,6 +41,16 @@ See
 [How Houndarr Works](/docs/concepts/how-scheduling-works#why-only-a-few-items-get-searched-each-cycle)
 for the full funnel.
 
+## I added an instance and it shows 0 wanted. Is it broken?
+
+Counts come from a snapshot taken shortly after the instance is
+added and refreshed every 10 minutes; until the first snapshot
+completes, the card shows `waiting for first sync` instead of
+numbers. A freshly reset \*arr also reports nothing until it has
+finished importing its library. `Run now` against an empty wanted
+list logs `Run now finished: no wanted items to evaluate` rather
+than staying silent.
+
 ## Why is Houndarr skipping so much?
 
 Each skipped row logs a reason string that tells you why. A high
@@ -103,6 +113,18 @@ format scores; Houndarr does not influence that decision.
 No. Houndarr only triggers searches within your *arr instances for
 items already tracked there. For request workflows, use Overseerr
 or Jellyseerr alongside your *arr stack.
+
+## Houndarr's history shows titles that aren't in my \*arr library. Where do they come from?
+
+Every history row is copied from a live wanted list response of the
+URL configured on that instance, and a `searched` row only appears
+after that same server accepts the search command. Compare the
+instance URL in Houndarr's settings against the \*arr you are
+viewing, then look for one of the titles under that server's
+`Wanted > Missing` page. A second container (a 4K instance, an old
+stack) or an import list quietly adding items is the usual cause.
+`Test connection` shows the server's custom instance name when it
+has one, which helps tell same-app servers apart.
 
 ## I deleted files to free up space. Will Houndarr re-download them?
 


### PR DESCRIPTION
## Summary

Makes three silent states visible so working-as-designed stops looking like breakage: never-synced instance cards, run-now cycles with nothing to do, and which *arr a connection test actually reached.

Closes #678

## Changes

- Dashboard cards show a `waiting for first sync` pill and muted dashes for Wanted / Eligible until the first snapshot completes, so a fresh or just-reset instance no longer renders a bare 0/0/0.
- `Run now` always leaves a history row: one info row when there was nothing to evaluate (with a distinct message when every search pass is disabled), and a `Could not reach <url>` error row on transport failure, paired with a `reachable again` info row once the instance responds again (next successful cycle or snapshot refresh, whichever comes first).
- The first failed snapshot refresh in a streak logs at WARNING with the instance URL instead of debug only; repeats stay at DEBUG and the warning re-arms on success.
- `Test connection` appends the *arr's self-reported instance name when it differs from the app name, which tells same-app servers apart in multi-instance setups.
- FAQ entries for history titles that are not in the library you are viewing, and for new instances showing 0 wanted.

## Testing

New unit tests cover the empty-cycle epilogue (empty fetch, all passes disabled, skip and search suppression), the transport error row and both recovery pairings (including flag survival when the write fails), the warn-once streak, the `instanceName` wire parse, and the connection message variants. Also driven end-to-end against the seeded mock *arr (populated, empty, and all-passes-off run-now scenarios). All checks pass.

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
