### PR TITLE
docs: match branch protection docs to settings

### DIFF
--- a/.agents/skills/houndarr-ci/SKILL.md
+++ b/.agents/skills/houndarr-ci/SKILL.md
@@ -47,11 +47,16 @@ identical check names so branch protection is satisfied.
 ## Branch protection on `main`
 
 - 11 required status checks (strict; branch must be up to date)
-- Required PR reviews enabled (dismiss stale reviews, required conversation resolution)
+- PRs required, stale reviews dismissed, conversation resolution required
+- Required approving reviews is 0, so no approval blocks a merge
 - Linear history enforced (no merge commits)
 - No force pushes, no branch deletions
-- Enforce admins enabled
-- CODEOWNERS: `@av1155` owns all files
+- Admin enforcement is off. The rules above bind contributors; the
+  maintainer account can push to `main` and merge past a failing check.
+  The hooks in `.claude/settings.json` are the real block on direct
+  edits and pushes while on `main`.
+- CODEOWNERS assigns `@av1155` to every file, but code owner review is
+  not a required gate
 
 ## Don't break this
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,12 @@ docs-only PRs satisfy branch protection. **Do not modify the 11 required
 check job names**: branch protection depends on exact name matches.
 
 Branch protection on `main`: 11 required status checks (strict; branch
-must be up to date), required PR reviews, linear history, no force
-pushes, no branch deletions, enforce admins, CODEOWNERS `@av1155`.
+must be up to date), PRs required, stale reviews dismissed,
+conversation resolution required, linear history, no force pushes, no
+branch deletions. Required approving reviews is 0 and CODEOWNERS
+`@av1155` is informational, so no approval blocks a merge. Admin
+enforcement is off, which means the rules above bind contributors while
+the maintainer account can bypass them.
 
 ---
 
@@ -277,7 +281,11 @@ Subject line max 50 characters (including the `type(scope): ` prefix); body line
 
 ### Restrictions on `main`
 
-- No direct pushes (branch protection + enforce admins)
+- No direct pushes. Admin enforcement is off, so the remote accepts a
+  push to `main` from the maintainer account; the hooks in
+  `.claude/settings.json` are what actually block editing repo files and
+  pushing while on `main`. Treat this as policy, not as a guarantee the
+  server will catch the mistake.
 - No force pushes
 - No branch deletion
 - All changes go through PRs with passing required checks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
-# Global code owner — all files require review from @av1155
+# Global code owner: @av1155 is requested for review on every file.
+# Code owner review is not a required merge gate on `main`.
 * @av1155


### PR DESCRIPTION
## Summary

Branch protection on `main` has admin enforcement off and
`required_approving_review_count` set to 0, but three places describe it as
having "enforce admins" and "required PR reviews". The admin line is the one
that misleads: it presents direct pushes to `main` as blocked server-side,
when the remote will accept one from the maintainer account and the real
block is the hooks in `.claude/settings.json`.

Closes #688

## Changes

- `AGENTS.md`: the branch protection summary and the "Restrictions on `main`"
  entry now describe the settings as configured, and say which layer actually
  stops a direct push
- `.agents/skills/houndarr-ci/SKILL.md`: same correction in the "Branch
  protection on `main`" section
- `CODEOWNERS`: the header no longer claims every file requires review;
  code owner review is not a required gate

No branch protection settings were changed. Whether to turn admin
enforcement on is left open in the issue.

## Testing

Every line checked against the branch protection API response. The two hooks
referenced in the new text were read from `.claude/settings.json` to confirm
they block what the docs now say they block. All checks pass.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes (N/A: documentation only)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
