### PR TITLE
docs: update release skills for provenance

### DIFF
--- a/.agents/skills/bump/SKILL.md
+++ b/.agents/skills/bump/SKILL.md
@@ -102,3 +102,15 @@ gh pr create --title "chore: bump version to X.Y.Z" --body "..."
 ```
 
 After merge, remind the user to run `git tag vX.Y.Z && git push origin vX.Y.Z` to trigger docker.yml, release.yml, and chart.yml.
+
+## 11. Verify the Tag Push
+
+The tag fires docker.yml and release.yml independently. docker.yml attaches the provenance bundle to the release that release.yml creates, so that upload can fail *after* the image is already on GHCR. The result is a release that looks complete sitting beside a red workflow run, which is easy to miss.
+
+```
+gh run list --workflow=docker.yml --limit 1
+gh release view vX.Y.Z --json assets --jq '.assets[].name'
+gh attestation verify oci://ghcr.io/av1155/houndarr:vX.Y.Z --repo av1155/houndarr
+```
+
+Expect a green run, a `houndarr-vX.Y.Z.sigstore.json` asset on the release, and a verify that reports a matching provenance attestation. If the asset is missing, re-run the failed docker.yml job rather than re-tagging.

--- a/.agents/skills/houndarr-changelog/SKILL.md
+++ b/.agents/skills/houndarr-changelog/SKILL.md
@@ -84,7 +84,10 @@ Caddy, and other self-hosted tools targeting the same audience.
   Changelog explicitly excludes these; they live in PR bodies).
 - Test-only changes.
 - Docs-only changes (the docs site has its own deploy log).
-- CI / workflow changes that do not affect deployers.
+- CI / workflow changes that do not affect deployers. Note the
+  qualifier: a workflow change that alters what a release *ships*
+  (signatures, attestations, published assets, image contents) does
+  reach deployers and is bulleted.
 - Dependency bumps with no security or behaviour impact.
 
 ## Schema version bumps
@@ -164,7 +167,7 @@ section that has no entries.
 - **Every bullet must be justified by a PR-body sentence, a diff fragment,
   or a source `file:line`.** Do not draft from PR titles, commit messages,
   or memory alone. The verification protocol lives in
-  `.claude/commands/bump.md` §3b; skipping it is what shipped the
+  `.agents/skills/bump/SKILL.md` §3b; skipping it is what shipped the
   inaccurate v1.9.0 bullets that had to be corrected in #420.
 - Adopt the PR author's vocabulary for nuance. If the PR body says
   "new default for fresh installs; existing instances keep their prior


### PR DESCRIPTION
## Summary

Brings the two release-workflow skills in line with the provenance attestation added in #737.

Closes #749

## Changes

- `bump`: new step 11 verifying the tag push. `docker.yml` attaches the bundle to the release that `release.yml` creates, so the upload can fail after the image is already on GHCR, leaving a release that looks complete beside a red run.
- `houndarr-changelog`: spells out that a workflow change altering what a release ships does reach deployers. The qualifier on "CI / workflow changes that do not affect deployers" was being read as a blanket rule, which is how #737 shipped without a bullet.
- `houndarr-changelog`: repoint the bullet-justification xref from `.claude/commands/bump.md`, deleted when the command became a skill, to `.agents/skills/bump/SKILL.md`.

## Testing

Verified the repointed xref resolves and that `### 3b.` is still the bullet-justification section. Confirmed no `.claude/commands/bump` references remain. Frontmatter parses on both skills and the `.claude/skills` symlinks still resolve.

The commands in the new step 11 were checked against `gh attestation verify --help`: it requires `--owner` or `--repo`, and takes `oci://<image-uri>` for a container image.

Deliberately not touching the global `ship` skill. It lives outside this repo and applies to every project, so its CI-prefix default is not being bent for one repo.

## Type of Change

- [x] Documentation (`docs:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope
- [ ] Tests added/updated for all changes — N/A, skill docs only
- [x] Documentation updated
- [x] No secrets or sensitive data committed
- [x] **Scope check**: release tooling docs only