### PR TITLE
fix: separate star chart x labels on short windows

### DIFF
--- a/scripts/star_history.py
+++ b/scripts/star_history.py
@@ -25,7 +25,7 @@ import math
 import sys
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 # Geometry in user units. The SVG scales to its container, so only the
@@ -113,6 +113,24 @@ def nice_step(span: float, ticks: int) -> float:
     return max(1.0, 10 * magnitude)
 
 
+def _x_tick_format(span: timedelta) -> str:
+    """Pick the coarsest date format that still tells adjacent x ticks apart.
+
+    Ticks are spread evenly across the window, so what governs collisions is
+    the gap between them rather than the window itself. The one exception is
+    the year: a day-and-month label repeats once the window reaches a year,
+    however wide the gaps are.
+    """
+    gap = span / (X_TICKS - 1)
+    if span >= timedelta(days=365):
+        return "%b %Y"
+    if gap >= timedelta(days=1):
+        return "%b %d"
+    if gap >= timedelta(minutes=1):
+        return "%b %d %H:%M"
+    return "%b %d %H:%M:%S"
+
+
 def _scale_x(stamp: datetime, first: datetime, last: datetime) -> float:
     span = (last - first).total_seconds()
     usable = WIDTH - PAD_LEFT - PAD_RIGHT
@@ -154,9 +172,10 @@ def render(series: Sequence[Point], repo: str, theme: Theme) -> str:
 
     parts: list[str] = []
     label = html.escape(repo)
-    # A day-and-month tick repeats once the window crosses a year boundary,
-    # which would print the same label twice on the axis.
-    tick_format = "%b %d" if first.year == last.year else "%b %Y"
+    tick_format = _x_tick_format(last - first)
+    # Below a second apart no format separates the ticks, and a window of zero
+    # stacks them all on one pixel anyway, so draw the single moment instead.
+    x_ticks = X_TICKS if (last - first) / (X_TICKS - 1) >= timedelta(seconds=1) else 1
     window = f"{first.strftime('%b %Y')} to {last.strftime('%b %Y')}"
 
     parts.append(
@@ -195,11 +214,13 @@ def render(series: Sequence[Point], repo: str, theme: Theme) -> str:
         )
         tick += step
 
-    for index in range(X_TICKS):
-        fraction = index / (X_TICKS - 1)
+    for index in range(x_ticks):
+        fraction = index / (x_ticks - 1) if x_ticks > 1 else 1.0
         stamp = first + (last - first) * fraction
         x = _scale_x(stamp, first, last)
