### PR TITLE
ci: fail workflow-lint on unpinned action references

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -30,3 +30,39 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
+
+  # Separate from the actionlint job on purpose: actionlint has no rule for
+  # pinning, so a failure reported under its name would send whoever hits
+  # this looking for an actionlint config that does not exist.
+  pin-check:
+    name: Actions pinned to commit SHAs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check action pins
+        run: |
+          set -euo pipefail
+          # actionlint's `uses:` checks validate format and flag outdated
+          # popular actions; both accept @v4 and @main, so this gap is ours
+          # to cover. Local composite actions (uses: ./path) live in this
+          # repo and have no SHA to pin, so they are exempt. Everything else
+          # must carry a full commit SHA plus a trailing version comment,
+          # and the version has to be the comment's last token or Dependabot
+          # stops updating it alongside the SHA.
+          #
+          # `|| true` because grep exits 1 when it matches nothing, which is
+          # the passing case and which `set -e` would otherwise treat as a
+          # failure.
+          offenders=$(grep -rnE '^[[:space:]]*-?[[:space:]]*uses:' .github/workflows/ \
+            | grep -vE 'uses:[[:space:]]*\./' \
+            | grep -vE 'uses:[[:space:]]*[A-Za-z0-9._/-]+@[0-9a-f]{40}[[:space:]]+#[[:space:]]+\S' \
+            || true)
+          if [ -n "$offenders" ]; then
+            echo "::error::Actions must be pinned as 'owner/repo@<40-char-sha> # vX.Y.Z'"
+            echo "$offenders"
+            exit 1
+          fi
+          echo "All action references are SHA-pinned"


### PR DESCRIPTION
## Summary

#699 pinned all 71 action references to commit SHAs and #707 wrote the
convention down, but nothing enforced it. An edit reverting a pin to
`uses: actions/checkout@v7` still merged cleanly. That revert is the natural
thing to type: it is what upstream READMEs show and what a copied snippet
contains, so it reads as normal and reviews as harmless while the guarantee
quietly goes away for that action.

`workflow-lint.yml` already triggers on `paths: [".github/workflows/**"]`, which
is exactly when a pin can change and never otherwise, so the check lives there.

Closes #709

## Changes

One new job in `.github/workflows/workflow-lint.yml`. Nothing else changes.

**Why a grep rather than actionlint config.** actionlint has no pinning rule.
Its checks doc lists two `uses:`-related rules, "Action format in `uses:`" and
"Outdated popular actions detection", and format validation accepts any ref
including `@v4` and `@main`. The existing `reviewdog/action-actionlint` step
will never catch this, so there is no knob to turn.

**Why a separate job.** Given the above, a pin failure surfacing under the check
named `Lint GitHub Actions workflows (actionlint)` would send whoever hits it
looking for an actionlint config that does not exist. A distinctly named job
attributes the failure correctly. `workflow-lint` is not one of the 11 required
checks, so adding a job name here carries no branch-protection risk.

**Why not a dedicated action.** `zgosalvez/github-actions-ensure-sha-pinned-actions`
is maintained but small, and using a third-party action to enforce supply-chain
hygiene means pinning and Dependabot-tracking one more dependency in order to
police dependencies. The grep has no supply-chain surface of its own and matches
the hand-rolled precedent in `version-check.yml`.

Local `uses: ./` composite actions are exempt because they have no SHA to pin.
None exist today (`.github/actions/` is absent); the exclusion is there before
it is needed rather than after it blocks someone.

## Testing

Red and green were both proven by extracting the check body straight out of the
workflow and running it, so the test exercises the shipped code rather than a
retyped copy of it.

Against the real tree:

```
All action references are SHA-pinned
EXIT: 0
```

Against a fixture copy with one pin reverted to `actions/checkout@v7`:

```
::error::Actions must be pinned as 'owner/repo@<40-char-sha> # vX.Y.Z'
.github/workflows/version-check.yml:28:        uses: actions/checkout@v7
EXIT: 1
```

The predicate was also checked against the cases that could bite it. Tag refs,
branch refs, and a bare SHA with no version comment are all flagged. Correctly
pinned refs pass, subpath actions like `github/codeql-action/upload-sarif` pass,
`uses: ./` passes, and a comment line mentioning `uses: x@v1` passes because the
pattern anchors on the start of the line.

`actionlint` reports the same single pre-existing shellcheck warning it reports
on `main` and nothing new, so the new `run:` block is shellcheck-clean. The YAML
parses with both jobs present.

No CHANGELOG entry: CI-only changes do not get one.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
