### PR TITLE
docs: add OpenSSF best practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Small batches. Polite intervals. Zero indexer abuse.
 [![GitHub release](https://img.shields.io/github/v/release/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/releases/latest)
 [![GHCR pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fghcr-badge.andrea-venti12.workers.dev%2Fapi%2Fav1155%2Fhoundarr&query=downloadCount&label=ghcr%20pulls&color=2496ed&logo=docker&logoColor=white&style=flat)](https://github.com/av1155/houndarr/pkgs/container/houndarr)
 [![Contributors](https://img.shields.io/github/contributors/av1155/houndarr?style=flat)](https://github.com/av1155/houndarr/graphs/contributors)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14028/badge)](https://www.bestpractices.dev/projects/14028)
 [![Discord](https://img.shields.io/discord/1495186820806213743?style=flat&logo=discord&logoColor=white&label=discord&color=5865F2)](https://discord.gg/t29AhAarYk)
 
 [Documentation](https://av1155.github.io/houndarr/)


### PR DESCRIPTION
## Summary

Adds the OpenSSF Best Practices badge (passing, project 14028) to the README badge row.

Closes #738

## Changes

- `README.md`: badge added after Contributors.

## Testing

Badge image and project page both return 200.

## Type of Change

- [x] Documentation (`docs:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope
- [ ] Tests added/updated for all changes — N/A, README only
- [x] Documentation updated
- [x] No secrets or sensitive data committed
- [x] **Scope check**: README only