-        anchor = "start" if index == 0 else "end" if index == X_TICKS - 1 else "middle"
+        # Last-index first so the lone tick, which sits at the right edge,
+        # anchors "end" rather than running off it.
+        anchor = "end" if index == x_ticks - 1 else "start" if index == 0 else "middle"
         parts.append(
             f'<text x="{x:.1f}" y="{HEIGHT - PAD_BOTTOM + 22}" text-anchor="{anchor}" '
             f'font-family="{FONT}" font-size="12" fill="{theme.text}">'

--- a/tests/test_star_history.py
+++ b/tests/test_star_history.py
@@ -142,6 +142,41 @@ class TestRender:
             assert len(labels) == star_history.X_TICKS
             assert len(labels) == len(set(labels)), f"span={span} duplicated labels: {labels}"
 
+    def test_date_labels_are_unique_on_short_windows(self):
+        # The format used to be chosen from `first.year == last.year`, which
+        # says nothing about how far apart the ticks are, so anything under
+        # five days printed the same day repeatedly. A two-hour window
+        # rendered one distinct label across all five ticks.
+        for hours in (1, 2, 6, 24, 72, 120):
+            svg = star_history.render(
+                _series_spanning(hours / 24), "av1155/houndarr", star_history.THEMES[0]
+            )
+            labels = _axis_labels(svg, "x")
+            assert len(labels) == star_history.X_TICKS
+            assert len(labels) == len(set(labels)), f"{hours}h duplicated labels: {labels}"
+
+    def test_short_windows_crossing_a_year_keep_day_resolution(self):
+        # The same year comparison forced a week that straddles 31 December
+        # all the way up to month resolution, which cannot separate ticks
+        # seven days apart.
+        start = datetime(2026, 12, 28, tzinfo=UTC)
+        for days in (7, 21, 62):
+            svg = star_history.render(
+                _series_spanning(days, start=start), "av1155/houndarr", star_history.THEMES[0]
+            )
+            labels = _axis_labels(svg, "x")
+            assert len(labels) == len(set(labels)), f"{days}d duplicated labels: {labels}"
+
+    def test_a_window_of_zero_renders_one_tick(self):
+        # Every tick resolves to the same instant on the same pixel, so no
+        # format tells them apart; five stacked copies is the wrong answer.
+        svg = star_history.render(
+            star_history.build_series([BASE, BASE, BASE]),
+            "av1155/houndarr",
+            star_history.THEMES[0],
+        )
+        assert _axis_labels(svg, "x") == [BASE.strftime("%b %d %H:%M:%S")]
+
     def test_both_themes_namespace_their_gradient(self):
         series = _series(50)
         ids = {


### PR DESCRIPTION
## Summary

The chart's x-axis tick format was chosen like this:

```python
tick_format = "%b %d" if first.year == last.year else "%b %Y"
```

`X_TICKS` is fixed at 5 and the ticks are spread evenly across the window, so
what decides whether two of them collide is the gap between them. A calendar
year comparison says nothing about that gap, and it fails in both directions:
short windows collapse under `%b %d`, and a short window that happens to
straddle 31 December is pushed all the way to `%b %Y`, which cannot separate
ticks a few days apart.

Measured against the current renderer, reading the x-tick row:

| Window | Rendered | Distinct |
| --- | --- | --- |
| 2 hours | `Aug 01` five times | 1/5 |
| 1 day | `Aug 01` four times, `Aug 02` | 2/5 |
| 3 days | `Aug 01, Aug 01, Aug 02, Aug 03, Aug 04` | 4/5 |
| 7 days from 28 Dec | `Dec 2026` three times, `Jan 2027` twice | 2/5 |
| 15 Dec to 15 Feb | `Dec 2026, Dec 2026, Jan 2027, Jan 2027, Feb 2027` | 3/5 |
| same instant | `Jan 01` five times | 1/5 |

Closes #725

## Changes

- `_x_tick_format` picks the coarsest format that still separates adjacent
  ticks, from the gap between them: month and year at a year or more, day below
  that, dropping to hours and then seconds as the gap shrinks.
- A window under a second wide renders one tick instead of five. No format can
  separate ticks that are the same instant, and `_scale_x` already stacks them
  on a single pixel, so five copies was the wrong answer rather than a
  formatting problem.

The 7-days-across-New-Year case now reads `Dec 28, Dec 29, Dec 31, Jan 02, Jan
04`, which is both distinct and more useful than the month labels it produced
before.

## Testing

Full gate green: `2806 passed`.

The three new tests were run against the pre-fix renderer first and all three
fail there, which is the point of them:

```
FAILED tests/test_star_history.py::TestRender::test_date_labels_are_unique_on_short_windows
FAILED tests/test_star_history.py::TestRender::test_short_windows_crossing_a_year_keep_day_resolution
FAILED tests/test_star_history.py::TestRender::test_a_window_of_zero_renders_one_tick
```

Two properties worth calling out, both checked rather than assumed:

- **The existing year-boundary test is untouched and still passes.** Its spans
  (200 to 3000 days) select the same formats as before.
- **The live chart does not change.** Rendering the real 264-star data through
  both the old and new renderer gives byte-identical SVGs, and both match what
  is currently published on `assets`. That matters because the workflow treats
  an unchanged render as a no-op, so a format change would have pushed one
  pointless refresh commit.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`; the script is clean under it too)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way — N/A, README chart renderer
