### PR TITLE
ci: attribute star history commits to the bot

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -126,5 +126,8 @@ jobs:
           # accumulating a commit per day would add megabytes of dead history
           # to every clone. The force-push is scoped to this orphan branch and
           # can never reach main.
-          git commit --amend -m "chore: refresh star history chart"
+          # --reset-author because a plain amend keeps the seed commit's author
+          # and author date, so every refresh would read as authored by whoever
+          # seeded the branch, on the day they seeded it.
+          git commit --amend --reset-author -m "chore: refresh star history chart"
           git push --force-with-lease origin HEAD:assets


### PR DESCRIPTION
## Summary

Published chart commits are attributed to the wrong person. The current tip of
`assets`, written by the workflow earlier today:

```
author:    Andrea Arturo Venti Fuentes   2026-08-06T18:06:30Z
committer: github-actions[bot]           2026-08-11T16:36:54Z
```

`git commit --amend` preserves the original author and author date, so the bot
identity configured just above it only ever reaches the committer field. Since
the branch is amended in place forever, the author date is pinned to the
seeding and never moves again.

Closes #733

## Changes

- `--reset-author` on the amend, so the bot is recorded as both author and
  committer with the current timestamp.

## Testing

Simulated against a real shallow clone of `assets`, since the publish path only
runs when the chart actually changes and the live count currently matches what
is published:

```
without --reset-author:
  author:    Andrea Arturo Venti Fuentes   2026-08-06T14:06:30-04:00
  committer: github-actions[bot]           2026-08-11T13:49:44-04:00

with --reset-author:
  author:    github-actions[bot]           2026-08-11T13:49:44-04:00
  committer: github-actions[bot]           2026-08-11T13:49:44-04:00
```

The amended commit stays parentless (`parents=[]`), so the orphan branch keeps
the property the `--force-with-lease` push relies on.

`actionlint` clean. This will not be visible until the next refresh that
actually changes the chart, which means the next star.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [x] CI/CD (`ci:`)
- [ ] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [ ] Tests added/updated for all changes — N/A, one git flag; verified as above
- [ ] Type check passes (`mypy src/`) — N/A, no Python changed
- [ ] Lint passes (`ruff check .`) — N/A, no Python changed
- [ ] Format passes (`ruff format --check .`) — N/A, no Python changed
- [ ] Documentation updated (if applicable) — N/A
- [x] No secrets or sensitive data committed
- [ ] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way — N/A, repo tooling
