### PR TITLE
chore(deps): clear website Dependabot advisories

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -11,11 +11,11 @@ overrides:
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   fast-uri: '>=3.1.4 <4'
   mermaid: '>=11.15.0'
-  webpack-dev-server: '>=5.2.5 <6'
+  webpack-dev-server: '>=5.2.6 <6'
   ws: '>=8.21.0'
   shell-quote: '>=1.8.4'
   undici: '>=7.28.0 <8'
-  dompurify: '>=3.4.11 <4'
+  dompurify: '>=3.4.12 <4'
   '@babel/core': '>=7.29.1 <8'
   http-proxy-middleware: '>=2.0.10 <3'
   joi: '>=17.13.4 <18'
@@ -23,6 +23,7 @@ overrides:
   js-yaml@4: '>=4.1.2 <5'
   launch-editor: '>=2.14.1 <3'
   qs: '>=6.15.2 <7'
+  body-parser: '>=1.20.6 <2'
   websocket-driver: '>=0.7.5 <0.8'
   brace-expansion@1: '>=1.1.16 <2'
   sharp: '>=0.35.0 <0.36'
@@ -2778,8 +2779,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  body-parser@1.20.5:
-    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   bonjour-service@1.3.0:
@@ -3490,8 +3491,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -6202,8 +6203,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.5:
-    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
+  webpack-dev-server@5.2.6:
+    resolution: {integrity: sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -7742,7 +7743,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.106.2(@swc/core@1.15.33)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.5(debug@4.4.3)(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33))
+      webpack-dev-server: 5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33))
       webpack-merge: 6.0.1
     optionalDependencies:
       '@docusaurus/faster': 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -8939,7 +8940,7 @@ snapshots:
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
       '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.2
     optional: true
 
@@ -9991,7 +9992,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  body-parser@1.20.5:
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -10772,7 +10773,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10964,7 +10965,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.5
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
@@ -12011,7 +12012,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -14013,7 +14014,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.5(debug@4.4.3)(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)):
+  webpack-dev-server@5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.33)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -30,11 +30,12 @@ overrides:
   # classDefs, configuration, and Gantt-chart sanitisation.
   # Transitive via @docusaurus/theme-mermaid.
   mermaid: ">=11.15.0"
-  # GHSA-mx8g-39q3-5c79: webpack-dev-server <5.2.5 lets a malicious
-  # page intercept the HMR WebSocket through permissive user proxies;
-  # supersedes the earlier CVE-2026-6402 <=5.2.3 floor. Transitive via
-  # @docusaurus/core; only active during `pnpm start`.
-  webpack-dev-server: ">=5.2.5 <6"
+  # webpack-dev-server <=5.2.5 carries GHSA-m28w-2pqf-7qgj (DoS via a
+  # malformed Host or Origin header) and GHSA-f5vj-f2hx-8m93 (CSRF
+  # through internal developer endpoints), both fixed in 5.2.6;
+  # supersedes the earlier GHSA-mx8g-39q3-5c79 <5.2.5 floor.
+  # Transitive via @docusaurus/core; only active during `pnpm start`.
+  webpack-dev-server: ">=5.2.6 <6"
   # CVE-2026-48779 (GHSA-96hv-2xvq-fx4p): ws >=8.0.0 <8.21.0 allows a
   # memory-exhaustion DoS from a flood of tiny WebSocket fragments;
   # supersedes the earlier CVE-2026-45736 <8.20.1 floor. Transitive
@@ -54,13 +55,15 @@ overrides:
   # line since the fix landed in 7.28.0 and nothing in the tree needs
   # undici 8.
   undici: ">=7.28.0 <8"
-  # dompurify <3.4.11 carries a cluster of eight sanitizer-bypass and
-  # config-pollution advisories (GHSA-x4vx-rjvf-j5p4,
-  # GHSA-vxr8-fq34-vvx9, GHSA-gvmj-g25r-r7wr, GHSA-rp9w-3fw7-7cwq,
-  # GHSA-hpcv-96wg-7vj8, GHSA-r47g-fvhr-h676, GHSA-76mc-f452-cxcm,
-  # GHSA-cmwh-pvxp-8882), all fixed by 3.4.11. Transitive via
-  # @docusaurus/theme-mermaid > mermaid.
-  dompurify: ">=3.4.11 <4"
+  # dompurify <=3.4.11 lets an allowed custom element bypass
+  # afterSanitizeElements via CUSTOM_ELEMENT_HANDLING
+  # (GHSA-c2j3-45gr-mqc4), fixed in 3.4.12; supersedes the earlier
+  # >=3.4.11 floor that cleared the eight-advisory sanitizer-bypass
+  # cluster (GHSA-x4vx-rjvf-j5p4, GHSA-vxr8-fq34-vvx9,
+  # GHSA-gvmj-g25r-r7wr, GHSA-rp9w-3fw7-7cwq, GHSA-hpcv-96wg-7vj8,
+  # GHSA-r47g-fvhr-h676, GHSA-76mc-f452-cxcm, GHSA-cmwh-pvxp-8882).
+  # Transitive via @docusaurus/theme-mermaid > mermaid.
+  dompurify: ">=3.4.12 <4"
   # GHSA-4x5r-pxfx-6jf8: @babel/core <7.29.1 can read arbitrary files
   # through a crafted sourceMappingURL comment during compilation.
   # Transitive via @docusaurus/core > @docusaurus/babel.
@@ -91,6 +94,12 @@ overrides:
   # encodeValuesOnly is set. Transitive via @docusaurus/core >
   # webpack-dev-server > express > body-parser.
   qs: ">=6.15.2 <7"
+  # GHSA-v422-hmwv-36x6: body-parser <1.20.6 silently disables size
+  # enforcement when the `limit` option parses to an invalid value,
+  # allowing an unbounded-body DoS. Transitive via @docusaurus/core >
+  # webpack-dev-server > express; only active during `pnpm start`.
+  # Held to the 1.x line that express 4 declares.
+  body-parser: ">=1.20.6 <2"
   # websocket-driver <0.7.5 carries two advisories, both fixed in
   # 0.7.5: GHSA-xv26-6w52-cph6 (CVE-2026-54466, message corruption by
   # abusing protocol length headers) and GHSA-mp7j-qc5w-4988


### PR DESCRIPTION
## Summary

Clears the four Dependabot advisories open against the docs-site lockfile. All transitive through the Docusaurus toolchain; the Trivy filesystem scan is a required check, so these would block PRs once they reach its database.

Closes #682

## Changes

- `body-parser` floored at `>=1.20.6` (new override): DoS when an invalid `limit` silently disables size enforcement (GHSA-v422-hmwv-36x6).
- `webpack-dev-server` floor raised `>=5.2.5` -> `>=5.2.6`: DoS via malformed Host/Origin header (GHSA-m28w-2pqf-7qgj) and CSRF via internal developer endpoints (GHSA-f5vj-f2hx-8m93).
- `dompurify` floor raised `>=3.4.11` -> `>=3.4.12`: `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` for allowed custom elements (GHSA-c2j3-45gr-mqc4).
- `pnpm-lock.yaml` refreshed: the three resolve to 1.20.6, 5.2.6, and 3.4.12.

Docs site is served as static files on Pages, so webpack-dev-server and body-parser execute only during local `pnpm start`.

## Testing

`pnpm install --frozen-lockfile` clean and `pnpm build` succeeds (mermaid pages render). All checks pass.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes (N/A: dependency lockfile bump)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
