### PR TITLE
docs: record the action SHA-pinning convention

### DIFF
--- a/.agents/skills/houndarr-ci/SKILL.md
+++ b/.agents/skills/houndarr-ci/SKILL.md
@@ -66,3 +66,11 @@ identical check names so branch protection is satisfied.
 - Keep `paths-ignore` patterns in sync across the six main workflows.
 - If mypy CI fails with "merge ref not found": push an empty commit to
   retrigger.
+- Keep every action pinned to a full 40-character commit SHA with the
+  release version as the last token of a trailing comment
+  (`uses: owner/repo@<sha> # vX.Y.Z`). Dependabot rewrites the SHA and
+  the comment together, but only while the version ends the comment.
+  A tag or branch ref can be repointed by the action owner; a SHA
+  cannot. When pinning by hand, dereference annotated tags to their
+  commit: for those actions `git/ref/tags/vN` returns a tag object
+  whose SHA the runner cannot resolve.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,14 @@ someone comments, so reporters get immediate feedback.
 - Do not change `ci-skip.yml` job names without updating branch protection
 - If mypy CI fails with "merge ref not found": push an empty commit to retrigger
 - Keep `paths-ignore` patterns in sync across the six main workflows
+- Keep every action pinned to a full 40-character commit SHA with the release
+  version as the last token of a trailing comment
+  (`uses: owner/repo@<sha> # vX.Y.Z`). Dependabot rewrites the SHA and the
+  comment together, but only while the version ends the comment, so
+  `# v7.0.1 (pinned)` silently stops the comment tracking the SHA. A tag or
+  branch ref can be repointed by the action owner; a SHA cannot. When pinning
+  by hand, dereference annotated tags to their commit: for those actions
+  `git/ref/tags/vN` returns a tag object whose SHA the runner cannot resolve
 
 ### Handling conflicts between docs and practice
 


### PR DESCRIPTION
## Summary

#699 converted all 71 action references to full commit SHAs, but nothing in the
repo records that this is the convention. The pinning is easy to undo without
anyone noticing: a contributor tidying a workflow, or a snippet copied from
upstream docs, naturally produces `uses: actions/checkout@v7`, which reads as
normal and reviews as harmless while the supply-chain guarantee quietly goes
away.

Closes #700

## Changes

The same bullet lands in both places that enumerate the CI invariants, since
they otherwise mirror each other and would drift:

- `AGENTS.md`, under `### Avoiding CI/release breakage`
- `.agents/skills/houndarr-ci/SKILL.md`, under `## Don't break this`
  (`.claude/skills/houndarr-ci` is a directory symlink into this file)

It records two details that are easy to get wrong and expensive to rediscover:

- Dependabot rewrites the SHA and the trailing version comment together, but
  only while the version is the **last token** of the comment. Something like
  `# v7.0.1 (pinned)` silently stops the comment tracking the SHA, leaving a pin
  whose stated version drifts from what it actually runs.
- Annotated tags have to be dereferenced to their commit. For those actions
  `git/ref/tags/vN` returns a tag object, and pinning that SHA records a ref the
  runner cannot resolve. 7 of the 26 actions here are annotated tags, and the
  failure would land in schedule-only workflows that a PR never exercises.

## Testing

Documentation only, no behaviour change. The pin audit still reports zero
non-SHA references across the 23 workflow files:

```
$ grep -rn "uses:" .github/workflows/ | grep -vE "uses: [A-Za-z0-9._/-]+@[0-9a-f]{40} # "
(no output)
```

Both files are Markdown, so `paths-ignore` routes this through `ci-skip`.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes (N/A: documentation only)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
