### PR TITLE
ci: scope workflow write permissions to jobs

### DIFF
--- a/.github/workflows/api-snapshot-refresh.yml
+++ b/.github/workflows/api-snapshot-refresh.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +16,10 @@ concurrency:
 jobs:
   refresh:
     name: Refresh *arr OpenAPI snapshots
+    permissions:
+      # Committing the refreshed snapshots and opening the PR.
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -16,7 +16,7 @@ on:
       - "scripts/marketing/**"
 
 permissions:
-  checks: write
+  contents: read
 
 concurrency:
   group: ci-skip-${{ github.event.pull_request.number || github.ref }}
@@ -25,6 +25,9 @@ concurrency:
 jobs:
   skip-checks:
     name: CI Skip (docs-only)
+    permissions:
+      # Publishing the no-op check runs that satisfy branch protection.
+      checks: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/cleanup-actions-cache.yml
+++ b/.github/workflows/cleanup-actions-cache.yml
@@ -34,8 +34,7 @@ on:
           - "true"
 
 permissions:
-  # gh cache delete requires actions: write.
-  actions: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}
@@ -44,6 +43,9 @@ concurrency:
 jobs:
   cleanup:
     name: Prune stale caches
+    permissions:
+      # gh cache delete requires actions: write.
+      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,14 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     name: Create GitHub Release
+    permissions:
+      # Creating the GitHub Release requires contents: write.
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -18,7 +18,7 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}
@@ -32,6 +32,9 @@ jobs:
     # Forks have no `assets` branch, so a dispatched run there would fail on
     # the checkout below.
     if: github.repository == 'av1155/houndarr'
+    permissions:
+      # Force-pushing the rendered chart to the orphan `assets` branch.
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary

Moves top-level workflow write permissions down to the single job that needs them, so a step added later cannot silently inherit write access.

Closes #735

## Changes

- `release.yml`, `star-history.yml`, `api-snapshot-refresh.yml`, `cleanup-actions-cache.yml`, `ci-skip.yml`: default to `contents: read`, grant the write on the one job that uses it.

Each of these has exactly one job, and job-level permissions replace rather than merge, so every job keeps precisely the grants it had before. Only the blast radius changes.

Left alone deliberately: `issues: write` in the AI triage/moderation and stale workflows, and `pages`/`id-token` in `pages.yml`. Those are already single-job and carry no equivalent risk.

## Testing

`actionlint` clean across all workflows (the one finding is a pre-existing SC2034 in `browser-e2e.yml`, untouched here). Job names are unchanged, so the 11 required checks still match branch protection.

## Type of Change

- [x] CI/CD (`ci:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope
- [ ] Tests added/updated for all changes — N/A, no application code
- [x] No secrets or sensitive data committed
- [x] **Scope check**: infrastructure hardening only, no behaviour change