### PR TITLE
docs(changelog): backfill entry for runtime image pip removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - `cryptography` bumped to 50.0.0, clearing GHSA-g6cj-pr64-35w5, a Bleichenbacher oracle in PKCS#7 decryption; Houndarr links it only through Fernet encryption of stored \*arr API keys. (#704)
+- `pip` and `uv` are uninstalled from the runtime image after the dependency install, dropping the two HIGH findings pip's vendored copies added to image scans (GHSA-6v7p-g79w-8964, CVE-2025-47273). Neither was reachable at run time. (#697)
 
 ---
 


### PR DESCRIPTION
## Summary

#696 uninstalled `pip` and `uv` from the runtime image but shipped no CHANGELOG
bullet, so `## [Unreleased]` recorded only the `cryptography` bump.

That removal is the only change since v1.13.0 that alters what self-hosters
actually run. Eleven commits landed in that window; the other ten are CI, tests,
docs, or the docs-site lockfile, none of which belongs in a changelog. The
Dockerfile diff since the release is a single behavioural line:

```
+    && pip uninstall -y uv pip
```

Everything else in it is comments.

Two things an operator can observe: `pip` and `uv` are gone from the container,
and the two HIGH findings pip's vendored copies contributed
(GHSA-6v7p-g79w-8964 for msgpack, CVE-2025-47273 for setuptools) disappear from
image scans. That last one matters to anyone scanning
`ghcr.io/av1155/houndarr` themselves.

Same reasoning as #627, which backfilled a `### Security` entry for the urllib3
bump #623 shipped without one.

Closes #711

## Changes

One bullet under the existing `### Security` heading. It references #697, the
issue the removal closed, rather than the omnibus PR, so the reference points at
the change being described.

The entry says plainly that neither finding was reachable at run time. Implying
users were exposed would be a false security claim in a public changelog.

## Testing

Documentation only. Both bullets are within the 250-character ceiling (192 and
240), the block keeps its noun-led present-tense voice, and the structure
`version-check.yml` enforces still holds: `## [Unreleased]` is the topmost
`## [...]` block, `### Security` is an allowed header, the trailing `---` is
present, and no em dashes. `VERSION` stays at `1.13.0`, matching the latest tag.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [x] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes (N/A: changelog only)
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
