### PR TITLE
chore: test on python 3.14 and ship it in the image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.13", "3.14"]
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # syntax=docker/dockerfile:1
 # =============================================================================
 # Houndarr — production Docker image
-# Base: python:3.13-slim (Debian bookworm slim)
+# Base: python:3.14-slim (Debian trixie slim)
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -33,7 +33,7 @@ RUN pnpm run build-css
 # -----------------------------------------------------------------------------
 # Stage 2: runtime
 # -----------------------------------------------------------------------------
-FROM python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a
+FROM python:3.14-slim@sha256:cae66f2ef0ec51a9891263eeee7f987dacf0a9879e8aa9353d5606e0530619a5
 
 ARG HOUNDARR_VERSION=dev
 


### PR DESCRIPTION
## Summary

Runs the suite on Python 3.14 alongside 3.13 and moves the runtime image to `python:3.14-slim`. This is the remaining half of #762, whose `node:24-alpine` digest landed in #773.

Closes #775

## Changes

- `tests.yml` matrix gains `"3.14"`. The job name is templated, so this adds a `Test (Python 3.14)` check and leaves the 11 required check names untouched.
- Runtime base moves to `python:3.14-slim`, pinned by digest.
- The Dockerfile header said bookworm; both bases are Debian 13 trixie.

`requires-python = ">=3.13"` and ruff's `target-version` are unchanged, since 3.13 stays supported, and mypy keeps checking against 3.13 as the lower bound.

## Testing

- Every dependency resolves to a prebuilt cp314 wheel for both `x86_64` and `aarch64`, so neither published arch falls back to a source build, and `uv sync --frozen` needs no lockfile change.
- The full suite passes on 3.13 and 3.14, on macOS and inside both slim images, with no new failures or warnings. Ruff, mypy and bandit are clean under 3.14.
- Images built from both bases behave the same: healthy container, `/api/health` returning ok, identical setup page and startup logs. The 3.14 image is about 10 MB smaller. A container built from this branch reports Python 3.14.7 and starts clean.

## Type of Change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Refactoring (`refactor:`)
- [ ] Documentation (`docs:`)
- [ ] CI/CD (`ci:`)
- [x] Chore (`chore:`)

## Checklist

- [x] **Issue exists** and is linked above with `Closes #N`
- [x] Linked issue has exactly one `type:*` and one `priority:*` label
- [x] Linked issue has at most one `phase:*` label (or none when not roadmap work)
- [x] Branch name matches issue scope (`feat/<slug>`, `fix/<slug>`, etc.)
- [x] Tests added/updated for all changes
- [x] Type check passes (`mypy src/`)
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] Documentation updated (if applicable)
- [x] No secrets or sensitive data committed
- [x] **Scope check**: This change helps search for missing or cutoff-unmet media in a controlled way
