### PR TITLE
fix(deps): raise mermaid and dompurify floors

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -10,12 +10,12 @@ overrides:
   uuid: '>=14.0.0'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   fast-uri: '>=3.1.5 <4'
-  mermaid: '>=11.15.0'
+  mermaid: '>=11.16.1'
   webpack-dev-server: '>=5.2.6 <6'
   ws: '>=8.21.0'
   shell-quote: '>=1.8.4'
   undici: '>=7.29.0 <8'
-  dompurify: '>=3.4.12 <4'
+  dompurify: '>=3.4.13 <4'
   '@babel/core': '>=7.29.1 <8'
   http-proxy-middleware: '>=2.0.10 <3'
   joi: '>=17.13.4 <18'
@@ -1752,8 +1752,8 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@mermaid-js/parser@1.1.1':
-    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@module-federation/error-codes@0.22.0':
     resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
@@ -3492,8 +3492,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -4551,8 +4551,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.15.0:
-    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -8358,7 +8358,7 @@ snapshots:
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.11)(@swc/core@1.15.33)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.33)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/types': 3.10.1(@swc/core@1.15.33)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.33)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
@@ -8902,7 +8902,7 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
-  '@mermaid-js/parser@1.1.1':
+  '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
 
@@ -10774,7 +10774,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -11999,11 +11999,11 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.15.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.1
-      '@mermaid-js/parser': 1.1.1
+      '@mermaid-js/parser': 1.2.0
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.3
@@ -12013,7 +12013,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -32,10 +32,16 @@ overrides:
   # Transitive via @docusaurus/core > webpack > schema-utils > ajv.
   # Held to the 3.x line expected by ajv.
   fast-uri: ">=3.1.5 <4"
-  # mermaid <11.15.0 resolves four moderate alerts on classDef,
-  # classDefs, configuration, and Gantt-chart sanitisation.
+  # mermaid <11.16.1 carries five advisories, all fixed in 11.16.1:
+  # GHSA-3rrr-jr9j-h3q3 (prototype pollution through Architecture
+  # diagrams), GHSA-rhh3-jpg6-66xh (DoS via radar diagrams),
+  # GHSA-6x64-9x62-f2gx (CSS injection reaching siblings of the
+  # diagram), GHSA-2v8p-3f2j-5mp7 (infinite-loop DoS in XY charts),
+  # and GHSA-c4c3-pg64-4m4v (prototype pollution via the configuration
+  # APIs). Supersedes the earlier >=11.15.0 floor that cleared the
+  # classDef, classDefs, configuration, and Gantt sanitisation alerts.
   # Transitive via @docusaurus/theme-mermaid.
-  mermaid: ">=11.15.0"
+  mermaid: ">=11.16.1"
   # webpack-dev-server <=5.2.5 carries GHSA-m28w-2pqf-7qgj (DoS via a
   # malformed Host or Origin header) and GHSA-f5vj-f2hx-8m93 (CSRF
   # through internal developer endpoints), both fixed in 5.2.6;
@@ -67,15 +73,18 @@ overrides:
   # @easyops-cn/docusaurus-search-local > cheerio. Held to the 7.x
   # line since nothing in the tree needs undici 8.
   undici: ">=7.29.0 <8"
-  # dompurify <=3.4.11 lets an allowed custom element bypass
-  # afterSanitizeElements via CUSTOM_ELEMENT_HANDLING
-  # (GHSA-c2j3-45gr-mqc4), fixed in 3.4.12; supersedes the earlier
-  # >=3.4.11 floor that cleared the eight-advisory sanitizer-bypass
-  # cluster (GHSA-x4vx-rjvf-j5p4, GHSA-vxr8-fq34-vvx9,
-  # GHSA-gvmj-g25r-r7wr, GHSA-rp9w-3fw7-7cwq, GHSA-hpcv-96wg-7vj8,
-  # GHSA-r47g-fvhr-h676, GHSA-76mc-f452-cxcm, GHSA-cmwh-pvxp-8882).
+  # dompurify <=3.4.12 leaves a subtree executable after an IN_PLACE
+  # hook detaches it, which is an XSS path (GHSA-55q2-fjhq-7xh7),
+  # fixed in 3.4.13; supersedes the earlier >=3.4.12 floor for
+  # GHSA-c2j3-45gr-mqc4 (custom element bypassing
+  # afterSanitizeElements via CUSTOM_ELEMENT_HANDLING) and the
+  # >=3.4.11 floor before it that cleared the eight-advisory
+  # sanitizer-bypass cluster (GHSA-x4vx-rjvf-j5p4,
+  # GHSA-vxr8-fq34-vvx9, GHSA-gvmj-g25r-r7wr, GHSA-rp9w-3fw7-7cwq,
+  # GHSA-hpcv-96wg-7vj8, GHSA-r47g-fvhr-h676, GHSA-76mc-f452-cxcm,
+  # GHSA-cmwh-pvxp-8882).
   # Transitive via @docusaurus/theme-mermaid > mermaid.
-  dompurify: ">=3.4.12 <4"
+  dompurify: ">=3.4.13 <4"
   # GHSA-4x5r-pxfx-6jf8: @babel/core <7.29.1 can read arbitrary files
   # through a crafted sourceMappingURL comment during compilation.
   # Transitive via @docusaurus/core > @docusaurus/babel.


### PR DESCRIPTION
## Summary

Six Dependabot alerts on `website/pnpm-lock.yaml`, both packages already
floored but now one release behind.

Mermaid 11.16.1 clears five: prototype pollution through Architecture diagrams
(GHSA-3rrr-jr9j-h3q3) and through the configuration APIs (GHSA-c4c3-pg64-4m4v),
DoS via radar diagrams (GHSA-rhh3-jpg6-66xh) and XY charts
(GHSA-2v8p-3f2j-5mp7), and CSS injection reaching siblings of the diagram
(GHSA-6x64-9x62-f2gx). DOMPurify 3.4.13 clears GHSA-55q2-fjhq-7xh7, where an
`IN_PLACE` hook leaves a detached subtree executable.

Both arrive through `@docusaurus/theme-mermaid`. Neither was failing CI: Trivy
runs with `--ignore-unfixed` and did not rank them CRITICAL or HIGH with a fix,
so this is alert hygiene rather than a broken build.

Closes #731

## Changes

- `mermaid` floor to `>=11.16.1`, resolving 11.16.1.
- `dompurify` floor to `>=3.4.13 <4`, resolving 3.4.13.

## Testing

`trivy fs .` with CI's flags reports 0 findings across all three targets CI
scans (`uv.lock`, `tests/e2e_browser/requirements.txt`,
`website/pnpm-lock.yaml`).

Mermaid 11.15 to 11.16 is a minor bump on something the docs site actually
renders, so I checked the output rather than trusting the build exit code. I
built `docs/concepts/how-scheduling-works`, which carries two flowcharts, on
this branch and again on `main`, and the page is identical either way at 37408
bytes. Docusaurus renders mermaid client-side, so the diagram source is not in
the SSR HTML on either build; the mermaid runtime is bundled in both.

## Type of Change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A, dependency floors only
- [ ] Type check passes (`mypy src/`) — N/A, no Python changed
- [ ] Lint passes (`ruff check .`) — N/A, no Python changed
- [ ] Format passes (`ruff format --check .`) — N/A, no Python changed
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way — N/A, docs-site dependencies
