### PR TITLE
ci: add a force input to the star history floor

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -11,6 +11,11 @@ on:
   watch:
     types: [started]
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Publish even if the star count fell below the floor"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -50,6 +55,7 @@ jobs:
       - name: Fetch stargazer timestamps
         env:
           GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
           gh api --paginate \
@@ -66,16 +72,31 @@ jobs:
           # count in the aria-label, which makes a usable floor: real unstarring
           # is gradual, so losing half the stars in a day means the fetch was
           # truncated rather than the stars being gone.
-          PREVIOUS=$(sed -n 's/.*: \([0-9]\{1,\}\) stars,.*/\1/p' \
-            assets-branch/star-history-dark.svg)
+          PUBLISHED=assets-branch/star-history-dark.svg
+          if [ ! -f "${PUBLISHED}" ]; then
+            # Without this, `sed` exits non-zero under `set -e` and the step
+            # dies with a bare exit code that reads like an unrelated failure.
+            echo "::error::${PUBLISHED} is missing from the assets branch."
+            exit 1
+          fi
+          PREVIOUS=$(sed -n 's/.*: \([0-9]\{1,\}\) stars,.*/\1/p' "${PUBLISHED}")
           echo "Previously published: ${PREVIOUS:-unknown}"
 
+          # Unconditional even under force: publishing the "No stars yet"
+          # placeholder over a good chart is the exact accident the guard
+          # exists to prevent, and no legitimate force case wants it.
           if [ "${COUNT}" -eq 0 ]; then
             echo "::error::Stargazer fetch returned no rows; refusing to publish."
             exit 1
           fi
-          if [ -n "${PREVIOUS}" ] && [ "${COUNT}" -lt $((PREVIOUS / 2)) ]; then
+          # The floor reads back from the published chart, so a run that
+          # refuses never moves it: without an override a genuine halving
+          # (mass unstar, repo transfer) wedges every later run forever.
+          if [ "${FORCE}" = "true" ]; then
+            echo "Force requested; skipping the floor check."
+          elif [ -n "${PREVIOUS}" ] && [ "${COUNT}" -lt $((PREVIOUS / 2)) ]; then
             echo "::error::Fetched ${COUNT} rows against ${PREVIOUS} published; refusing to publish."
+            echo "::error::Re-run with the force input if the drop is real."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

The truncation guard in the star history workflow cannot recover once it trips.
It refuses to publish when the fresh count is under half the published count,
and it reads that published count back out of the chart's own `aria-label`. A
run that refuses never publishes, so the number it compares against never
moves, and every later run fails identically. `workflow_dispatch` took no
inputs, so the only way out was hand-editing the `aria-label` on the `assets`
branch.

The guard itself is right: a truncated API response should not overwrite a good
chart with a near-empty one. But a legitimate halving, from a mass unstar or a
repo transfer, is indistinguishable from truncation at that point and needs a
way through.

Closes #726

## Changes

- `workflow_dispatch` gains a `force` boolean input, default false, passed to
  the step through `env:` rather than interpolated into the script.
- `force` skips only the floor comparison. The zero-row refusal stays
  unconditional, because publishing the "No stars yet" placeholder over a good
  chart is the exact accident the guard exists to prevent and no legitimate
  force case wants it.
- The refusal message now says how to get past it.
- A missing published chart fails with an `::error::` annotation. Previously
  `sed` exited non-zero under `set -euo pipefail` and the step died with a bare
  exit code that reads like an unrelated failure.

## Testing

`actionlint` clean. I ran the guard logic as a standalone script across all six
paths, including the one that is easy to get wrong: on `schedule` and `watch`
there are no inputs, so `FORCE` expands to an empty string, and it has to stay
harmless under `set -u`.

| FORCE | count | published | result |
| --- | --- | --- | --- |
| empty (schedule/watch) | 264 | 262 | publish |
| empty | 100 | 262 | refuse, below floor |
| empty | 0 | 262 | refuse, zero rows |
| false | 100 | 262 | refuse, below floor |
| true | 100 | 262 | publish |
| true | 0 | 262 | refuse, zero rows |

After merge this wants one plain dispatch to confirm the normal path still
publishes.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A, workflow shell; verified as above
- [ ] Type check passes (`mypy src/`) — N/A, no Python changed
- [ ] Lint passes (`ruff check .`) — N/A, no Python changed
- [ ] Format passes (`ruff format --check .`) — N/A, no Python changed
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way — N/A, repo tooling
