### PR TITLE
fix: drop pip and uv from the runtime image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Docker image no longer ships `pip` or `uv` and is roughly 87MB smaller; `docker exec` sessions no longer have either available. (#693)
 
-### Security
-
-- Image scans stop reporting the `msgpack` and `setuptools` advisories, which came from pip's vendored manifest and no Houndarr code path reached. (#693)
-
 ---
 
 ## [1.13.0] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Docker image ships without `pip` and `uv`, which were only ever build-time tools, and is about 87MB smaller for it. `docker exec` sessions no longer have either on `PATH`. (#693)
+
+### Security
+
+- Image scans no longer report `msgpack` and `setuptools` advisories. Both were pins inside pip's vendored manifest rather than installed packages, and no Houndarr code path reached them. (#693)
+
 ---
 
 ## [1.13.0] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The Docker image ships without `pip` and `uv`, which were only ever build-time tools, and is about 87MB smaller for it. `docker exec` sessions no longer have either on `PATH`. (#693)
+- The Docker image no longer ships `pip` or `uv` and is roughly 87MB smaller; `docker exec` sessions no longer have either available. (#693)
 
 ### Security
 
-- Image scans no longer report `msgpack` and `setuptools` advisories. Both were pins inside pip's vendored manifest rather than installed packages, and no Houndarr code path reached them. (#693)
+- Image scans stop reporting the `msgpack` and `setuptools` advisories, which came from pip's vendored manifest and no Houndarr code path reached. (#693)
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,11 +65,20 @@ RUN apt-get update \
 # reads the project version; copy them too so `uv export` can resolve the
 # build backend without the rest of the source tree.
 COPY pyproject.toml uv.lock VERSION hatch_build.py ./
+#
+# pip and uv are removed in the same layer once the install finishes.  Neither
+# is invoked at runtime, and pip's vendored dependency set (`pip/_vendor/
+# vendor.txt`, which pins msgpack and setuptools) is what image scanners report
+# against the published image even though no Houndarr code path can reach it.
+# Dropping them here keeps them out of the layer instead of whiting them out in
+# a later one, so the image shrinks as well.
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --upgrade pip uv \
     && uv export --frozen --no-hashes --no-emit-project --no-dev -o /tmp/requirements.txt \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
-    && rm /tmp/requirements.txt
+    && rm /tmp/requirements.txt \
+    && python -m pip uninstall --yes uv \
+    && python -m pip uninstall --yes pip
 
 # Copy application source
 COPY src/ ./src/


### PR DESCRIPTION
The `Trivy image scan` required check fails on every PR touching a non-docs path, reporting `msgpack` 1.1.2 (GHSA-6v7p-g79w-8964) and `setuptools` 70.3.0 (CVE-2025-47273) as HIGH.

Neither package is installed in the image. Both are entries in `pip/_vendor/vendor.txt`, which Trivy parses as a package manifest. They came in with pip 26.2; the published image still carries pip 26.1.2 and scans clean, so this is a new finding rather than a stale result. I reproduced it with a `--no-cache` build of `main` before changing anything.

`uv` only exports the pinned requirements list and `pip` only installs it, so neither is needed after that layer. Removing both in the same `RUN` clears the findings and drops about 87MB.

Verified locally on the built image:

- Trivy library scan reports no HIGH or CRITICAL findings
- dependency set unchanged, 33 dist-info entries, only `pip` and `uv` gone
- bytecode still precompiled (626 `.pyc`), so startup is unaffected
- 404MB to 317MB
- `/api/health` returns 200 under the default PUID/PGID remap, under `PUID=1500`, and under `PUID=0`
- `--user 1001` produces byte-identical output to `main`

Operators lose `pip` and `uv` from `docker exec` sessions, noted in the changelog.

Closes #693