### PR TITLE
fix(deps): raise js-yaml and nanoid floors

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -19,9 +19,10 @@ overrides:
   '@babel/core': '>=7.29.1 <8'
   http-proxy-middleware: '>=2.0.10 <3'
   joi: '>=17.13.4 <18'
-  js-yaml@3: '>=3.15.0 <4'
-  js-yaml@4: '>=4.1.2 <5'
+  js-yaml@3: '>=3.15.1 <4'
+  js-yaml@4: '>=4.3.1 <5'
   launch-editor: '>=2.14.1 <3'
+  nanoid: '>=3.3.17 <4'
   qs: '>=6.15.2 <7'
   body-parser: '>=1.20.6 <2'
   websocket-driver: '>=0.7.5 <0.8'
@@ -4242,12 +4243,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4757,8 +4758,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7944,7 +7945,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -8470,7 +8471,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.33)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.4
       joi: 17.13.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -8495,7 +8496,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3
       jiti: 1.21.7
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -10318,7 +10319,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -11181,7 +11182,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -11610,12 +11611,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -12382,7 +12383,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   negotiator@0.6.3: {}
 
@@ -13049,7 +13050,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -89,18 +89,25 @@ overrides:
   # deeply nested input through recursive link() schemas. Transitive
   # via @docusaurus/core > @docusaurus/utils > @docusaurus/types.
   joi: ">=17.13.4 <18"
-  # GHSA-h67p-54hq-rp68: js-yaml quadratic-complexity DoS in merge-key
-  # handling via repeated aliases, fixed in 3.15.0 and 4.1.2. Two
-  # lines resolve in the tree: gray-matter pins js-yaml 3 (kept on the
-  # 3.x fix so its safeLoad API survives) and Docusaurus build tooling
-  # pulls js-yaml 4.
-  "js-yaml@3": ">=3.15.0 <4"
-  "js-yaml@4": ">=4.1.2 <5"
+  # CVE-2026-59870 (GHSA-5p4m-2wfm-xmqj): js-yaml quadratic CPU
+  # consumption resolving !!omap, fixed in 3.15.1 and 4.3.1;
+  # supersedes the earlier >=3.15.0 and >=4.1.2 floors that cleared
+  # GHSA-h67p-54hq-rp68 (quadratic-complexity DoS in merge-key
+  # handling via repeated aliases). Two lines resolve in the tree:
+  # gray-matter pins js-yaml 3 (kept on the 3.x fix so its safeLoad
+  # API survives) and Docusaurus build tooling pulls js-yaml 4.
+  "js-yaml@3": ">=3.15.1 <4"
+  "js-yaml@4": ">=4.3.1 <5"
   # GHSA-v6wh-96g9-6wx3: launch-editor <2.14.1 leaks an NTLMv2 hash
   # through UNC path handling on Windows. Transitive via
   # @docusaurus/core > webpack-dev-server; only active during
   # `pnpm start`.
   launch-editor: ">=2.14.1 <3"
+  # CVE-2026-67213: nanoid <3.3.17 spins in an infinite loop generating
+  # random IDs, a DoS reachable from whatever feeds it a size. Held to
+  # the 3.x line that postcss 8 declares; the other fix, 5.1.6, is
+  # ESM-only. Transitive via @docusaurus/core > postcss.
+  nanoid: ">=3.3.17 <4"
   # GHSA-q8mj-m7cp-5q26: qs 6.11.1..=6.15.1 crashes with a TypeError
   # (DoS) on null/undefined entries in comma-format arrays when
   # encodeValuesOnly is set. Transitive via @docusaurus/core >


### PR DESCRIPTION
## Summary

The Trivy filesystem scan has been failing on every PR and on the scheduled
Security run, with three HIGH findings in `website/pnpm-lock.yaml`. Since it is
one of the eleven required checks, nothing can merge until the floors move.

CVE-2026-59870 (GHSA-5p4m-2wfm-xmqj) is a new js-yaml advisory, quadratic CPU
consumption resolving `!!omap`, and it hits both lines that resolve in the tree.
The floors from #719 target the earlier merge-key advisory, so `js-yaml@3` sat
at `>=3.15.0` and `js-yaml@4` at `>=4.1.2`, each one patch short of the fix.
`nanoid` had no override and resolved to 3.3.16, which carries CVE-2026-67213,
an infinite loop in random ID generation.

Closes #723

## Changes

- `js-yaml@3` floor to `>=3.15.1 <4`, staying on the 3.x line gray-matter needs
  for its `safeLoad` API. Resolves 3.15.1.
- `js-yaml@4` floor to `>=4.3.1 <5`. Resolves 4.3.1.
- New `nanoid` floor at `>=3.3.17 <4`, held to the line postcss 8 declares since
  the other fixed version, 5.1.6, is ESM-only. Resolves 3.3.18.

## Testing

`trivy fs .` with the same flags CI uses now reports 0 findings for
`website/pnpm-lock.yaml`, alongside the 0 it already reported for `uv.lock` and
`tests/e2e_browser/requirements.txt`. The docs site builds.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A, dependency floors only
- [ ] Type check passes (`mypy src/`) — N/A, no Python changed
- [ ] Lint passes (`ruff check .`) — N/A, no Python changed
- [ ] Format passes (`ruff format --check .`) — N/A, no Python changed
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way — N/A, docs-site dependencies
