### PR TITLE
test(e2e): seed setup in e2e-up so local runs match CI

### DIFF
--- a/scripts/e2e_browser/capture_baselines.sh
+++ b/scripts/e2e_browser/capture_baselines.sh
@@ -149,6 +149,35 @@ _wait_for_houndarr() {
     exit 1
 }
 
+# Create the admin account, mirroring the "Create test admin account" step
+# in .github/workflows/browser-e2e.yml.  Without it a local stack diverges
+# from CI: POST /setup is what seeds ``changelog_last_seen_version``, and
+# an unseeded marker makes the What's-new modal auto-open 800ms after
+# every page load, where showModal() renders the page inert and every
+# subsequent click in the suite is intercepted.
+#
+# A 302 means setup already ran against a database this stack inherited,
+# so the marker was never seeded and the modal will interfere.  That is
+# the only reliable way to detect the condition: on macOS the host copy
+# of DATA_DIR looks empty even when the container's /data is not.
+_seed_setup() {
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -X POST "http://localhost:${HOUNDARR_HOST_PORT}/setup" \
+        -d 'username=admin&password=CITestPass1!&password_confirm=CITestPass1!')
+    case "${code}" in
+        303) _info "admin account created (admin / CITestPass1!)" ;;
+        302)
+            _warn "setup already complete: this stack inherited a database"
+            _warn "the What's-new modal will steal clicks; run 'just e2e-down' first"
+            ;;
+        *)
+            _fail "unexpected status ${code} from POST /setup"
+            exit 1
+            ;;
+    esac
+}
+
 _teardown() {
     _info "tearing down e2e stack"
     docker rm -f houndarr-e2e mock-sonarr mock-radarr >/dev/null 2>&1 || true
@@ -158,6 +187,13 @@ _teardown() {
     # specific dataset in their home dir) should not have that
     # directory wiped on teardown; leave it in place and warn instead.
     if [ "${DATA_DIR}" = "/tmp/houndarr-e2e-data" ]; then
+        # Docker Desktop on macOS keeps bind-mount contents inside its VM
+        # rather than on the host path, so a host-side rm leaves the
+        # container's /data untouched and the next ``up`` inherits a
+        # completed setup.  Clear it through a container first so
+        # teardown means the same thing on Linux and macOS.
+        docker run --rm -v "${DATA_DIR}:/data" --entrypoint sh "${IMAGE}" \
+            -c 'find /data -mindepth 1 -delete' >/dev/null 2>&1 || true
         rm -rf "${DATA_DIR}"
     else
         _warn "DATA_DIR override detected (${DATA_DIR}); leaving contents intact"
@@ -172,6 +208,7 @@ _up() {
     _wait_for_mocks
     _start_houndarr
     _wait_for_houndarr
+    _seed_setup
     _info "stack up.  docker ps | grep -E 'houndarr-e2e|mock-'"
     _info "when finished, tear down with: just e2e-down"
 }

--- a/tests/e2e_browser/test_flows.py
+++ b/tests/e2e_browser/test_flows.py
@@ -778,6 +778,10 @@ def test_instance_toggle_and_delete_keeps_layout_stable(
     # Toggle back so the row is Active again, then delete.
     toggle_btn.click()
     expect(toggle_btn).to_have_text(re.compile(r"Disable", re.I), timeout=5_000)
+    # The label flips mid-swap, so match the first toggle above and wait for
+    # the swap to settle. Otherwise the delete click below can land on the
+    # row HTMX is still replacing.
+    _wait_for_htmx_idle(page)
 
     delete_btn = row.locator("button[hx-delete]")
     # settings.js intercepts htmx:confirm and routes delete through the


### PR DESCRIPTION
## Summary

`just e2e-up` never created the admin account, while
`.github/workflows/browser-e2e.yml` does it in a dedicated step. That single
difference makes a local stack diverge from CI in a way that reads as a flaky
test.

`POST /setup` is what seeds `changelog_last_seen_version`. Without it,
`should_show` reaches `_parse_version(None) is None` and returns `True`, so
`base.html` pulls the What's-new modal 800 ms after every page load and
`changelog.js` opens it with `showModal()`, which makes the rest of the document
inert. Every click the suite issues after that is intercepted:

```
57 x waiting for element to be visible, enabled and stable
   - element is visible, enabled and stable
   - <dialog open="" id="changelog-modal" ...> subtree intercepts pointer events
```

Teardown had a second, compounding problem. It only removed the host path, but
Docker Desktop on macOS keeps bind-mount contents inside its VM, so the
container's `/data` survived `just e2e-down` untouched. The stack I hit this on
was still carrying a `houndarr.masterkey` dated 18 July across many teardowns,
which is why setup kept returning 302 and the marker was never seeded.

Closes #706

## Changes

- `_up` creates the admin account after the health check, mirroring the
  workflow. A 303 means it was created; a 302 means this stack inherited a
  database, and the warning says so and points at `just e2e-down`. That status
  code is the only reliable signal, because on macOS the host copy of
  `DATA_DIR` looks empty even when the container's `/data` is not.
- `_teardown` clears the data directory through a container before the
  host-side `rm`, so teardown means the same thing on Linux and macOS. The
  existing `DATA_DIR` override guard is unchanged, so a custom directory is
  still left alone.
- `test_instance_toggle_and_delete_keeps_layout_stable` waits for HTMX to settle
  after the second toggle, matching the first. The delete click otherwise
  follows a row swap with no settle wait. This one is hardening rather than a
  fix for an observed failure.

No application code changes. `setup_post` returning 302 when setup is complete
is correct, and the popup behaviour is correct; the local script simply did not
do what the workflow does.

## Testing

The before/after is deterministic rather than a race. On the stale stack,
`test_instance_toggle_and_delete_keeps_layout_stable` failed 3 runs out of 4.
After `just e2e-down && just e2e-up` with these changes:

```
run 1: exit=0    run 2: exit=0    run 3: exit=0    run 4: exit=0
```

and the full chromium file passes twice, 18 of 18 both times.

The acceptance criteria check out directly. Teardown now empties the container's
`/data` (verified by mounting it from a throwaway container), `e2e-up` reports
`admin account created`, and the popup endpoint returns the empty slot rather
than modal markup:

```
$ curl -s -b cookies http://localhost:8877/settings/changelog/popup
<div id="changelog-slot" aria-hidden="true"></div>
[HTTP 200]
```

`bash -n` and `shellcheck` are clean on the script. `ruff check` and
`ruff format --check` pass. Skipping pytest: the diff is a shell script plus one
e2e-only line, and no unit test covers either. CI runs the three-engine matrix.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
