### PR TITLE
chore: move css build stage to node 24 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,12 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    ignore:
+      # TypeScript 7 removed the `baseUrl` compiler option that
+      # `@docusaurus/tsconfig` still sets, and an extending config cannot
+      # unset an inherited option. Revisit when Docusaurus drops it.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       production-deps:
         dependency-type: production
@@ -79,6 +85,12 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    ignore:
+      # Odd-numbered Node majors are Current, not LTS, and Dependabot has
+      # no concept of the release line. Node 25 also dropped the bundled
+      # corepack the css-build stage relies on. Move the LTS line by hand.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     groups:
       docker-base-images:
         patterns:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,12 @@
 # Compile Tailwind v4 + Houndarr custom CSS into a single static file. Node
 # lives only in this stage; the final runtime image stays Python-only.
 # -----------------------------------------------------------------------------
-FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS css-build
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS css-build
 WORKDIR /build
 
-# Enable pnpm via corepack (bundled with Node 20+). The packageManager field
-# in package.json pins the exact pnpm version.
+# Enable pnpm via corepack, which the Node 24 LTS image still bundles.
+# Node 25 dropped it, so a major bump here needs pnpm installed another way.
+# The packageManager field in package.json pins the exact pnpm version.
 RUN corepack enable
 
 # Copy manifest + lockfile + workspace config first for better layer caching.


### PR DESCRIPTION
Replaces #743, which fails to build.

Closes #751

## Summary

Node 25 dropped the bundled corepack the css-build stage uses, so that bump died at `RUN corepack enable` with `exit code: 127`. It is also a Current release rather than LTS. Node 24 is the current LTS (Krypton) and still ships corepack, so nothing about how pnpm is installed has to change.

## Changes

- `Dockerfile`: css-build stage moves to `node:24-alpine`, digest-pinned. Comment updated, since "bundled with Node 20+" is no longer true above 24.
- `.github/dependabot.yml`: ignore `node` major updates. Dependabot has no concept of LTS, so it will keep proposing Current lines.
- `.github/dependabot.yml`: ignore `typescript` major updates. TS 7 removed the `baseUrl` option `@docusaurus/tsconfig` still sets, and an extending config cannot unset an inherited option (see #746).

Patch and minor updates keep flowing for both.

## Testing

Built the css-build stage locally against the pinned digest: Node v24.19.0, `corepack enable` succeeds, pnpm 11.21.0 activates, Tailwind 4.2.4 compiles `app.built.css`. `hadolint` clean, and the Dependabot config parses with both ignore rules applied to the right ecosystems.

## Type of Change

- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope
- [ ] Tests added/updated for all changes — N/A, build config only
- [x] No secrets or sensitive data committed
- [x] **Scope check**: build tooling only, image contents unchanged