### PR TITLE
docs: record release provenance in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Release images carry a signed build provenance attestation, and each GitHub release ships the matching `.sigstore.json` bundle for verification with `gh attestation verify`. (#737)
+
 ---
 
 ## [1.13.1] - 2026-08-03


### PR DESCRIPTION
## Summary

Adds the missing `### Security` bullet for the provenance work, which shipped without one and left `## [Unreleased]` empty so `/bump` refused to run.

Closes #747

## Changes

- `CHANGELOG.md`: `### Security` bullet naming the `.sigstore.json` release asset and the `gh attestation verify` command.

The three changes merged alongside #737 stay unbulleted. Scoped workflow permissions and the README badge are invisible to deployers, and the base image digest pin leaves the shipped image behaving identically.

## Testing

Ran `version-check.yml`'s assertions against the edited file locally: Unreleased is still the topmost `## [...]` block, keeps its trailing `---`, and uses an allowed `###` header. Rendered the bullet through `_render_changelog_bullet` to confirm the backticks and `(#737)` ref render correctly in the in-app What's New modal.

## Type of Change

- [x] Documentation (`docs:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope
- [ ] Tests added/updated for all changes — N/A, changelog only
- [x] Documentation updated
- [x] No secrets or sensitive data committed
- [x] **Scope check**: changelog only