### PR TITLE
ci: ignore brace-expansion CVE-2026-14257

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -110,6 +110,10 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: "true"
           exit-code: "1"
+          # Scoped, dated suppressions for advisories with no resolvable
+          # fix. Trivy only auto-detects the plain-text `.trivyignore`
+          # name, so the YAML form has to be passed explicitly.
+          trivyignores: .trivyignore.yaml
 
       # Upload SARIF to the GitHub Security tab for non-fork runs.
       # Fork PRs lack security-events: write so this step is skipped.
@@ -124,6 +128,7 @@ jobs:
           severity: CRITICAL,HIGH
           ignore-unfixed: "true"
           exit-code: "0"
+          trivyignores: .trivyignore.yaml
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,23 @@
+# Advisories the lockfiles cannot resolve away yet. Read by the Trivy
+# filesystem scan through the `trivyignores` input in
+# .github/workflows/security.yml.
+#
+# Every entry is scoped to the lockfile it applies to and carries an
+# `expired_at` date, so the scan turns red again if the upstream fix
+# never lands. Delete the entry once the floor can be raised instead.
+
+vulnerabilities:
+  - id: CVE-2026-14257
+    paths:
+      - "website/pnpm-lock.yaml"
+    expired_at: 2026-09-08
+    statement: >-
+      brace-expansion is patched only in 5.0.8; the advisory covers every
+      earlier release across all four majors, so no 1.x floor can satisfy
+      it. The docs-site tree reaches brace-expansion through minimatch 3,
+      which needs the CommonJS default export that 5.x replaced with a
+      named one, so the tree stays on 1.x until the upstream v1 backport
+      (juliangruber/brace-expansion#129) ships 1.1.17. minimatch 3 is
+      pulled in only by serve-handler behind `docusaurus serve`, which
+      passes no rewrite, redirect or header globs, so nothing in this
+      repo reaches the expansion code.


### PR DESCRIPTION
## Summary

Unblocks the Trivy filesystem scan, which has been failing on `main` since
CVE-2026-14257 was published for brace-expansion. The advisory covers every
release through 5.0.7 across all four majors, so the docs-site 1.x floor
cannot be raised past it, and 5.0.8 cannot be forced because `minimatch@3.1.5`
needs the CommonJS default export that 5.x replaced with a named one.

Closes #686

## Changes

- New `.trivyignore.yaml` suppressing CVE-2026-14257, scoped to
  `website/pnpm-lock.yaml` and expiring 2026-09-08. The statement records why
  no floor satisfies the advisory and that nothing in the tree reaches the
  expansion code: minimatch 3 is pulled in only by `serve-handler` behind
  `docusaurus serve`, which passes no rewrite, redirect or header globs.
- `security.yml` passes `trivyignores: .trivyignore.yaml` to both trivy-action
  steps. Trivy auto-detects only the plain-text `.trivyignore` name, so the
  YAML form has to be named explicitly. Job names are unchanged.

The upstream v1 backport is open as juliangruber/brace-expansion#129. When it
ships 1.1.17, raise the floor in `website/pnpm-workspace.yaml` and drop the
ignore entry.

## Testing

`trivy fs` over a clean export of the tracked tree exits 1 without the ignore
file and 0 with it, scanning the same three targets as the failing run.
`--show-suppressed` lists exactly one entry. `actionlint` is clean on the
workflow. All checks pass.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes (N/A: CI configuration only)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
