### PR TITLE
docs: drop corepack from pnpm setup steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The missing-CSS-bundle startup error drops the `corepack enable` step, which fails on Node 25 and newer; `pnpm install` alone honours the `packageManager` pin. (#691)
+
 ---
 
 ## [1.13.0] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The missing-CSS-bundle startup error drops the `corepack enable` step, which fails on Node 25 and newer; `pnpm install` alone honours the `packageManager` pin. (#691)
+- The missing-CSS-bundle startup error no longer prefixes its fix command with `corepack enable`, which Node 25 and newer do not ship. (#691)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- The missing-CSS-bundle startup error no longer prefixes its fix command with `corepack enable`, which Node 25 and newer do not ship. (#691)
-
 ---
 
 ## [1.13.0] - 2026-07-24

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@
 FROM node:22-alpine AS css-build
 WORKDIR /build
 
-# node:22-alpine still bundles corepack, which is the only route to pnpm in
-# this image. Node 25 dropped it from the distribution, so a base bump past
-# 24 has to install pnpm another way. The packageManager field in
-# package.json pins the exact pnpm version.
+# corepack ships with node:22-alpine, so enabling it is the cheapest way to
+# get pnpm here. Node 25 stopped distributing corepack, so a base bump past 24
+# needs `npm i -g pnpm` or the standalone installer instead. The packageManager
+# field in package.json pins the exact pnpm version either way.
 RUN corepack enable
 
 # Copy manifest + lockfile + workspace config first for better layer caching.

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@
 FROM node:22-alpine AS css-build
 WORKDIR /build
 
-# Enable pnpm via corepack (bundled with Node 20+). The packageManager field
-# in package.json pins the exact pnpm version.
+# node:22-alpine still bundles corepack, which is the only route to pnpm in
+# this image. Node 25 dropped it from the distribution, so a base bump past
+# 24 has to install pnpm another way. The packageManager field in
+# package.json pins the exact pnpm version.
 RUN corepack enable
 
 # Copy manifest + lockfile + workspace config first for better layer caching.

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -92,7 +92,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
             "pnpm run build-css` from the project root before starting "
             "Houndarr, or use the official Docker image which builds "
             "it automatically. See "
-            "docs/guides/installation/from-source.md.",
+            "https://av1155.github.io/houndarr/docs/guides/installation/from-source.",
             css_bundle,
         )
         msg = "Compiled CSS bundle missing; refusing to start"

--- a/src/houndarr/app.py
+++ b/src/houndarr/app.py
@@ -88,7 +88,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     if not css_bundle.is_file():
         logger.critical(
             "Compiled CSS bundle not found at %s. Run "
-            "`corepack enable && pnpm install --frozen-lockfile && "
+            "`pnpm install --frozen-lockfile && "
             "pnpm run build-css` from the project root before starting "
             "Houndarr, or use the official Docker image which builds "
             "it automatically. See "

--- a/tests/test_app_startup.py
+++ b/tests/test_app_startup.py
@@ -100,7 +100,10 @@ async def test_lifespan_fails_when_css_bundle_missing(
 
     messages = [record.getMessage() for record in caplog.records]
     assert any("pnpm run build-css" in m for m in messages)
-    assert any("from-source.md" in m for m in messages)
+    assert any("installation/from-source" in m for m in messages)
+    # The old message told operators to run `corepack enable` first, which
+    # Node 25 and newer no longer ship (#691).
+    assert not any("corepack" in m for m in messages)
 
 
 async def test_lifespan_succeeds_when_css_bundle_present(

--- a/website/docs/guides/installation/from-source.md
+++ b/website/docs/guides/installation/from-source.md
@@ -17,7 +17,7 @@ is for development.
 - Python 3.13 or later
 - [uv](https://docs.astral.sh/uv/) (preferred) or pip
 - Node.js 22 or later
-- pnpm 11 or later (via `corepack enable`)
+- pnpm 11 or later ([install](https://pnpm.io/installation))
 
 ## Setup
 
@@ -31,8 +31,8 @@ cd houndarr
 # by default.
 uv sync
 
-# Compile the Tailwind + daisyUI CSS bundle
-corepack enable
+# Compile the Tailwind + daisyUI CSS bundle. pnpm reads the packageManager
+# pin in package.json and fetches that exact version itself.
 pnpm install --frozen-lockfile
 pnpm run build-css
 


### PR DESCRIPTION
Node stopped shipping Corepack with the v25 distribution, so `corepack enable` fails on a current Node install. pnpm 11 reads the `packageManager` pin and fetches that exact version itself, so the step is redundant even where it still works.

Changed the from-source install guide (prerequisites and setup block) and the missing-CSS-bundle startup message.

The Dockerfile keeps `corepack enable`: `node:22-alpine` bundles it and there is no other route to pnpm in that image. Its comment now records that a base bump past 24 needs a different install path.

Closes #691