### PR TITLE
ci: type check the docs site

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - "website/**"
+      # Self-triggering, so a change to this workflow is exercised by the
+      # PR that makes it rather than by the next unrelated docs change.
+      - ".github/workflows/test-deploy.yml"
 
 permissions:
   contents: read
@@ -35,6 +38,13 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        working-directory: website
+
+      # The Docusaurus build transpiles TypeScript without checking it, so a
+      # type error builds clean. Runs before the build because it is the
+      # cheaper of the two.
+      - name: Type check
+        run: pnpm run typecheck
         working-directory: website
 
       - name: Build site


### PR DESCRIPTION
Closes #753

## Summary

`test-deploy.yml` ran only `pnpm run build`, and the Docusaurus build transpiles TypeScript without checking it. A type error in `website/` passed CI silently.

## Changes

- `test-deploy.yml`: run `pnpm run typecheck` before the build. It is the cheaper of the two, so it fails first.
- `test-deploy.yml`: trigger on changes to the workflow itself, so this PR exercises the new step rather than deferring proof to the next unrelated docs change.

## Testing

Appended a deliberate type error to `website/src/pages/index.tsx` and ran both scripts against it:

```
pnpm run typecheck  -> exit 2   src/pages/index.tsx(279,7): error TS2322:
                                Type 'string' is not assignable to type 'number'
pnpm run build      -> exit 0   [SUCCESS] Generated static files in "build".
                                (and printed "not a number" during the build)
```

The build cannot catch this, which is the gap being closed. The probe was reverted and `website/` confirmed clean before committing.

Also checked that `typecheck` passes from a clean checkout with no generated `.docusaurus` directory, so it does not depend on running after the build.

Verified against live branch protection that `Test docs build` is not one of the 11 required checks, and the job name is unchanged, so nothing about the required set moves. The new step is named `Type check`, but steps do not create check names, so there is no collision with the required `Type check (mypy)` job.

## Type of Change

- [x] CI/CD (`ci:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope
- [ ] Tests added/updated for all changes — N/A, CI config
- [x] No secrets or sensitive data committed
- [x] **Scope check**: CI coverage only, no runtime change