### PR TITLE
fix(ci): raise lychee timeout and retries

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,9 +1,13 @@
 # Lychee link-checker configuration.
 # https://lychee.cli.rs/configuration/
 
-max_retries = 2
-retry_wait_time = 2
-timeout = 20
+# Generous because a timeout counts as a failure and fails the whole run, even
+# though lychee reports it separately from errors. www.authelia.com answers in
+# well under a second from an ordinary client but intermittently stalls when
+# asked from an Actions runner, which is what every red run so far has been.
+max_retries = 3
+retry_wait_time = 3
+timeout = 45
 no_progress = true
 
 # 2xx is fine; 403 and 429 usually mean the host rate-limited an


### PR DESCRIPTION
## Summary

The weekly Link Check has been failing on a summary that looks like a pass:

```
| ✅ Successful  | 85    |
| ⏳ Timeouts    | 1     |
| 🚫 Errors      | 0     |
```

lychee counts a timeout as a failure and exits 2, so one slow host turns the
run red with no broken links. All three red runs report the same single URL and
nothing else: `https://www.authelia.com/integration/proxies/traefik/`, linked
from `website/docs/guides/sso-proxy-auth.md:137`.

The link is not broken. It answers 200 in 0.2-0.4s on both HEAD and GET from an
ordinary client, so this is specific to Actions runner IPs. It is also
intermittent rather than a hard block: a dispatch on 6 August passed with zero
timeouts about twenty minutes after a PR run failed on the same URL.

Closes #727

## Changes

- `timeout` 20 to 45, `max_retries` 2 to 3, `retry_wait_time` 2 to 3.

Worst case for one bad link becomes roughly three minutes, inside the job's
`timeout-minutes: 8`. lychee checks concurrently and only this one link is
slow, so normal runtime is unchanged.

## Testing

Link Check runs on this PR, since its trigger includes `lychee.toml`. That is
the real test: it exercises the actual host from an actual runner. Given the
failure is intermittent, one green run is not conclusive, so I re-dispatched it
several times before merging.

If it turns out 45s is still not enough, the follow-up is to exclude the host
with a comment recording that it is unreliable from runners and that the link
was verified good by hand. Excluding it is the fallback rather than the opening
move, because it means the repo stops noticing if Authelia ever moves the page.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A, checker config; the run is the test
- [ ] Type check passes (`mypy src/`) — N/A, no Python changed
- [ ] Lint passes (`ruff check .`) — N/A, no Python changed
- [ ] Format passes (`ruff format --check .`) — N/A, no Python changed
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way — N/A, repo tooling
