### PR TITLE
build: pin base image digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Let a freshly published version sit before proposing it, so a
+    # compromised release is more likely to be pulled first. Security
+    # updates are exempt from cooldown, so patches are not delayed.
+    cooldown:
+      default-days: 7
     groups:
       production-deps:
         patterns:
@@ -36,6 +41,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       production-deps:
         dependency-type: production
@@ -55,7 +62,24 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
+        patterns:
+          - "*"
+
+  # Dockerfile base images. Required: the FROM lines are digest-pinned, so
+  # without this the bases never pick up upstream security patches.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      docker-base-images:
         patterns:
           - "*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # Compile Tailwind v4 + Houndarr custom CSS into a single static file. Node
 # lives only in this stage; the final runtime image stays Python-only.
 # -----------------------------------------------------------------------------
-FROM node:22-alpine AS css-build
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS css-build
 WORKDIR /build
 
 # Enable pnpm via corepack (bundled with Node 20+). The packageManager field
@@ -32,7 +32,7 @@ RUN pnpm run build-css
 # -----------------------------------------------------------------------------
 # Stage 2: runtime
 # -----------------------------------------------------------------------------
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a
 
 ARG HOUNDARR_VERSION=dev
 


### PR DESCRIPTION
## Summary

Pins both Dockerfile base images to their manifest list digest, and adds the Dependabot coverage that keeps them current.

Closes #736

## Changes

- `Dockerfile`: `node:22-alpine` and `python:3.13-slim` now carry the multi-arch manifest list digest. The tag stays for readability and Dependabot tracking; buildx still resolves the correct per-arch image.
- `.github/dependabot.yml`: add the `docker` ecosystem. This is required, not optional: a digest pin with nothing watching it freezes the bases and stops upstream security patches, which is worse than the mutable tag it replaces.
- `.github/dependabot.yml`: add `cooldown: default-days: 7` to all four ecosystems. Security updates are exempt from cooldown, so patches are not delayed.

## Testing

Both digests verified to resolve against the registry. `hadolint` clean. No Python touched and no test references the Dockerfile or Dependabot config.

## Type of Change

- [x] Chore (`chore:`) — commit is typed `build:`

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope
- [ ] Tests added/updated for all changes — N/A, no application code
- [x] No secrets or sensitive data committed
- [x] **Scope check**: supply-chain hardening only, image contents unchanged